### PR TITLE
fix: update message on session finish (#1530)

### DIFF
--- a/.changeset/fix-session-finish-message-1530.md
+++ b/.changeset/fix-session-finish-message-1530.md
@@ -1,0 +1,5 @@
+---
+'@link-assistant/hive-mind': patch
+---
+
+Fix session finish message update not working (#1530): pass --auto-terminate to start-screen so screen sessions terminate when the command finishes, enabling completion detection via session monitoring. Remove misleading notification promise text. Add verbose logging to session monitoring.

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,1 +1,0 @@
-# .gitkeep file auto-generated at 2026-04-06T09:44:39.128Z for PR creation at branch issue-1530-4a26ca5709fb for issue https://github.com/link-assistant/hive-mind/issues/1530

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,0 +1,1 @@
+# .gitkeep file auto-generated at 2026-04-06T09:44:39.128Z for PR creation at branch issue-1530-4a26ca5709fb for issue https://github.com/link-assistant/hive-mind/issues/1530

--- a/docs/case-studies/issue-1530/README.md
+++ b/docs/case-studies/issue-1530/README.md
@@ -1,0 +1,75 @@
+# Case Study: Issue #1530 — Update message on session finish does not work
+
+## Problem Statement
+
+When a `/solve` command is executed via Telegram, the bot sends a message:
+```
+✅ Solve command started successfully!
+📊 Session: solve-link-assistant-web-capture-9
+🔔 You will receive a notification when the session finishes.
+```
+
+However, the message is **never updated** when the session finishes. The notification promise is misleading.
+
+## Timeline of Events
+
+1. **08:06:49 UTC** — User sends `/solve https://github.com/link-assistant/web-capture/pull/9` in Telegram
+2. **08:06:49 UTC** — Bot receives command, starts `start-screen` to launch solve in a screen session
+3. **08:06:49 UTC** — Bot calls `trackSession("solve-link-assistant-web-capture-9", ...)` with `messageId` in the in-memory `activeSessions` Map
+4. **08:06:49 UTC** — Bot edits Telegram message to show "🔔 You will receive a notification..."
+5. **08:07:09 UTC** — Claude Code starts executing inside the screen session
+6. **08:19:56 UTC** — Solve command completes successfully with `✅ Process completed`
+7. **08:19:56+ UTC** — Session monitoring polls `screen -ls` every 30 seconds
+8. **Never** — Session is detected as finished → notification is never sent
+
+## Root Cause Analysis
+
+### Primary Root Cause: Screen session persists after command completion
+
+In `src/start-screen.mjs` (line 200), when `autoTerminate` is `false` (the default), the screen session is created as:
+
+```javascript
+screenCommand = `screen -dmS ${sessionName} bash -c '${escapedCommand}; exec bash'`;
+```
+
+The `; exec bash` ensures the screen session **stays alive** after the solve command finishes. This is intentional (allows reattachment for review), but it breaks session monitoring.
+
+The session monitor in `src/session-monitor.lib.mjs` (`monitorSessions`, line 156-216) checks:
+```javascript
+stillRunning = await checkScreenSessionExists(sessionName); // Uses `screen -ls`
+```
+
+Since the screen session persists indefinitely (bash shell remains), `checkScreenSessionExists` always returns `true`, and the completion notification is **never triggered**.
+
+### Secondary Root Cause: In-memory session store
+
+Session tracking data is stored in a JavaScript `Map` (`activeSessions` at line 34 of `session-monitor.lib.mjs`). If the bot process restarts during the 10-20 minutes a solve session typically runs, all tracking data is lost permanently.
+
+### Contributing Factor: No `--auto-terminate` flag passed
+
+The Telegram bot (`src/telegram-bot.mjs`, `executeStartScreen` function at line 347) calls `start-screen` without `--auto-terminate`, so the default behavior (persistent session) is always used.
+
+## Evidence
+
+- **Session log**: Full log available at the [gist](https://gist.githubusercontent.com/konard/f124db87ef8bee931033804aeae863e3/raw/8f3e7a4039139025f741163563b66c7d8fb3eef0/2342752c-2639-4d23-9689-b977ec29dbd9.log)
+- **Screenshot**: Shows Telegram message with notification promise but no update (see issue #1530)
+- **Code evidence**: `start-screen.mjs:200` shows `exec bash` keeping session alive; `telegram-bot.mjs` never passes `--auto-terminate`
+
+## Solution
+
+### Fix 1: Pass `--auto-terminate` when starting sessions from Telegram bot
+
+When the bot starts a solve session via `start-screen`, it should pass `--auto-terminate` so the screen session terminates when the command finishes. This allows `screen -ls` based monitoring to detect completion.
+
+### Fix 2: Improve session monitoring with verbose logging
+
+Add detailed logging to `monitorSessions` to track what happens during each monitoring cycle, making future debugging easier.
+
+### Fix 3: Remove misleading notification promise from message
+
+Instead of promising "🔔 You will receive a notification when the session finishes", change the message text to avoid the broken promise. The notification should happen automatically when the fix works.
+
+## Related Issues
+
+- Issue #380: Original session monitoring implementation
+- Issue #1062: Bug where `messageInfo` was cleared before use in queue path (fixed)

--- a/docs/case-studies/issue-1530/README.md
+++ b/docs/case-studies/issue-1530/README.md
@@ -3,6 +3,7 @@
 ## Problem Statement
 
 When a `/solve` command is executed via Telegram, the bot sends a message:
+
 ```
 ✅ Solve command started successfully!
 📊 Session: solve-link-assistant-web-capture-9
@@ -35,6 +36,7 @@ screenCommand = `screen -dmS ${sessionName} bash -c '${escapedCommand}; exec bas
 The `; exec bash` ensures the screen session **stays alive** after the solve command finishes. This is intentional (allows reattachment for review), but it breaks session monitoring.
 
 The session monitor in `src/session-monitor.lib.mjs` (`monitorSessions`, line 156-216) checks:
+
 ```javascript
 stillRunning = await checkScreenSessionExists(sessionName); // Uses `screen -ls`
 ```

--- a/src/session-monitor.lib.mjs
+++ b/src/session-monitor.lib.mjs
@@ -170,13 +170,23 @@ export async function monitorSessions(bot, verbose = false) {
 
     if (sessionInfo.isolationBackend && sessionInfo.sessionId) {
       // Isolation mode: use $ --status for reliable tracking
+      if (verbose) {
+        console.log(`[VERBOSE] Session ${sessionName}: checking isolation status (backend: ${sessionInfo.isolationBackend}, id: ${sessionInfo.sessionId})`);
+      }
       stillRunning = await checkIsolatedSessionRunning(sessionInfo.sessionId, verbose);
       if (!stillRunning) {
         exitCode = await getIsolatedSessionExitCode(sessionInfo.sessionId, verbose);
       }
     } else {
       // Screen mode: use screen -ls for detection
+      if (verbose) {
+        console.log(`[VERBOSE] Session ${sessionName}: checking screen session existence`);
+      }
       stillRunning = await checkScreenSessionExists(sessionName);
+    }
+
+    if (verbose) {
+      console.log(`[VERBOSE] Session ${sessionName}: stillRunning=${stillRunning}, exitCode=${exitCode}, messageId=${sessionInfo.messageId}`);
     }
 
     if (!stillRunning) {
@@ -199,11 +209,21 @@ export async function monitorSessions(bot, verbose = false) {
         message += `🔗 URL: ${sessionInfo.url}${isolationInfo}\n\n`;
         message += `The work session has finished. You can now review the results.`;
 
+        if (verbose) {
+          console.log(`[VERBOSE] Session ${sessionName}: sending completion notification (messageId: ${sessionInfo.messageId}, chatId: ${sessionInfo.chatId})`);
+        }
+
         // Update the original reply message if messageId is available, otherwise send new message
         if (sessionInfo.messageId) {
           await bot.telegram.editMessageText(sessionInfo.chatId, sessionInfo.messageId, undefined, message, { parse_mode: 'Markdown' });
+          if (verbose) {
+            console.log(`[VERBOSE] Session ${sessionName}: updated original message ${sessionInfo.messageId}`);
+          }
         } else {
           await bot.telegram.sendMessage(sessionInfo.chatId, message, { parse_mode: 'Markdown' });
+          if (verbose) {
+            console.log(`[VERBOSE] Session ${sessionName}: sent new notification message`);
+          }
         }
 
         completeSession(sessionName, exitCode || 0, verbose);

--- a/src/telegram-bot.mjs
+++ b/src/telegram-bot.mjs
@@ -379,7 +379,9 @@ async function executeStartScreen(command, args) {
 
 function executeWithCommand(startScreenCmd, command, args) {
   return new Promise(resolve => {
-    const allArgs = [command, ...args];
+    // Pass --auto-terminate so the screen session terminates when the command finishes,
+    // allowing session monitoring to detect completion via `screen -ls` (issue #1530)
+    const allArgs = ['--auto-terminate', command, ...args];
 
     if (VERBOSE) {
       console.log(`[VERBOSE] Executing: ${startScreenCmd} ${allArgs.join(' ')}`);
@@ -613,7 +615,7 @@ async function executeAndUpdateMessage(ctx, startingMessage, commandName, args, 
     if (result.success && session !== 'unknown') trackSession(session, { chatId: ctx.chat.id, messageId: msgId, startTime: new Date(), url: args[0], command: commandName }, VERBOSE);
   }
   if (result.warning) return safeEdit(`⚠️  ${result.warning}`);
-  if (result.success) await safeEdit(`✅ ${commandName.charAt(0).toUpperCase() + commandName.slice(1)} command started successfully!\n\n📊 Session: \`${session}\`${extraInfo}\n\n${infoBlock}\n\n🔔 You will receive a notification when the session finishes.`);
+  if (result.success) await safeEdit(`✅ ${commandName.charAt(0).toUpperCase() + commandName.slice(1)} command started successfully!\n\n📊 Session: \`${session}\`${extraInfo}\n\n${infoBlock}`);
   else await safeEdit(`❌ Error executing ${commandName} command:\n\n\`\`\`\n${result.error || result.output}\n\`\`\``);
 }
 

--- a/src/telegram-bot.mjs
+++ b/src/telegram-bot.mjs
@@ -379,9 +379,7 @@ async function executeStartScreen(command, args) {
 
 function executeWithCommand(startScreenCmd, command, args) {
   return new Promise(resolve => {
-    // Pass --auto-terminate so the screen session terminates when the command finishes,
-    // allowing session monitoring to detect completion via `screen -ls` (issue #1530)
-    const allArgs = ['--auto-terminate', command, ...args];
+    const allArgs = ['--auto-terminate', command, ...args]; // issue #1530: terminate screen session on finish for monitoring
 
     if (VERBOSE) {
       console.log(`[VERBOSE] Executing: ${startScreenCmd} ${allArgs.join(' ')}`);

--- a/tests/test-session-finish-message-update-1530.mjs
+++ b/tests/test-session-finish-message-update-1530.mjs
@@ -1,0 +1,111 @@
+#!/usr/bin/env node
+
+/**
+ * Test suite for session finish message update (issue #1530)
+ *
+ * Verifies that:
+ * 1. start-screen is called with --auto-terminate so screen sessions
+ *    terminate when the command finishes, enabling completion detection
+ * 2. The misleading "You will receive a notification" text is not present
+ * 3. Session monitoring logs verbose output for debugging
+ *
+ * @see https://github.com/link-assistant/hive-mind/issues/1530
+ */
+
+import { readFileSync } from 'fs';
+import { fileURLToPath } from 'url';
+import { dirname, join } from 'path';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+
+let testsPassed = 0;
+let testsFailed = 0;
+
+function runTest(name, testFn) {
+  process.stdout.write(`Testing ${name}... `);
+  try {
+    testFn();
+    console.log('✅ PASSED');
+    testsPassed++;
+  } catch (error) {
+    console.log(`❌ FAILED: ${error.message}`);
+    testsFailed++;
+  }
+}
+
+function assert(condition, message) {
+  if (!condition) throw new Error(message);
+}
+
+// Read source files for static analysis
+const telegramBotSource = readFileSync(join(__dirname, '..', 'src', 'telegram-bot.mjs'), 'utf-8');
+const sessionMonitorSource = readFileSync(join(__dirname, '..', 'src', 'session-monitor.lib.mjs'), 'utf-8');
+
+console.log('Testing session finish message update (issue #1530)');
+console.log('='.repeat(60));
+
+// Test 1: --auto-terminate flag is passed to start-screen
+runTest('executeWithCommand passes --auto-terminate to start-screen', () => {
+  // The executeWithCommand function should include --auto-terminate in the allArgs array
+  // so that screen sessions terminate when the command finishes
+  assert(telegramBotSource.includes("'--auto-terminate'"), "executeWithCommand should pass '--auto-terminate' flag");
+
+  // Verify it's in the allArgs construction
+  assert(telegramBotSource.includes("const allArgs = ['--auto-terminate', command, ...args]"), "allArgs should start with '--auto-terminate' before command and args");
+});
+
+// Test 2: No misleading "notification" text in messages
+runTest('no misleading notification promise in Telegram message', () => {
+  assert(!telegramBotSource.includes('You will receive a notification when the session finishes'), 'Should not contain "You will receive a notification when the session finishes" text');
+});
+
+// Test 3: Session monitoring has verbose logging for status checks
+runTest('session monitor has verbose logging for screen mode checks', () => {
+  assert(sessionMonitorSource.includes('checking screen session existence'), 'Should log when checking screen session existence in verbose mode');
+});
+
+runTest('session monitor has verbose logging for isolation mode checks', () => {
+  assert(sessionMonitorSource.includes('checking isolation status'), 'Should log when checking isolation status in verbose mode');
+});
+
+runTest('session monitor has verbose logging for stillRunning result', () => {
+  assert(sessionMonitorSource.includes('stillRunning='), 'Should log stillRunning result in verbose mode');
+});
+
+runTest('session monitor has verbose logging for completion notification', () => {
+  assert(sessionMonitorSource.includes('sending completion notification'), 'Should log when sending completion notification in verbose mode');
+});
+
+// Test 4: Session monitoring still updates message on completion
+runTest('session monitor updates message via editMessageText on completion', () => {
+  assert(sessionMonitorSource.includes('editMessageText'), 'Should use editMessageText to update the original message on completion');
+});
+
+runTest('session monitor sends new message when no messageId available', () => {
+  assert(sessionMonitorSource.includes('sendMessage'), 'Should use sendMessage when messageId is not available');
+});
+
+// Test 5: Session monitor correctly checks exit code for status
+runTest('session monitor shows exit code in failure message', () => {
+  assert(sessionMonitorSource.includes('exit code:'), 'Should show exit code in failure status message');
+});
+
+// Test 6: Verify the success message still contains session info
+runTest('success message still contains session info', () => {
+  // The success message should have session name and info block
+  assert(telegramBotSource.includes('command started successfully!'), 'Should contain "command started successfully!" in success message');
+  assert(telegramBotSource.includes('Session:'), 'Should contain session info in success message');
+});
+
+// Results
+console.log('\n' + '='.repeat(60));
+console.log(`Results: ${testsPassed} passed, ${testsFailed} failed, ${testsPassed + testsFailed} total`);
+console.log('='.repeat(60));
+
+if (testsFailed > 0) {
+  console.error(`\n❌ ${testsFailed} test(s) failed!`);
+  process.exit(1);
+} else {
+  console.log('\n✅ All tests passed!');
+}


### PR DESCRIPTION
## Summary

Fixes #1530 — The Telegram message promising "🔔 You will receive a notification when the session finishes" was never updated because session monitoring could not detect when the solve command completed.

### Root Cause

In `src/start-screen.mjs` (line 200), screen sessions are created with `exec bash` at the end:
```javascript
screenCommand = `screen -dmS ${sessionName} bash -c '${escapedCommand}; exec bash'`;
```

This keeps the screen session alive after the solve command finishes (by design, for reattachment). However, the session monitor in `src/session-monitor.lib.mjs` checks `screen -ls` to detect completion — since the screen session never terminates, completion was never detected, and the notification was never sent.

The bot (`telegram-bot.mjs`) never passes `--auto-terminate` to `start-screen`, so the persistent session behavior was always used.

### Changes

**`src/telegram-bot.mjs`:**
- Pass `--auto-terminate` to `start-screen` via `executeWithCommand()` so screen sessions terminate when the solve command finishes, enabling `screen -ls` based completion detection
- Remove misleading "🔔 You will receive a notification when the session finishes" text from the success message — the notification now happens automatically when the session monitor detects completion

**`src/session-monitor.lib.mjs`:**
- Add verbose logging throughout `monitorSessions()` for easier debugging: session type checks, stillRunning results, notification sending, and message update status

**`tests/test-session-finish-message-update-1530.mjs`:**
- 10 tests verifying: `--auto-terminate` flag is passed, notification text is removed, verbose logging is present, message update paths are intact

**`docs/case-studies/issue-1530/README.md`:**
- Root cause analysis with timeline reconstruction and evidence

### Test plan
- [x] All 10 new tests pass (`node tests/test-session-finish-message-update-1530.mjs`)
- [x] All 8 existing session monitor tests pass (`node tests/test-session-monitor-isolation.mjs`)
- [x] Full `npm test` passes (41 tests)
- [x] ESLint passes on changed source files
- [x] Prettier formatting passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)