### PR TITLE
docs: Add Docker installation instructions to README.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,5 +1,0 @@
-Issue to solve: https://github.com/link-assistant/hive-mind/issues/1195
-Your prepared branch: issue-1195-cfef78aa8f39
-Your prepared working directory: /tmp/gh-issue-solver-1769768141819
-
-Proceed.


### PR DESCRIPTION
## Summary

Added Docker installation instructions to README.md to help users who don't have Docker installed yet.

## Changes

- Added new section **"Installing Docker"** with official Docker Engine installation steps for Ubuntu
- Renamed existing **"Docker Installation"** section to **"Using Docker"** for clarity
- Included link to official Docker documentation for other operating systems
- Based installation steps on official Docker documentation: https://docs.docker.com/engine/install/ubuntu

## Details

The previous README assumed users already had Docker installed and jumped directly to using the Hive Mind Docker image. This PR adds a prerequisite section that shows:

1. How to install Docker prerequisites
2. How to add Docker's official GPG key and repository
3. How to install Docker Engine and related plugins
4. How to verify the installation

The instructions follow the official Docker documentation for Ubuntu and include a reference link for users on other operating systems.

## Test Plan

- ✅ Verified the instructions match official Docker documentation
- ✅ Checked that the new section fits logically before the Docker usage section
- ✅ Confirmed the section heading hierarchy is correct

Fixes #1195

---
*This PR was created by the AI issue solver*