### PR TITLE
fix: reduce code duplication to pass jscpd CI check

### DIFF
--- a/.changeset/fix-ci-code-duplication-1559.md
+++ b/.changeset/fix-ci-code-duplication-1559.md
@@ -1,0 +1,5 @@
+---
+'@link-assistant/hive-mind': patch
+---
+
+Fix CI/CD lint failure caused by code duplication exceeding jscpd threshold (11.03% > 11%). Refactored test files to use shared `test-helpers.mjs` instead of duplicating assert/summary boilerplate, reducing duplication to 10.93%.

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,0 +1,1 @@
+# .gitkeep file auto-generated at 2026-04-10T17:03:10.349Z for PR creation at branch issue-1559-bb998c78b47b for issue https://github.com/link-assistant/hive-mind/issues/1559

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,1 +1,0 @@
-# .gitkeep file auto-generated at 2026-04-10T17:03:10.349Z for PR creation at branch issue-1559-bb998c78b47b for issue https://github.com/link-assistant/hive-mind/issues/1559

--- a/docs/case-studies/issue-1559/README.md
+++ b/docs/case-studies/issue-1559/README.md
@@ -1,0 +1,90 @@
+# Case Study: Issue #1559 — Fix CI/CD error, to make all releases pass
+
+## Summary
+
+CI/CD pipeline failed on the `main` branch after merging PR #1546 (issue #1545 — isolation screen session monitoring tests). The `lint` job failed because the jscpd code duplication checker found 11.03% duplicated lines, exceeding the configured 11% threshold.
+
+## Timeline
+
+1. **2026-04-10T16:41:48Z** — Push to `main` (commit `93959bd7`) triggered CI workflow run [#24253636325](https://github.com/link-assistant/hive-mind/actions/runs/24253636325)
+2. **2026-04-10T16:42:51Z** — `lint` job failed at the "Run code duplication check" step
+3. The merge of PR #1546 introduced two new test files with duplicated assert/summary patterns that pushed duplication over threshold
+
+## Root Cause Analysis
+
+### Direct Cause
+
+The jscpd code duplication checker reported **11.03%** duplicated lines (6998 out of 63419), exceeding the **11% threshold** configured in `.jscpd.json`.
+
+### Contributing Factors
+
+PR #1546 added two new test files:
+
+- `tests/test-isolation-screen-fallback-1545.mjs` (87 lines)
+- `tests/test-isolation-screen-integration-1545.mjs` (194 lines)
+
+These files contained duplicated boilerplate patterns that are common across the test suite:
+
+1. **`assert(condition, message)` function** — duplicated in 3+ test files (8 lines each)
+2. **Results/summary block** — duplicated in 3+ test files (7 lines each)
+3. **`skip(message)` function** — duplicated in 2+ test files (4 lines each)
+
+The codebase already had a shared test helper (`tests/test-helpers.mjs`) with `test()`, `asyncTest()`, `printSummary()`, and `getFailCount()` exports, but many test files did not use it. The new files followed the existing (duplicated) pattern instead of using the shared helper.
+
+### Evidence
+
+From CI logs (`ci-run-24253636325.log`):
+
+```
+ERROR: jscpd found too many duplicates (11.03%) over threshold (11%)
+```
+
+jscpd report summary:
+| Metric | Value |
+|--------|-------|
+| Files analyzed | 229 |
+| Total lines | 63,419 |
+| Clones found | 622 |
+| Duplicated lines | 6,998 (11.03%) |
+
+Specific duplications involving new files:
+
+- `test-isolation-screen-fallback-1545.mjs` <-> `test-session-monitor-isolation.mjs`: 38 lines across 3 clone pairs
+- `test-isolation-screen-integration-1545.mjs` <-> `test-session-monitor-isolation.mjs`: 21 lines across 2 clone pairs
+- `src/isolation-runner.lib.mjs` <-> `src/youtrack/youtrack.lib.mjs`: 7 lines (import pattern)
+
+## Solution
+
+### Approach
+
+Extended the existing shared test helper (`tests/test-helpers.mjs`) with `assert()`, `skip()` functions that match the pattern used across test files, then refactored the three most duplicated test files to use these shared helpers.
+
+### Changes
+
+1. **`tests/test-helpers.mjs`** — Added `assert(condition, message)`, `skip(message)` exports; updated `printSummary()` to support skip counts and configurable separator width
+2. **`tests/test-isolation-screen-fallback-1545.mjs`** — Replaced inline `assert` function and results block with imports from `test-helpers.mjs`
+3. **`tests/test-isolation-screen-integration-1545.mjs`** — Replaced inline `assert`, `skip` functions and results block with imports from `test-helpers.mjs`
+4. **`tests/test-session-monitor-isolation.mjs`** — Replaced inline `assert` function and results block with imports from `test-helpers.mjs`
+
+### Result
+
+| Metric           | Before         | After          | Change             |
+| ---------------- | -------------- | -------------- | ------------------ |
+| Duplicated lines | 6,998 (11.03%) | 6,925 (10.93%) | -73 lines (-0.10%) |
+| Clones found     | 622            | 616            | -6 clones          |
+| Total lines      | 63,419         | 63,381         | -38 lines          |
+
+Duplication is now **10.93%**, safely below the **11% threshold**.
+
+## Lessons Learned
+
+1. **Use shared helpers**: The codebase has `tests/test-helpers.mjs` but many test files don't use it. New tests should import from this shared module instead of duplicating boilerplate.
+2. **Monitor duplication trends**: The threshold was only barely exceeded (0.03% over). Regular monitoring of duplication trends could catch these issues before they block CI.
+3. **PR review checklist**: PRs adding test files should be checked for use of shared test utilities.
+
+## References
+
+- Issue: https://github.com/link-assistant/hive-mind/issues/1559
+- Failing CI run: https://github.com/link-assistant/hive-mind/actions/runs/24253636325
+- PR #1546 that introduced the threshold breach: https://github.com/link-assistant/hive-mind/pull/1546
+- jscpd configuration: `.jscpd.json` (threshold: 11%, minTokens: 30, minLines: 5)

--- a/docs/case-studies/issue-1559/ci-jobs.json
+++ b/docs/case-studies/issue-1559/ci-jobs.json
@@ -1,0 +1,113 @@
+{
+  "jobs": [
+    {
+      "completedAt": "2026-04-10T16:42:00Z",
+      "conclusion": "success",
+      "databaseId": 70819409486,
+      "name": "detect-changes",
+      "startedAt": "2026-04-10T16:41:51Z",
+      "status": "completed",
+      "steps": [
+        { "completedAt": "2026-04-10T16:41:52Z", "conclusion": "success", "name": "Set up job", "number": 1, "startedAt": "2026-04-10T16:41:52Z", "status": "completed" },
+        { "completedAt": "2026-04-10T16:41:59Z", "conclusion": "success", "name": "Run actions/checkout@v5", "number": 2, "startedAt": "2026-04-10T16:41:52Z", "status": "completed" },
+        { "completedAt": "2026-04-10T16:41:59Z", "conclusion": "success", "name": "Detect changes", "number": 3, "startedAt": "2026-04-10T16:41:59Z", "status": "completed" },
+        { "completedAt": "2026-04-10T16:41:59Z", "conclusion": "success", "name": "Post Run actions/checkout@v5", "number": 6, "startedAt": "2026-04-10T16:41:59Z", "status": "completed" },
+        { "completedAt": "2026-04-10T16:41:59Z", "conclusion": "success", "name": "Complete job", "number": 7, "startedAt": "2026-04-10T16:41:59Z", "status": "completed" }
+      ],
+      "url": "https://github.com/link-assistant/hive-mind/actions/runs/24253636325/job/70819409486"
+    },
+    { "completedAt": "2026-04-10T16:41:49Z", "conclusion": "skipped", "databaseId": 70819409639, "name": "Instant Release", "startedAt": "2026-04-10T16:41:49Z", "status": "completed", "steps": [], "url": "https://github.com/link-assistant/hive-mind/actions/runs/24253636325/job/70819409639" },
+    { "completedAt": "2026-04-10T16:41:49Z", "conclusion": "skipped", "databaseId": 70819409746, "name": "Create Changeset PR", "startedAt": "2026-04-10T16:41:49Z", "status": "completed", "steps": [], "url": "https://github.com/link-assistant/hive-mind/actions/runs/24253636325/job/70819409746" },
+    { "completedAt": "2026-04-10T16:41:49Z", "conclusion": "skipped", "databaseId": 70819410003, "name": "Docker Publish Instant (${{ matrix.platform }})", "startedAt": "2026-04-10T16:41:49Z", "status": "completed", "steps": [], "url": "https://github.com/link-assistant/hive-mind/actions/runs/24253636325/job/70819410003" },
+    { "completedAt": "2026-04-10T16:41:49Z", "conclusion": "skipped", "databaseId": 70819410348, "name": "Docker Publish Instant (Merge)", "startedAt": "2026-04-10T16:41:49Z", "status": "completed", "steps": [], "url": "https://github.com/link-assistant/hive-mind/actions/runs/24253636325/job/70819410348" },
+    { "completedAt": "2026-04-10T16:41:49Z", "conclusion": "skipped", "databaseId": 70819410878, "name": "Helm Release (Instant)", "startedAt": "2026-04-10T16:41:49Z", "status": "completed", "steps": [], "url": "https://github.com/link-assistant/hive-mind/actions/runs/24253636325/job/70819410878" },
+    {
+      "completedAt": "2026-04-10T16:42:53Z",
+      "conclusion": "failure",
+      "databaseId": 70819437583,
+      "name": "lint",
+      "startedAt": "2026-04-10T16:42:04Z",
+      "status": "completed",
+      "steps": [
+        { "completedAt": "2026-04-10T16:42:05Z", "conclusion": "success", "name": "Set up job", "number": 1, "startedAt": "2026-04-10T16:42:05Z", "status": "completed" },
+        { "completedAt": "2026-04-10T16:42:11Z", "conclusion": "success", "name": "Checkout repository", "number": 2, "startedAt": "2026-04-10T16:42:05Z", "status": "completed" },
+        { "completedAt": "2026-04-10T16:42:11Z", "conclusion": "skipped", "name": "Simulate fresh merge with base branch (PR only)", "number": 3, "startedAt": "2026-04-10T16:42:11Z", "status": "completed" },
+        { "completedAt": "2026-04-10T16:42:15Z", "conclusion": "success", "name": "Setup Node.js", "number": 4, "startedAt": "2026-04-10T16:42:11Z", "status": "completed" },
+        { "completedAt": "2026-04-10T16:42:23Z", "conclusion": "success", "name": "Install dependencies", "number": 5, "startedAt": "2026-04-10T16:42:15Z", "status": "completed" },
+        { "completedAt": "2026-04-10T16:42:41Z", "conclusion": "success", "name": "Run Prettier format check", "number": 6, "startedAt": "2026-04-10T16:42:23Z", "status": "completed" },
+        { "completedAt": "2026-04-10T16:42:45Z", "conclusion": "success", "name": "Run ESLint", "number": 7, "startedAt": "2026-04-10T16:42:41Z", "status": "completed" },
+        { "completedAt": "2026-04-10T16:42:51Z", "conclusion": "failure", "name": "Run code duplication check", "number": 8, "startedAt": "2026-04-10T16:42:45Z", "status": "completed" },
+        { "completedAt": "2026-04-10T16:42:51Z", "conclusion": "skipped", "name": "Post Setup Node.js", "number": 15, "startedAt": "2026-04-10T16:42:51Z", "status": "completed" },
+        { "completedAt": "2026-04-10T16:42:51Z", "conclusion": "success", "name": "Post Checkout repository", "number": 16, "startedAt": "2026-04-10T16:42:51Z", "status": "completed" },
+        { "completedAt": "2026-04-10T16:42:51Z", "conclusion": "success", "name": "Complete job", "number": 17, "startedAt": "2026-04-10T16:42:51Z", "status": "completed" }
+      ],
+      "url": "https://github.com/link-assistant/hive-mind/actions/runs/24253636325/job/70819437583"
+    },
+    {
+      "completedAt": "2026-04-10T16:42:22Z",
+      "conclusion": "success",
+      "databaseId": 70819437824,
+      "name": "test-compilation",
+      "startedAt": "2026-04-10T16:42:03Z",
+      "status": "completed",
+      "steps": [
+        { "completedAt": "2026-04-10T16:42:04Z", "conclusion": "success", "name": "Set up job", "number": 1, "startedAt": "2026-04-10T16:42:04Z", "status": "completed" },
+        { "completedAt": "2026-04-10T16:42:11Z", "conclusion": "success", "name": "Checkout repository", "number": 2, "startedAt": "2026-04-10T16:42:04Z", "status": "completed" },
+        { "completedAt": "2026-04-10T16:42:15Z", "conclusion": "success", "name": "Setup Node.js", "number": 3, "startedAt": "2026-04-10T16:42:11Z", "status": "completed" },
+        { "completedAt": "2026-04-10T16:42:15Z", "conclusion": "success", "name": "Test solve.mjs compilation", "number": 4, "startedAt": "2026-04-10T16:42:15Z", "status": "completed" },
+        { "completedAt": "2026-04-10T16:42:15Z", "conclusion": "success", "name": "Test hive.mjs compilation", "number": 5, "startedAt": "2026-04-10T16:42:15Z", "status": "completed" },
+        { "completedAt": "2026-04-10T16:42:21Z", "conclusion": "success", "name": "Check Node.js syntax for all .mjs files", "number": 6, "startedAt": "2026-04-10T16:42:15Z", "status": "completed" },
+        { "completedAt": "2026-04-10T16:42:21Z", "conclusion": "success", "name": "Post Setup Node.js", "number": 11, "startedAt": "2026-04-10T16:42:21Z", "status": "completed" },
+        { "completedAt": "2026-04-10T16:42:21Z", "conclusion": "success", "name": "Post Checkout repository", "number": 12, "startedAt": "2026-04-10T16:42:21Z", "status": "completed" },
+        { "completedAt": "2026-04-10T16:42:21Z", "conclusion": "success", "name": "Complete job", "number": 13, "startedAt": "2026-04-10T16:42:21Z", "status": "completed" }
+      ],
+      "url": "https://github.com/link-assistant/hive-mind/actions/runs/24253636325/job/70819437824"
+    },
+    {
+      "completedAt": "2026-04-10T16:42:13Z",
+      "conclusion": "success",
+      "databaseId": 70819437873,
+      "name": "check-file-line-limits",
+      "startedAt": "2026-04-10T16:42:04Z",
+      "status": "completed",
+      "steps": [
+        { "completedAt": "2026-04-10T16:42:05Z", "conclusion": "success", "name": "Set up job", "number": 1, "startedAt": "2026-04-10T16:42:04Z", "status": "completed" },
+        { "completedAt": "2026-04-10T16:42:10Z", "conclusion": "success", "name": "Checkout repository", "number": 2, "startedAt": "2026-04-10T16:42:05Z", "status": "completed" },
+        { "completedAt": "2026-04-10T16:42:10Z", "conclusion": "skipped", "name": "Simulate fresh merge with base branch (PR only)", "number": 3, "startedAt": "2026-04-10T16:42:10Z", "status": "completed" },
+        { "completedAt": "2026-04-10T16:42:12Z", "conclusion": "success", "name": "Check file line limits (.mjs files and release.yml)", "number": 4, "startedAt": "2026-04-10T16:42:10Z", "status": "completed" },
+        { "completedAt": "2026-04-10T16:42:12Z", "conclusion": "success", "name": "Post Checkout repository", "number": 8, "startedAt": "2026-04-10T16:42:12Z", "status": "completed" },
+        { "completedAt": "2026-04-10T16:42:12Z", "conclusion": "success", "name": "Complete job", "number": 9, "startedAt": "2026-04-10T16:42:12Z", "status": "completed" }
+      ],
+      "url": "https://github.com/link-assistant/hive-mind/actions/runs/24253636325/job/70819437873"
+    },
+    {
+      "completedAt": "2026-04-10T16:42:33Z",
+      "conclusion": "success",
+      "databaseId": 70819437877,
+      "name": "validate-docs",
+      "startedAt": "2026-04-10T16:42:04Z",
+      "status": "completed",
+      "steps": [
+        { "completedAt": "2026-04-10T16:42:05Z", "conclusion": "success", "name": "Set up job", "number": 1, "startedAt": "2026-04-10T16:42:05Z", "status": "completed" },
+        { "completedAt": "2026-04-10T16:42:25Z", "conclusion": "success", "name": "Run actions/checkout@v5", "number": 2, "startedAt": "2026-04-10T16:42:05Z", "status": "completed" },
+        { "completedAt": "2026-04-10T16:42:28Z", "conclusion": "success", "name": "Use Node.js 20.x", "number": 3, "startedAt": "2026-04-10T16:42:25Z", "status": "completed" },
+        { "completedAt": "2026-04-10T16:42:30Z", "conclusion": "success", "name": "Validate documentation files", "number": 4, "startedAt": "2026-04-10T16:42:28Z", "status": "completed" },
+        { "completedAt": "2026-04-10T16:42:30Z", "conclusion": "success", "name": "Post Use Node.js 20.x", "number": 7, "startedAt": "2026-04-10T16:42:30Z", "status": "completed" },
+        { "completedAt": "2026-04-10T16:42:31Z", "conclusion": "success", "name": "Post Run actions/checkout@v5", "number": 8, "startedAt": "2026-04-10T16:42:30Z", "status": "completed" },
+        { "completedAt": "2026-04-10T16:42:31Z", "conclusion": "success", "name": "Complete job", "number": 9, "startedAt": "2026-04-10T16:42:31Z", "status": "completed" }
+      ],
+      "url": "https://github.com/link-assistant/hive-mind/actions/runs/24253636325/job/70819437877"
+    },
+    { "completedAt": "2026-04-10T16:42:01Z", "conclusion": "skipped", "databaseId": 70819437937, "name": "Check for Manual Version Changes", "startedAt": "2026-04-10T16:42:01Z", "status": "completed", "steps": [], "url": "https://github.com/link-assistant/hive-mind/actions/runs/24253636325/job/70819437937" },
+    { "completedAt": "2026-04-10T16:42:01Z", "conclusion": "skipped", "databaseId": 70819437989, "name": "Check for Changesets", "startedAt": "2026-04-10T16:42:01Z", "status": "completed", "steps": [], "url": "https://github.com/link-assistant/hive-mind/actions/runs/24253636325/job/70819437989" },
+    { "completedAt": "2026-04-10T16:42:01Z", "conclusion": "skipped", "databaseId": 70819438431, "name": "helm-pr-check", "startedAt": "2026-04-10T16:42:01Z", "status": "completed", "steps": [], "url": "https://github.com/link-assistant/hive-mind/actions/runs/24253636325/job/70819438431" },
+    { "completedAt": "2026-04-10T16:42:54Z", "conclusion": "skipped", "databaseId": 70819561954, "name": "test-execution", "startedAt": "2026-04-10T16:42:54Z", "status": "completed", "steps": [], "url": "https://github.com/link-assistant/hive-mind/actions/runs/24253636325/job/70819561954" },
+    { "completedAt": "2026-04-10T16:42:54Z", "conclusion": "skipped", "databaseId": 70819562069, "name": "memory-check-linux", "startedAt": "2026-04-10T16:42:54Z", "status": "completed", "steps": [], "url": "https://github.com/link-assistant/hive-mind/actions/runs/24253636325/job/70819562069" },
+    { "completedAt": "2026-04-10T16:42:54Z", "conclusion": "skipped", "databaseId": 70819562168, "name": "docker-pr-check", "startedAt": "2026-04-10T16:42:54Z", "status": "completed", "steps": [], "url": "https://github.com/link-assistant/hive-mind/actions/runs/24253636325/job/70819562168" },
+    { "completedAt": "2026-04-10T16:42:54Z", "conclusion": "skipped", "databaseId": 70819562192, "name": "test-suites", "startedAt": "2026-04-10T16:42:54Z", "status": "completed", "steps": [], "url": "https://github.com/link-assistant/hive-mind/actions/runs/24253636325/job/70819562192" },
+    { "completedAt": "2026-04-10T16:42:54Z", "conclusion": "skipped", "databaseId": 70819562201, "name": "Release", "startedAt": "2026-04-10T16:42:54Z", "status": "completed", "steps": [], "url": "https://github.com/link-assistant/hive-mind/actions/runs/24253636325/job/70819562201" },
+    { "completedAt": "2026-04-10T16:42:54Z", "conclusion": "skipped", "databaseId": 70819562420, "name": "Docker Publish (${{ matrix.platform }})", "startedAt": "2026-04-10T16:42:54Z", "status": "completed", "steps": [], "url": "https://github.com/link-assistant/hive-mind/actions/runs/24253636325/job/70819562420" },
+    { "completedAt": "2026-04-10T16:42:54Z", "conclusion": "skipped", "databaseId": 70819562730, "name": "Docker Publish (Merge)", "startedAt": "2026-04-10T16:42:54Z", "status": "completed", "steps": [], "url": "https://github.com/link-assistant/hive-mind/actions/runs/24253636325/job/70819562730" },
+    { "completedAt": "2026-04-10T16:42:54Z", "conclusion": "skipped", "databaseId": 70819562987, "name": "Helm Release", "startedAt": "2026-04-10T16:42:54Z", "status": "completed", "steps": [], "url": "https://github.com/link-assistant/hive-mind/actions/runs/24253636325/job/70819562987" }
+  ]
+}

--- a/tests/test-helpers.mjs
+++ b/tests/test-helpers.mjs
@@ -8,6 +8,22 @@
 
 let testsPassed = 0;
 let testsFailed = 0;
+let testsSkipped = 0;
+
+export function assert(condition, message) {
+  if (condition) {
+    console.log(`  ✅ PASS: ${message}`);
+    testsPassed++;
+  } else {
+    console.error(`  ❌ FAIL: ${message}`);
+    testsFailed++;
+  }
+}
+
+export function skip(message) {
+  console.log(`  ⏭️ SKIP: ${message}`);
+  testsSkipped++;
+}
 
 export function test(name, fn) {
   try {
@@ -33,9 +49,12 @@ export async function asyncTest(name, fn) {
   }
 }
 
-export function printSummary() {
-  console.log('\n' + '='.repeat(60));
-  console.log(`\n📊 Results: ${testsPassed} passed, ${testsFailed} failed, ${testsPassed + testsFailed} total\n`);
+export function printSummary(separator = 60) {
+  console.log('\n' + '='.repeat(separator));
+  const skipPart = testsSkipped > 0 ? `, ${testsSkipped} skipped` : '';
+  const total = testsPassed + testsFailed + testsSkipped;
+  console.log(`Results: ${testsPassed} passed, ${testsFailed} failed${skipPart}, ${total} total`);
+  console.log('='.repeat(separator));
 }
 
 export function getFailCount() {

--- a/tests/test-isolation-screen-fallback-1545.mjs
+++ b/tests/test-isolation-screen-fallback-1545.mjs
@@ -13,19 +13,7 @@
 
 import { checkScreenSessionRunning, isSessionRunning } from '../src/isolation-runner.lib.mjs';
 import { trackSession, getActiveSessionCount } from '../src/session-monitor.lib.mjs';
-
-let passed = 0;
-let failed = 0;
-
-function assert(condition, message) {
-  if (condition) {
-    console.log(`  ✅ PASS: ${message}`);
-    passed++;
-  } else {
-    console.error(`  ❌ FAIL: ${message}`);
-    failed++;
-  }
-}
+import { assert, printSummary, getFailCount } from './test-helpers.mjs';
 
 console.log('Testing isolation screen fallback (issue #1545)');
 console.log('='.repeat(60));
@@ -75,13 +63,8 @@ const count = getActiveSessionCount(false);
 assert(count >= 1, `Session tracked successfully (${count} active)`);
 
 // Results
-console.log('\n' + '='.repeat(60));
-console.log(`Results: ${passed} passed, ${failed} failed, ${passed + failed} total`);
-console.log('='.repeat(60));
+printSummary();
 
-if (failed > 0) {
-  console.error(`\n❌ ${failed} test(s) failed!`);
+if (getFailCount() > 0) {
   process.exit(1);
-} else {
-  console.log('\n✅ All tests passed!');
 }

--- a/tests/test-isolation-screen-integration-1545.mjs
+++ b/tests/test-isolation-screen-integration-1545.mjs
@@ -18,25 +18,7 @@
 
 import { execSync } from 'child_process';
 import { querySessionStatus, checkScreenSessionRunning, isSessionRunning, executeWithIsolation } from '../src/isolation-runner.lib.mjs';
-
-let passed = 0;
-let failed = 0;
-let skipped = 0;
-
-function assert(condition, message) {
-  if (condition) {
-    console.log(`  ✅ PASS: ${message}`);
-    passed++;
-  } else {
-    console.error(`  ❌ FAIL: ${message}`);
-    failed++;
-  }
-}
-
-function skip(message) {
-  console.log(`  ⏭️ SKIP: ${message}`);
-  skipped++;
-}
+import { assert, skip, printSummary, getFailCount } from './test-helpers.mjs';
 
 /**
  * Check if a tool is available
@@ -182,13 +164,8 @@ if (hasScreen && hasStartCommand) {
 }
 
 // Results
-console.log('\n' + '='.repeat(70));
-console.log(`Results: ${passed} passed, ${failed} failed, ${skipped} skipped, ${passed + failed + skipped} total`);
-console.log('='.repeat(70));
+printSummary(70);
 
-if (failed > 0) {
-  console.error(`\n❌ ${failed} test(s) failed!`);
+if (getFailCount() > 0) {
   process.exit(1);
-} else {
-  console.log('\n✅ All tests passed!');
 }

--- a/tests/test-session-monitor-isolation.mjs
+++ b/tests/test-session-monitor-isolation.mjs
@@ -9,19 +9,7 @@
  */
 
 import { trackSession, getActiveSessionCount, getSessionStats, checkScreenSessionExists } from '../src/session-monitor.lib.mjs';
-
-let passed = 0;
-let failed = 0;
-
-function assert(condition, message) {
-  if (condition) {
-    console.log(`  ✅ PASS: ${message}`);
-    passed++;
-  } else {
-    console.error(`  ❌ FAIL: ${message}`);
-    failed++;
-  }
-}
+import { assert, printSummary, getFailCount } from './test-helpers.mjs';
 
 console.log('Testing session-monitor.lib.mjs (isolation support)');
 console.log('='.repeat(60));
@@ -84,13 +72,8 @@ const exists = await checkScreenSessionExists('non-existent-session-' + Date.now
 assert(exists === false, 'Returns false for non-existent screen session');
 
 // Results
-console.log('\n' + '='.repeat(60));
-console.log(`Results: ${passed} passed, ${failed} failed, ${passed + failed} total`);
-console.log('='.repeat(60));
+printSummary();
 
-if (failed > 0) {
-  console.error(`\n❌ ${failed} test(s) failed!`);
+if (getFailCount() > 0) {
   process.exit(1);
-} else {
-  console.log('\n✅ All tests passed!');
 }


### PR DESCRIPTION
## Summary

- Fix CI/CD lint failure caused by jscpd code duplication checker reporting 11.03% > 11% threshold
- Refactored 3 test files to use shared `test-helpers.mjs` instead of duplicating assert/skip/summary boilerplate
- Added `assert()` and `skip()` exports to `test-helpers.mjs` to support the pattern used across test files
- Duplication reduced from 11.03% to 10.92%, safely below the 11% threshold

## Root Cause

PR #1546 added two new test files (`test-isolation-screen-fallback-1545.mjs` and `test-isolation-screen-integration-1545.mjs`) that contained duplicated boilerplate patterns (assert function, results block) already present in `test-session-monitor-isolation.mjs`. This pushed the overall code duplication from just under 11% to 11.03%, exceeding the jscpd threshold.

Failing CI run: https://github.com/link-assistant/hive-mind/actions/runs/24253636325/job/70819437583

## Changes

| File | Change |
|------|--------|
| `tests/test-helpers.mjs` | Added `assert()`, `skip()` exports; updated `printSummary()` for skip counts |
| `tests/test-isolation-screen-fallback-1545.mjs` | Use shared helpers instead of inline boilerplate |
| `tests/test-isolation-screen-integration-1545.mjs` | Use shared helpers instead of inline boilerplate |
| `tests/test-session-monitor-isolation.mjs` | Use shared helpers instead of inline boilerplate |

## Test plan

- [x] All 3 refactored test files pass locally
- [x] Existing tests using `test-helpers.mjs` still pass (`test-version-info.mjs`, `test-version-parsing.mjs`)
- [x] `npm run lint` passes
- [x] `npm run check:duplication` passes (10.92% < 11% threshold)
- [x] All `.mjs` files pass `node --check` syntax validation

Fixes #1559