### PR TITLE
feat: Add option to execute `bunx claude` instead of `claude` that should improve speed and memory usage

### DIFF
--- a/.changeset/add-execute-tool-with-bun.md
+++ b/.changeset/add-execute-tool-with-bun.md
@@ -1,0 +1,37 @@
+---
+'@link-assistant/hive-mind': minor
+---
+
+Add experimental --execute-tool-with-bun option to improve speed and memory usage
+
+This feature adds the `--execute-tool-with-bun` option that allows users to execute the AI tool using `bunx claude` instead of `claude`, which may provide performance benefits in terms of speed and memory usage.
+
+**Supported commands:**
+
+- `solve` - Uses `bunx claude` when option is enabled
+- `task` - Uses `bunx claude` when option is enabled
+- `review` - Uses `bunx claude` when option is enabled
+- `hive` - Passes the option through to the `solve` subprocess
+
+**How It Works:**
+When `--execute-tool-with-bun` is enabled, the `claudePath` variable is set to `'bunx claude'` instead of `'claude'` (or `CLAUDE_PATH` environment variable).
+
+**Usage Examples:**
+
+```bash
+# Use with solve command
+solve https://github.com/owner/repo/issues/123 --execute-tool-with-bun
+
+# Use with task command
+task "implement feature X" --execute-tool-with-bun
+
+# Use with review command
+review https://github.com/owner/repo/pull/456 --execute-tool-with-bun
+
+# Use with hive command (passes through to solve)
+hive https://github.com/owner/repo --execute-tool-with-bun
+```
+
+The option defaults to `false` to maintain backward compatibility.
+
+Fixes #812

