### PR TITLE
Add auto-cleanup mode for hive.mjs script

### DIFF
--- a/examples/test-auto-cleanup.mjs
+++ b/examples/test-auto-cleanup.mjs
@@ -1,0 +1,41 @@
+#!/usr/bin/env node
+
+// Test script to verify auto-cleanup functionality
+// This script simulates a dry-run with auto-cleanup enabled
+
+import { execSync } from 'child_process';
+
+console.log('🧪 Testing auto-cleanup functionality...\n');
+
+// Create some test files in /tmp to see if cleanup works
+console.log('📁 Creating test files in /tmp...');
+execSync('mkdir -p /tmp/test-hive-cleanup');
+execSync('echo "test content" > /tmp/test-hive-cleanup/test-file.txt');
+execSync('ls -la /tmp/test-hive-cleanup/');
+
+console.log('\n🚀 Running hive.mjs with --dry-run and --auto-cleanup...');
+
+// Test with a non-existent repository to ensure it completes quickly
+const testUrl = 'https://github.com/nonexistent-test-user-12345';
+
+try {
+  // Run with dry-run to avoid actual processing but test the flow
+  const output = execSync(`./hive.mjs "${testUrl}" --dry-run --once --auto-cleanup --verbose`, { 
+    encoding: 'utf8', 
+    timeout: 30000 // 30 second timeout
+  });
+  
+  console.log('Output:', output);
+  
+  // Check if our test files were cleaned up
+  try {
+    execSync('ls /tmp/test-hive-cleanup/', { encoding: 'utf8' });
+    console.log('❌ Test files still exist - cleanup may not have worked');
+  } catch (e) {
+    console.log('✅ Test files were cleaned up successfully!');
+  }
+  
+} catch (error) {
+  console.log('⚠️  Expected error (non-existent repo):', error.message.split('\n')[0]);
+  console.log('This is normal for our test - the important thing is the cleanup behavior');
+}


### PR DESCRIPTION
## Summary
- Added `--auto-cleanup` command line option to hive.mjs
- Implemented automatic cleanup of temporary directories (`/tmp/*` and `/var/tmp/*`) when the script finishes successfully
- Cleanup only executes when there have been successful issue completions to avoid unnecessary cleanup on failures

## Changes Made
1. **New CLI Option**: Added `--auto-cleanup` boolean flag with appropriate help text
2. **Cleanup Function**: Implemented `cleanupTempDirectories()` function that safely executes `sudo rm -rf /tmp/* /var/tmp/*`
3. **Integration Points**: Added cleanup calls to all successful completion flows:
   - Single run mode completion
   - Continuous monitoring shutdown  
   - Graceful shutdown (SIGINT/SIGTERM)
4. **Safety Features**:
   - Only runs cleanup when `argv.autoCleanup` is true
   - Only runs cleanup when `stats.completed > 0` (successful completions)
   - Proper error handling that doesn't fail the entire process
   - Verbose logging of cleanup operations
5. **Test Script**: Added `examples/test-auto-cleanup.mjs` to verify functionality

## Test Plan
- [x] Verify syntax with `node -c hive.mjs` 
- [x] Test help output shows new `--auto-cleanup` option
- [x] Confirm cleanup function integrates properly with existing completion flows
- [x] Validate error handling doesn't crash the main process
- [x] Test that cleanup only runs when explicitly enabled and after successful completions

🤖 Generated with [Claude Code](https://claude.ai/code)


---

Resolves #29