### PR TITLE
Fix limit logic to exclude skipped issues from count

### DIFF
--- a/examples/test-limit-fix.mjs
+++ b/examples/test-limit-fix.mjs
@@ -1,0 +1,74 @@
+#!/usr/bin/env node
+
+// Test script to verify the limit fix works correctly
+// This script simulates the issue filtering logic to demonstrate the fix
+
+console.log('🧪 Testing limit fix for skipped issues...\n');
+
+// Simulate issues data
+const allIssues = [
+  { title: 'Issue 1', url: 'https://github.com/test/repo/issues/1', hasPR: true },
+  { title: 'Issue 2', url: 'https://github.com/test/repo/issues/2', hasPR: false },
+  { title: 'Issue 3', url: 'https://github.com/test/repo/issues/3', hasPR: true },
+  { title: 'Issue 4', url: 'https://github.com/test/repo/issues/4', hasPR: false },
+  { title: 'Issue 5', url: 'https://github.com/test/repo/issues/5', hasPR: true },
+  { title: 'Issue 6', url: 'https://github.com/test/repo/issues/6', hasPR: false },
+  { title: 'Issue 7', url: 'https://github.com/test/repo/issues/7', hasPR: false },
+  { title: 'Issue 8', url: 'https://github.com/test/repo/issues/8', hasPR: false },
+];
+
+const maxIssues = 3;
+const skipIssuesWithPrs = true;
+
+console.log(`📋 Total issues found: ${allIssues.length}`);
+console.log(`🔢 Max issues limit: ${maxIssues}`);
+console.log(`🚫 Skip issues with PRs: ${skipIssuesWithPrs ? 'Yes' : 'No'}\n`);
+
+// OLD LOGIC (buggy - applies limit before filtering)
+console.log('❌ OLD LOGIC (buggy):');
+let oldIssuesToProcess = allIssues;
+
+// Apply limit first (old way)
+if (maxIssues > 0 && allIssues.length > maxIssues) {
+  oldIssuesToProcess = allIssues.slice(0, maxIssues);
+  console.log(`   🔢 Applied limit first: ${oldIssuesToProcess.length} issues`);
+}
+
+// Then filter
+if (skipIssuesWithPrs) {
+  const oldFilteredIssues = oldIssuesToProcess.filter(issue => !issue.hasPR);
+  const oldSkippedCount = oldIssuesToProcess.length - oldFilteredIssues.length;
+  console.log(`   ⏭️  Skipped ${oldSkippedCount} issues with PRs`);
+  console.log(`   ✅ Final issues to process: ${oldFilteredIssues.length}`);
+  oldFilteredIssues.forEach(issue => console.log(`      - ${issue.title}`));
+} else {
+  console.log(`   ✅ Final issues to process: ${oldIssuesToProcess.length}`);
+}
+
+console.log('\n' + '='.repeat(50) + '\n');
+
+// NEW LOGIC (fixed - applies limit after filtering)
+console.log('✅ NEW LOGIC (fixed):');
+let newIssuesToProcess = allIssues;
+
+// Filter first
+if (skipIssuesWithPrs) {
+  const newFilteredIssues = newIssuesToProcess.filter(issue => !issue.hasPR);
+  const newSkippedCount = newIssuesToProcess.length - newFilteredIssues.length;
+  console.log(`   ⏭️  Skipped ${newSkippedCount} issues with PRs`);
+  newIssuesToProcess = newFilteredIssues;
+}
+
+// Then apply limit (new way)
+if (maxIssues > 0 && newIssuesToProcess.length > maxIssues) {
+  newIssuesToProcess = newIssuesToProcess.slice(0, maxIssues);
+  console.log(`   🔢 Applied limit after filtering: ${maxIssues} issues`);
+}
+
+console.log(`   ✅ Final issues to process: ${newIssuesToProcess.length}`);
+newIssuesToProcess.forEach(issue => console.log(`      - ${issue.title}`));
+
+console.log('\n🎯 Result:');
+console.log(`   Old logic would process: ${skipIssuesWithPrs ? allIssues.slice(0, maxIssues).filter(issue => !issue.hasPR).length : Math.min(maxIssues, allIssues.length)} issues`);
+console.log(`   New logic processes: ${newIssuesToProcess.length} issues`);
+console.log('   ✨ New logic correctly excludes skipped issues from the limit count!');

--- a/hive.mjs
+++ b/hive.mjs
@@ -526,14 +526,8 @@ async function fetchIssues() {
       await log(`   📋 Found ${issues.length} issue(s) with label "${argv.monitorTag}"`);
     }
     
-    // Apply max issues limit if set
-    let issuesToProcess = issues;
-    if (argv.maxIssues > 0 && issues.length > argv.maxIssues) {
-      issuesToProcess = issues.slice(0, argv.maxIssues);
-      await log(`   🔢 Limiting to first ${argv.maxIssues} issues`);
-    }
-    
     // Filter out issues with open PRs if option is enabled
+    let issuesToProcess = issues;
     if (argv.skipIssuesWithPrs) {
       await log(`   🔍 Checking for existing pull requests...`);
       const filteredIssues = [];
@@ -552,6 +546,12 @@ async function fetchIssues() {
         await log(`   ⏭️  Skipped ${skippedCount} issue(s) with existing pull requests`);
       }
       issuesToProcess = filteredIssues;
+    }
+    
+    // Apply max issues limit if set (after filtering to exclude skipped issues from count)
+    if (argv.maxIssues > 0 && issuesToProcess.length > argv.maxIssues) {
+      issuesToProcess = issuesToProcess.slice(0, argv.maxIssues);
+      await log(`   🔢 Limiting to first ${argv.maxIssues} issues (after filtering)`);
     }
     
     // In dry-run mode, show the issues that would be processed


### PR DESCRIPTION
## 🐛 Problem

When using `--max-issues` with `--skip-issues-with-prs`, the limit was applied **before** filtering out issues with pull requests. This meant that skipped issues were counted towards the limit, preventing users from processing their configured number of actual issues.

### Example Issue:
- 100 total issues found
- 70 issues have existing PRs (should be skipped)
- `--max-issues 30` configured
- **Old behavior**: Process only first 30 issues → filter out those with PRs → end up with maybe 8-12 actual issues processed
- **Expected behavior**: Filter out issues with PRs → process 30 of the remaining valid issues

## ✅ Solution

Reordered the filtering logic in `hive.mjs`:

1. **Before**: Apply limit → Filter out issues with PRs → Process remaining
2. **After**: Filter out issues with PRs → Apply limit → Process issues

This ensures that skipped issues don't count towards the limit, allowing users to process their full configured number of valid issues.

## 🧪 Testing

Added `examples/test-limit-fix.mjs` that demonstrates the fix:
- Simulates 8 issues, 3 with PRs, limit of 3
- **Old logic**: Would process 1 issue (3 limited - 2 skipped = 1)
- **New logic**: Processes 3 issues (skip 3 with PRs, then limit to 3 of remaining 5)

Run the test:
```bash
node examples/test-limit-fix.mjs
```

## 📋 Changes Made

- **Modified `hive.mjs`**: Moved max-issues limit application after PR filtering (lines 529-555)
- **Added test script**: `examples/test-limit-fix.mjs` to verify the fix
- **Updated log message**: Now shows "after filtering" to clarify when limit is applied

## 🎯 Impact

This fix ensures that:
- Users get the full configured number of issues processed
- Skipped issues don't consume the limit quota  
- The system can prepare drafts for the intended number of issues

Fixes #49

---
*🤖 Generated with [Claude Code](https://claude.ai/code)*