### PR TITLE
Use workflow runs API for instant CI detection instead of timeout (Issue #1442)

### DIFF
--- a/.changeset/issue-1442-no-ci-checks-timeout.md
+++ b/.changeset/issue-1442-no-ci-checks-timeout.md
@@ -2,8 +2,8 @@
 '@link-assistant/hive-mind': patch
 ---
 
-Add timeout for no-CI-checks waiting to prevent infinite loop (Issue #1442)
+Use workflow runs API to detect when CI is not triggered, preventing infinite loop (Issue #1442)
 
-When `--auto-restart-until-mergeable` monitors a PR in a repo that has active GitHub Actions workflows but CI checks never start (e.g., fork PRs needing maintainer approval, `paths-ignore` filtering all changed files, workflow trigger conditions not matching), the monitoring loop now exits gracefully after a configurable timeout instead of waiting indefinitely.
+When `--auto-restart-until-mergeable` monitors a PR in a repo that has active GitHub Actions workflows but CI checks never start (e.g., fork PRs needing maintainer approval, `paths-ignore` filtering all changed files, workflow trigger conditions not matching), the monitoring loop now exits immediately instead of waiting indefinitely.
 
-New `--no-ci-checks-timeout` option (default: 10 iterations, ~10 min at 60s interval) controls the maximum wait. At timeout, the system checks PR mergeability and either exits successfully (PR is mergeable) or reports the issue with a diagnostic PR comment explaining possible reasons and requesting manual intervention.
+Instead of using a timeout-based approach, the fix uses the GitHub Actions workflow runs API (`repos/{owner}/{repo}/actions/runs?head_sha={sha}`) to definitively determine if any workflow runs were triggered for the PR's commit. If zero workflow runs exist, CI was not triggered and there is nothing to wait for — the system exits immediately with a diagnostic PR comment.

--- a/docs/case-studies/issue-1442/README.md
+++ b/docs/case-studies/issue-1442/README.md
@@ -53,7 +53,7 @@ PR #149 is a **cross-repository (fork) PR** from `konard/netkeep80-BinDiffSynchr
 - Repository-level Actions settings disabling fork PR runs
 - All changed files matching `paths-ignore`
 
-### The Code Path
+### The Code Path (before fix)
 
 ```
 watchUntilMergeable() loop
@@ -64,31 +64,36 @@ watchUntilMergeable() loop
     → Returns blocker: {type: 'ci_pending', message: '...have not started yet...'}
   → isNoCIChecks=true, repoHasWorkflows=true
   → Logs "No checks yet (CI workflows exist, waiting for them to start)"
-  → NO TIMEOUT → loops forever
+  → NO EXIT CONDITION → loops forever
 ```
 
-### Missing: No timeout on "waiting for CI to start"
+### Key Insight: GitHub API provides definitive answer
 
-The code at line 868-870 of `solve.auto-merge.lib.mjs`:
+The reviewer asked: "Does GitHub API have a clear answer whether CI/CD will ever be started on the commit?"
 
-```javascript
-} else {
-  // Repo has workflows but CI hasn't started yet — transient race condition, keep waiting
-  await log(formatAligned('⏳', 'Waiting for CI:', 'No checks yet (CI workflows exist, waiting for them to start)', 2));
-}
-```
+**Yes.** The GitHub Actions workflow runs API (`GET /repos/{owner}/{repo}/actions/runs?head_sha={sha}`) definitively shows if any workflow runs were triggered for a specific commit:
 
-There is no counter, timer, or maximum wait for this specific state. The loop will continue indefinitely until the user manually interrupts.
+- `total_count > 0` → workflows were triggered, check-runs will appear soon (genuine race condition)
+- `total_count === 0` → no workflows were triggered for this commit (CI will NOT start)
+
+This is more reliable than a timeout because it gives an immediate, definitive answer.
 
 ## Solution
 
-Add a configurable maximum number of iterations to wait for CI checks to appear when the repo has workflows but no checks have started. After this limit:
+Use the workflow runs API in `getMergeBlockers()` to check if any workflow runs were triggered for the PR's HEAD SHA. This creates a four-way discrimination:
 
-1. Check if the PR is otherwise mergeable (mergeStateStatus === 'CLEAN')
-2. If mergeable: treat as "CI not required for this PR" and exit successfully
-3. If not mergeable: report the situation and exit with a diagnostic message
+1. `no_checks + NOT MERGEABLE` → pending race condition (wait)
+2. `no_checks + MERGEABLE + no workflows` → no CI configured (exit immediately)
+3. `no_checks + MERGEABLE + has workflows + has workflow runs` → genuine race condition (wait)
+4. `no_checks + MERGEABLE + has workflows + NO workflow runs` → **CI not triggered** (exit immediately)
 
-A reasonable default is 10 iterations (10 minutes with default 60s interval), which is well beyond the typical ~10-30s GitHub takes to register checks.
+State 4 is the new state that fixes the infinite loop. The existing `getWorkflowRunsForSha()` function was already available in the codebase but not used in this detection path.
+
+### Advantages over timeout approach
+
+- **Immediate**: Detects the condition on the first check, not after N minutes of waiting
+- **Definitive**: Based on actual API data, not heuristic timeout
+- **No configuration needed**: Removed the `--no-ci-checks-timeout` option since detection is instant
 
 ## Artifacts
 

--- a/src/solve.auto-merge.lib.mjs
+++ b/src/solve.auto-merge.lib.mjs
@@ -197,6 +197,7 @@ const getMergeBlockers = async (owner, repo, prNumber, verbose = false) => {
     // No CI checks exist yet - this could be:
     // 1. A race condition after push (checks haven't started yet) - wait
     // 2. A repository with no CI/CD configured at all - should be mergeable immediately
+    // 3. CI workflows exist but were not triggered for this commit (fork PR, paths-ignore, etc.)
     //
     // Issue #1345: Distinguish by checking the PR's mergeability status.
     // If GitHub says the PR is MERGEABLE (mergeStateStatus === 'CLEAN'),
@@ -215,16 +216,33 @@ const getMergeBlockers = async (owner, repo, prNumber, verbose = false) => {
       // - check_runs=[] (CI hasn't started yet — race condition)
       const repoWorkflows = await getActiveRepoWorkflows(owner, repo, verbose);
       if (repoWorkflows.hasWorkflows) {
-        // Repo HAS workflows — this is a race condition, not "no CI configured"
-        // Wait for CI checks to appear
-        if (verbose) {
-          console.log(`[VERBOSE] /merge: PR #${prNumber} has no CI checks yet, but repo has ${repoWorkflows.count} active workflow(s) - treating as race condition (CI hasn't started)`);
+        // Repo HAS workflows — but were they triggered for this commit?
+        // Issue #1442: Use the GitHub Actions workflow runs API to definitively check
+        // if any workflow runs were triggered for this PR's HEAD SHA. This avoids
+        // the need for timeout-based detection:
+        //   - workflow_runs.length > 0 → genuine race condition (CI started, check-runs not yet registered)
+        //   - workflow_runs.length === 0 → CI was NOT triggered (fork PR, paths-ignore, etc.)
+        const workflowRuns = await getWorkflowRunsForSha(owner, repo, ciStatus.sha, verbose);
+        if (workflowRuns.length > 0) {
+          // Workflow runs exist but check-runs haven't appeared yet — genuine race condition
+          if (verbose) {
+            console.log(`[VERBOSE] /merge: PR #${prNumber} has no CI check-runs yet, but ${workflowRuns.length} workflow run(s) were triggered for SHA ${ciStatus.sha.substring(0, 7)} - genuine race condition (waiting for check-runs to appear)`);
+          }
+          blockers.push({
+            type: 'ci_pending',
+            message: `CI/CD checks have not started yet (${workflowRuns.length} workflow run(s) triggered, waiting for check-runs to appear)`,
+            details: workflowRuns.map(r => r.name),
+          });
+        } else {
+          // No workflow runs for this SHA — CI was definitively NOT triggered
+          // Issue #1442: This is the root cause of the infinite loop. Fork PRs needing
+          // maintainer approval, paths-ignore filtering, workflow conditions not matching,
+          // etc. all result in zero workflow runs. No need for timeout — exit immediately.
+          if (verbose) {
+            console.log(`[VERBOSE] /merge: PR #${prNumber} has no CI checks and no workflow runs for SHA ${ciStatus.sha.substring(0, 7)} — CI was not triggered (fork PR, paths-ignore, workflow conditions, etc.)`);
+          }
+          return { blockers, ciStatus, noCiConfigured: false, noCiTriggered: true };
         }
-        blockers.push({
-          type: 'ci_pending',
-          message: `CI/CD checks have not started yet (${repoWorkflows.count} workflow(s) configured, waiting for checks to appear)`,
-          details: repoWorkflows.workflows.map(wf => wf.name),
-        });
       } else {
         // Repo has NO workflows — this is truly "no CI configured"
         // PR is already mergeable with no CI checks configured.
@@ -323,7 +341,7 @@ const getMergeBlockers = async (owner, repo, prNumber, verbose = false) => {
     });
   }
 
-  return { blockers, ciStatus, noCiConfigured: false };
+  return { blockers, ciStatus, noCiConfigured: false, noCiTriggered: false };
 };
 
 /**
@@ -368,19 +386,6 @@ export const watchUntilMergeable = async params => {
   let iteration = 0;
   let lastCheckTime = new Date();
 
-  // Issue #1335: Cache whether the repo has CI workflows to avoid repeated API calls.
-  // When 'no_checks' is seen, we check if the repo actually has workflows configured.
-  // - If no workflows exist → 'no_checks' is permanent; treat PR as CI-passing and exit.
-  // - If workflows exist → 'no_checks' is a transient race condition; keep waiting.
-  let repoHasWorkflows = null; // null = not yet checked; true/false = cached result
-
-  // Issue #1442: Track consecutive iterations where CI checks never appear despite
-  // workflows existing. After a configurable timeout, stop waiting indefinitely.
-  // Reasons CI may never start: fork PRs needing approval, paths-ignore filtering,
-  // workflow trigger conditions not matching, GitHub Actions disabled for forks, etc.
-  let consecutiveNoCIChecksIterations = 0;
-  const noCIChecksMaxWaitIterations = argv.noCiChecksTimeout || 10; // default: 10 iterations (~10 min at 60s interval)
-
   while (true) {
     iteration++;
     const currentTime = new Date();
@@ -409,13 +414,19 @@ export const watchUntilMergeable = async params => {
 
     try {
       // Get merge blockers
-      const { blockers, noCiConfigured } = await getMergeBlockers(owner, repo, prNumber, argv.verbose);
+      const { blockers, noCiConfigured, noCiTriggered } = await getMergeBlockers(owner, repo, prNumber, argv.verbose);
 
       // Check for new comments from non-bot users
       const { hasNewComments, comments } = await checkForNonBotComments(owner, repo, prNumber, issueNumber, lastCheckTime, argv.verbose);
 
       // Check for uncommitted changes using shared utility
       const hasUncommittedChanges = await checkForUncommittedChanges(tempDir, argv);
+
+      // Issue #1442: If CI workflows exist but were not triggered for this commit,
+      // log why before proceeding to the mergeable path.
+      if (noCiTriggered) {
+        await log(formatAligned('ℹ️', 'CI not triggered:', 'Workflows exist but no workflow runs for this commit (fork PR, paths-ignore, workflow conditions)', 2));
+      }
 
       // If PR is mergeable, no blockers, no new comments, and no uncommitted changes
       if (blockers.length === 0 && !hasNewComments && !hasUncommittedChanges) {
@@ -433,7 +444,7 @@ export const watchUntilMergeable = async params => {
             // Post success comment
             try {
               // Issue #1345: Differentiate message when no CI is configured
-              const ciLine = noCiConfigured ? '- No CI/CD checks are configured for this repository' : '- All CI checks have passed';
+              const ciLine = noCiConfigured ? '- No CI/CD checks are configured for this repository' : noCiTriggered ? '- CI workflows exist but were not triggered for this commit' : '- All CI checks have passed';
               const commentBody = `## 🎉 Auto-merged\n\nThis pull request has been automatically merged by hive-mind.\n${ciLine}\n\n---\n*Auto-merged by hive-mind with --auto-merge flag*`;
               await $`gh pr comment ${prNumber} --repo ${owner}/${repo} --body ${commentBody}`;
             } catch {
@@ -457,7 +468,7 @@ export const watchUntilMergeable = async params => {
           try {
             if (!readyToMergeCommentPosted) {
               // Issue #1345: Differentiate message when no CI is configured
-              const ciLine = noCiConfigured ? '- No CI/CD checks are configured for this repository' : '- All CI checks have passed';
+              const ciLine = noCiConfigured ? '- No CI/CD checks are configured for this repository' : noCiTriggered ? '- CI workflows exist but were not triggered for this commit' : '- All CI checks have passed';
               const commentBody = `## ✅ Ready to merge\n\nThis pull request is now ready to be merged:\n${ciLine}\n- No merge conflicts\n- No pending changes\n\n---\n*Monitored by hive-mind with --auto-restart-until-mergeable flag*`;
               await $`gh pr comment ${prNumber} --repo ${owner}/${repo} --body ${commentBody}`;
               readyToMergeCommentPosted = true;
@@ -895,145 +906,16 @@ Once the billing issue is resolved, you can re-run the CI checks or push a new c
         // Issue #1314: Distinguish between different waiting reasons
         const pendingBlocker = blockers.find(b => b.type === 'ci_pending');
         const cancelledOnly = blockers.every(b => b.type === 'ci_cancelled' || b.type === 'ci_pending');
+        const cancelledBlocker = blockers.find(b => b.type === 'ci_cancelled');
 
-        // Issue #1335: Detect permanent 'no_checks' state (repo has no CI workflows).
-        // The 'ci_pending' blocker with message 'have not started yet' means GitHub returned
-        // zero check-runs and zero commit statuses for this PR's HEAD SHA. This is ambiguous:
-        //   (a) Transient race condition — CI workflows exist but haven't queued yet after push.
-        //   (b) Permanent state — the repository has no CI/CD workflows configured at all.
-        // We resolve the ambiguity by checking if the repo actually has workflow files via the
-        // GitHub API. If it has none, the 'no_checks' state is permanent and the PR should be
-        // treated as CI-passing (no CI = nothing to wait for).
-        const isNoCIChecks = pendingBlocker && pendingBlocker.message.includes('have not started yet');
-        if (isNoCIChecks) {
-          // Lazy-check whether the repo has workflows (cache result to avoid repeated API calls)
-          if (repoHasWorkflows === null) {
-            const workflowCheck = await getActiveRepoWorkflows(owner, repo, argv.verbose);
-            repoHasWorkflows = workflowCheck.hasWorkflows;
-            if (argv.verbose) {
-              await log(formatAligned('', 'Repo workflow check:', repoHasWorkflows ? `${workflowCheck.count} workflow(s) found — CI check is a transient race condition` : 'No workflows configured — no CI expected', 2));
-            }
-          }
-
-          if (!repoHasWorkflows) {
-            // Root cause confirmed: repo has no CI. The 'no_checks' state is permanent.
-            // Treat the PR as CI-passing and exit the monitoring loop immediately.
-            await log('');
-            await log(formatAligned('ℹ️', 'NO CI WORKFLOWS CONFIGURED', 'Repository has no GitHub Actions workflows'));
-            await log(formatAligned('', 'Conclusion:', 'No CI expected — treating PR as CI-passing', 2));
-            await log(formatAligned('', 'Action:', 'Exiting monitoring loop', 2));
-            await log('');
-
-            // Post a comment explaining the situation
-            try {
-              const commentBody = `## ℹ️ No CI Workflows Detected
-
-No CI/CD checks are configured for this pull request. The repository has no GitHub Actions workflow files in \`.github/workflows/\`.
-
-The auto-restart-until-mergeable monitor is stopping since there is no CI to wait for. The PR may be ready to merge if there are no other issues.
-
----
-*Monitored by hive-mind with --auto-restart-until-mergeable flag*`;
-              await $`gh pr comment ${prNumber} --repo ${owner}/${repo} --body ${commentBody}`;
-            } catch {
-              // Don't fail if comment posting fails
-            }
-
-            return { success: true, reason: 'no_ci_checks', latestSessionId, latestAnthropicCost };
-          } else {
-            // Repo has workflows but CI hasn't started yet — transient race condition, keep waiting
-            consecutiveNoCIChecksIterations++;
-
-            // Issue #1442: After waiting long enough, stop assuming it's a transient race condition.
-            // CI may never start due to: fork PR needing maintainer approval, paths-ignore filtering
-            // all changed files, workflow trigger conditions not matching, etc.
-            if (consecutiveNoCIChecksIterations >= noCIChecksMaxWaitIterations) {
-              const waitedMinutes = Math.round((consecutiveNoCIChecksIterations * watchInterval) / 60);
-              await log('');
-              await log(formatAligned('⚠️', 'CI CHECKS NEVER STARTED', `Waited ${waitedMinutes} minute(s) across ${consecutiveNoCIChecksIterations} check(s)`));
-
-              // Re-check mergeability to decide the outcome
-              const finalMergeStatus = await checkPRMergeable(owner, repo, prNumber, argv.verbose);
-              if (finalMergeStatus.mergeable) {
-                await log(formatAligned('', 'PR status:', 'Mergeable (no required status checks blocking)', 2));
-                await log(formatAligned('', 'Conclusion:', 'CI workflows exist but are not triggered for this PR — treating as CI-passing', 2));
-                await log(formatAligned('', 'Possible reasons:', 'Fork PR needing approval, paths-ignore filtering, workflow conditions not met', 2));
-                await log(formatAligned('', 'Action:', 'Exiting monitoring loop', 2));
-                await log('');
-
-                // Post a comment explaining the situation
-                try {
-                  const commentBody = `## ⚠️ CI Checks Did Not Start
-
-The repository has GitHub Actions workflows configured, but no CI checks were triggered for this pull request after waiting ~${waitedMinutes} minute(s).
-
-**Possible reasons:**
-- Fork/cross-repository PR requiring maintainer approval to run CI
-- All changed files match \`paths-ignore\` filters in workflow configuration
-- Workflow trigger conditions (\`on:\` rules) do not match this PR
-- GitHub Actions is disabled for fork PRs in repository settings
-
-The PR is otherwise mergeable (no required status checks blocking). Exiting the monitoring loop.
-
----
-*Monitored by hive-mind with --auto-restart-until-mergeable flag*`;
-                  await $`gh pr comment ${prNumber} --repo ${owner}/${repo} --body ${commentBody}`;
-                } catch {
-                  // Don't fail if comment posting fails
-                }
-
-                return { success: true, reason: 'ci_checks_not_triggered', latestSessionId, latestAnthropicCost };
-              } else {
-                await log(formatAligned('', 'PR status:', `Not mergeable (${finalMergeStatus.mergeStateStatus || 'unknown'})`, 2));
-                await log(formatAligned('', 'Conclusion:', 'CI checks never started and PR is not mergeable — cannot proceed', 2));
-                await log(formatAligned('', 'Possible reasons:', 'Fork PR needing approval, required status checks configured but CI not triggered', 2));
-                await log(formatAligned('', 'Action:', 'Exiting monitoring loop — manual intervention required', 2));
-                await log('');
-
-                // Post a comment explaining the situation
-                try {
-                  const commentBody = `## ⚠️ CI Checks Did Not Start — PR Not Mergeable
-
-The repository has GitHub Actions workflows configured, but no CI checks were triggered for this pull request after waiting ~${waitedMinutes} minute(s).
-
-The PR is currently **not mergeable** (merge state: \`${finalMergeStatus.mergeStateStatus || 'unknown'}\`). This likely means required status checks are configured but CI was not triggered.
-
-**Possible reasons:**
-- Fork/cross-repository PR requiring maintainer approval to run CI
-- All changed files match \`paths-ignore\` filters in workflow configuration
-- Workflow trigger conditions (\`on:\` rules) do not match this PR
-- GitHub Actions is disabled for fork PRs in repository settings
-
-**Manual intervention needed:** A repository maintainer may need to approve the CI run or merge the PR manually.
-
----
-*Monitored by hive-mind with --auto-restart-until-mergeable flag*`;
-                  await $`gh pr comment ${prNumber} --repo ${owner}/${repo} --body ${commentBody}`;
-                } catch {
-                  // Don't fail if comment posting fails
-                }
-
-                return { success: false, reason: 'ci_checks_not_triggered', latestSessionId, latestAnthropicCost };
-              }
-            }
-
-            await log(formatAligned('⏳', 'Waiting for CI:', `No checks yet (CI workflows exist, waiting for them to start — attempt ${consecutiveNoCIChecksIterations}/${noCIChecksMaxWaitIterations})`, 2));
-          }
+        if (cancelledOnly && cancelledBlocker) {
+          await log(formatAligned('🔄', 'Waiting for re-triggered CI:', cancelledBlocker.details.join(', '), 2));
+        } else if (pendingBlocker) {
+          await log(formatAligned('⏳', 'Waiting for CI:', pendingBlocker.details.length > 0 ? pendingBlocker.details.join(', ') : pendingBlocker.message, 2));
         } else {
-          // Issue #1442: CI checks exist (not "no checks" state) — reset the no-CI-checks counter
-          consecutiveNoCIChecksIterations = 0;
-
-          if (cancelledOnly && cancelledBlocker) {
-            await log(formatAligned('🔄', 'Waiting for re-triggered CI:', cancelledBlocker.details.join(', '), 2));
-          } else if (pendingBlocker) {
-            await log(formatAligned('⏳', 'Waiting for CI:', pendingBlocker.details.length > 0 ? pendingBlocker.details.join(', ') : pendingBlocker.message, 2));
-          } else {
-            await log(formatAligned('⏳', 'Waiting for:', blockers.map(b => b.message).join(', '), 2));
-          }
+          await log(formatAligned('⏳', 'Waiting for:', blockers.map(b => b.message).join(', '), 2));
         }
       } else {
-        // Issue #1442: No blockers — CI checks appeared and passed (or no CI needed), reset counter
-        consecutiveNoCIChecksIterations = 0;
         await log(formatAligned('', 'No action needed', 'Continuing to monitor...', 2));
       }
 

--- a/src/solve.config.lib.mjs
+++ b/src/solve.config.lib.mjs
@@ -184,11 +184,6 @@ export const SOLVE_OPTION_DEFINITIONS = {
     description: 'Auto-restart until PR becomes mergeable (no iteration limit). Restarts on new comments from non-bot users, CI failures, merge conflicts, or other issues. Does NOT auto-merge.',
     default: true,
   },
-  'no-ci-checks-timeout': {
-    type: 'number',
-    description: 'Maximum number of check iterations to wait for CI checks to appear when a repo has workflows but no checks start (e.g., fork PRs needing approval, paths-ignore filtering). After this limit, exits gracefully. Default: 10 iterations (~10 min at 60s interval).',
-    default: 10,
-  },
   'auto-restart-on-non-updated-pull-request-description': {
     type: 'boolean',
     description: 'Automatically restart if PR title or description still contains auto-generated placeholder text after agent execution. Restarts with a hint about what was not updated.',

--- a/tests/test-no-ci-checks-timeout-1442.mjs
+++ b/tests/test-no-ci-checks-timeout-1442.mjs
@@ -4,17 +4,20 @@
  * Unit Tests: Issue #1442 - `--auto-restart-until-mergeable` stuck on no CI checks
  *
  * Tests verify that:
- * 1. When a repo has CI workflows but checks never start, the monitoring loop exits
- *    after a configurable timeout instead of waiting indefinitely
- * 2. When the PR is mergeable at timeout, it exits successfully with reason 'ci_checks_not_triggered'
- * 3. When the PR is NOT mergeable at timeout, it exits with failure
- * 4. The counter resets when CI checks appear (non-no_checks state)
- * 5. The timeout is configurable via --no-ci-checks-timeout
- * 6. Default timeout is 10 iterations
+ * 1. When a repo has CI workflows but no workflow runs were triggered for the commit,
+ *    getMergeBlockers returns noCiTriggered=true so the monitoring loop exits immediately
+ * 2. When workflow runs exist but check-runs haven't appeared yet, it's a genuine race
+ *    condition and a ci_pending blocker is returned
+ * 3. Existing behavior for no-workflows repos is preserved (noCiConfigured=true)
+ * 4. The workflow runs API check only happens when no_checks + mergeable + hasWorkflows
  *
  * Root cause: Repo has active workflows but CI never starts for the PR (e.g., fork PRs
  * needing maintainer approval, paths-ignore filtering all files, trigger conditions not met).
- * The code assumed this was always a transient race condition and waited indefinitely.
+ * The old code assumed this was always a transient race condition and waited indefinitely.
+ *
+ * Fix: Use GitHub Actions workflow runs API (repos/{owner}/{repo}/actions/runs?head_sha={sha})
+ * to definitively determine if any workflow runs were triggered for the commit. If zero
+ * workflow runs exist, CI was not triggered — exit immediately, no timeout needed.
  *
  * Run with: node tests/test-no-ci-checks-timeout-1442.mjs
  *
@@ -50,284 +53,279 @@ const assert = (condition, message) => {
 };
 
 console.log('================================================================================');
-console.log('Unit Tests: Issue #1442 - No CI checks timeout');
+console.log('Unit Tests: Issue #1442 - No CI checks (workflow runs API detection)');
 console.log('================================================================================\n');
 
-// ===== Simulate the watchUntilMergeable timeout logic =====
+// ===== Simulate the getMergeBlockers logic for CI detection =====
 
 /**
- * Simulates the no-CI-checks timeout logic from watchUntilMergeable.
+ * Simulates the three-way CI detection logic from getMergeBlockers.
  * This mirrors the actual behavior after the fix in src/solve.auto-merge.lib.mjs.
  *
+ * The key insight is that instead of using timeout-based detection, we now use
+ * the GitHub Actions API to definitively check if workflow runs were triggered
+ * for the PR's HEAD SHA. This gives us four distinct states:
+ *
+ * 1. no_checks + NOT MERGEABLE → pending race condition (wait)
+ * 2. no_checks + MERGEABLE + no workflows → no CI configured (exit: noCiConfigured)
+ * 3. no_checks + MERGEABLE + has workflows + has workflow runs → genuine race condition (wait)
+ * 4. no_checks + MERGEABLE + has workflows + NO workflow runs → CI not triggered (exit: noCiTriggered)
+ *
  * @param {Object} params
- * @param {number} params.maxWaitIterations - Max iterations to wait (--no-ci-checks-timeout)
- * @param {Array<Object>} params.iterationStates - Array of states per iteration, each with:
- *   - isNoCIChecks: boolean - Whether the "no checks yet" condition is detected
- *   - repoHasWorkflows: boolean - Whether repo has active workflows
- *   - prMergeable: boolean - Whether PR is mergeable (used at timeout)
- *   - mergeStateStatus: string - PR merge state (used in error messages)
- * @returns {Object} - { exitedAt, reason, success, consecutiveCount }
+ * @param {string} params.ciStatusStatus - CI status from getDetailedCIStatus ('no_checks', 'pending', etc.)
+ * @param {boolean} params.prMergeable - Whether PR is mergeable
+ * @param {boolean} params.repoHasWorkflows - Whether repo has active workflows
+ * @param {number} params.workflowRunsCount - Number of workflow runs for this SHA
+ * @returns {Object} - { blockers, noCiConfigured, noCiTriggered }
  */
-function simulateTimeoutLogic({ maxWaitIterations, iterationStates }) {
-  let consecutiveNoCIChecksIterations = 0;
-  let repoHasWorkflows = null; // cached
+function simulateMergeBlockers({ ciStatusStatus, prMergeable, repoHasWorkflows, workflowRunsCount }) {
+  const blockers = [];
 
-  for (let i = 0; i < iterationStates.length; i++) {
-    const state = iterationStates[i];
-
-    if (state.isNoCIChecks) {
-      // Lazy-cache workflow check
-      if (repoHasWorkflows === null) {
-        repoHasWorkflows = state.repoHasWorkflows;
-      }
-
-      if (repoHasWorkflows === false) {
-        // No workflows → exit as "no CI configured" (existing behavior from #1335)
-        return { exitedAt: i + 1, reason: 'no_ci_checks', success: true, consecutiveCount: consecutiveNoCIChecksIterations };
-      }
-
-      // Workflows exist but no checks started
-      consecutiveNoCIChecksIterations++;
-
-      if (consecutiveNoCIChecksIterations >= maxWaitIterations) {
-        // Timeout reached — check mergeability
-        if (state.prMergeable) {
-          return { exitedAt: i + 1, reason: 'ci_checks_not_triggered', success: true, consecutiveCount: consecutiveNoCIChecksIterations };
+  if (ciStatusStatus === 'no_checks') {
+    if (prMergeable) {
+      if (repoHasWorkflows) {
+        if (workflowRunsCount > 0) {
+          // Workflow runs exist but check-runs haven't appeared yet — genuine race condition
+          blockers.push({
+            type: 'ci_pending',
+            message: `CI/CD checks have not started yet (${workflowRunsCount} workflow run(s) triggered, waiting for check-runs to appear)`,
+          });
         } else {
-          return { exitedAt: i + 1, reason: 'ci_checks_not_triggered', success: false, consecutiveCount: consecutiveNoCIChecksIterations };
+          // No workflow runs — CI was definitively NOT triggered
+          return { blockers, noCiConfigured: false, noCiTriggered: true };
         }
+      } else {
+        // No workflows — no CI configured
+        return { blockers, noCiConfigured: true, noCiTriggered: false };
       }
-      // Keep waiting...
     } else {
-      // CI checks appeared (or different state) — reset counter
-      consecutiveNoCIChecksIterations = 0;
+      // PR not mergeable — treat as pending race condition
+      blockers.push({
+        type: 'ci_pending',
+        message: 'CI/CD checks have not started yet (waiting for checks to appear)',
+      });
     }
+  } else if (ciStatusStatus === 'pending') {
+    blockers.push({
+      type: 'ci_pending',
+      message: 'CI/CD checks are still running or queued',
+    });
+  } else if (ciStatusStatus === 'success') {
+    // No blocker
   }
 
-  // Ran out of iteration states without exiting
-  return { exitedAt: null, reason: 'still_running', success: null, consecutiveCount: consecutiveNoCIChecksIterations };
+  return { blockers, noCiConfigured: false, noCiTriggered: false };
 }
 
-// ===== Test: Basic timeout behavior =====
-console.log('📋 Basic Timeout Behavior\n');
+// ===== Test: Core four-way discrimination =====
+console.log('📋 Four-Way CI Detection (Issue #1442)\n');
 
-test('Exits after maxWaitIterations when CI never starts and PR is mergeable', () => {
-  const states = Array.from({ length: 10 }, () => ({
-    isNoCIChecks: true,
-    repoHasWorkflows: true,
-    prMergeable: true,
-    mergeStateStatus: 'CLEAN',
-  }));
-
-  const result = simulateTimeoutLogic({ maxWaitIterations: 10, iterationStates: states });
-
-  assert(result.exitedAt === 10, `Should exit at iteration 10, got ${result.exitedAt}`);
-  assert(result.reason === 'ci_checks_not_triggered', `Reason should be ci_checks_not_triggered, got ${result.reason}`);
-  assert(result.success === true, 'Should succeed when PR is mergeable');
-  assert(result.consecutiveCount === 10, `Consecutive count should be 10, got ${result.consecutiveCount}`);
-});
-
-test('Exits after maxWaitIterations when CI never starts and PR is NOT mergeable', () => {
-  const states = Array.from({ length: 10 }, () => ({
-    isNoCIChecks: true,
-    repoHasWorkflows: true,
+test('State 1: no_checks + NOT MERGEABLE → pending race condition (wait)', () => {
+  const result = simulateMergeBlockers({
+    ciStatusStatus: 'no_checks',
     prMergeable: false,
-    mergeStateStatus: 'BLOCKED',
-  }));
-
-  const result = simulateTimeoutLogic({ maxWaitIterations: 10, iterationStates: states });
-
-  assert(result.exitedAt === 10, `Should exit at iteration 10, got ${result.exitedAt}`);
-  assert(result.reason === 'ci_checks_not_triggered', `Reason should be ci_checks_not_triggered, got ${result.reason}`);
-  assert(result.success === false, 'Should fail when PR is not mergeable');
-});
-
-test('Does NOT exit before maxWaitIterations', () => {
-  // Only 5 iterations but timeout is 10
-  const states = Array.from({ length: 5 }, () => ({
-    isNoCIChecks: true,
     repoHasWorkflows: true,
+    workflowRunsCount: 0,
+  });
+
+  assert(result.blockers.length === 1, `Should have 1 blocker, got ${result.blockers.length}`);
+  assert(result.blockers[0].type === 'ci_pending', `Blocker type should be ci_pending, got ${result.blockers[0].type}`);
+  assert(result.noCiConfigured === false, 'noCiConfigured should be false');
+  assert(result.noCiTriggered === false, 'noCiTriggered should be false');
+});
+
+test('State 2: no_checks + MERGEABLE + no workflows → no CI configured (exit)', () => {
+  const result = simulateMergeBlockers({
+    ciStatusStatus: 'no_checks',
     prMergeable: true,
-  }));
-
-  const result = simulateTimeoutLogic({ maxWaitIterations: 10, iterationStates: states });
-
-  assert(result.exitedAt === null, 'Should not exit before timeout');
-  assert(result.reason === 'still_running', 'Should still be running');
-  assert(result.consecutiveCount === 5, `Consecutive count should be 5, got ${result.consecutiveCount}`);
-});
-
-// ===== Test: Counter reset =====
-console.log('\n📋 Counter Reset on CI Check Appearance\n');
-
-test('Counter resets when CI checks appear between no-checks iterations', () => {
-  const states = [
-    // 3 iterations of no checks
-    { isNoCIChecks: true, repoHasWorkflows: true, prMergeable: true },
-    { isNoCIChecks: true, repoHasWorkflows: true, prMergeable: true },
-    { isNoCIChecks: true, repoHasWorkflows: true, prMergeable: true },
-    // CI appears (e.g., checks start running)
-    { isNoCIChecks: false },
-    // 3 more iterations of no checks (counter should restart from 0)
-    { isNoCIChecks: true, repoHasWorkflows: true, prMergeable: true },
-    { isNoCIChecks: true, repoHasWorkflows: true, prMergeable: true },
-    { isNoCIChecks: true, repoHasWorkflows: true, prMergeable: true },
-  ];
-
-  const result = simulateTimeoutLogic({ maxWaitIterations: 5, iterationStates: states });
-
-  assert(result.exitedAt === null, 'Should not exit — counter was reset at iteration 4');
-  assert(result.reason === 'still_running', 'Should still be running');
-  assert(result.consecutiveCount === 3, `Should have 3 consecutive (after reset), got ${result.consecutiveCount}`);
-});
-
-test('Counter resets prevent false timeout when CI intermittently appears', () => {
-  // Pattern: no-checks, no-checks, checks-appear, no-checks, no-checks, checks-appear...
-  // Should never timeout with maxWait=3 because counter keeps resetting
-  const states = [];
-  for (let i = 0; i < 20; i++) {
-    if (i % 3 === 2) {
-      states.push({ isNoCIChecks: false }); // CI appears every 3rd iteration
-    } else {
-      states.push({ isNoCIChecks: true, repoHasWorkflows: true, prMergeable: true });
-    }
-  }
-
-  const result = simulateTimeoutLogic({ maxWaitIterations: 3, iterationStates: states });
-
-  assert(result.exitedAt === null, 'Should never timeout with intermittent CI');
-  assert(result.reason === 'still_running', 'Should still be running');
-});
-
-// ===== Test: Configurable timeout =====
-console.log('\n📋 Configurable Timeout\n');
-
-test('Custom timeout of 5 iterations works correctly', () => {
-  const states = Array.from({ length: 5 }, () => ({
-    isNoCIChecks: true,
-    repoHasWorkflows: true,
-    prMergeable: true,
-  }));
-
-  const result = simulateTimeoutLogic({ maxWaitIterations: 5, iterationStates: states });
-
-  assert(result.exitedAt === 5, `Should exit at iteration 5, got ${result.exitedAt}`);
-  assert(result.success === true, 'Should succeed');
-});
-
-test('Custom timeout of 1 iteration exits immediately', () => {
-  const states = [{ isNoCIChecks: true, repoHasWorkflows: true, prMergeable: true }];
-
-  const result = simulateTimeoutLogic({ maxWaitIterations: 1, iterationStates: states });
-
-  assert(result.exitedAt === 1, `Should exit at iteration 1, got ${result.exitedAt}`);
-  assert(result.success === true, 'Should succeed');
-});
-
-test('Custom timeout of 20 iterations waits longer', () => {
-  const states = Array.from({ length: 15 }, () => ({
-    isNoCIChecks: true,
-    repoHasWorkflows: true,
-    prMergeable: true,
-  }));
-
-  const result = simulateTimeoutLogic({ maxWaitIterations: 20, iterationStates: states });
-
-  assert(result.exitedAt === null, 'Should not exit after 15 iterations with timeout of 20');
-  assert(result.reason === 'still_running', 'Should still be running');
-});
-
-// ===== Test: Interaction with no-workflows detection =====
-console.log('\n📋 Interaction with No-Workflows Detection (#1335)\n');
-
-test('No-workflows still exits immediately (existing behavior preserved)', () => {
-  const states = [{ isNoCIChecks: true, repoHasWorkflows: false, prMergeable: true }];
-
-  const result = simulateTimeoutLogic({ maxWaitIterations: 10, iterationStates: states });
-
-  assert(result.exitedAt === 1, `Should exit at iteration 1, got ${result.exitedAt}`);
-  assert(result.reason === 'no_ci_checks', `Reason should be no_ci_checks, got ${result.reason}`);
-  assert(result.success === true, 'Should succeed');
-});
-
-test('No-workflows detection takes priority over timeout (exits before timeout)', () => {
-  // 5 iterations but workflow check finds no workflows on first check
-  const states = Array.from({ length: 5 }, () => ({
-    isNoCIChecks: true,
     repoHasWorkflows: false,
+    workflowRunsCount: 0,
+  });
+
+  assert(result.blockers.length === 0, `Should have 0 blockers, got ${result.blockers.length}`);
+  assert(result.noCiConfigured === true, 'noCiConfigured should be true');
+  assert(result.noCiTriggered === false, 'noCiTriggered should be false');
+});
+
+test('State 3: no_checks + MERGEABLE + has workflows + has workflow runs → genuine race condition (wait)', () => {
+  const result = simulateMergeBlockers({
+    ciStatusStatus: 'no_checks',
     prMergeable: true,
-  }));
+    repoHasWorkflows: true,
+    workflowRunsCount: 2,
+  });
 
-  const result = simulateTimeoutLogic({ maxWaitIterations: 10, iterationStates: states });
+  assert(result.blockers.length === 1, `Should have 1 blocker, got ${result.blockers.length}`);
+  assert(result.blockers[0].type === 'ci_pending', `Blocker type should be ci_pending, got ${result.blockers[0].type}`);
+  assert(result.blockers[0].message.includes('2 workflow run(s) triggered'), `Message should mention 2 workflow runs, got: ${result.blockers[0].message}`);
+  assert(result.noCiConfigured === false, 'noCiConfigured should be false');
+  assert(result.noCiTriggered === false, 'noCiTriggered should be false');
+});
 
-  assert(result.exitedAt === 1, 'Should exit at iteration 1 (no-workflows detection is immediate)');
-  assert(result.reason === 'no_ci_checks', 'Reason should be no_ci_checks, not timeout');
+test('State 4: no_checks + MERGEABLE + has workflows + NO workflow runs → CI not triggered (exit immediately)', () => {
+  const result = simulateMergeBlockers({
+    ciStatusStatus: 'no_checks',
+    prMergeable: true,
+    repoHasWorkflows: true,
+    workflowRunsCount: 0,
+  });
+
+  assert(result.blockers.length === 0, `Should have 0 blockers, got ${result.blockers.length}`);
+  assert(result.noCiConfigured === false, 'noCiConfigured should be false');
+  assert(result.noCiTriggered === true, 'noCiTriggered should be true');
 });
 
 // ===== Test: Exact reproduction of issue #1442 scenario =====
 console.log('\n📋 Exact Reproduction of Issue #1442\n');
 
-test('BinDiffSynchronizer scenario: fork PR with CI workflow, checks never start, exits after timeout', () => {
+test('BinDiffSynchronizer scenario: fork PR with CI workflow, no workflow runs → exits immediately', () => {
   // Reproduce the exact scenario from the issue:
   // - Repo: netkeep80/BinDiffSynchronizer has 1 active workflow (CI)
   // - PR #149 is a cross-repository (fork) PR
   // - CI never starts (needs maintainer approval for fork PRs)
   // - PR is mergeable (CLEAN state, no required status checks)
-  // Before fix: infinite loop. After fix: exits after 10 iterations.
-  const states = Array.from({ length: 22 }, () => ({
-    // 22 iterations = what actually happened
-    isNoCIChecks: true,
-    repoHasWorkflows: true, // 1 active workflow: CI
-    prMergeable: true, // CLEAN state
-    mergeStateStatus: 'CLEAN',
-  }));
-
-  const result = simulateTimeoutLogic({ maxWaitIterations: 10, iterationStates: states });
-
-  assert(result.exitedAt === 10, `Should exit at iteration 10 (not 22 like before), got ${result.exitedAt}`);
-  assert(result.reason === 'ci_checks_not_triggered', `Reason should be ci_checks_not_triggered, got ${result.reason}`);
-  assert(result.success === true, 'Should succeed — PR is mergeable');
-});
-
-test('Similar scenario but PR is BLOCKED (required checks configured): fails gracefully', () => {
-  // If the repo has required status checks in branch protection,
-  // the PR won't be mergeable and we should fail with a clear message
-  const states = Array.from({ length: 10 }, () => ({
-    isNoCIChecks: true,
+  // - GitHub API: GET /repos/.../actions/runs?head_sha=<sha> returns { total_count: 0, workflow_runs: [] }
+  // Before fix: infinite loop (22+ minutes). After fix: exits immediately on first check.
+  const result = simulateMergeBlockers({
+    ciStatusStatus: 'no_checks',
+    prMergeable: true,
     repoHasWorkflows: true,
-    prMergeable: false, // BLOCKED — required checks are configured
-    mergeStateStatus: 'BLOCKED',
-  }));
+    workflowRunsCount: 0, // No workflow runs triggered for this SHA
+  });
 
-  const result = simulateTimeoutLogic({ maxWaitIterations: 10, iterationStates: states });
-
-  assert(result.exitedAt === 10, `Should exit at iteration 10, got ${result.exitedAt}`);
-  assert(result.reason === 'ci_checks_not_triggered', `Reason should be ci_checks_not_triggered, got ${result.reason}`);
-  assert(result.success === false, 'Should fail — PR is not mergeable');
+  assert(result.noCiTriggered === true, 'Should detect CI was not triggered');
+  assert(result.blockers.length === 0, 'Should have no blockers (not waiting for anything)');
+  assert(result.noCiConfigured === false, 'noCiConfigured should be false (repo has workflows)');
 });
 
-// ===== Test: Default config value =====
-console.log('\n📋 Default Configuration\n');
+test('Similar scenario but PR is BLOCKED → waits (pending race condition)', () => {
+  // If the repo has required status checks in branch protection,
+  // the PR won't be mergeable — we wait since CI might still start
+  const result = simulateMergeBlockers({
+    ciStatusStatus: 'no_checks',
+    prMergeable: false,
+    repoHasWorkflows: true,
+    workflowRunsCount: 0,
+  });
 
-test('Default noCiChecksTimeout is 10', () => {
-  // The default from config should be 10
-  const defaultTimeout = 10;
-  assert(defaultTimeout === 10, `Default timeout should be 10, got ${defaultTimeout}`);
+  assert(result.noCiTriggered === false, 'noCiTriggered should be false (PR not mergeable)');
+  assert(result.blockers.length === 1, 'Should have 1 blocker');
+  assert(result.blockers[0].type === 'ci_pending', 'Should be a ci_pending blocker');
 });
 
-test('Config value 0 means no timeout (original behavior)', () => {
-  // If someone sets --no-ci-checks-timeout=0, it should effectively disable the timeout
-  // Since 0 >= 0 is true on first iteration, let's test with a large number of iterations
-  // Actually, the code uses `consecutiveNoCIChecksIterations >= noCIChecksMaxWaitIterations`
-  // With maxWait=0: 0 >= 0 is true on first no-checks iteration → immediate exit
-  // This is actually a valid edge case: "don't wait at all for CI to start"
-  const states = [{ isNoCIChecks: true, repoHasWorkflows: true, prMergeable: true }];
+// ===== Test: Existing behavior preservation =====
+console.log('\n📋 Existing Behavior Preservation\n');
 
-  const result = simulateTimeoutLogic({ maxWaitIterations: 0, iterationStates: states });
+test('No-workflows still exits immediately (existing behavior from #1335 preserved)', () => {
+  const result = simulateMergeBlockers({
+    ciStatusStatus: 'no_checks',
+    prMergeable: true,
+    repoHasWorkflows: false,
+    workflowRunsCount: 0,
+  });
 
-  // With maxWait=0, the counter starts at 0 and increments to 1 before checking >= 0
-  // Wait — let's check: consecutiveNoCIChecksIterations++ makes it 1, then 1 >= 0 → exit
-  assert(result.exitedAt === 1, `With timeout=0, should exit at first no-checks iteration, got ${result.exitedAt}`);
+  assert(result.noCiConfigured === true, 'noCiConfigured should be true');
+  assert(result.noCiTriggered === false, 'noCiTriggered should be false');
+  assert(result.blockers.length === 0, 'Should have no blockers');
+});
+
+test('CI success status returns no blockers (normal flow)', () => {
+  const result = simulateMergeBlockers({
+    ciStatusStatus: 'success',
+    prMergeable: true,
+    repoHasWorkflows: true,
+    workflowRunsCount: 1,
+  });
+
+  assert(result.blockers.length === 0, 'Should have no blockers');
+  assert(result.noCiConfigured === false, 'noCiConfigured should be false');
+  assert(result.noCiTriggered === false, 'noCiTriggered should be false');
+});
+
+test('CI pending status returns blocker (normal flow)', () => {
+  const result = simulateMergeBlockers({
+    ciStatusStatus: 'pending',
+    prMergeable: true,
+    repoHasWorkflows: true,
+    workflowRunsCount: 1,
+  });
+
+  assert(result.blockers.length === 1, 'Should have 1 blocker');
+  assert(result.blockers[0].type === 'ci_pending', 'Should be ci_pending');
+  assert(result.noCiTriggered === false, 'noCiTriggered should be false');
+});
+
+// ===== Test: Workflow runs count edge cases =====
+console.log('\n📋 Workflow Runs Edge Cases\n');
+
+test('Single workflow run → genuine race condition (wait for check-runs)', () => {
+  const result = simulateMergeBlockers({
+    ciStatusStatus: 'no_checks',
+    prMergeable: true,
+    repoHasWorkflows: true,
+    workflowRunsCount: 1,
+  });
+
+  assert(result.blockers.length === 1, 'Should have 1 blocker');
+  assert(result.blockers[0].message.includes('1 workflow run(s) triggered'), `Message should mention 1 workflow run`);
+  assert(result.noCiTriggered === false, 'Should not flag noCiTriggered');
+});
+
+test('Multiple workflow runs → genuine race condition (wait for check-runs)', () => {
+  const result = simulateMergeBlockers({
+    ciStatusStatus: 'no_checks',
+    prMergeable: true,
+    repoHasWorkflows: true,
+    workflowRunsCount: 5,
+  });
+
+  assert(result.blockers.length === 1, 'Should have 1 blocker');
+  assert(result.blockers[0].message.includes('5 workflow run(s) triggered'), `Message should mention 5 workflow runs`);
+  assert(result.noCiTriggered === false, 'Should not flag noCiTriggered');
+});
+
+test('Zero workflow runs with multiple workflows → CI not triggered', () => {
+  // Repo has 3 workflows but none triggered for this commit
+  const result = simulateMergeBlockers({
+    ciStatusStatus: 'no_checks',
+    prMergeable: true,
+    repoHasWorkflows: true,
+    workflowRunsCount: 0,
+  });
+
+  assert(result.noCiTriggered === true, 'Should flag noCiTriggered');
+  assert(result.blockers.length === 0, 'Should have no blockers');
+});
+
+// ===== Test: Advantage over timeout approach =====
+console.log('\n📋 Advantage Over Timeout Approach\n');
+
+test('Detection is immediate — no need to wait 10 iterations', () => {
+  // With the old timeout approach, this would wait 10 iterations (~10 minutes).
+  // With the new approach, it exits on the very first check.
+  const result = simulateMergeBlockers({
+    ciStatusStatus: 'no_checks',
+    prMergeable: true,
+    repoHasWorkflows: true,
+    workflowRunsCount: 0,
+  });
+
+  assert(result.noCiTriggered === true, 'Should detect immediately, not after timeout');
+  assert(result.blockers.length === 0, 'No need to add blockers and wait');
+});
+
+test('Genuine race condition still waits (no false positives)', () => {
+  // When workflow runs ARE triggered but check-runs haven't appeared yet,
+  // we correctly identify this as a race condition and wait
+  const result = simulateMergeBlockers({
+    ciStatusStatus: 'no_checks',
+    prMergeable: true,
+    repoHasWorkflows: true,
+    workflowRunsCount: 1,
+  });
+
+  assert(result.noCiTriggered === false, 'Should NOT flag as not triggered');
+  assert(result.blockers.length === 1, 'Should wait for check-runs to appear');
 });
 
 // Summary


### PR DESCRIPTION
## Summary

Fixes #1442

When `--auto-restart-until-mergeable` monitors a PR, it checks for CI status. If a repository has active GitHub Actions workflows but no CI check-runs appear for the PR's HEAD SHA, the code previously assumed this was a transient race condition and kept waiting **indefinitely**.

### The reviewer's key question

> Does GitHub API have a clear answer whether CI/CD will ever be started on the commit? Do we really need to use any timeouts?

**Answer: Yes, and no.** The GitHub Actions workflow runs API (`GET /repos/{owner}/{repo}/actions/runs?head_sha={sha}`) definitively shows whether any workflow runs were triggered for a specific commit:
- `workflow_runs.length > 0` → CI was triggered, check-runs will appear soon (genuine race condition — keep waiting)
- `workflow_runs.length === 0` → CI was NOT triggered (exit immediately, nothing to wait for)

This eliminates the need for any timeout-based detection.

### Changes

- **`src/solve.auto-merge.lib.mjs`**: In `getMergeBlockers()`, when `no_checks` + `MERGEABLE` + `hasWorkflows`, now checks `getWorkflowRunsForSha()` to determine if workflow runs were triggered:
  - If workflow runs exist → genuine race condition (wait for check-runs)
  - If zero workflow runs → CI not triggered (return `noCiTriggered: true`, exit immediately)
  - Removed timeout counter, `consecutiveNoCIChecksIterations`, `repoHasWorkflows` cache
  - Simplified `watchUntilMergeable()` by removing timeout logic (~120 lines removed)

- **`src/solve.config.lib.mjs`**: Removed `--no-ci-checks-timeout` option (no longer needed)

- **`tests/test-no-ci-checks-timeout-1442.mjs`**: Rewritten 14 unit tests covering:
  - Four-way CI detection: not-mergeable, no-workflows, has-workflow-runs, no-workflow-runs
  - Exact reproduction of issue #1442 scenario (BinDiffSynchronizer fork PR)
  - Existing behavior preservation (issues #1335, #1363)
  - Edge cases and advantage over timeout approach

- **`docs/case-studies/issue-1442/README.md`**: Updated with new approach details

### Root Cause

```
watchUntilMergeable() → getMergeBlockers() → getDetailedCIStatus() returns 'no_checks'
  → checkPRMergeable() returns mergeable=true
  → getActiveRepoWorkflows() returns hasWorkflows=true
  → [OLD] Returns ci_pending blocker → waits forever
  → [NEW] getWorkflowRunsForSha() returns [] → noCiTriggered=true → exits immediately
```

### Four-way discrimination (new)

| CI Status | PR Mergeable | Has Workflows | Workflow Runs | Result |
|-----------|-------------|---------------|---------------|--------|
| no_checks | NO | * | * | Wait (pending race condition) |
| no_checks | YES | NO | * | Exit: no CI configured |
| no_checks | YES | YES | > 0 | Wait (genuine race condition) |
| no_checks | YES | YES | 0 | **Exit: CI not triggered** ← NEW |

## Test plan

- [x] All 14 new unit tests pass (`node tests/test-no-ci-checks-timeout-1442.mjs`)
- [x] All 12 existing related tests pass (`node tests/test-false-positive-ready-to-merge-1363.mjs`)
- [x] Full test suite passes (`npm test`)
- [x] ESLint + Prettier pass on changed files
- [ ] CI pipeline passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)