### PR TITLE
docs: Case study for issue #1106 - streaming mode error analysis

### DIFF
--- a/docs/case-studies/issue-1106/README.md
+++ b/docs/case-studies/issue-1106/README.md
@@ -2,19 +2,27 @@
 
 ## Error: `error_during_execution` - `only prompt commands are supported in streaming mode`
 
-**Date:** 2026-01-11
-**Status:** Analysis Complete
-**Related Bug Reports:** [claude-code#8126](https://github.com/anthropics/claude-code/issues/8126), [claude-code#5034](https://github.com/anthropics/claude-code/issues/5034)
+**Date:** 2026-01-11 (Updated: 2026-01-16)
+**Status:** Analysis Complete - Fix Available
+**Related Bug Reports:**
+
+- [claude-code#16768](https://github.com/anthropics/claude-code/issues/16768) - **FIXED in v2.1.7** - Spurious error_during_execution after background task
+- [claude-code#17406](https://github.com/anthropics/claude-code/issues/17406) - **OPEN** - Mid-execution input fails with `--model haiku`
+- [claude-code#8126](https://github.com/anthropics/claude-code/issues/8126) - Missing result in stream-json
+- [claude-code#5034](https://github.com/anthropics/claude-code/issues/5034) - Duplicate entries in session files
 
 ---
 
 ## Executive Summary
 
 This case study investigates a recurring error pattern where Claude Code CLI emits **two consecutive `result` events** at the end of a session:
+
 1. First result: `subtype: "success"` - Normal completion with full statistics
 2. Second result: `subtype: "error_during_execution"` - Error with message "only prompt commands are supported in streaming mode"
 
-The error appears to be a **bug in Claude Code CLI's streaming mode** rather than an issue with the hive-mind integration. Despite the error message, the actual work was completed successfully in all observed cases.
+**Key Finding:** This bug was **FIXED in Claude Code CLI v2.1.7** ([#16768](https://github.com/anthropics/claude-code/issues/16768)). Updating the CLI to v2.1.7 or later should resolve this issue.
+
+The error was a **bug in Claude Code CLI's streaming mode** rather than an issue with the hive-mind integration. Despite the error message, the actual work was completed successfully in all observed cases.
 
 ---
 
@@ -22,12 +30,12 @@ The error appears to be a **bug in Claude Code CLI's streaming mode** rather tha
 
 ### Affected Sessions
 
-| PR | Timestamp | Session ID | First Result | Second Result |
-|----|-----------|------------|--------------|---------------|
+| PR                                                              | Timestamp            | Session ID                           | First Result       | Second Result                    |
+| --------------------------------------------------------------- | -------------------- | ------------------------------------ | ------------------ | -------------------------------- |
 | [#585](https://github.com/VisageDvachevsky/StoryGraph/pull/585) | 2026-01-11T03:14:20Z | 064e3157-c2b3-4cec-a7b3-e2b64741c012 | success (72 turns) | error_during_execution (0 turns) |
-| [#588](https://github.com/VisageDvachevsky/StoryGraph/pull/588) | 2026-01-11T03:12:17Z | 5fcc0441-5e26-419b-8541-d7a66bf0fb2e | success | error_during_execution (0 turns) |
-| [#591](https://github.com/VisageDvachevsky/StoryGraph/pull/591) | 2026-01-11T03:16:03Z | d3e1fd0d-377a-4cde-97b4-9a21fb4cadf8 | success | error_during_execution (0 turns) |
-| [#594](https://github.com/VisageDvachevsky/StoryGraph/pull/594) | 2026-01-11T03:19:25Z | da9ffea7-e88a-42bc-afcc-b5e877e74949 | success | error_during_execution (0 turns) |
+| [#588](https://github.com/VisageDvachevsky/StoryGraph/pull/588) | 2026-01-11T03:12:17Z | 5fcc0441-5e26-419b-8541-d7a66bf0fb2e | success            | error_during_execution (0 turns) |
+| [#591](https://github.com/VisageDvachevsky/StoryGraph/pull/591) | 2026-01-11T03:16:03Z | d3e1fd0d-377a-4cde-97b4-9a21fb4cadf8 | success            | error_during_execution (0 turns) |
+| [#594](https://github.com/VisageDvachevsky/StoryGraph/pull/594) | 2026-01-11T03:19:25Z | da9ffea7-e88a-42bc-afcc-b5e877e74949 | success            | error_during_execution (0 turns) |
 
 ### Sequence of Events (per session)
 
@@ -62,13 +70,16 @@ The error appears to be a **bug in Claude Code CLI's streaming mode** rather tha
 ### Hypothesis 1: Duplicate Session Command (REJECTED)
 
 Initially suspected that hive-mind might be sending a second command after the first completes. However:
+
 - Only ONE claude process is spawned per session
 - The second result has `num_turns: 0` and `duration_ms: 0` - impossible for a separate command
 - The `session_id` is identical for both results
 
-### Hypothesis 2: Claude Code CLI Internal Bug (LIKELY)
+### Hypothesis 2: Claude Code CLI Internal Bug (CONFIRMED)
 
-Evidence suggests this is an internal Claude Code CLI bug:
+This was confirmed as an internal Claude Code CLI bug and has been **FIXED in v2.1.7**.
+
+**Evidence:**
 
 1. **Pattern Consistency**: The error occurs in 100% of analyzed sessions with identical characteristics
 2. **Zero-Duration Second Result**: The second result has:
@@ -77,16 +88,25 @@ Evidence suggests this is an internal Claude Code CLI bug:
    - `duration_api_ms: 0`
    - `total_cost_usd: 0`
    - Empty `usage` statistics
-
 3. **Same Session ID**: Both results share the same `session_id`, indicating they're from the same CLI process
 
-4. **Related Known Bugs**:
-   - [Issue #8126](https://github.com/anthropics/claude-code/issues/8126): Missing result in stream-json (39.5% failure rate reported)
-   - [Issue #5034](https://github.com/anthropics/claude-code/issues/5034): Duplicate entries in session files
+**Root Cause** (from [#16768](https://github.com/anthropics/claude-code/issues/16768)):
+
+- Task completion enqueues a command with `mode: "task-notification"`
+- Streaming mode handler only accepts `mode: "prompt"` or `mode: "orphaned-permission"`
+- When background tasks complete, they try to notify but the streaming mode throws the error
+
+**Related Known Bugs**:
+
+- [Issue #16768](https://github.com/anthropics/claude-code/issues/16768): **FIXED in v2.1.7** - Spurious error_during_execution after background task
+- [Issue #17406](https://github.com/anthropics/claude-code/issues/17406): **OPEN** - Similar error with `--model haiku` during mid-execution input
+- [Issue #8126](https://github.com/anthropics/claude-code/issues/8126): Missing result in stream-json (39.5% failure rate reported)
+- [Issue #5034](https://github.com/anthropics/claude-code/issues/5034): Duplicate entries in session files
 
 ### Hypothesis 3: Streaming Mode Limitation
 
 The error message "only prompt commands are supported in streaming mode" suggests:
+
 - The CLI might be attempting to perform a non-prompt operation after the session completes
 - This could be related to session cleanup, telemetry, or internal state management
 - According to Anthropic documentation, streaming mode has specific limitations:
@@ -105,7 +125,7 @@ execCommand = $({
   cwd: tempDir,
   stdin: prompt,
   mirror: false,
-  env: claudeEnv
+  env: claudeEnv,
 })`${claudePath} --output-format stream-json --verbose --dangerously-skip-permissions --model ${mappedModel} --append-system-prompt "${systemPrompt}"`;
 ```
 
@@ -126,7 +146,7 @@ execCommand = $({
     "cache_creation_input_tokens": 0,
     "cache_read_input_tokens": 0,
     "output_tokens": 0,
-    "server_tool_use": {"web_search_requests": 0, "web_fetch_requests": 0},
+    "server_tool_use": { "web_search_requests": 0, "web_fetch_requests": 0 },
     "service_tier": "standard"
   },
   "modelUsage": {},
@@ -138,6 +158,7 @@ execCommand = $({
 ### Additional Errors (in some sessions)
 
 Some sessions showed additional error messages:
+
 - `AxiosError: timeout of 5000ms exceeded` - Network timeout during cleanup
 - `1P event logging: 99 events failed to export` - Telemetry export failure
 - `Failed to export 99 events` - Event export failure
@@ -151,6 +172,7 @@ These suggest the error occurs during CLI cleanup/shutdown phase when attempting
 ### Severity: LOW
 
 Despite the error message:
+
 - All code changes were successfully committed and pushed
 - All PRs were created/updated correctly
 - CI pipelines ran as expected
@@ -166,7 +188,32 @@ Despite the error message:
 
 ## Proposed Solutions
 
-### Solution 1: Improve Error Detection in hive-mind (RECOMMENDED)
+### Solution 0: Update Claude Code CLI (RECOMMENDED)
+
+**This is the simplest and most effective solution.**
+
+The bug was fixed in Claude Code CLI v2.1.7. To resolve this issue:
+
+```bash
+# Update Claude Code CLI to the latest version
+npm update -g @anthropic/claude-code
+
+# Verify version is 2.1.7 or later
+claude --version
+```
+
+**Version History:**
+
+| Version | Status                                    |
+| ------- | ----------------------------------------- |
+| 2.0.76  | Working (last working version before bug) |
+| 2.1.1   | Affected (bug introduced)                 |
+| 2.1.2   | Still affected                            |
+| 2.1.7   | **FIXED**                                 |
+
+**Note:** Issue [#17406](https://github.com/anthropics/claude-code/issues/17406) reports a similar error specifically with `--model haiku` that may still occur. If you encounter this error only when using Haiku model, this is a separate issue.
+
+### Solution 1: Improve Error Detection in hive-mind (FALLBACK)
 
 Modify the error detection logic to recognize this specific pattern:
 
@@ -206,6 +253,7 @@ if (data.subtype === 'error_during_execution' && sessionCompletedSuccessfully) {
 ### Solution 3: Report Bug to Anthropic
 
 File a bug report with Anthropic for the Claude Code CLI with:
+
 - Detailed reproduction steps
 - Log files demonstrating the issue
 - Link to existing related issues (#8126, #5034)
@@ -215,6 +263,7 @@ File a bug report with Anthropic for the Claude Code CLI with:
 ## Workaround (Current)
 
 The current hive-mind implementation partially handles this by:
+
 1. Treating `error_during_execution` differently from true failures
 2. Marking the session as "finished with errors" rather than "failed"
 3. Still processing the successful result's statistics
@@ -237,16 +286,21 @@ The following log files are preserved in this directory for reference:
 ## References
 
 ### External Documentation
+
 - [Claude Agent SDK - Streaming vs Single Mode](https://platform.claude.com/docs/en/agent-sdk/streaming-vs-single-mode)
 - [Claude Agent SDK - Session Management](https://platform.claude.com/docs/en/agent-sdk/sessions)
 - [Claude Code CLI Reference](https://code.claude.com/docs/en/cli-reference)
 
 ### Related GitHub Issues
+
+- [anthropics/claude-code#16768](https://github.com/anthropics/claude-code/issues/16768) - **FIXED in v2.1.7** - Spurious error_during_execution after background task
+- [anthropics/claude-code#17406](https://github.com/anthropics/claude-code/issues/17406) - **OPEN** - Mid-execution input fails with `--model haiku`
 - [anthropics/claude-code#8126](https://github.com/anthropics/claude-code/issues/8126) - Missing result in stream-json
 - [anthropics/claude-code#5034](https://github.com/anthropics/claude-code/issues/5034) - Duplicate entries in session files
 - [anthropics/claude-code#3188](https://github.com/anthropics/claude-code/issues/3188) - Resume bug
 
 ### Internal Files
+
 - `src/claude.lib.mjs` - Claude CLI execution logic
 - `src/interactive-mode.lib.mjs` - Real-time PR comment posting
 - `src/solve.auto-continue.lib.mjs` - Session continuation logic
@@ -255,6 +309,14 @@ The following log files are preserved in this directory for reference:
 
 ## Conclusion
 
-The error "only prompt commands are supported in streaming mode" is a **Claude Code CLI bug** that emits a spurious error result after a successful session completion. The error has zero impact on actual functionality but creates confusing output.
+The error "only prompt commands are supported in streaming mode" was a **Claude Code CLI bug** ([#16768](https://github.com/anthropics/claude-code/issues/16768)) that emits a spurious error result after a successful session completion. The error had zero impact on actual functionality but created confusing output.
 
-**Recommended Action**: Implement Solution 1 or 2 to suppress this specific error pattern, and file a bug report with Anthropic to address the root cause in the CLI.
+**Resolution**: This bug was **FIXED in Claude Code CLI v2.1.7**. Updating the CLI to this version or later will resolve the issue.
+
+**Recommended Action**: Update Claude Code CLI to v2.1.7 or later:
+
+```bash
+npm update -g @anthropic/claude-code
+```
+
+**Note**: A related but distinct issue ([#17406](https://github.com/anthropics/claude-code/issues/17406)) may still cause similar errors when using `--model haiku` specifically. This is a separate bug that remains open.

--- a/docs/case-studies/issue-1106/log-references.md
+++ b/docs/case-studies/issue-1106/log-references.md
@@ -7,21 +7,25 @@ This document provides links to the complete log files for the sessions analyzed
 The original log files are too large to include in the repository (666KB - 919KB each). They are available at the following locations:
 
 ### PR #585 - Session 064e3157-c2b3-4cec-a7b3-e2b64741c012
+
 - **Gist URL:** https://gist.githubusercontent.com/konard/4673f1ca95855c990971daf38db833e8/raw/d26ce1f6735b6448c595655214a99e84443f2ace/solution-draft-log-pr-1768101269099.txt
 - **Size:** 666 KB (8,120 lines)
 - **PR Comment:** https://github.com/VisageDvachevsky/StoryGraph/pull/585#issuecomment-3733921967
 
 ### PR #588 - Session 5fcc0441-5e26-419b-8541-d7a66bf0fb2e
+
 - **Gist URL:** https://gist.githubusercontent.com/konard/8ae7fcd7bbab3f1df2276c5803a8f0ea/raw/e0da5a99bb6fb7523c7ea4125d77ec84bff6d123/solution-draft-log-pr-1768101144012.txt
 - **Size:** 695 KB (10,437 lines)
 - **PR Comment:** https://github.com/VisageDvachevsky/StoryGraph/pull/588#issuecomment-3733920308
 
 ### PR #591 - Session d3e1fd0d-377a-4cde-97b4-9a21fb4cadf8
+
 - **Gist URL:** https://gist.githubusercontent.com/konard/607bcdb1e231947744b6d98d51588d95/raw/6e24a9b364ed814b86623103fa81b4ce288323ea/solution-draft-log-pr-1768101368776.txt
 - **Size:** 676 KB (8,682 lines)
 - **PR Comment:** https://github.com/VisageDvachevsky/StoryGraph/pull/591#issuecomment-3733923044
 
 ### PR #594 - Session da9ffea7-e88a-42bc-afcc-b5e877e74949
+
 - **Gist URL:** https://gist.githubusercontent.com/konard/f6e19bf287a4deea5e8ddf556ae58630/raw/d8373455e009e1ac83ea5a5753bb13d769a03626/solution-draft-log-pr-1768101570495.txt
 - **Size:** 919 KB (8,334 lines)
 - **PR Comment:** https://github.com/VisageDvachevsky/StoryGraph/pull/594#issuecomment-3733925276
@@ -33,6 +37,7 @@ The original log files are too large to include in the repository (666KB - 919KB
 The specific error pattern appears at the end of each log file, showing two consecutive `result` events:
 
 **First Result (Success):**
+
 ```json
 {
   "type": "result",
@@ -45,6 +50,7 @@ The specific error pattern appears at the end of each log file, showing two cons
 ```
 
 **Second Result (Error - immediately after):**
+
 ```json
 {
   "type": "result",


### PR DESCRIPTION
## Summary

This PR adds a comprehensive case study analyzing the recurring error `only prompt commands are supported in streaming mode` that appears in Claude Code CLI sessions.

## Key Findings

### The Problem
After Claude Code successfully completes a task in streaming mode (`--output-format stream-json`), the CLI emits **two consecutive `result` events**:

1. **First result**: `subtype: "success"` - Normal completion with full statistics (72+ turns, $2+ cost)
2. **Second result**: `subtype: "error_during_execution"` - Error with `num_turns: 0`, `duration_ms: 0`, `total_cost_usd: 0`

### Root Cause (CONFIRMED)
This was a **bug in Claude Code CLI's streaming mode** ([#16768](https://github.com/anthropics/claude-code/issues/16768)):
- Task completion enqueues a command with `mode: "task-notification"`
- Streaming mode handler only accepts `mode: "prompt"` or `mode: "orphaned-permission"`
- When background tasks complete, they try to notify but the streaming mode throws the error

### Resolution: **FIXED in Claude Code CLI v2.1.7**

Updating the CLI to v2.1.7 or later resolves this issue:
```bash
npm update -g @anthropic/claude-code
```

### Related Issues
- [anthropics/claude-code#16768](https://github.com/anthropics/claude-code/issues/16768) - **FIXED in v2.1.7** - Spurious error_during_execution after background task
- [anthropics/claude-code#17406](https://github.com/anthropics/claude-code/issues/17406) - **OPEN** - Mid-execution input fails with `--model haiku` (separate issue)
- [anthropics/claude-code#8126](https://github.com/anthropics/claude-code/issues/8126) - Missing result in stream-json
- [anthropics/claude-code#5034](https://github.com/anthropics/claude-code/issues/5034) - Duplicate entries in session files

### Impact
- **Severity: LOW** - All work was completed successfully despite the error
- The error message was misleading and caused unnecessary confusion

## Files Changed

- `docs/case-studies/issue-1106/README.md` - Comprehensive case study document
- `docs/case-studies/issue-1106/log-references.md` - Links to external log files (via GitHub Gist)

## Test Plan

- [x] Analyzed 4 affected sessions with identical error patterns
- [x] Verified all sessions completed successfully despite error message
- [x] Documented root cause from upstream issue discussions
- [x] Documented fix available in Claude Code CLI v2.1.7

---
Fixes #1106