### PR TITLE
feat: better cost display in GitHub comments (#1557)

### DIFF
--- a/.changeset/feat-simplified-cost-display-1557.md
+++ b/.changeset/feat-simplified-cost-display-1557.md
@@ -1,0 +1,5 @@
+---
+'@link-assistant/hive-mind': patch
+---
+
+Simplified cost display when public and Anthropic costs match, removed USD suffix from Anthropic cost line

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,0 +1,1 @@
+# .gitkeep file auto-generated at 2026-04-10T11:09:28.250Z for PR creation at branch issue-1557-acde5fc55612 for issue https://github.com/link-assistant/hive-mind/issues/1557

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,1 +1,0 @@
-# .gitkeep file auto-generated at 2026-04-10T11:09:28.250Z for PR creation at branch issue-1557-acde5fc55612 for issue https://github.com/link-assistant/hive-mind/issues/1557

--- a/docs/case-studies/issue-1557/README.md
+++ b/docs/case-studies/issue-1557/README.md
@@ -1,0 +1,87 @@
+# Case Study: Issue #1557 - Better Cost Display in GitHub Comments
+
+## Summary
+
+The cost estimation section in GitHub PR/issue comments was verbose and showed redundant information when the public pricing estimate matched the Anthropic-calculated cost. The display showed a full breakdown (Public pricing estimate, Calculated by Anthropic, Difference: $0.000000) even when the difference was zero, adding visual clutter without value.
+
+## Problem Description
+
+### Before (verbose, redundant display when costs match)
+
+```markdown
+### 💰 **Cost estimation:**
+- Public pricing estimate: $5.207635
+- Calculated by Anthropic: $5.207635 USD
+- Difference: $0.000000 (0.00%)
+```
+
+Issues:
+1. **Redundant information**: When both calculations agree, showing both values plus a zero difference is noise
+2. **Unnecessary "USD" suffix**: The "Calculated by Anthropic" line included a "USD" suffix not present on other cost lines, creating inconsistency
+3. **Visual clutter**: Three lines of cost data when a single line would suffice
+
+### After (simplified when costs match)
+
+```markdown
+### 💰 Cost: **$5.207635**
+```
+
+When there IS a difference:
+
+```markdown
+### 💰 **Cost estimation:**
+- Public pricing estimate: $5.207635
+- Calculated by Anthropic: $5.207636
+- Difference: $0.000001 (+0.00%)
+```
+
+## Requirements Analysis
+
+| # | Requirement | Source |
+|---|-------------|--------|
+| 1 | Remove "USD" suffix from "Calculated by Anthropic" line | Issue description |
+| 2 | When costs match: show simplified `💰 Cost: **$X.XXXXXX**` header | Issue description |
+| 3 | When costs differ: show full breakdown with Public/Anthropic/Difference | Issue description |
+| 4 | Apply changes to all tools (agent, claude, codex) | Issue description |
+| 5 | Bold formatting for cost value in simplified display | Issue description |
+
+## Root Cause Analysis
+
+### Affected Components
+
+| File | Function | Role |
+|------|----------|------|
+| `src/github.lib.mjs` | `buildCostInfoString()` | Generates cost markdown for GitHub comments (used by all tools) |
+| `src/claude.budget-stats.lib.mjs` | `displayCostComparison()` | Displays cost comparison in terminal/log output |
+| `tests/test-build-cost-info-string.mjs` | Test suite | Unit tests for `buildCostInfoString()` |
+
+### Architecture
+
+All tools (agent, claude, codex) share the same `buildCostInfoString()` function in `src/github.lib.mjs` for generating cost information in GitHub comments. The `displayCostComparison()` function in `src/claude.budget-stats.lib.mjs` handles the equivalent terminal output. Fixing these two functions applies the change across all tools.
+
+## Solution
+
+### Approach
+
+1. **Early return for matching costs**: Added a check at the top of `buildCostInfoString()` that compares `totalCostUSD.toFixed(6)` with `anthropicTotalCostUSD.toFixed(6)`. When they match, return the simplified format immediately.
+
+2. **Removed "USD" suffix**: Changed the Anthropic cost line from `$X.XXXXXX USD` to `$X.XXXXXX` for consistency with other cost lines.
+
+3. **Applied same logic to terminal output**: Updated `displayCostComparison()` with the same matching-costs check and USD removal.
+
+### Key Design Decisions
+
+- **String comparison of `.toFixed(6)`**: Used string equality of formatted values (rather than numeric equality) to match costs. This ensures that values like `5.2076351` and `5.2076349` that round to the same 6-decimal display are treated as matching.
+- **Simplified format ignores model/token info**: When costs match, only the cost value is shown. Model name, provider, and token usage are omitted for maximum brevity. This is intentional — the cost is the headline.
+
+## Testing
+
+- 48 unit tests passing (6 new tests added for Issue #1557)
+- New tests cover: exact match, real-world match, slight difference, single-cost scenarios, and USD removal verification
+- All existing tests updated to expect no "USD" suffix
+
+## Related Issues
+
+- Issue #1015: Original cost estimation display implementation
+- Issue #1250: OpenCode Zen cost and base model pricing support
+- Issue #1448: Cost estimation header formatting improvements

--- a/docs/case-studies/issue-1557/README.md
+++ b/docs/case-studies/issue-1557/README.md
@@ -10,12 +10,14 @@ The cost estimation section in GitHub PR/issue comments was verbose and showed r
 
 ```markdown
 ### 💰 **Cost estimation:**
+
 - Public pricing estimate: $5.207635
 - Calculated by Anthropic: $5.207635 USD
 - Difference: $0.000000 (0.00%)
 ```
 
 Issues:
+
 1. **Redundant information**: When both calculations agree, showing both values plus a zero difference is noise
 2. **Unnecessary "USD" suffix**: The "Calculated by Anthropic" line included a "USD" suffix not present on other cost lines, creating inconsistency
 3. **Visual clutter**: Three lines of cost data when a single line would suffice
@@ -30,6 +32,7 @@ When there IS a difference:
 
 ```markdown
 ### 💰 **Cost estimation:**
+
 - Public pricing estimate: $5.207635
 - Calculated by Anthropic: $5.207636
 - Difference: $0.000001 (+0.00%)
@@ -37,23 +40,23 @@ When there IS a difference:
 
 ## Requirements Analysis
 
-| # | Requirement | Source |
-|---|-------------|--------|
-| 1 | Remove "USD" suffix from "Calculated by Anthropic" line | Issue description |
-| 2 | When costs match: show simplified `💰 Cost: **$X.XXXXXX**` header | Issue description |
-| 3 | When costs differ: show full breakdown with Public/Anthropic/Difference | Issue description |
-| 4 | Apply changes to all tools (agent, claude, codex) | Issue description |
-| 5 | Bold formatting for cost value in simplified display | Issue description |
+| #   | Requirement                                                             | Source            |
+| --- | ----------------------------------------------------------------------- | ----------------- |
+| 1   | Remove "USD" suffix from "Calculated by Anthropic" line                 | Issue description |
+| 2   | When costs match: show simplified `💰 Cost: **$X.XXXXXX**` header       | Issue description |
+| 3   | When costs differ: show full breakdown with Public/Anthropic/Difference | Issue description |
+| 4   | Apply changes to all tools (agent, claude, codex)                       | Issue description |
+| 5   | Bold formatting for cost value in simplified display                    | Issue description |
 
 ## Root Cause Analysis
 
 ### Affected Components
 
-| File | Function | Role |
-|------|----------|------|
-| `src/github.lib.mjs` | `buildCostInfoString()` | Generates cost markdown for GitHub comments (used by all tools) |
-| `src/claude.budget-stats.lib.mjs` | `displayCostComparison()` | Displays cost comparison in terminal/log output |
-| `tests/test-build-cost-info-string.mjs` | Test suite | Unit tests for `buildCostInfoString()` |
+| File                                    | Function                  | Role                                                            |
+| --------------------------------------- | ------------------------- | --------------------------------------------------------------- |
+| `src/github.lib.mjs`                    | `buildCostInfoString()`   | Generates cost markdown for GitHub comments (used by all tools) |
+| `src/claude.budget-stats.lib.mjs`       | `displayCostComparison()` | Displays cost comparison in terminal/log output                 |
+| `tests/test-build-cost-info-string.mjs` | Test suite                | Unit tests for `buildCostInfoString()`                          |
 
 ### Architecture
 

--- a/src/claude.budget-stats.lib.mjs
+++ b/src/claude.budget-stats.lib.mjs
@@ -118,15 +118,23 @@ export const displayModelUsage = async (usage, log) => {
 
 /**
  * Display cost comparison between public pricing and Anthropic's official cost
+ * Issue #1557: Show simplified format when costs match, remove USD suffix
  * @param {number|null} publicCost - Public pricing estimate
  * @param {number|null} anthropicCost - Anthropic's official cost
  * @param {Function} log - Logging function
  */
 export const displayCostComparison = async (publicCost, anthropicCost, log) => {
+  const hasPublic = publicCost !== null && publicCost !== undefined;
+  const hasAnthropic = anthropicCost !== null && anthropicCost !== undefined;
+  // Issue #1557: When both costs match, show simplified format
+  if (hasPublic && hasAnthropic && publicCost.toFixed(6) === anthropicCost.toFixed(6)) {
+    await log(`\n   💰 Cost: $${anthropicCost.toFixed(6)}`);
+    return;
+  }
   await log('\n   💰 Cost estimation:');
-  await log(`      Public pricing estimate: ${publicCost !== null && publicCost !== undefined ? `$${publicCost.toFixed(6)} USD` : 'unknown'}`);
-  await log(`      Calculated by Anthropic: ${anthropicCost !== null && anthropicCost !== undefined ? `$${anthropicCost.toFixed(6)} USD` : 'unknown'}`);
-  if (publicCost !== null && publicCost !== undefined && anthropicCost !== null && anthropicCost !== undefined) {
+  await log(`      Public pricing estimate: ${hasPublic ? `$${publicCost.toFixed(6)}` : 'unknown'}`);
+  await log(`      Calculated by Anthropic: ${hasAnthropic ? `$${anthropicCost.toFixed(6)}` : 'unknown'}`);
+  if (hasPublic && hasAnthropic) {
     const difference = anthropicCost - publicCost;
     const percentDiff = publicCost > 0 ? (difference / publicCost) * 100 : 0;
     await log(`      Difference:              $${difference.toFixed(6)} (${percentDiff > 0 ? '+' : ''}${percentDiff.toFixed(2)}%)`);

--- a/src/github.lib.mjs
+++ b/src/github.lib.mjs
@@ -15,13 +15,18 @@ import { getToolDisplayName, getModelInfoForComment } from './models/index.mjs';
 export { getToolDisplayName }; // Re-export for use by other modules
 import { buildBudgetStatsString } from './claude.budget-stats.lib.mjs';
 
-/** Build cost estimation string for log comments (Issue #1250) */
+/** Build cost estimation string for log comments (Issue #1250, Issue #1557) */
 const buildCostInfoString = (totalCostUSD, anthropicTotalCostUSD, pricingInfo) => {
   const hasPublic = totalCostUSD !== null && totalCostUSD !== undefined;
   const hasAnthropic = anthropicTotalCostUSD !== null && anthropicTotalCostUSD !== undefined;
   const hasPricing = pricingInfo && (pricingInfo.modelName || pricingInfo.tokenUsage || pricingInfo.isFreeModel || pricingInfo.isOpencodeFreeModel);
   const hasOpencodeCost = pricingInfo?.opencodeCost !== null && pricingInfo?.opencodeCost !== undefined;
   if (!hasPublic && !hasAnthropic && !hasPricing && !hasOpencodeCost) return '';
+  // Issue #1557: When both public and Anthropic costs match (no difference), show simplified format
+  const costsMatch = hasPublic && hasAnthropic && totalCostUSD.toFixed(6) === anthropicTotalCostUSD.toFixed(6);
+  if (costsMatch) {
+    return `\n\n### 💰 Cost: **$${anthropicTotalCostUSD.toFixed(6)}**`;
+  }
   let costInfo = '\n\n### 💰 **Cost estimation:**';
   if (pricingInfo?.modelName) {
     costInfo += `\n- Model: ${pricingInfo.modelName}`;
@@ -57,7 +62,7 @@ const buildCostInfoString = (totalCostUSD, anthropicTotalCostUSD, pricingInfo) =
     costInfo += tokenInfo;
   }
   if (hasAnthropic) {
-    costInfo += `\n- Calculated by Anthropic: $${anthropicTotalCostUSD.toFixed(6)} USD`;
+    costInfo += `\n- Calculated by Anthropic: $${anthropicTotalCostUSD.toFixed(6)}`;
     if (hasPublic) {
       const diff = anthropicTotalCostUSD - totalCostUSD;
       const pct = totalCostUSD > 0 ? (diff / totalCostUSD) * 100 : 0;

--- a/src/github.lib.mjs
+++ b/src/github.lib.mjs
@@ -22,11 +22,8 @@ const buildCostInfoString = (totalCostUSD, anthropicTotalCostUSD, pricingInfo) =
   const hasPricing = pricingInfo && (pricingInfo.modelName || pricingInfo.tokenUsage || pricingInfo.isFreeModel || pricingInfo.isOpencodeFreeModel);
   const hasOpencodeCost = pricingInfo?.opencodeCost !== null && pricingInfo?.opencodeCost !== undefined;
   if (!hasPublic && !hasAnthropic && !hasPricing && !hasOpencodeCost) return '';
-  // Issue #1557: When both public and Anthropic costs match (no difference), show simplified format
-  const costsMatch = hasPublic && hasAnthropic && totalCostUSD.toFixed(6) === anthropicTotalCostUSD.toFixed(6);
-  if (costsMatch) {
-    return `\n\n### 💰 Cost: **$${anthropicTotalCostUSD.toFixed(6)}**`;
-  }
+  // Issue #1557: Simplified display when public and Anthropic costs match
+  if (hasPublic && hasAnthropic && totalCostUSD.toFixed(6) === anthropicTotalCostUSD.toFixed(6)) return `\n\n### 💰 Cost: **$${anthropicTotalCostUSD.toFixed(6)}**`;
   let costInfo = '\n\n### 💰 **Cost estimation:**';
   if (pricingInfo?.modelName) {
     costInfo += `\n- Model: ${pricingInfo.modelName}`;
@@ -71,12 +68,8 @@ const buildCostInfoString = (totalCostUSD, anthropicTotalCostUSD, pricingInfo) =
   }
   return costInfo;
 };
-
-// Helper function to mask GitHub tokens (alias for backward compatibility)
-export const maskGitHubToken = maskToken;
-// Escape ``` in logs for safe markdown embedding (replaces with \`\`\` to prevent code block closure)
-export const escapeCodeBlocksInLog = logContent => logContent.replace(/```/g, '\\`\\`\\`');
-// Helper function to check if a file exists in a GitHub branch
+export const maskGitHubToken = maskToken; // Alias for backward compatibility
+export const escapeCodeBlocksInLog = logContent => logContent.replace(/```/g, '\\`\\`\\`'); // Escape ``` in logs
 export const checkFileInBranch = async (owner, repo, fileName, branchName) => {
   const { $ } = await use('command-stream');
 

--- a/tests/test-build-cost-info-string.mjs
+++ b/tests/test-build-cost-info-string.mjs
@@ -26,11 +26,8 @@ const buildCostInfoString = (totalCostUSD, anthropicTotalCostUSD, pricingInfo) =
   // Issue #1250: Check for OpenCode Zen actual cost
   const hasOpencodeCost = pricingInfo?.opencodeCost !== null && pricingInfo?.opencodeCost !== undefined;
   if (!hasPublic && !hasAnthropic && !hasPricing && !hasOpencodeCost) return '';
-  // Issue #1557: When both public and Anthropic costs match (no difference), show simplified format
-  const costsMatch = hasPublic && hasAnthropic && totalCostUSD.toFixed(6) === anthropicTotalCostUSD.toFixed(6);
-  if (costsMatch) {
-    return `\n\n### 💰 Cost: **$${anthropicTotalCostUSD.toFixed(6)}**`;
-  }
+  // Issue #1557: Simplified display when public and Anthropic costs match
+  if (hasPublic && hasAnthropic && totalCostUSD.toFixed(6) === anthropicTotalCostUSD.toFixed(6)) return `\n\n### 💰 Cost: **$${anthropicTotalCostUSD.toFixed(6)}**`;
   let costInfo = '\n\n### 💰 **Cost estimation:**';
   if (pricingInfo?.modelName) {
     costInfo += `\n- Model: ${pricingInfo.modelName}`;

--- a/tests/test-build-cost-info-string.mjs
+++ b/tests/test-build-cost-info-string.mjs
@@ -17,6 +17,7 @@
 // Copy of the buildCostInfoString function from src/github.lib.mjs for testing
 // This allows us to test the function in isolation without requiring the full module dependencies
 // Issue #1250: Enhanced to support OpenCode Zen cost, original provider reference, and base model pricing
+// Issue #1557: Simplified display when costs match, removed USD suffix
 const buildCostInfoString = (totalCostUSD, anthropicTotalCostUSD, pricingInfo) => {
   // Issue #1015: Don't show cost section when all values are unknown (clutters output)
   const hasPublic = totalCostUSD !== null && totalCostUSD !== undefined;
@@ -25,6 +26,11 @@ const buildCostInfoString = (totalCostUSD, anthropicTotalCostUSD, pricingInfo) =
   // Issue #1250: Check for OpenCode Zen actual cost
   const hasOpencodeCost = pricingInfo?.opencodeCost !== null && pricingInfo?.opencodeCost !== undefined;
   if (!hasPublic && !hasAnthropic && !hasPricing && !hasOpencodeCost) return '';
+  // Issue #1557: When both public and Anthropic costs match (no difference), show simplified format
+  const costsMatch = hasPublic && hasAnthropic && totalCostUSD.toFixed(6) === anthropicTotalCostUSD.toFixed(6);
+  if (costsMatch) {
+    return `\n\n### 💰 Cost: **$${anthropicTotalCostUSD.toFixed(6)}**`;
+  }
   let costInfo = '\n\n### 💰 **Cost estimation:**';
   if (pricingInfo?.modelName) {
     costInfo += `\n- Model: ${pricingInfo.modelName}`;
@@ -66,7 +72,7 @@ const buildCostInfoString = (totalCostUSD, anthropicTotalCostUSD, pricingInfo) =
     costInfo += tokenInfo;
   }
   if (hasAnthropic) {
-    costInfo += `\n- Calculated by Anthropic: $${anthropicTotalCostUSD.toFixed(6)} USD`;
+    costInfo += `\n- Calculated by Anthropic: $${anthropicTotalCostUSD.toFixed(6)}`;
     if (hasPublic) {
       const diff = anthropicTotalCostUSD - totalCostUSD;
       const pct = totalCostUSD > 0 ? (diff / totalCostUSD) * 100 : 0;
@@ -160,7 +166,8 @@ console.log('\n📋 Test Group: Anthropic calculated cost\n');
 
 runTest('shows Anthropic calculated cost when available', () => {
   const result = buildCostInfoString(null, 2.5, null);
-  assertContains(result, 'Calculated by Anthropic: $2.500000 USD', 'Should show Anthropic cost');
+  assertContains(result, 'Calculated by Anthropic: $2.500000', 'Should show Anthropic cost');
+  assertNotContains(result, 'USD', 'Should not contain USD suffix (Issue #1557)');
 });
 
 runTest('shows difference when both costs available (Anthropic higher)', () => {
@@ -173,14 +180,17 @@ runTest('shows difference when both costs available (Anthropic lower)', () => {
   assertContains(result, 'Difference: $-0.500000 (-25.00%)', 'Should show negative difference');
 });
 
-runTest('shows zero difference when costs are equal', () => {
+runTest('shows simplified format when costs are equal (Issue #1557)', () => {
   const result = buildCostInfoString(1.0, 1.0, null);
-  assertContains(result, 'Difference: $0.000000 (0.00%)', 'Should show zero difference');
+  assertEqual(result, '\n\n### 💰 Cost: **$1.000000**', 'Should show simplified cost header');
+  assertNotContains(result, 'Difference', 'Should not show difference when costs match');
+  assertNotContains(result, 'Public pricing estimate', 'Should not show breakdown when costs match');
 });
 
 runTest('handles zero public cost in percentage calculation', () => {
   const result = buildCostInfoString(0, 1.0, null);
   assertContains(result, 'Difference: $1.000000 (0.00%)', 'Should handle division by zero');
+  assertNotContains(result, 'USD', 'Should not contain USD suffix (Issue #1557)');
 });
 
 // ==== Pricing info tests ====
@@ -322,7 +332,8 @@ runTest('shows all information when everything is available', () => {
   assertContains(result, '1,000 reasoning', 'Should show reasoning tokens');
   assertContains(result, 'cache read', 'Should show cache read');
   assertContains(result, 'cache write', 'Should show cache write');
-  assertContains(result, 'Calculated by Anthropic: $1.200000 USD', 'Should have Anthropic cost');
+  assertContains(result, 'Calculated by Anthropic: $1.200000', 'Should have Anthropic cost');
+  assertNotContains(result, 'USD', 'Should not contain USD suffix (Issue #1557)');
   assertContains(result, 'Difference:', 'Should have difference');
 });
 
@@ -345,7 +356,8 @@ runTest('real-world example with actual work', () => {
   });
 
   assertContains(result, '$8.089715', 'Should show public cost');
-  assertContains(result, '$5.636999 USD', 'Should show Anthropic cost');
+  assertContains(result, 'Calculated by Anthropic: $5.636999', 'Should show Anthropic cost');
+  assertNotContains(result, 'USD', 'Should not contain USD suffix (Issue #1557)');
   assertContains(result, 'Difference: $-2.452716 (-30.32%)', 'Should show negative difference');
 });
 
@@ -366,7 +378,8 @@ runTest('handles large token counts', () => {
 runTest('handles very small costs', () => {
   const result = buildCostInfoString(0.000001, 0.000002, null);
   assertContains(result, '$0.000001', 'Should show small public cost');
-  assertContains(result, '$0.000002 USD', 'Should show small Anthropic cost');
+  assertContains(result, 'Calculated by Anthropic: $0.000002', 'Should show small Anthropic cost');
+  assertNotContains(result, 'USD', 'Should not contain USD suffix (Issue #1557)');
 });
 
 runTest('returns proper string format starting with newlines', () => {
@@ -560,9 +573,54 @@ runTest('does not show base model reference when no baseModelName', () => {
   assertNotContains(result, 'gpt-4o-mini prices', 'Should not reference model name in pricing');
 });
 
+// ==== Issue #1557: Simplified cost display ====
+console.log('\n📋 Test Group: Issue #1557 - Simplified cost display when costs match\n');
+
+runTest('shows simplified format when public and Anthropic costs match exactly', () => {
+  const result = buildCostInfoString(5.207635, 5.207635, null);
+  assertEqual(result, '\n\n### 💰 Cost: **$5.207635**', 'Should show simplified cost header with bold amount');
+});
+
+runTest('shows simplified format with real-world matching costs', () => {
+  const result = buildCostInfoString(0.123456, 0.123456, {
+    modelName: 'claude-3-opus',
+    provider: 'Anthropic',
+    tokenUsage: { inputTokens: 1000, outputTokens: 500 },
+  });
+  // Even with pricing info, simplified format is used when costs match
+  assertEqual(result, '\n\n### 💰 Cost: **$0.123456**', 'Should show simplified format ignoring model/token info');
+});
+
+runTest('shows full format when costs differ slightly', () => {
+  const result = buildCostInfoString(5.207635, 5.207636, null);
+  assertContains(result, '### 💰 **Cost estimation:**', 'Should show full header when costs differ');
+  assertContains(result, 'Public pricing estimate: $5.207635', 'Should show public estimate');
+  assertContains(result, 'Calculated by Anthropic: $5.207636', 'Should show Anthropic cost');
+  assertContains(result, 'Difference:', 'Should show difference');
+  assertNotContains(result, 'USD', 'Should not contain USD suffix');
+});
+
+runTest('does not show simplified format when only public cost available', () => {
+  const result = buildCostInfoString(5.0, null, null);
+  assertContains(result, '### 💰 **Cost estimation:**', 'Should show full header');
+  assertContains(result, 'Public pricing estimate: $5.000000', 'Should show public estimate');
+});
+
+runTest('does not show simplified format when only Anthropic cost available', () => {
+  const result = buildCostInfoString(null, 5.0, null);
+  assertContains(result, '### 💰 **Cost estimation:**', 'Should show full header');
+  assertContains(result, 'Calculated by Anthropic: $5.000000', 'Should show Anthropic cost');
+});
+
+runTest('no USD suffix in Anthropic cost line (Issue #1557)', () => {
+  const result = buildCostInfoString(1.0, 2.0, null);
+  assertContains(result, 'Calculated by Anthropic: $2.000000', 'Should show Anthropic cost');
+  assertNotContains(result, 'USD', 'Should not contain USD anywhere');
+});
+
 // Summary
 console.log('\n' + '='.repeat(80));
-console.log(`Test Results for buildCostInfoString (Issues #1015 & #1250):`);
+console.log(`Test Results for buildCostInfoString (Issues #1015, #1250 & #1557):`);
 console.log(`  ✅ Passed: ${testsPassed}`);
 console.log(`  ❌ Failed: ${testsFailed}`);
 console.log('='.repeat(80));


### PR DESCRIPTION
## Summary

- When public pricing estimate and Anthropic-calculated cost **match**: show simplified `### 💰 Cost: **$X.XXXXXX**` instead of full breakdown
- When costs **differ**: show full breakdown (Public pricing estimate, Calculated by Anthropic, Difference) without "USD" suffix
- Applied to both GitHub comment output (`buildCostInfoString`) and terminal output (`displayCostComparison`)
- All tools (agent, claude, codex) benefit from the change since they share the same formatting functions

Fixes #1557

## Before / After

**Before (when costs match):**
```markdown
### 💰 **Cost estimation:**
- Public pricing estimate: $5.207635
- Calculated by Anthropic: $5.207635 USD
- Difference: $0.000000 (0.00%)
```

**After (when costs match):**
```markdown
### 💰 Cost: **$5.207635**
```

**Before (when costs differ):**
```markdown
- Calculated by Anthropic: $5.636999 USD
```

**After (when costs differ):**
```markdown
- Calculated by Anthropic: $5.636999
```

## Test plan

- [x] All 48 unit tests pass (6 new tests added for Issue #1557)
- [x] Tests verify: exact match simplified display, slight difference full display, USD removal, single-cost scenarios
- [x] Existing tests updated to expect no "USD" suffix
- [ ] CI pipeline passes `node tests/test-build-cost-info-string.mjs`

🤖 Generated with [Claude Code](https://claude.com/claude-code)