### PR TITLE
fix: allow parallel queue execution when no limits exceeded

### DIFF
--- a/.changeset/parallel-queue-execution.md
+++ b/.changeset/parallel-queue-execution.md
@@ -10,4 +10,4 @@ Changes:
 
 - `claude_running` is now tracked as a metric, not a blocking reason
 - Commands can run in parallel as long as actual limits are not exceeded
-- If Claude limits show 100% but no Claude process is running, allow one command through to test if limits are really exhausted
+- When any limit >= threshold, allow exactly one claude command to pass

--- a/src/telegram-solve-queue.lib.mjs
+++ b/src/telegram-solve-queue.lib.mjs
@@ -358,11 +358,10 @@ export class SolveQueue {
   /**
    * Check if a new command can start
    *
-   * Logic:
+   * Logic per issue #1061:
    * 1. "Claude process is already running" is NOT a limit by itself - it's a metric
    * 2. Commands can run in parallel as long as actual limits are not exceeded
-   * 3. If Claude limits are at 100% but no Claude process is running, allow one
-   *    command to go through (to test if limits are really exhausted)
+   * 3. When any limit >= threshold, allow exactly one claude command to pass
    *
    * @returns {Promise<{canStart: boolean, reason?: string, reasons?: string[], oneAtATime?: boolean}>}
    */
@@ -478,10 +477,10 @@ export class SolveQueue {
   /**
    * Check API limits (Claude, GitHub) using cached values
    *
-   * Special handling per issue #1061:
-   * - If Claude limits are at 100% but no Claude process is running, allow one
-   *   command to go through (to test if limits are really exhausted)
-   * - The API's 100% might be stale/cached - running claude is the ultimate test
+   * Simplified logic per issue #1061:
+   * - When any limit >= threshold, allow exactly one claude command to pass
+   * - Only block if there's already a command in progress
+   * - Running claude is the ultimate test of whether limits are really exhausted
    *
    * @param {boolean} hasRunningClaude - Whether claude processes are running
    * @returns {Promise<{ok: boolean, reasons: string[], oneAtATime: boolean}>}
@@ -497,41 +496,26 @@ export class SolveQueue {
       const weeklyPercent = claudeResult.usage.allModels.percentage;
 
       // Session limit (5-hour)
+      // When above threshold: allow exactly one command, block if one is running
       if (sessionPercent !== null) {
         const sessionRatio = sessionPercent / 100;
-        if (sessionRatio >= 1.0) {
-          // At 100% session limit:
-          // - If no Claude process running, allow one to test if really exhausted
-          // - If Claude process running, block
-          if (hasRunningClaude) {
-            reasons.push('Claude session limit is 100% (waiting for reset)');
-          }
-          this.recordThrottle('claude_session_100');
-        } else if (sessionRatio >= QUEUE_CONFIG.CLAUDE_SESSION_THRESHOLD) {
-          // Below 100% but above threshold - only block if Claude is running
+        if (sessionRatio >= QUEUE_CONFIG.CLAUDE_SESSION_THRESHOLD) {
+          // Only block if Claude is already running
           if (hasRunningClaude) {
             reasons.push(formatWaitingReason('claude_session', sessionPercent, QUEUE_CONFIG.CLAUDE_SESSION_THRESHOLD));
           }
-          this.recordThrottle('claude_session_high');
+          this.recordThrottle(sessionRatio >= 1.0 ? 'claude_session_100' : 'claude_session_high');
         }
       }
 
       // Weekly limit
+      // When above threshold: allow exactly one command, block if one is in progress
       if (weeklyPercent !== null) {
         const weeklyRatio = weeklyPercent / 100;
-        if (weeklyRatio >= 1.0) {
+        if (weeklyRatio >= QUEUE_CONFIG.CLAUDE_WEEKLY_THRESHOLD) {
           oneAtATime = true;
-          this.recordThrottle('claude_weekly_100');
-          // At 100% weekly limit:
-          // - If no Claude process running, allow one to test if really exhausted
-          // - If Claude process running or command in progress, block
-          if (hasRunningClaude || this.processing.size > 0) {
-            reasons.push('Claude weekly limit is 100% (waiting for current command)');
-          }
-        } else if (weeklyRatio >= QUEUE_CONFIG.CLAUDE_WEEKLY_THRESHOLD) {
-          oneAtATime = true;
-          this.recordThrottle('claude_weekly_high');
-          // Above threshold but below 100% - only block if command in progress
+          this.recordThrottle(weeklyRatio >= 1.0 ? 'claude_weekly_100' : 'claude_weekly_high');
+          // Only block if command is already in progress
           if (this.processing.size > 0) {
             reasons.push(formatWaitingReason('claude_weekly', weeklyPercent, QUEUE_CONFIG.CLAUDE_WEEKLY_THRESHOLD) + ' (waiting for current command)');
           }
@@ -545,12 +529,9 @@ export class SolveQueue {
       if (githubResult.success) {
         const usedPercent = githubResult.githubRateLimit.usedPercentage;
         const usedRatio = usedPercent / 100;
-        if (usedRatio >= 1.0) {
-          reasons.push('GitHub API limit is 100% (waiting for reset)');
-          this.recordThrottle('github_100');
-        } else if (usedRatio >= QUEUE_CONFIG.GITHUB_API_THRESHOLD) {
+        if (usedRatio >= QUEUE_CONFIG.GITHUB_API_THRESHOLD) {
           reasons.push(formatWaitingReason('github', usedPercent, QUEUE_CONFIG.GITHUB_API_THRESHOLD));
-          this.recordThrottle('github_high');
+          this.recordThrottle(usedRatio >= 1.0 ? 'github_100' : 'github_high');
         }
       }
     }

--- a/tests/test-telegram-solve-queue.mjs
+++ b/tests/test-telegram-solve-queue.mjs
@@ -522,13 +522,14 @@ await runTestAsync('canStartCommand allows parallel execution when no limits exc
   queue.stop();
 });
 
-// Test 19: checkApiLimits allows command when at 100% but no Claude running (issue #1061)
-await runTestAsync('checkApiLimits allows one command when at 100% limit but no Claude running (issue #1061)', async () => {
+// Test 19: checkApiLimits allows one command when no Claude running (issue #1061)
+// Simplified logic: any limit >= threshold allows exactly one command to pass
+await runTestAsync('checkApiLimits allows one command when limit >= threshold but no Claude running (issue #1061)', async () => {
   resetSolveQueue();
   resetLimitCache();
   const queue = new SolveQueue({ verbose: false });
 
-  // Test the logic: when hasRunningClaude=false, even high limits should not block
+  // Test the logic: when hasRunningClaude=false, limits should not block
   // because running claude is the ultimate test of whether limits are really exhausted
   const result = await queue.checkApiLimits(false);
 


### PR DESCRIPTION
## 🤖 AI-Powered Solution

This pull request fixes issue #1061.

### 📋 Issue Reference
Fixes #1061

### 📝 Problem
The queue logic was treating "Claude process is already running" as a blocking reason on its own, preventing parallel execution even when all system and API limits were within thresholds. This caused commands to be unnecessarily queued:

```
[VERBOSE] /solve-queue: Cannot start: Claude process is already running (1 processes)
[VERBOSE] /solve-queue: Throttled: Claude process is already running (1 processes)
```

### 🔧 Solution
Simplified logic per review feedback:

1. **`claude_running` is now a metric, not a blocking reason** - Commands can run in parallel as long as actual limits (RAM, CPU, disk, Claude API, GitHub API) are not exceeded

2. **Unified threshold handling** - Any `limit >= threshold` allows exactly one claude command to pass through, regardless of whether it's 100% or just above threshold

3. **Combined blocking** - `claude_running` info is only added to the reason list when combined with actual limit violations

### 📊 Changes
- Modified `checkApiLimits()` in `telegram-solve-queue.lib.mjs`:
  - Removed separate handling for 100% vs above-threshold cases
  - Unified logic: any limit >= threshold allows exactly one command
  - Session limit: only blocks if Claude is already running
  - Weekly limit: only blocks if command is already in progress

- Modified `canStartCommand()` in `telegram-solve-queue.lib.mjs`:
  - `claude_running` is tracked as a metric but not added to blocking reasons directly
  - Only blocks when combined with other actual limit violations

- Updated changeset and tests to reflect simplified logic

### ✅ Testing
- All 19 tests pass locally
- ESLint and Prettier checks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)