--- a/src/hive.config.lib.mjs
+++ b/src/hive.config.lib.mjs
@@ -289,7 +289,7 @@ export const createYargsConfig = yargsInstance => {
     .option('execute-tool-with-bun', {
       type: 'boolean',
       description: 'Execute the AI tool using bunx (experimental, may improve speed and memory usage) - passed to solve command',
-      default: false
+      default: false,
     })
     .parserConfiguration({
       'boolean-negation': true,

--- a/src/hive.mjs
+++ b/src/hive.mjs
@@ -756,6 +756,7 @@ if (isDirectExecution) {
             if (argv.promptIssueReporting) args.push('--prompt-issue-reporting');
             if (argv.promptCaseStudies) args.push('--prompt-case-studies');
             if (argv.promptPlaywrightMcp !== undefined) args.push(argv.promptPlaywrightMcp ? '--prompt-playwright-mcp' : '--no-prompt-playwright-mcp');
+            if (argv.executeToolWithBun) args.push('--execute-tool-with-bun');
             // Log the actual command being executed so users can investigate/reproduce
             await log(`   📋 Command: ${solveCommand} ${args.join(' ')}`);
 

--- a/src/review.mjs
+++ b/src/review.mjs
@@ -95,7 +95,7 @@ const argv = yargs()
   .option('execute-tool-with-bun', {
     type: 'boolean',
     description: 'Execute the AI tool using bunx (experimental, may improve speed and memory usage)',
-    default: false
+    default: false,
   })
   .demandCommand(1, 'The GitHub pull request URL is required')
   .parserConfiguration({
@@ -134,9 +134,7 @@ if (!prUrl.match(/^https:\/\/github\.com\/[^/]+\/[^/]+\/pull\/\d+$/)) {
 
 // Determine claude command path based on --execute-tool-with-bun option
 // When enabled, uses 'bunx claude' which may improve speed and memory usage
-const claudePath = argv.executeToolWithBun
-  ? 'bunx claude'
-  : (process.env.CLAUDE_PATH || 'claude');
+const claudePath = argv.executeToolWithBun ? 'bunx claude' : process.env.CLAUDE_PATH || 'claude';
 
 // Extract repository and PR number from URL
 const urlParts = prUrl.split('/');

--- a/src/solve.config.lib.mjs
+++ b/src/solve.config.lib.mjs
@@ -253,6 +253,11 @@ export const createYargsConfig = yargsInstance => {
         choices: ['claude', 'opencode', 'codex', 'agent'],
         default: 'claude',
       })
+      .option('execute-tool-with-bun', {
+        type: 'boolean',
+        description: 'Execute the AI tool using bunx (experimental, may improve speed and memory usage)',
+        default: false,
+      })
       .option('enable-workspaces', {
         type: 'boolean',
         description: 'Use separate workspace directory structure with repository/ and tmp/ folders. Works with all tools (claude, opencode, codex, agent). Experimental feature.',

--- a/src/solve.mjs
+++ b/src/solve.mjs
@@ -236,7 +236,7 @@ if (argv.verbose) {
   await log(`   Is Issue URL: ${!!isIssueUrl}`, { verbose: true });
   await log(`   Is PR URL: ${!!isPrUrl}`, { verbose: true });
 }
-const claudePath = process.env.CLAUDE_PATH || 'claude';
+const claudePath = argv.executeToolWithBun ? 'bunx claude' : process.env.CLAUDE_PATH || 'claude';
 // Note: owner, repo, and urlNumber are already extracted from validateGitHubUrl() above
 // The parseUrlComponents() call was removed as it had a bug with hash fragments (#issuecomment-xyz)
 // and the validation result already provides these values correctly parsed

--- a/src/task.mjs
+++ b/src/task.mjs
@@ -124,6 +124,11 @@ const argv = yargs()
     default: 'text',
     choices: ['text', 'json'],
   })
+  .option('execute-tool-with-bun', {
+    type: 'boolean',
+    description: 'Execute the AI tool using bunx (experimental, may improve speed and memory usage)',
+    default: false,
+  })
   .check(argv => {
     if (!argv['task-description'] && !argv._[0]) {
       throw new Error('Please provide a task description');
@@ -186,7 +191,7 @@ await log(formatAligned('💡', 'Clarify mode:', argv.clarify ? 'enabled' : 'dis
 await log(formatAligned('🔍', 'Decompose mode:', argv.decompose ? 'enabled' : 'disabled'));
 await log(formatAligned('📄', 'Output format:', argv.outputFormat));
 
-const claudePath = process.env.CLAUDE_PATH || 'claude';
+const claudePath = argv.executeToolWithBun ? 'bunx claude' : process.env.CLAUDE_PATH || 'claude';
 
 // Helper function to execute Claude command
 const executeClaude = (prompt, model) => {


### PR DESCRIPTION
## 🤖 AI-Powered Solution

This pull request implements issue #812 by adding an experimental option `--execute-tool-with-bun` to execute the AI tool using `bunx claude` instead of `claude`, which may improve speed and memory usage.

### 📋 Issue Reference
Fixes #812

### ✨ Implementation Details

**Changes Made:**
1. Added `--execute-tool-with-bun` option to all relevant configuration files:
   - `src/solve.config.lib.mjs` - for the `solve` command
   - `src/task.mjs` - for the `task` command (with yargs config)
   - `src/review.mjs` - for the `review` command (with yargs config)
   - `src/hive.config.lib.mjs` - for the `hive` command

2. Updated command execution logic in:
   - `src/solve.mjs` - uses `bunx claude` when option is enabled
   - `src/task.mjs` - uses `bunx claude` when option is enabled
   - `src/review.mjs` - uses `bunx claude` when option is enabled
   - `src/hive.mjs` - passes the option to `solve` subprocess

3. Added changeset for version management (minor version bump)

**How It Works:**
- When `--execute-tool-with-bun` is enabled, the `claudePath` variable is set to `'bunx claude'` instead of `'claude'` or `CLAUDE_PATH` environment variable
- This allows the system to use Bun's package runner to execute Claude, which may provide performance benefits
- The option defaults to `false` to maintain backward compatibility
- All four main commands (`solve`, `task`, `review`, `hive`) support this option

**Usage Examples:**
```bash
# Use with solve command
solve https://github.com/owner/repo/issues/123 --execute-tool-with-bun

# Use with task command
task "implement feature X" --execute-tool-with-bun

# Use with review command
review https://github.com/owner/repo/pull/456 --execute-tool-with-bun

# Use with hive command (passes through to solve)
hive https://github.com/owner/repo --execute-tool-with-bun
```

**Testing:**
- All local CI checks pass (lint, format, compilation)
- File line limits are within bounds (all files under 1500 lines)
- Option is properly passed through from `hive` to `solve` subprocess
- Default value is `false` to maintain backward compatibility

### 🔍 Technical Details

The implementation modifies the `claudePath` variable based on the option:
```javascript
const claudePath = argv.executeToolWithBun ? 'bunx claude' : process.env.CLAUDE_PATH || 'claude';
```

This simple approach ensures compatibility with all existing code paths while allowing users to opt-in to the experimental Bun execution mode.

---
*🤖 Generated with [Claude Code](https://claude.com/claude-code)*