### PR TITLE
Fix OpenCode permission prompt for external directory access

### DIFF
--- a/.changeset/opencode-permission-detection.md
+++ b/.changeset/opencode-permission-detection.md
@@ -2,4 +2,8 @@
 '@link-assistant/hive-mind': patch
 ---
 
-Detect OpenCode permission prompts and recommend Agent CLI for autonomous workflows
+Detect OpenCode permission prompts and recommend @link-assistant/agent for autonomous workflows
+
+- Configure all OpenCode permissions to "allow" (edit, bash, webfetch, skill, doom_loop, external_directory)
+- Detect interactive permission prompts that block automated execution
+- Recommend @link-assistant/agent (100% unrestricted OpenCode fork) when prompts are detected

--- a/src/opencode.lib.mjs
+++ b/src/opencode.lib.mjs
@@ -214,21 +214,26 @@ export const executeOpenCodeCommand = async params => {
     // Create OpenCode configuration file with unrestricted permissions
     // This allows OpenCode to access files outside the working directory without prompting
     // Fixes issue #755: "Permission required to run: Access file outside working directory"
+    // Reference: https://opencode.ai/docs/config - see permissions documentation
     const opencodeConfigPath = path.join(tempDir, 'opencode.json');
     const opencodeConfig = {
       $schema: 'https://opencode.ai/config.json',
       permission: {
-        edit: 'allow',
-        bash: 'allow',
-        webfetch: 'allow',
-        external_directory: 'allow',
+        // All tool permissions set to 'allow' for unrestricted autonomous execution
+        // See: https://github.com/sst/opencode - permission options: "allow", "ask", "deny"
+        edit: 'allow', // File modification operations
+        bash: 'allow', // Command execution
+        webfetch: 'allow', // Web page retrieval
+        skill: 'allow', // Custom skills execution
+        doom_loop: 'allow', // Allow repeated identical tool calls (default: ask)
+        external_directory: 'allow', // File operations outside working directory (default: ask)
       },
     };
     try {
       await fs.writeFile(opencodeConfigPath, JSON.stringify(opencodeConfig, null, 2));
       if (argv.verbose) {
         await log(`   Created OpenCode config: ${opencodeConfigPath}`, { verbose: true });
-        await log('   Permissions set: edit=allow, bash=allow, webfetch=allow, external_directory=allow', { verbose: true });
+        await log('   Permissions set: edit=allow, bash=allow, webfetch=allow, skill=allow, doom_loop=allow, external_directory=allow', { verbose: true });
       }
     } catch (configError) {
       await log(`⚠️  Warning: Could not create OpenCode config file: ${configError.message}`, { level: 'warning' });
@@ -342,13 +347,18 @@ export const executeOpenCodeCommand = async params => {
         await log('\n\n❌ OpenCode encountered a permission prompt', { level: 'error' });
         await log('', { level: 'error' });
         await log('OpenCode CLI does not support autonomous agents in its full potential.', { level: 'error' });
-        await log('Interactive permission prompts block automated execution.', { level: 'error' });
+        await log('Interactive permission prompts block automated execution, even with', { level: 'error' });
+        await log('all permissions set to "allow" in opencode.json configuration.', { level: 'error' });
         await log('', { level: 'error' });
-        await log('💡 Recommendation: Use Agent CLI instead for autonomous workflow', { level: 'error' });
+        await log('💡 Recommendation: Use @link-assistant/agent instead', { level: 'error' });
+        await log('', { level: 'error' });
+        await log('   @link-assistant/agent is a 100% unrestricted fork of OpenCode', { level: 'error' });
+        await log('   specifically designed for autonomous agents in isolated environments.', { level: 'error' });
+        await log('', { level: 'error' });
+        await log('   Install: bun install -g @link-assistant/agent', { level: 'error' });
         await log('   Run with: --tool agent', { level: 'error' });
         await log('', { level: 'error' });
-        await log('   Agent CLI is specifically designed for autonomous agents and', { level: 'error' });
-        await log('   does not have interactive prompts that block execution.', { level: 'error' });
+        await log('   More info: https://github.com/link-assistant/agent', { level: 'error' });
         await log('', { level: 'error' });
 
         const resourcesAfter = await getResourceSnapshot();


### PR DESCRIPTION
## Summary

Fixes #755

Detects when OpenCode encounters interactive permission prompts and recommends using `@link-assistant/agent` for fully autonomous workflows.

## Root Cause

OpenCode CLI has a built-in permission system that triggers interactive prompts when trying to access files outside the working directory:

```
◆  Permission required to run: Access file outside working directory: /tmp/opencode-source/package.json
│  ● Allow once
│  ○ Always allow
│  ○ Reject
└
```

These interactive prompts block automated execution and cause the process to hang, waiting for user input that never comes in an autonomous workflow.

## Solution

We now configure **all available OpenCode permissions** to "allow" in `opencode.json`:

```json
{
  "$schema": "https://opencode.ai/config.json",
  "permission": {
    "edit": "allow",
    "bash": "allow", 
    "webfetch": "allow",
    "skill": "allow",
    "doom_loop": "allow",
    "external_directory": "allow"
  }
}
```

**Important**: Even with all permissions enabled, OpenCode may still trigger interactive prompts in certain scenarios (it's designed for interactive use, not fully autonomous execution).

When permission prompts are detected, we:
1. **Detect the prompt** - Monitor output for permission-related patterns
2. **Provide clear guidance** - Explain the limitation and recommend the unrestricted alternative
3. **Fail fast** - Return immediately instead of hanging

## Recommendation When Prompts Occur

We now recommend `@link-assistant/agent` - a 100% unrestricted fork of OpenCode specifically designed for autonomous agents in isolated environments:

```
❌ OpenCode encountered a permission prompt

OpenCode CLI does not support autonomous agents in its full potential.
Interactive permission prompts block automated execution, even with
all permissions set to "allow" in opencode.json configuration.

💡 Recommendation: Use @link-assistant/agent instead

   @link-assistant/agent is a 100% unrestricted fork of OpenCode
   specifically designed for autonomous agents in isolated environments.

   Install: bun install -g @link-assistant/agent
   Run with: --tool agent

   More info: https://github.com/link-assistant/agent
```

## Changes

- **`src/opencode.lib.mjs`**: 
  - Configure all 6 OpenCode permissions to "allow" (edit, bash, webfetch, skill, doom_loop, external_directory)
  - Added detailed comments referencing OpenCode documentation
  - Updated error message to recommend `@link-assistant/agent` with installation instructions
  - Added link to the agent repository

- **`.changeset/opencode-permission-detection.md`**:
  - Updated changeset description to reflect full scope of changes

## Test Plan

- [x] ESLint passes for all modified files
- [x] Pre-commit hooks pass (prettier formatting applied)
- [x] Changes committed and pushed successfully
- [ ] CI checks pass

## References

- [OpenCode Permission Documentation](https://opencode.ai/docs/config)
- [OpenCode Source Code](https://github.com/sst/opencode)
- [@link-assistant/agent](https://github.com/link-assistant/agent) - 100% unrestricted OpenCode fork
- [Full error log from issue](https://gist.github.com/konard/d475d3323f432f23fbd28f4846b87d97) - Shows the permission prompt that blocks execution
- Issue #755: OpenCode permission prompt blocking automated execution

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)