### PR TITLE
Add npm package configuration and GitHub Actions workflow for CLI publication

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,74 @@
+name: Publish to NPM and GitHub Releases
+
+on:
+  push:
+    branches: [ main ]
+    paths:
+      - 'package.json'
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v4
+      
+    - name: Setup Node.js
+      uses: actions/setup-node@v4
+      with:
+        node-version: '18'
+        registry-url: 'https://registry.npmjs.org'
+        
+    - name: Get package version
+      id: package
+      run: echo "version=$(node -p "require('./package.json').version")" >> $GITHUB_OUTPUT
+      
+    - name: Check if version is published
+      id: version_check
+      run: |
+        VERSION=$(node -p "require('./package.json').version")
+        PACKAGE_NAME=$(node -p "require('./package.json').name")
+        if npm view "$PACKAGE_NAME@$VERSION" version 2>/dev/null; then
+          echo "already_published=true" >> $GITHUB_OUTPUT
+        else
+          echo "already_published=false" >> $GITHUB_OUTPUT
+        fi
+      
+    - name: Make scripts executable
+      if: steps.version_check.outputs.already_published == 'false'
+      run: |
+        chmod +x hive.mjs
+        chmod +x solve.mjs
+        
+    - name: Publish to NPM
+      if: steps.version_check.outputs.already_published == 'false'
+      run: npm publish --access public
+      env:
+        NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        
+    - name: Create GitHub Release
+      if: steps.version_check.outputs.already_published == 'false'
+      uses: actions/create-release@v1
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        tag_name: v${{ steps.package.outputs.version }}
+        release_name: Release v${{ steps.package.outputs.version }}
+        body: |
+          ## Changes in v${{ steps.package.outputs.version }}
+          
+          This release includes updates to the @deep-assistant/hive-mind package.
+          
+          ### Installation
+          ```bash
+          npm install -g @deep-assistant/hive-mind
+          ```
+          
+          ### Usage
+          ```bash
+          hive --help
+          solve --help
+          ```
+        draft: false
+        prerelease: false

--- a/package.json
+++ b/package.json
@@ -1,0 +1,40 @@
+{
+  "name": "@deep-assistant/hive-mind",
+  "version": "0.0.1",
+  "description": "AI-powered issue solver and hive mind for collaborative problem solving",
+  "main": "hive.mjs",
+  "type": "module",
+  "bin": {
+    "hive": "./hive.mjs",
+    "solve": "./solve.mjs"
+  },
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/deep-assistant/hive-mind.git"
+  },
+  "keywords": [
+    "ai",
+    "automation",
+    "issue-solver",
+    "cli",
+    "hive-mind",
+    "collaborative"
+  ],
+  "author": "deep-assistant",
+  "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/deep-assistant/hive-mind/issues"
+  },
+  "homepage": "https://github.com/deep-assistant/hive-mind#readme",
+  "engines": {
+    "node": ">=18.0.0"
+  },
+  "files": [
+    "hive.mjs",
+    "solve.mjs",
+    "*.md"
+  ]
+}


### PR DESCRIPTION
## Summary
- Add package.json with @deep-assistant/hive-mind package configuration  
- Configure 'hive' and 'solve' CLI commands as global binaries
- Add GitHub Actions workflow to publish on version changes
- Set initial version to 0.0.1 as requested

## Implementation Details

### Package Configuration
- Created `package.json` with proper npm package metadata
- Configured `bin` field to expose `hive` and `solve` commands globally
- Set package name as `@deep-assistant/hive-mind` 
- Initial version set to `0.0.1` as specified in issue

### CLI Commands
After installing globally with `npm install -g @deep-assistant/hive-mind`, users can run:
```bash
hive --help    # Monitor GitHub repos for issues to solve
solve --help   # Solve specific GitHub issues
```

### GitHub Actions Workflow  
- Triggers on pushes to main branch when `package.json` changes
- Checks if version is already published to avoid duplicates
- Publishes to npm registry with public access
- Creates matching GitHub release with installation/usage instructions
- Only runs when version hasn't been published yet

## Test Plan
- [x] Verify CLI commands work locally (`./hive.mjs --help` and `./solve.mjs --help`)
- [x] Confirm package.json structure follows npm standards
- [x] Test workflow configuration syntax
- [ ] Trigger workflow by merging PR and verify npm publication
- [ ] Test global installation: `npm install -g @deep-assistant/hive-mind`

🤖 Generated with [Claude Code](https://claude.ai/code)


---

Resolves #55