### PR TITLE
feat: Prevent duplicate URLs in /solve queue

### DIFF
--- a/.changeset/duplicate-url-prevention.md
+++ b/.changeset/duplicate-url-prevention.md
@@ -1,0 +1,10 @@
+---
+'@link-assistant/hive-mind': patch
+---
+
+Prevent duplicate URLs from being added to the /solve queue (Issue #1080)
+
+- Added `findByUrl()` method to SolveQueue to detect existing items by URL
+- Updated /solve command handler to check for duplicates before queueing
+- Uses normalized URLs for consistent comparison
+- Returns informative error message when duplicate is detected

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,5 +1,0 @@
-Issue to solve: https://github.com/link-assistant/hive-mind/issues/1080
-Your prepared branch: issue-1080-16877073170a
-Your prepared working directory: /tmp/gh-issue-solver-1768104546749
-
-Proceed.

--- a/src/telegram-bot.mjs
+++ b/src/telegram-bot.mjs
@@ -1051,18 +1051,32 @@ bot.command(/^solve$/i, async ctx => {
     return;
   }
 
+  // Use normalized URL from validation to ensure consistent duplicate detection
+  // See: https://github.com/link-assistant/hive-mind/issues/1080
+  const normalizedUrl = validation.parsed.normalized;
+
   const requester = buildUserMention({ user: ctx.from, parseMode: 'Markdown' });
   const optionsText = args.slice(1).join(' ') || 'none';
-  let infoBlock = `Requested by: ${requester}\nURL: ${escapeMarkdown(args[0])}\nOptions: ${optionsText}`;
+  let infoBlock = `Requested by: ${requester}\nURL: ${escapeMarkdown(normalizedUrl)}\nOptions: ${optionsText}`;
   if (solveOverrides.length > 0) infoBlock += `\n🔒 Locked options: ${solveOverrides.join(' ')}`;
   const solveQueue = getSolveQueue({ verbose: VERBOSE });
+
+  // Check for duplicate URL in queue
+  // See: https://github.com/link-assistant/hive-mind/issues/1080
+  const existingItem = solveQueue.findByUrl(normalizedUrl);
+  if (existingItem) {
+    const statusText = existingItem.status === 'starting' || existingItem.status === 'started' ? 'being processed' : 'already in the queue';
+    await ctx.reply(`❌ This URL is ${statusText}.\n\nURL: ${escapeMarkdown(normalizedUrl)}\nStatus: ${existingItem.status}\n\n💡 Use /solve-queue to check the queue status.`, { parse_mode: 'Markdown', reply_to_message_id: ctx.message.message_id });
+    return;
+  }
+
   const check = await solveQueue.canStartCommand();
   const queueStats = solveQueue.getStats();
   if (check.canStart && queueStats.queued === 0) {
     const startingMessage = await ctx.reply(`🚀 Starting solve command...\n\n${infoBlock}`, { parse_mode: 'Markdown', reply_to_message_id: ctx.message.message_id });
     await executeAndUpdateMessage(ctx, startingMessage, 'solve', args, infoBlock);
   } else {
-    const queueItem = solveQueue.enqueue({ url: args[0], args, ctx, requester, infoBlock, tool: solveTool });
+    const queueItem = solveQueue.enqueue({ url: normalizedUrl, args, ctx, requester, infoBlock, tool: solveTool });
     let queueMessage = `📋 Solve command queued (position #${queueStats.queued + 1})\n\n${infoBlock}`;
     if (check.reason) queueMessage += `\n\n⏳ Waiting: ${check.reason}`;
     const queuedMessage = await ctx.reply(queueMessage, { parse_mode: 'Markdown', reply_to_message_id: ctx.message.message_id });

--- a/src/telegram-solve-queue.lib.mjs
+++ b/src/telegram-solve-queue.lib.mjs
@@ -302,6 +302,30 @@ export class SolveQueue {
   }
 
   /**
+   * Find an item by URL in the queue or processing items
+   * Used to prevent duplicate URLs from being added to the queue
+   * @param {string} url - The URL to search for
+   * @returns {SolveQueueItem|null} The found item or null
+   * @see https://github.com/link-assistant/hive-mind/issues/1080
+   */
+  findByUrl(url) {
+    // Check queued items
+    const queuedItem = this.queue.find(item => item.url === url);
+    if (queuedItem) {
+      return queuedItem;
+    }
+
+    // Check processing items
+    for (const item of this.processing.values()) {
+      if (item.url === url) {
+        return item;
+      }
+    }
+
+    return null;
+  }
+
+  /**
    * Cancel a queued item by ID
    * @param {string} id - Item ID
    * @returns {boolean} True if cancelled

--- a/tests/solve-queue.test.mjs
+++ b/tests/solve-queue.test.mjs
@@ -196,6 +196,109 @@ test('getQueueSummary returns correct structure', () => {
 });
 
 // ============================================================================
+// Duplicate URL Prevention Tests (Issue #1080)
+// ============================================================================
+
+console.log('\n📋 Duplicate URL Prevention Tests (Issue #1080)\n');
+
+test('findByUrl returns null for empty queue', () => {
+  beforeEach();
+  const queue = new SolveQueue();
+
+  const result = queue.findByUrl('https://github.com/test/repo/issues/1');
+  assert.equal(result, null, 'Should return null for empty queue');
+
+  queue.stop();
+});
+
+test('findByUrl finds item in queue', () => {
+  beforeEach();
+  const queue = new SolveQueue();
+
+  const item = queue.enqueue({
+    url: 'https://github.com/test/repo/issues/1',
+    args: '--model opus',
+    requester: 'testuser',
+    infoBlock: 'Test info',
+  });
+
+  const found = queue.findByUrl('https://github.com/test/repo/issues/1');
+  assert.ok(found !== null, 'Should find the item');
+  assert.equal(found.id, item.id, 'Should return the correct item');
+
+  queue.stop();
+});
+
+test('findByUrl returns null for different URL', () => {
+  beforeEach();
+  const queue = new SolveQueue();
+
+  queue.enqueue({
+    url: 'https://github.com/test/repo/issues/1',
+    args: '--model opus',
+    requester: 'testuser',
+    infoBlock: 'Test info',
+  });
+
+  const found = queue.findByUrl('https://github.com/test/repo/issues/2');
+  assert.equal(found, null, 'Should return null for different URL');
+
+  queue.stop();
+});
+
+test('findByUrl finds item among multiple queued items', () => {
+  beforeEach();
+  const queue = new SolveQueue();
+
+  queue.enqueue({
+    url: 'https://github.com/test/repo/issues/1',
+    args: '--model opus',
+    requester: 'testuser1',
+    infoBlock: 'Test info 1',
+  });
+
+  const targetItem = queue.enqueue({
+    url: 'https://github.com/test/repo/issues/2',
+    args: '--model sonnet',
+    requester: 'testuser2',
+    infoBlock: 'Test info 2',
+  });
+
+  queue.enqueue({
+    url: 'https://github.com/test/repo/issues/3',
+    args: '--model haiku',
+    requester: 'testuser3',
+    infoBlock: 'Test info 3',
+  });
+
+  const found = queue.findByUrl('https://github.com/test/repo/issues/2');
+  assert.ok(found !== null, 'Should find the item');
+  assert.equal(found.id, targetItem.id, 'Should return the correct item');
+
+  queue.stop();
+});
+
+test('findByUrl does not find cancelled items', () => {
+  beforeEach();
+  const queue = new SolveQueue();
+
+  const item = queue.enqueue({
+    url: 'https://github.com/test/repo/issues/1',
+    args: '--model opus',
+    requester: 'testuser',
+    infoBlock: 'Test info',
+  });
+
+  // Cancel the item - this removes it from the queue
+  queue.cancel(item.id);
+
+  const found = queue.findByUrl('https://github.com/test/repo/issues/1');
+  assert.equal(found, null, 'Should not find cancelled item');
+
+  queue.stop();
+});
+
+// ============================================================================
 // Message Update Tests
 // ============================================================================
 


### PR DESCRIPTION
## Summary

- Add `findByUrl()` method to SolveQueue class to detect items with the same URL
- Update /solve command handler to check for duplicates before enqueueing or starting
- Use normalized URLs for consistent comparison across the queue
- Return informative error message when a duplicate is detected

This ensures that users cannot accidentally add the same GitHub issue or PR to the queue twice, preventing wasted resources and confusion.

## Test Plan

- [x] Added unit tests for `findByUrl()` method
- [x] Tests verify finding items in queue, empty queue handling, and cancelled items
- [x] All existing tests pass
- [x] ESLint and Prettier checks pass

## Implementation Details

### Changes to `telegram-solve-queue.lib.mjs`
- Added `findByUrl(url)` method that searches both queued and processing items

### Changes to `telegram-bot.mjs`
- Added duplicate check before queue operations
- Uses normalized URL from `parseGitHubUrl()` for consistent matching
- Returns clear error message with status and suggestion to check queue

### Changes to `tests/solve-queue.test.mjs`
- Added 5 new tests for duplicate URL prevention feature

Fixes #1080

🤖 Generated with [Claude Code](https://claude.com/claude-code)