### PR TITLE
Fix Ubuntu 24 installation script GPG key issue

### DIFF
--- a/examples/test-gh-install.sh
+++ b/examples/test-gh-install.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+echo "[*] Testing GitHub CLI installation..."
+
+# Create test directory
+mkdir -p /tmp/test-gh-install
+cd /tmp/test-gh-install
+
+# Test the GitHub CLI installation method
+echo "[*] Installing GitHub CLI using the fixed method..."
+sudo mkdir -p -m 755 /etc/apt/keyrings
+out=$(mktemp)
+wget -nv -O$out https://cli.github.com/packages/githubcli-archive-keyring.gpg
+cat $out | sudo tee /etc/apt/keyrings/githubcli-archive-keyring.gpg > /dev/null
+sudo chmod go+r /etc/apt/keyrings/githubcli-archive-keyring.gpg
+rm -f $out
+
+sudo mkdir -p -m 755 /etc/apt/sources.list.d
+echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" \
+  | sudo tee /etc/apt/sources.list.d/github-cli.list > /dev/null
+
+echo "[*] Updating apt sources..."
+sudo apt update -y
+
+echo "[*] Installing gh..."
+sudo apt install -y gh
+
+echo "[*] Testing gh installation..."
+gh --version
+
+echo "[*] GitHub CLI installation test completed successfully!"

--- a/ubuntu-24-server-install.sh
+++ b/ubuntu-24-server-install.sh
@@ -46,22 +46,22 @@ echo "[*] Installing as hive user..."
 # --- GitHub CLI ---
 if ! command -v gh &>/dev/null; then
   echo "[*] Installing GitHub CLI..."
-  mkdir -p -m 755 ~/.local/share/keyrings
-  mkdir -p $HOME/.config
-  wget -qO- https://cli.github.com/packages/githubcli-archive-keyring.gpg \
-    | tee ~/.local/share/keyrings/githubcli-archive-keyring.gpg >/dev/null
-  chmod go+r ~/.local/share/keyrings/githubcli-archive-keyring.gpg
-
-  ARCH=$(dpkg --print-architecture)
-  echo "deb [arch=${ARCH} signed-by=$HOME/.local/share/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" \
-    | tee $HOME/.config/github-cli.list >/dev/null
-
-  # Temporary local sources dir
-  sudo mkdir -p /etc/apt/sources.list.d/
-  sudo cp $HOME/.config/github-cli.list /etc/apt/sources.list.d/github-cli.list
-
+  # Use official installation method from GitHub CLI maintainers
+  sudo mkdir -p -m 755 /etc/apt/keyrings
+  out=$(mktemp)
+  wget -nv -O$out https://cli.github.com/packages/githubcli-archive-keyring.gpg
+  cat $out | sudo tee /etc/apt/keyrings/githubcli-archive-keyring.gpg > /dev/null
+  sudo chmod go+r /etc/apt/keyrings/githubcli-archive-keyring.gpg
+  rm -f $out
+  
+  sudo mkdir -p -m 755 /etc/apt/sources.list.d
+  echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" \
+    | sudo tee /etc/apt/sources.list.d/github-cli.list > /dev/null
+  
   sudo apt update -y
   sudo apt install -y gh
+else
+  echo "[*] GitHub CLI already installed."
 fi
 
 # --- Run interactive GitHub login ---


### PR DESCRIPTION
## Summary
- Fixes GitHub CLI installation failure due to GPG key verification issues on Ubuntu 24 server
- Replaces problematic user-specific keyring approach with official system-wide method
- Updates installation method to match GitHub CLI maintainer recommendations

## Root Cause
The original script was using a user-specific keyring location (`~/.local/share/keyrings/`) and copying sources files between user and system directories, causing GPG signature verification to fail:

```
W: GPG error: https://cli.github.com/packages stable InRelease: The following signatures couldn't be verified because the public key is not available: NO_PUBKEY 23F3D4EA75716059
E: The repository 'https://cli.github.com/packages stable InRelease' is not signed.
```

## Changes Made
- **Updated GitHub CLI installation**: Now uses official installation method from GitHub CLI maintainers
- **Fixed GPG key handling**: Uses `/etc/apt/keyrings/` instead of user-specific location  
- **Improved file management**: Proper temporary file cleanup and correct repository configuration
- **Added test script**: `examples/test-gh-install.sh` for verification

## Test Plan
- [x] Script syntax validation passes
- [x] GPG key download verification works
- [x] Updated installation method follows official GitHub CLI docs
- [x] Added test script for future verification

🤖 Generated with [Claude Code](https://claude.ai/code)


---

Resolves #19