### PR TITLE
fix: use fork repo path in screenshot URL template (#1561)

### DIFF
--- a/.changeset/fix-fork-screenshot-url-1561.md
+++ b/.changeset/fix-fork-screenshot-url-1561.md
@@ -1,0 +1,5 @@
+---
+'@link-assistant/hive-mind': patch
+---
+
+Fix broken screenshot URL in fork mode: use forked repo path instead of original repo path in screenshot URL template when operating in fork mode (#1561).

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,0 +1,1 @@
+# .gitkeep file auto-generated at 2026-04-10T19:22:35.899Z for PR creation at branch issue-1561-3d3858b3890e for issue https://github.com/link-assistant/hive-mind/issues/1561

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,1 +1,0 @@
-# .gitkeep file auto-generated at 2026-04-10T19:22:35.899Z for PR creation at branch issue-1561-3d3858b3890e for issue https://github.com/link-assistant/hive-mind/issues/1561

--- a/docs/case-studies/issue-1561/case-study.md
+++ b/docs/case-studies/issue-1561/case-study.md
@@ -1,0 +1,197 @@
+# Case Study: Broken Screenshot Attached to Pull Request
+
+**Issue:** [#1561](https://github.com/link-assistant/hive-mind/issues/1561)
+**Related PR:** [Jhon-Crow/godot-topdown-MVP#1796](https://github.com/Jhon-Crow/godot-topdown-MVP/pull/1796)
+**Broken Comment:** [#issuecomment-4226047641](https://github.com/Jhon-Crow/godot-topdown-MVP/pull/1796#issuecomment-4226047641)
+
+## 1. Executive Summary
+
+A screenshot was generated correctly and committed to the repository, but appeared **broken** in the PR description and comment because the image URL pointed to the **original repository** (`Jhon-Crow/godot-topdown-MVP`) instead of the **fork** (`konard/Jhon-Crow-godot-topdown-MVP`) where the image was actually pushed. Since the branch `issue-1790-92dae9f72c05` only exists in the fork, GitHub returns a 404 HTML page instead of the image, resulting in a broken image display.
+
+## 2. Timeline / Sequence of Events
+
+| Time (UTC) | Event                     | Details                                                                                                                                                                                 |
+| ---------- | ------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| 18:16:47   | Fork mode detected        | `Auto-fork: No write access detected, enabling fork mode`                                                                                                                               |
+| 18:16:49   | Fork identified           | `konard/Jhon-Crow-godot-topdown-MVP`                                                                                                                                                    |
+| 18:17:09   | Remote configured         | `origin = https://github.com/konard/Jhon-Crow-godot-topdown-MVP.git`                                                                                                                    |
+| 18:17:12   | Branch created            | `issue-1790-92dae9f72c05` pushed to fork                                                                                                                                                |
+| 18:17:19   | PR created                | PR #1796 opened on `Jhon-Crow/godot-topdown-MVP`                                                                                                                                        |
+| 18:21:25   | Initial solve log         | Solution draft completed (iteration 1)                                                                                                                                                  |
+| 18:42:40   | Auto-restart #1           | Merge conflicts detected                                                                                                                                                                |
+| 18:42:59   | User comment              | Jhon-Crow: "resolve conflict and attach screenshot of new combo text" (in Russian)                                                                                                      |
+| 18:50:57   | Auto-restart #2           | New user comment + merge conflicts                                                                                                                                                      |
+| ~18:52:00  | Screenshot generated      | Python PIL script renders combo counter using `gothic_bitmap.fnt` glyphs                                                                                                                |
+| ~18:52:23  | Screenshot verified       | AI reads the PNG via Read tool — image is valid                                                                                                                                         |
+| 18:53:24   | Screenshot committed      | `docs/screenshots/combo_gothic_font.png` pushed to **fork** (`konard/Jhon-Crow-godot-topdown-MVP`)                                                                                      |
+| 18:53:46   | **Broken comment posted** | Comment uses URL: `https://github.com/Jhon-Crow/godot-topdown-MVP/blob/issue-1790-92dae9f72c05/docs/screenshots/combo_gothic_font.png?raw=true` — points to **original repo**, not fork |
+| 18:54:00   | Solve log posted          | Iteration 2 completed                                                                                                                                                                   |
+
+## 3. Requirements from Issue
+
+1. Download all logs and data related to the broken screenshot
+2. Compile data to `./docs/case-studies/issue-{id}` folder
+3. Reconstruct timeline/sequence of events
+4. List all requirements from the issue
+5. Find root causes of each problem
+6. Propose possible solutions and solution plans
+7. Check known existing components/libraries that solve similar problems
+8. If insufficient data, add debug output and verbose mode
+9. Report issues to relevant repositories with reproducible examples
+
+## 4. Root Cause Analysis
+
+### Root Cause #1: Screenshot URL Template Uses Original Repo Instead of Fork
+
+**Severity:** Critical
+**Files affected:**
+
+- `src/claude.prompts.lib.mjs` (line 342)
+- `src/agent.prompts.lib.mjs` (line 248)
+
+**Problem:** The system prompt template that instructs the AI how to reference screenshots uses `${owner}/${repo}` which always resolves to the **original** repository (e.g., `Jhon-Crow/godot-topdown-MVP`), even when fork mode is active and the code is pushed to a different repository (e.g., `konard/Jhon-Crow-godot-topdown-MVP`).
+
+**The broken template (line 342 of claude.prompts.lib.mjs):**
+
+```javascript
+`https://github.com/${owner}/${repo}/blob/${branchName}/docs/screenshots/result.png?raw=true`;
+```
+
+**What should happen:** When `argv.fork` is active and `forkedRepo` is available, the URL should point to the fork:
+
+```javascript
+`https://github.com/${forkedRepo}/blob/${branchName}/docs/screenshots/result.png?raw=true`;
+```
+
+**Evidence chain:**
+
+1. `owner = "Jhon-Crow"`, `repo = "godot-topdown-MVP"` (from issue URL parsing at `solve.mjs:176`)
+2. `forkedRepo = "konard/Jhon-Crow-godot-topdown-MVP"` (detected at solve.mjs:523)
+3. `buildSystemPrompt` in `claude.prompts.lib.mjs:95` destructures `params` but does NOT extract `forkedRepo`
+4. The screenshot URL template at line 342 uses `${owner}/${repo}` => `Jhon-Crow/godot-topdown-MVP`
+5. The actual push destination is `konard/Jhon-Crow-godot-topdown-MVP`
+6. Branch `issue-1790-92dae9f72c05` exists ONLY in the fork, not in the original repo
+7. GitHub returns 404 HTML for the URL, which renders as a broken image
+
+### Root Cause #2: No URL Validation After Screenshot Commit
+
+**Severity:** Medium
+
+The system has no validation step to verify that the screenshot URL is actually accessible after committing and pushing. If a URL validation check existed (e.g., a HEAD request to verify the URL returns 200), the AI would have detected the broken URL and could have self-corrected.
+
+### Root Cause #3: Branch-Based URLs Are Inherently Fragile
+
+**Severity:** Low (design concern)
+
+Using branch-name-based URLs (`/blob/{branchName}/...`) is fragile because:
+
+- Branches can be deleted after PR merge
+- In fork mode, the branch exists in a different repository than the URL points to
+- Even when working correctly, the URL becomes permanently broken after branch deletion
+
+A more robust approach would use commit-SHA-based URLs or GitHub's upload API.
+
+## 5. Proposed Solutions
+
+### Solution A: Fix Screenshot URL Template for Fork Mode (Recommended - Minimal Fix)
+
+**What:** Modify the `buildSystemPrompt` function in both `claude.prompts.lib.mjs` and `agent.prompts.lib.mjs` to use `forkedRepo` when available.
+
+**How:**
+
+1. Add `forkedRepo` to the destructured params in `buildSystemPrompt`
+2. Compute `screenshotRepoPath = (argv?.fork && forkedRepo) ? forkedRepo : `${owner}/${repo}``
+3. Use `screenshotRepoPath` in the URL template
+
+**Pros:** Minimal change, fixes the immediate bug
+**Cons:** Still uses branch-based URLs (fragile after branch deletion)
+
+### Solution B: Use Commit SHA-Based URLs
+
+**What:** Instead of branch-based URLs, use commit SHA-based URLs that are permanent.
+
+**Format:** `https://raw.githubusercontent.com/${repoPath}/${commitSHA}/docs/screenshots/result.png`
+
+**Pros:** URLs are permanent and never break
+**Cons:** Requires knowing the commit SHA at URL construction time (the AI knows it after `git push`)
+
+### Solution C: Use GitHub's Upload API for PR Attachments
+
+**What:** Use GitHub's native image upload mechanism (drag-and-drop style uploads via API) instead of committing images to the repository.
+
+**How:** Use the `uploads.github.com` endpoint or `gh` CLI to upload images as PR attachments.
+
+**Pros:** Images are stored in GitHub's CDN, URLs never break, no repo bloat
+**Cons:** Requires API integration, images not in version control
+
+### Solution D: Add URL Validation After Screenshot Commit
+
+**What:** After committing and pushing a screenshot, verify the URL is accessible.
+
+**How:** Add a system prompt instruction to verify screenshot URLs with a HEAD request after pushing.
+
+**Pros:** Catches broken URLs regardless of cause
+**Cons:** Reactive rather than preventive
+
+### Recommended Plan: Solution A + D
+
+1. **Immediate fix (Solution A):** Fix the URL template to use fork repo path when in fork mode
+2. **Defensive measure (Solution D):** Add instruction to verify screenshot URL accessibility after push
+
+## 6. Existing Components / Libraries
+
+- **GitHub REST API - Contents endpoint:** `GET /repos/{owner}/{repo}/contents/{path}?ref={ref}` - can verify file exists at a specific ref
+- **raw.githubusercontent.com:** Direct raw file serving, supports commit SHAs: `https://raw.githubusercontent.com/{owner}/{repo}/{sha}/{path}`
+- **GitHub Upload API:** `POST https://uploads.github.com/repos/{owner}/{repo}/releases/{release_id}/assets` - for release assets (not directly applicable for PR comments)
+- **GitHub Issue/PR comment image uploads:** GitHub supports drag-and-drop image uploads which use `user-attachments` CDN — however there's no documented API for this
+
+## 7. Data Files
+
+All solve execution logs are stored in `./docs/case-studies/issue-1561/logs/`:
+
+| File                              | Description                                        | Size   |
+| --------------------------------- | -------------------------------------------------- | ------ |
+| `solve-log-initial-38cab3cc.txt`  | Initial solve session log                          | 1.9 MB |
+| `solve-log-iter1-c06437c2.txt`    | Auto-restart iteration 1 (merge conflicts)         | 3.4 MB |
+| `solve-log-iter2-50c87aee.txt`    | Auto-restart iteration 2 (screenshot created here) | 5.6 MB |
+| `solve-log-iter3-e56531bd.txt`    | Auto-restart iteration 3                           | 6.9 MB |
+| `solve-log-session3-391840b7.txt` | Additional session log                             | 274 KB |
+
+## 8. Verification
+
+### Broken URL (returns HTML 404):
+
+```
+https://github.com/Jhon-Crow/godot-topdown-MVP/blob/issue-1790-92dae9f72c05/docs/screenshots/combo_gothic_font.png?raw=true
+```
+
+- Branch `issue-1790-92dae9f72c05` does NOT exist in `Jhon-Crow/godot-topdown-MVP` (original repo)
+- Returns HTML `<!DOCTYPE html>` (GitHub 404 page)
+
+### Working URL (returns valid PNG):
+
+```
+https://raw.githubusercontent.com/konard/Jhon-Crow-godot-topdown-MVP/issue-1790-92dae9f72c05/docs/screenshots/combo_gothic_font.png
+```
+
+- Branch `issue-1790-92dae9f72c05` EXISTS in `konard/Jhon-Crow-godot-topdown-MVP` (fork)
+- Returns valid PNG (89 50 4e 47 header, 21KB)
+
+### Permanent URL (using commit SHA):
+
+```
+https://raw.githubusercontent.com/konard/Jhon-Crow-godot-topdown-MVP/8ecd00178e5eb4ae9f66a3e50750e9dde7305e9b/docs/screenshots/combo_gothic_font.png
+```
+
+## 9. Screenshot Content
+
+The generated screenshot is actually a **valid, well-crafted image**. It was programmatically rendered using Python PIL by:
+
+1. Loading the `gothic_bitmap.fnt` font definition file
+2. Loading the `gothic_bitmap.png` sprite sheet
+3. Extracting individual glyph images for each character
+4. Compositing "x3 COMBO" in gold color (255, 215, 60) and "+150" in green (100, 255, 140)
+5. Adding a dark purple background with decorative border
+6. Saving as PNG to `docs/screenshots/combo_gothic_font.png`
+
+The image correctly demonstrates the Gothic bitmap font applied to the combo counter — the technical content is accurate, only the URL reference was broken.

--- a/src/agent.prompts.lib.mjs
+++ b/src/agent.prompts.lib.mjs
@@ -82,7 +82,10 @@ export const buildUserPrompt = params => {
  * @returns {string} The formatted system prompt
  */
 export const buildSystemPrompt = params => {
-  const { owner, repo, issueNumber, prNumber, branchName, workspaceTmpDir, argv, modelSupportsVision } = params;
+  const { owner, repo, issueNumber, prNumber, branchName, workspaceTmpDir, argv, modelSupportsVision, forkedRepo } = params;
+
+  // When in fork mode, screenshots are pushed to the fork, not the original repo
+  const screenshotRepoPath = argv?.fork && forkedRepo ? forkedRepo : `${owner}/${repo}`;
 
   // Build thinking instruction based on --think level
   let thinkLine = '';
@@ -245,7 +248,7 @@ GitHub CLI command patterns.
 Visual UI work and screenshots.
    - When you work on visual UI changes (frontend, CSS, HTML, design), include a render or screenshot of the final result in the pull request description.
    - When you need to show visual results, take a screenshot and save it to the repository (e.g., in a docs/screenshots/ or assets/ folder).
-   - When you save screenshots to the repository, use permanent links in the pull request description markdown (e.g., https://github.com/${owner}/${repo}/blob/${branchName}/docs/screenshots/result.png?raw=true).
+   - When you save screenshots to the repository, use permanent links in the pull request description markdown (e.g., https://github.com/${screenshotRepoPath}/blob/${branchName}/docs/screenshots/result.png?raw=true).
    - When uploading images, commit them to the branch first, then reference them using the GitHub blob URL format with ?raw=true suffix (works for both public and private repositories).
    - When the visual result is important for review, mention it explicitly in the pull request description with the embedded image.
    - When fixing UI bugs, capture both the "before" (problem) and "after" (fixed) screenshots as evidence for human verification.

--- a/src/claude.prompts.lib.mjs
+++ b/src/claude.prompts.lib.mjs
@@ -92,7 +92,10 @@ export const buildUserPrompt = params => {
  * @returns {string} The formatted system prompt
  */
 export const buildSystemPrompt = params => {
-  const { owner, repo, issueNumber, prNumber, branchName, workspaceTmpDir, argv, modelSupportsVision } = params;
+  const { owner, repo, issueNumber, prNumber, branchName, workspaceTmpDir, argv, modelSupportsVision, forkedRepo } = params;
+
+  // When in fork mode, screenshots are pushed to the fork, not the original repo
+  const screenshotRepoPath = argv?.fork && forkedRepo ? forkedRepo : `${owner}/${repo}`;
 
   // Note: --think keywords are deprecated for Claude Code >= 2.1.12
   // Thinking is now enabled by default with 31,999 token budget
@@ -339,7 +342,7 @@ Agent Commander usage (unified subagent delegation).
 Visual UI work and screenshots.
    - When you work on visual UI changes (frontend, CSS, HTML, design), include a render or screenshot of the final result in the pull request description.
    - When you need to show visual results, take a screenshot and save it to the repository (e.g., in a docs/screenshots/ or assets/ folder).
-   - When you save screenshots to the repository, use permanent links in the pull request description markdown (e.g., https://github.com/${owner}/${repo}/blob/${branchName}/docs/screenshots/result.png?raw=true).
+   - When you save screenshots to the repository, use permanent links in the pull request description markdown (e.g., https://github.com/${screenshotRepoPath}/blob/${branchName}/docs/screenshots/result.png?raw=true).
    - When uploading images, commit them to the branch first, then reference them using the GitHub blob URL format with ?raw=true suffix (works for both public and private repositories).
    - When the visual result is important for review, mention it explicitly in the pull request description with the embedded image.
    - When fixing UI bugs, capture both the "before" (problem) and "after" (fixed) screenshots as evidence for human verification.

--- a/src/codex.prompts.lib.mjs
+++ b/src/codex.prompts.lib.mjs
@@ -82,7 +82,10 @@ export const buildUserPrompt = params => {
  * @returns {string} The formatted system prompt
  */
 export const buildSystemPrompt = params => {
-  const { owner, repo, issueNumber, prNumber, branchName, workspaceTmpDir, argv } = params;
+  const { owner, repo, issueNumber, prNumber, branchName, workspaceTmpDir, argv, modelSupportsVision, forkedRepo } = params;
+
+  // When in fork mode, screenshots are pushed to the fork, not the original repo
+  const screenshotRepoPath = argv?.fork && forkedRepo ? forkedRepo : `${owner}/${repo}`;
 
   // Build thinking instruction based on --think level
   let thinkLine = '';
@@ -246,7 +249,22 @@ GitHub CLI command patterns.
    - When adding PR comment, use gh pr comment NUMBER --body "text" --repo OWNER/REPO.
    - When adding issue comment, use gh issue comment NUMBER --body "text" --repo OWNER/REPO.
    - When viewing PR details, use gh pr view NUMBER --repo OWNER/REPO.
-   - When filtering with jq, use gh api repos/\${owner}/\${repo}/pulls/\${prNumber}/comments --paginate --jq 'reverse | .[0:5]'.${ciExamples}${getArchitectureCareSubPrompt(argv)}`;
+   - When filtering with jq, use gh api repos/\${owner}/\${repo}/pulls/\${prNumber}/comments --paginate --jq 'reverse | .[0:5]'.${
+     modelSupportsVision
+       ? `
+
+Visual UI work and screenshots.
+   - When you work on visual UI changes (frontend, CSS, HTML, design), include a render or screenshot of the final result in the pull request description.
+   - When you need to show visual results, take a screenshot and save it to the repository (e.g., in a docs/screenshots/ or assets/ folder).
+   - When you save screenshots to the repository, use permanent links in the pull request description markdown (e.g., https://github.com/${screenshotRepoPath}/blob/${branchName}/docs/screenshots/result.png?raw=true).
+   - When uploading images, commit them to the branch first, then reference them using the GitHub blob URL format with ?raw=true suffix (works for both public and private repositories).
+   - When the visual result is important for review, mention it explicitly in the pull request description with the embedded image.
+   - When fixing UI bugs, capture both the "before" (problem) and "after" (fixed) screenshots as evidence for human verification.
+   - When reporting UI bugs, include a screenshot of the problem state to enable visual verification of the fix.
+   - When the fix is visual, include side-by-side or sequential comparison of before/after states in the PR description.
+   - When possible, create automated visual regression tests to prevent the UI bug from recurring.`
+       : ''
+   }${ciExamples}${getArchitectureCareSubPrompt(argv)}`;
 };
 
 // Export all functions as default object too

--- a/src/opencode.prompts.lib.mjs
+++ b/src/opencode.prompts.lib.mjs
@@ -82,7 +82,10 @@ export const buildUserPrompt = params => {
  * @returns {string} The formatted system prompt
  */
 export const buildSystemPrompt = params => {
-  const { owner, repo, issueNumber, prNumber, branchName, workspaceTmpDir, argv } = params;
+  const { owner, repo, issueNumber, prNumber, branchName, workspaceTmpDir, argv, modelSupportsVision, forkedRepo } = params;
+
+  // When in fork mode, screenshots are pushed to the fork, not the original repo
+  const screenshotRepoPath = argv?.fork && forkedRepo ? forkedRepo : `${owner}/${repo}`;
 
   // Build thinking instruction based on --think level
   let thinkLine = '';
@@ -239,7 +242,22 @@ GitHub CLI command patterns.
    - When adding PR comment, use gh pr comment NUMBER --body "text" --repo OWNER/REPO.
    - When adding issue comment, use gh issue comment NUMBER --body "text" --repo OWNER/REPO.
    - When viewing PR details, use gh pr view NUMBER --repo OWNER/REPO.
-   - When filtering with jq, use gh api repos/${owner}/${repo}/pulls/${prNumber}/comments --paginate --jq 'reverse | .[0:5]'.${ciExamples}${getArchitectureCareSubPrompt(argv)}`;
+   - When filtering with jq, use gh api repos/${owner}/${repo}/pulls/${prNumber}/comments --paginate --jq 'reverse | .[0:5]'.${
+     modelSupportsVision
+       ? `
+
+Visual UI work and screenshots.
+   - When you work on visual UI changes (frontend, CSS, HTML, design), include a render or screenshot of the final result in the pull request description.
+   - When you need to show visual results, take a screenshot and save it to the repository (e.g., in a docs/screenshots/ or assets/ folder).
+   - When you save screenshots to the repository, use permanent links in the pull request description markdown (e.g., https://github.com/${screenshotRepoPath}/blob/${branchName}/docs/screenshots/result.png?raw=true).
+   - When uploading images, commit them to the branch first, then reference them using the GitHub blob URL format with ?raw=true suffix (works for both public and private repositories).
+   - When the visual result is important for review, mention it explicitly in the pull request description with the embedded image.
+   - When fixing UI bugs, capture both the "before" (problem) and "after" (fixed) screenshots as evidence for human verification.
+   - When reporting UI bugs, include a screenshot of the problem state to enable visual verification of the fix.
+   - When the fix is visual, include side-by-side or sequential comparison of before/after states in the PR description.
+   - When possible, create automated visual regression tests to prevent the UI bug from recurring.`
+       : ''
+   }${ciExamples}${getArchitectureCareSubPrompt(argv)}`;
 };
 
 // Export all functions as default object too

--- a/tests/test-fork-screenshot-url-1561.mjs
+++ b/tests/test-fork-screenshot-url-1561.mjs
@@ -1,0 +1,217 @@
+#!/usr/bin/env node
+
+/**
+ * Unit Tests: Issue #1561 - Broken screenshot attached to pull request in fork mode
+ *
+ * Tests verify that:
+ * 1. Fork mode → screenshot URL uses forked repo path instead of original repo
+ * 2. Non-fork mode → screenshot URL uses original owner/repo (unchanged behavior)
+ * 3. Same behavior in both claude.prompts.lib.mjs and agent.prompts.lib.mjs
+ * 4. Source code uses screenshotRepoPath variable for fork-aware URL generation
+ *
+ * Run with: node tests/test-fork-screenshot-url-1561.mjs
+ *
+ * @see https://github.com/link-assistant/hive-mind/issues/1561
+ */
+
+import { readFileSync } from 'fs';
+import { fileURLToPath } from 'url';
+import { dirname, join } from 'path';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+
+// ANSI color codes for terminal output
+const GREEN = '\x1b[32m';
+const RED = '\x1b[31m';
+const BLUE = '\x1b[34m';
+const RESET = '\x1b[0m';
+
+let passed = 0;
+let failed = 0;
+
+const test = (description, fn) => {
+  try {
+    fn();
+    console.log(`  ${GREEN}✅ PASS:${RESET} ${description}`);
+    passed++;
+  } catch (e) {
+    console.log(`  ${RED}❌ FAIL:${RESET} ${description}`);
+    console.log(`      Error: ${e.message}`);
+    failed++;
+  }
+};
+
+const assert = (condition, message) => {
+  if (!condition) {
+    throw new Error(message);
+  }
+};
+
+console.log('================================================================================');
+console.log('Unit Tests: Issue #1561 - Fork mode screenshot URL fix');
+console.log('================================================================================\n');
+
+// Import the prompt builder functions
+let claudePrompts;
+let agentPrompts;
+
+try {
+  claudePrompts = await import('../src/claude.prompts.lib.mjs');
+  agentPrompts = await import('../src/agent.prompts.lib.mjs');
+} catch (e) {
+  console.error(`${RED}❌ Failed to import prompt modules: ${e.message}${RESET}`);
+  process.exit(1);
+}
+
+const { buildSystemPrompt: claudeBuildSystemPrompt } = claudePrompts;
+const { buildSystemPrompt: agentBuildSystemPrompt } = agentPrompts;
+
+// Common base params for tests
+const baseParams = {
+  owner: 'original-owner',
+  repo: 'original-repo',
+  issueNumber: '1790',
+  prNumber: '1796',
+  branchName: 'issue-1790-abc123',
+  workspaceTmpDir: null,
+  modelSupportsVision: true,
+};
+
+// ===== Tests for claude.prompts.lib.mjs: Fork mode =====
+console.log(`${BLUE}📋 Claude prompts: Fork mode screenshot URLs${RESET}\n`);
+
+test('Fork mode → screenshot URL uses forked repo path', () => {
+  const prompt = claudeBuildSystemPrompt({
+    ...baseParams,
+    argv: { fork: true },
+    forkedRepo: 'fork-user/original-repo',
+  });
+
+  assert(prompt.includes('github.com/fork-user/original-repo/blob/issue-1790-abc123'), 'Should use forked repo in screenshot URL');
+  assert(!prompt.includes('github.com/original-owner/original-repo/blob/issue-1790-abc123'), 'Should NOT use original repo in screenshot URL when in fork mode');
+});
+
+test('Non-fork mode → screenshot URL uses original repo', () => {
+  const prompt = claudeBuildSystemPrompt({
+    ...baseParams,
+    argv: {},
+  });
+
+  assert(prompt.includes('github.com/original-owner/original-repo/blob/issue-1790-abc123'), 'Should use original owner/repo in screenshot URL');
+});
+
+test('Fork mode without forkedRepo → falls back to original repo', () => {
+  const prompt = claudeBuildSystemPrompt({
+    ...baseParams,
+    argv: { fork: true },
+    // forkedRepo not provided
+  });
+
+  assert(prompt.includes('github.com/original-owner/original-repo/blob/issue-1790-abc123'), 'Should fall back to original repo when forkedRepo is not available');
+});
+
+test('Fork mode with empty argv → uses original repo', () => {
+  const prompt = claudeBuildSystemPrompt({
+    ...baseParams,
+    argv: {},
+    forkedRepo: 'fork-user/original-repo',
+  });
+
+  assert(prompt.includes('github.com/original-owner/original-repo/blob/issue-1790-abc123'), 'Should use original repo when fork flag is not set');
+});
+
+// ===== Tests for agent.prompts.lib.mjs: Fork mode =====
+console.log(`\n${BLUE}📋 Agent prompts: Fork mode screenshot URLs${RESET}\n`);
+
+test('[agent] Fork mode → screenshot URL uses forked repo path', () => {
+  const prompt = agentBuildSystemPrompt({
+    ...baseParams,
+    argv: { fork: true },
+    forkedRepo: 'fork-user/original-repo',
+  });
+
+  assert(prompt.includes('github.com/fork-user/original-repo/blob/issue-1790-abc123'), 'Should use forked repo in screenshot URL');
+  assert(!prompt.includes('github.com/original-owner/original-repo/blob/issue-1790-abc123'), 'Should NOT use original repo in screenshot URL when in fork mode');
+});
+
+test('[agent] Non-fork mode → screenshot URL uses original repo', () => {
+  const prompt = agentBuildSystemPrompt({
+    ...baseParams,
+    argv: {},
+  });
+
+  assert(prompt.includes('github.com/original-owner/original-repo/blob/issue-1790-abc123'), 'Should use original owner/repo in screenshot URL');
+});
+
+test('[agent] Fork mode without forkedRepo → falls back to original repo', () => {
+  const prompt = agentBuildSystemPrompt({
+    ...baseParams,
+    argv: { fork: true },
+  });
+
+  assert(prompt.includes('github.com/original-owner/original-repo/blob/issue-1790-abc123'), 'Should fall back to original repo when forkedRepo is not available');
+});
+
+// ===== Source code verification =====
+console.log(`\n${BLUE}📋 Source code verification${RESET}\n`);
+
+test('claude.prompts.lib.mjs: extracts forkedRepo from params', () => {
+  const content = readFileSync(join(__dirname, '../src/claude.prompts.lib.mjs'), 'utf-8');
+  assert(content.includes('forkedRepo'), 'Should destructure forkedRepo from params');
+  assert(content.includes('screenshotRepoPath'), 'Should compute screenshotRepoPath');
+});
+
+test('agent.prompts.lib.mjs: extracts forkedRepo from params', () => {
+  const content = readFileSync(join(__dirname, '../src/agent.prompts.lib.mjs'), 'utf-8');
+  assert(content.includes('forkedRepo'), 'Should destructure forkedRepo from params');
+  assert(content.includes('screenshotRepoPath'), 'Should compute screenshotRepoPath');
+});
+
+test('claude.prompts.lib.mjs: screenshotRepoPath uses fork when available', () => {
+  const content = readFileSync(join(__dirname, '../src/claude.prompts.lib.mjs'), 'utf-8');
+  assert(content.includes('argv?.fork && forkedRepo ? forkedRepo'), 'Should conditionally use forkedRepo when fork mode is active');
+});
+
+test('agent.prompts.lib.mjs: screenshotRepoPath uses fork when available', () => {
+  const content = readFileSync(join(__dirname, '../src/agent.prompts.lib.mjs'), 'utf-8');
+  assert(content.includes('argv?.fork && forkedRepo ? forkedRepo'), 'Should conditionally use forkedRepo when fork mode is active');
+});
+
+// ===== Regression: Existing tests from #1349 still hold =====
+console.log(`\n${BLUE}📋 Regression: Issue #1349 compatibility${RESET}\n`);
+
+test('Vision disabled → no screenshot section (claude)', () => {
+  const prompt = claudeBuildSystemPrompt({
+    ...baseParams,
+    modelSupportsVision: false,
+    argv: { fork: true },
+    forkedRepo: 'fork-user/original-repo',
+  });
+
+  assert(!prompt.includes('Visual UI work and screenshots'), 'Should not include screenshot section without vision');
+});
+
+test('Vision disabled → no screenshot section (agent)', () => {
+  const prompt = agentBuildSystemPrompt({
+    ...baseParams,
+    modelSupportsVision: false,
+    argv: { fork: true },
+    forkedRepo: 'fork-user/original-repo',
+  });
+
+  assert(!prompt.includes('Visual UI work and screenshots'), 'Should not include screenshot section without vision');
+});
+
+// ===== Summary =====
+console.log('\n================================================================================');
+console.log(`Test Summary: ${GREEN}${passed} passed${RESET}, ${failed > 0 ? RED : ''}${failed} failed${RESET}`);
+console.log('================================================================================\n');
+
+if (failed > 0) {
+  console.log(`${RED}❌ Tests FAILED${RESET}\n`);
+  process.exit(1);
+} else {
+  console.log(`${GREEN}✅ All tests PASSED${RESET}\n`);
+  process.exit(0);
+}

--- a/tests/test-fork-screenshot-url-1561.mjs
+++ b/tests/test-fork-screenshot-url-1561.mjs
@@ -14,43 +14,14 @@
  * @see https://github.com/link-assistant/hive-mind/issues/1561
  */
 
+import assert from 'node:assert/strict';
 import { readFileSync } from 'fs';
 import { fileURLToPath } from 'url';
 import { dirname, join } from 'path';
+import { test, printSummary, getFailCount } from './test-helpers.mjs';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
-
-// ANSI color codes for terminal output
-const GREEN = '\x1b[32m';
-const RED = '\x1b[31m';
-const BLUE = '\x1b[34m';
-const RESET = '\x1b[0m';
-
-let passed = 0;
-let failed = 0;
-
-const test = (description, fn) => {
-  try {
-    fn();
-    console.log(`  ${GREEN}✅ PASS:${RESET} ${description}`);
-    passed++;
-  } catch (e) {
-    console.log(`  ${RED}❌ FAIL:${RESET} ${description}`);
-    console.log(`      Error: ${e.message}`);
-    failed++;
-  }
-};
-
-const assert = (condition, message) => {
-  if (!condition) {
-    throw new Error(message);
-  }
-};
-
-console.log('================================================================================');
-console.log('Unit Tests: Issue #1561 - Fork mode screenshot URL fix');
-console.log('================================================================================\n');
 
 // Import the prompt builder functions
 let claudePrompts;
@@ -60,7 +31,7 @@ try {
   claudePrompts = await import('../src/claude.prompts.lib.mjs');
   agentPrompts = await import('../src/agent.prompts.lib.mjs');
 } catch (e) {
-  console.error(`${RED}❌ Failed to import prompt modules: ${e.message}${RESET}`);
+  console.error(`Failed to import prompt modules: ${e.message}`);
   process.exit(1);
 }
 
@@ -79,7 +50,7 @@ const baseParams = {
 };
 
 // ===== Tests for claude.prompts.lib.mjs: Fork mode =====
-console.log(`${BLUE}📋 Claude prompts: Fork mode screenshot URLs${RESET}\n`);
+console.log('\n📋 Claude prompts: Fork mode screenshot URLs\n');
 
 test('Fork mode → screenshot URL uses forked repo path', () => {
   const prompt = claudeBuildSystemPrompt({
@@ -88,8 +59,8 @@ test('Fork mode → screenshot URL uses forked repo path', () => {
     forkedRepo: 'fork-user/original-repo',
   });
 
-  assert(prompt.includes('github.com/fork-user/original-repo/blob/issue-1790-abc123'), 'Should use forked repo in screenshot URL');
-  assert(!prompt.includes('github.com/original-owner/original-repo/blob/issue-1790-abc123'), 'Should NOT use original repo in screenshot URL when in fork mode');
+  assert.ok(prompt.includes('github.com/fork-user/original-repo/blob/issue-1790-abc123'), 'Should use forked repo in screenshot URL');
+  assert.ok(!prompt.includes('github.com/original-owner/original-repo/blob/issue-1790-abc123'), 'Should NOT use original repo in screenshot URL when in fork mode');
 });
 
 test('Non-fork mode → screenshot URL uses original repo', () => {
@@ -98,17 +69,16 @@ test('Non-fork mode → screenshot URL uses original repo', () => {
     argv: {},
   });
 
-  assert(prompt.includes('github.com/original-owner/original-repo/blob/issue-1790-abc123'), 'Should use original owner/repo in screenshot URL');
+  assert.ok(prompt.includes('github.com/original-owner/original-repo/blob/issue-1790-abc123'), 'Should use original owner/repo in screenshot URL');
 });
 
 test('Fork mode without forkedRepo → falls back to original repo', () => {
   const prompt = claudeBuildSystemPrompt({
     ...baseParams,
     argv: { fork: true },
-    // forkedRepo not provided
   });
 
-  assert(prompt.includes('github.com/original-owner/original-repo/blob/issue-1790-abc123'), 'Should fall back to original repo when forkedRepo is not available');
+  assert.ok(prompt.includes('github.com/original-owner/original-repo/blob/issue-1790-abc123'), 'Should fall back to original repo when forkedRepo is not available');
 });
 
 test('Fork mode with empty argv → uses original repo', () => {
@@ -118,11 +88,11 @@ test('Fork mode with empty argv → uses original repo', () => {
     forkedRepo: 'fork-user/original-repo',
   });
 
-  assert(prompt.includes('github.com/original-owner/original-repo/blob/issue-1790-abc123'), 'Should use original repo when fork flag is not set');
+  assert.ok(prompt.includes('github.com/original-owner/original-repo/blob/issue-1790-abc123'), 'Should use original repo when fork flag is not set');
 });
 
 // ===== Tests for agent.prompts.lib.mjs: Fork mode =====
-console.log(`\n${BLUE}📋 Agent prompts: Fork mode screenshot URLs${RESET}\n`);
+console.log('\n📋 Agent prompts: Fork mode screenshot URLs\n');
 
 test('[agent] Fork mode → screenshot URL uses forked repo path', () => {
   const prompt = agentBuildSystemPrompt({
@@ -131,8 +101,8 @@ test('[agent] Fork mode → screenshot URL uses forked repo path', () => {
     forkedRepo: 'fork-user/original-repo',
   });
 
-  assert(prompt.includes('github.com/fork-user/original-repo/blob/issue-1790-abc123'), 'Should use forked repo in screenshot URL');
-  assert(!prompt.includes('github.com/original-owner/original-repo/blob/issue-1790-abc123'), 'Should NOT use original repo in screenshot URL when in fork mode');
+  assert.ok(prompt.includes('github.com/fork-user/original-repo/blob/issue-1790-abc123'), 'Should use forked repo in screenshot URL');
+  assert.ok(!prompt.includes('github.com/original-owner/original-repo/blob/issue-1790-abc123'), 'Should NOT use original repo in screenshot URL when in fork mode');
 });
 
 test('[agent] Non-fork mode → screenshot URL uses original repo', () => {
@@ -141,7 +111,7 @@ test('[agent] Non-fork mode → screenshot URL uses original repo', () => {
     argv: {},
   });
 
-  assert(prompt.includes('github.com/original-owner/original-repo/blob/issue-1790-abc123'), 'Should use original owner/repo in screenshot URL');
+  assert.ok(prompt.includes('github.com/original-owner/original-repo/blob/issue-1790-abc123'), 'Should use original owner/repo in screenshot URL');
 });
 
 test('[agent] Fork mode without forkedRepo → falls back to original repo', () => {
@@ -150,36 +120,36 @@ test('[agent] Fork mode without forkedRepo → falls back to original repo', () 
     argv: { fork: true },
   });
 
-  assert(prompt.includes('github.com/original-owner/original-repo/blob/issue-1790-abc123'), 'Should fall back to original repo when forkedRepo is not available');
+  assert.ok(prompt.includes('github.com/original-owner/original-repo/blob/issue-1790-abc123'), 'Should fall back to original repo when forkedRepo is not available');
 });
 
 // ===== Source code verification =====
-console.log(`\n${BLUE}📋 Source code verification${RESET}\n`);
+console.log('\n📋 Source code verification\n');
 
 test('claude.prompts.lib.mjs: extracts forkedRepo from params', () => {
   const content = readFileSync(join(__dirname, '../src/claude.prompts.lib.mjs'), 'utf-8');
-  assert(content.includes('forkedRepo'), 'Should destructure forkedRepo from params');
-  assert(content.includes('screenshotRepoPath'), 'Should compute screenshotRepoPath');
+  assert.ok(content.includes('forkedRepo'), 'Should destructure forkedRepo from params');
+  assert.ok(content.includes('screenshotRepoPath'), 'Should compute screenshotRepoPath');
 });
 
 test('agent.prompts.lib.mjs: extracts forkedRepo from params', () => {
   const content = readFileSync(join(__dirname, '../src/agent.prompts.lib.mjs'), 'utf-8');
-  assert(content.includes('forkedRepo'), 'Should destructure forkedRepo from params');
-  assert(content.includes('screenshotRepoPath'), 'Should compute screenshotRepoPath');
+  assert.ok(content.includes('forkedRepo'), 'Should destructure forkedRepo from params');
+  assert.ok(content.includes('screenshotRepoPath'), 'Should compute screenshotRepoPath');
 });
 
 test('claude.prompts.lib.mjs: screenshotRepoPath uses fork when available', () => {
   const content = readFileSync(join(__dirname, '../src/claude.prompts.lib.mjs'), 'utf-8');
-  assert(content.includes('argv?.fork && forkedRepo ? forkedRepo'), 'Should conditionally use forkedRepo when fork mode is active');
+  assert.ok(content.includes('argv?.fork && forkedRepo ? forkedRepo'), 'Should conditionally use forkedRepo when fork mode is active');
 });
 
 test('agent.prompts.lib.mjs: screenshotRepoPath uses fork when available', () => {
   const content = readFileSync(join(__dirname, '../src/agent.prompts.lib.mjs'), 'utf-8');
-  assert(content.includes('argv?.fork && forkedRepo ? forkedRepo'), 'Should conditionally use forkedRepo when fork mode is active');
+  assert.ok(content.includes('argv?.fork && forkedRepo ? forkedRepo'), 'Should conditionally use forkedRepo when fork mode is active');
 });
 
 // ===== Regression: Existing tests from #1349 still hold =====
-console.log(`\n${BLUE}📋 Regression: Issue #1349 compatibility${RESET}\n`);
+console.log('\n📋 Regression: Issue #1349 compatibility\n');
 
 test('Vision disabled → no screenshot section (claude)', () => {
   const prompt = claudeBuildSystemPrompt({
@@ -189,7 +159,7 @@ test('Vision disabled → no screenshot section (claude)', () => {
     forkedRepo: 'fork-user/original-repo',
   });
 
-  assert(!prompt.includes('Visual UI work and screenshots'), 'Should not include screenshot section without vision');
+  assert.ok(!prompt.includes('Visual UI work and screenshots'), 'Should not include screenshot section without vision');
 });
 
 test('Vision disabled → no screenshot section (agent)', () => {
@@ -200,18 +170,12 @@ test('Vision disabled → no screenshot section (agent)', () => {
     forkedRepo: 'fork-user/original-repo',
   });
 
-  assert(!prompt.includes('Visual UI work and screenshots'), 'Should not include screenshot section without vision');
+  assert.ok(!prompt.includes('Visual UI work and screenshots'), 'Should not include screenshot section without vision');
 });
 
 // ===== Summary =====
-console.log('\n================================================================================');
-console.log(`Test Summary: ${GREEN}${passed} passed${RESET}, ${failed > 0 ? RED : ''}${failed} failed${RESET}`);
-console.log('================================================================================\n');
+printSummary(80);
 
-if (failed > 0) {
-  console.log(`${RED}❌ Tests FAILED${RESET}\n`);
+if (getFailCount() > 0) {
   process.exit(1);
-} else {
-  console.log(`${GREEN}✅ All tests PASSED${RESET}\n`);
-  process.exit(0);
 }

--- a/tests/test-fork-screenshot-url-1561.mjs
+++ b/tests/test-fork-screenshot-url-1561.mjs
@@ -6,7 +6,7 @@
  * Tests verify that:
  * 1. Fork mode → screenshot URL uses forked repo path instead of original repo
  * 2. Non-fork mode → screenshot URL uses original owner/repo (unchanged behavior)
- * 3. Same behavior in both claude.prompts.lib.mjs and agent.prompts.lib.mjs
+ * 3. Same behavior in all prompt modules: claude, agent, codex, and opencode
  * 4. Source code uses screenshotRepoPath variable for fork-aware URL generation
  *
  * Run with: node tests/test-fork-screenshot-url-1561.mjs
@@ -23,20 +23,20 @@ import { test, printSummary, getFailCount } from './test-helpers.mjs';
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
 
-// Import the prompt builder functions
-let claudePrompts;
-let agentPrompts;
+// Import all prompt builder functions
+let modules;
 
 try {
-  claudePrompts = await import('../src/claude.prompts.lib.mjs');
-  agentPrompts = await import('../src/agent.prompts.lib.mjs');
+  modules = {
+    claude: await import('../src/claude.prompts.lib.mjs'),
+    agent: await import('../src/agent.prompts.lib.mjs'),
+    codex: await import('../src/codex.prompts.lib.mjs'),
+    opencode: await import('../src/opencode.prompts.lib.mjs'),
+  };
 } catch (e) {
   console.error(`Failed to import prompt modules: ${e.message}`);
   process.exit(1);
 }
-
-const { buildSystemPrompt: claudeBuildSystemPrompt } = claudePrompts;
-const { buildSystemPrompt: agentBuildSystemPrompt } = agentPrompts;
 
 // Common base params for tests
 const baseParams = {
@@ -49,129 +49,59 @@ const baseParams = {
   modelSupportsVision: true,
 };
 
-// ===== Tests for claude.prompts.lib.mjs: Fork mode =====
-console.log('\n📋 Claude prompts: Fork mode screenshot URLs\n');
+const forkUrl = 'github.com/fork-user/original-repo/blob/issue-1790-abc123';
+const originalUrl = 'github.com/original-owner/original-repo/blob/issue-1790-abc123';
 
-test('Fork mode → screenshot URL uses forked repo path', () => {
-  const prompt = claudeBuildSystemPrompt({
-    ...baseParams,
-    argv: { fork: true },
-    forkedRepo: 'fork-user/original-repo',
+// ===== Fork mode tests for all prompt modules =====
+for (const [name, mod] of Object.entries(modules)) {
+  const buildSystemPrompt = mod.buildSystemPrompt;
+
+  console.log(`\n📋 ${name} prompts: Fork mode screenshot URLs\n`);
+
+  test(`[${name}] Fork mode → screenshot URL uses forked repo path`, () => {
+    const prompt = buildSystemPrompt({ ...baseParams, argv: { fork: true }, forkedRepo: 'fork-user/original-repo' });
+    assert.ok(prompt.includes(forkUrl), 'Should use forked repo in screenshot URL');
+    assert.ok(!prompt.includes(originalUrl), 'Should NOT use original repo in screenshot URL when in fork mode');
   });
 
-  assert.ok(prompt.includes('github.com/fork-user/original-repo/blob/issue-1790-abc123'), 'Should use forked repo in screenshot URL');
-  assert.ok(!prompt.includes('github.com/original-owner/original-repo/blob/issue-1790-abc123'), 'Should NOT use original repo in screenshot URL when in fork mode');
-});
-
-test('Non-fork mode → screenshot URL uses original repo', () => {
-  const prompt = claudeBuildSystemPrompt({
-    ...baseParams,
-    argv: {},
+  test(`[${name}] Non-fork mode → screenshot URL uses original repo`, () => {
+    const prompt = buildSystemPrompt({ ...baseParams, argv: {} });
+    assert.ok(prompt.includes(originalUrl), 'Should use original owner/repo in screenshot URL');
   });
 
-  assert.ok(prompt.includes('github.com/original-owner/original-repo/blob/issue-1790-abc123'), 'Should use original owner/repo in screenshot URL');
-});
-
-test('Fork mode without forkedRepo → falls back to original repo', () => {
-  const prompt = claudeBuildSystemPrompt({
-    ...baseParams,
-    argv: { fork: true },
+  test(`[${name}] Fork mode without forkedRepo → falls back to original repo`, () => {
+    const prompt = buildSystemPrompt({ ...baseParams, argv: { fork: true } });
+    assert.ok(prompt.includes(originalUrl), 'Should fall back to original repo when forkedRepo is not available');
   });
+}
 
-  assert.ok(prompt.includes('github.com/original-owner/original-repo/blob/issue-1790-abc123'), 'Should fall back to original repo when forkedRepo is not available');
-});
-
+// Claude-specific: fork flag not set but forkedRepo provided
 test('Fork mode with empty argv → uses original repo', () => {
-  const prompt = claudeBuildSystemPrompt({
-    ...baseParams,
-    argv: {},
-    forkedRepo: 'fork-user/original-repo',
-  });
-
-  assert.ok(prompt.includes('github.com/original-owner/original-repo/blob/issue-1790-abc123'), 'Should use original repo when fork flag is not set');
-});
-
-// ===== Tests for agent.prompts.lib.mjs: Fork mode =====
-console.log('\n📋 Agent prompts: Fork mode screenshot URLs\n');
-
-test('[agent] Fork mode → screenshot URL uses forked repo path', () => {
-  const prompt = agentBuildSystemPrompt({
-    ...baseParams,
-    argv: { fork: true },
-    forkedRepo: 'fork-user/original-repo',
-  });
-
-  assert.ok(prompt.includes('github.com/fork-user/original-repo/blob/issue-1790-abc123'), 'Should use forked repo in screenshot URL');
-  assert.ok(!prompt.includes('github.com/original-owner/original-repo/blob/issue-1790-abc123'), 'Should NOT use original repo in screenshot URL when in fork mode');
-});
-
-test('[agent] Non-fork mode → screenshot URL uses original repo', () => {
-  const prompt = agentBuildSystemPrompt({
-    ...baseParams,
-    argv: {},
-  });
-
-  assert.ok(prompt.includes('github.com/original-owner/original-repo/blob/issue-1790-abc123'), 'Should use original owner/repo in screenshot URL');
-});
-
-test('[agent] Fork mode without forkedRepo → falls back to original repo', () => {
-  const prompt = agentBuildSystemPrompt({
-    ...baseParams,
-    argv: { fork: true },
-  });
-
-  assert.ok(prompt.includes('github.com/original-owner/original-repo/blob/issue-1790-abc123'), 'Should fall back to original repo when forkedRepo is not available');
+  const prompt = modules.claude.buildSystemPrompt({ ...baseParams, argv: {}, forkedRepo: 'fork-user/original-repo' });
+  assert.ok(prompt.includes(originalUrl), 'Should use original repo when fork flag is not set');
 });
 
 // ===== Source code verification =====
 console.log('\n📋 Source code verification\n');
 
-test('claude.prompts.lib.mjs: extracts forkedRepo from params', () => {
-  const content = readFileSync(join(__dirname, '../src/claude.prompts.lib.mjs'), 'utf-8');
-  assert.ok(content.includes('forkedRepo'), 'Should destructure forkedRepo from params');
-  assert.ok(content.includes('screenshotRepoPath'), 'Should compute screenshotRepoPath');
-});
+for (const name of Object.keys(modules)) {
+  test(`${name}.prompts.lib.mjs: extracts forkedRepo and computes screenshotRepoPath`, () => {
+    const content = readFileSync(join(__dirname, `../src/${name}.prompts.lib.mjs`), 'utf-8');
+    assert.ok(content.includes('forkedRepo'), 'Should destructure forkedRepo from params');
+    assert.ok(content.includes('screenshotRepoPath'), 'Should compute screenshotRepoPath');
+    assert.ok(content.includes('argv?.fork && forkedRepo ? forkedRepo'), 'Should conditionally use forkedRepo when fork mode is active');
+  });
+}
 
-test('agent.prompts.lib.mjs: extracts forkedRepo from params', () => {
-  const content = readFileSync(join(__dirname, '../src/agent.prompts.lib.mjs'), 'utf-8');
-  assert.ok(content.includes('forkedRepo'), 'Should destructure forkedRepo from params');
-  assert.ok(content.includes('screenshotRepoPath'), 'Should compute screenshotRepoPath');
-});
-
-test('claude.prompts.lib.mjs: screenshotRepoPath uses fork when available', () => {
-  const content = readFileSync(join(__dirname, '../src/claude.prompts.lib.mjs'), 'utf-8');
-  assert.ok(content.includes('argv?.fork && forkedRepo ? forkedRepo'), 'Should conditionally use forkedRepo when fork mode is active');
-});
-
-test('agent.prompts.lib.mjs: screenshotRepoPath uses fork when available', () => {
-  const content = readFileSync(join(__dirname, '../src/agent.prompts.lib.mjs'), 'utf-8');
-  assert.ok(content.includes('argv?.fork && forkedRepo ? forkedRepo'), 'Should conditionally use forkedRepo when fork mode is active');
-});
-
-// ===== Regression: Existing tests from #1349 still hold =====
+// ===== Regression: Vision disabled =====
 console.log('\n📋 Regression: Issue #1349 compatibility\n');
 
-test('Vision disabled → no screenshot section (claude)', () => {
-  const prompt = claudeBuildSystemPrompt({
-    ...baseParams,
-    modelSupportsVision: false,
-    argv: { fork: true },
-    forkedRepo: 'fork-user/original-repo',
+for (const [name, mod] of Object.entries(modules)) {
+  test(`[${name}] Vision disabled → no screenshot section`, () => {
+    const prompt = mod.buildSystemPrompt({ ...baseParams, modelSupportsVision: false, argv: { fork: true }, forkedRepo: 'fork-user/original-repo' });
+    assert.ok(!prompt.includes('Visual UI work and screenshots'), 'Should not include screenshot section without vision');
   });
-
-  assert.ok(!prompt.includes('Visual UI work and screenshots'), 'Should not include screenshot section without vision');
-});
-
-test('Vision disabled → no screenshot section (agent)', () => {
-  const prompt = agentBuildSystemPrompt({
-    ...baseParams,
-    modelSupportsVision: false,
-    argv: { fork: true },
-    forkedRepo: 'fork-user/original-repo',
-  });
-
-  assert.ok(!prompt.includes('Visual UI work and screenshots'), 'Should not include screenshot section without vision');
-});
+}
 
 // ===== Summary =====
 printSummary(80);

--- a/tests/test-private-repo-screenshots-1349.mjs
+++ b/tests/test-private-repo-screenshots-1349.mjs
@@ -154,18 +154,18 @@ test('[agent] No vision model → no screenshot section', () => {
 // ===== Source code verification tests =====
 console.log(`\n${BLUE}📋 Source code verification tests${RESET}\n`);
 
-test('claude.prompts.lib.mjs: uses github.com/blob/?raw=true URL format', () => {
+test('claude.prompts.lib.mjs: uses github.com/blob/?raw=true URL format via screenshotRepoPath', () => {
   const claudePromptsPath = join(__dirname, '../src/claude.prompts.lib.mjs');
   const content = readFileSync(claudePromptsPath, 'utf-8');
-  assert(content.includes('github.com/${owner}/${repo}/blob/${branchName}'), 'Should use github.com/blob/ URL format');
+  assert(content.includes('github.com/${screenshotRepoPath}/blob/${branchName}'), 'Should use github.com/blob/ URL format with screenshotRepoPath');
   assert(content.includes('?raw=true'), 'Should include ?raw=true suffix');
   assert(!content.includes('raw.githubusercontent.com'), 'Should NOT use raw.githubusercontent.com');
 });
 
-test('agent.prompts.lib.mjs: uses github.com/blob/?raw=true URL format', () => {
+test('agent.prompts.lib.mjs: uses github.com/blob/?raw=true URL format via screenshotRepoPath', () => {
   const agentPromptsPath = join(__dirname, '../src/agent.prompts.lib.mjs');
   const content = readFileSync(agentPromptsPath, 'utf-8');
-  assert(content.includes('github.com/${owner}/${repo}/blob/${branchName}'), 'Should use github.com/blob/ URL format');
+  assert(content.includes('github.com/${screenshotRepoPath}/blob/${branchName}'), 'Should use github.com/blob/ URL format with screenshotRepoPath');
   assert(content.includes('?raw=true'), 'Should include ?raw=true suffix');
   assert(!content.includes('raw.githubusercontent.com'), 'Should NOT use raw.githubusercontent.com');
 });

--- a/tests/test-private-repo-screenshots-1349.mjs
+++ b/tests/test-private-repo-screenshots-1349.mjs
@@ -14,47 +14,16 @@
  * @see https://github.com/link-assistant/hive-mind/issues/1349
  */
 
+import assert from 'node:assert/strict';
 import { readFileSync } from 'fs';
 import { fileURLToPath } from 'url';
 import { dirname, join } from 'path';
+import { test, printSummary, getFailCount } from './test-helpers.mjs';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
 
-// ANSI color codes for terminal output
-const GREEN = '\x1b[32m';
-const RED = '\x1b[31m';
-const YELLOW = '\x1b[33m';
-const BLUE = '\x1b[34m';
-const RESET = '\x1b[0m';
-
-let passed = 0;
-let failed = 0;
-
-const test = (description, fn) => {
-  try {
-    fn();
-    console.log(`  ${GREEN}✅ PASS:${RESET} ${description}`);
-    passed++;
-  } catch (e) {
-    console.log(`  ${RED}❌ FAIL:${RESET} ${description}`);
-    console.log(`      Error: ${e.message}`);
-    failed++;
-  }
-};
-
-const assert = (condition, message) => {
-  if (!condition) {
-    throw new Error(message);
-  }
-};
-
-console.log('================================================================================');
-console.log('Unit Tests: Issue #1349 - Broken image links in PR descriptions for private repos');
-console.log('================================================================================\n');
-
 // Import the prompt builder functions directly
-// We use dynamic import so we can test with real module
 let claudePrompts;
 let agentPrompts;
 
@@ -62,7 +31,7 @@ try {
   claudePrompts = await import('../src/claude.prompts.lib.mjs');
   agentPrompts = await import('../src/agent.prompts.lib.mjs');
 } catch (e) {
-  console.error(`${RED}❌ Failed to import prompt modules: ${e.message}${RESET}`);
+  console.error(`Failed to import prompt modules: ${e.message}`);
   process.exit(1);
 }
 
@@ -81,7 +50,7 @@ const baseParams = {
 };
 
 // ===== Tests for claude.prompts.lib.mjs =====
-console.log(`${BLUE}📋 Tests for claude.prompts.lib.mjs${RESET}\n`);
+console.log('\n📋 Tests for claude.prompts.lib.mjs\n');
 
 test('Vision model → screenshot section uses github.com/blob/?raw=true URL format', () => {
   const prompt = claudeBuildSystemPrompt({
@@ -89,10 +58,10 @@ test('Vision model → screenshot section uses github.com/blob/?raw=true URL for
     modelSupportsVision: true,
   });
 
-  assert(prompt.includes('Visual UI work and screenshots'), 'Should include screenshot section header');
-  assert(prompt.includes('github.com/test-owner/test-repo/blob/test-branch'), 'Should include github.com/blob/ URL with correct owner/repo/branch');
-  assert(prompt.includes('?raw=true'), 'Should include ?raw=true suffix');
-  assert(!prompt.includes('raw.githubusercontent.com'), 'Should NOT use raw.githubusercontent.com (broken for private repos)');
+  assert.ok(prompt.includes('Visual UI work and screenshots'), 'Should include screenshot section header');
+  assert.ok(prompt.includes('github.com/test-owner/test-repo/blob/test-branch'), 'Should include github.com/blob/ URL with correct owner/repo/branch');
+  assert.ok(prompt.includes('?raw=true'), 'Should include ?raw=true suffix');
+  assert.ok(!prompt.includes('raw.githubusercontent.com'), 'Should NOT use raw.githubusercontent.com (broken for private repos)');
 });
 
 test('Vision model → screenshot section works universally (no private/public distinction)', () => {
@@ -101,9 +70,9 @@ test('Vision model → screenshot section works universally (no private/public d
     modelSupportsVision: true,
   });
 
-  assert(prompt.includes('works for both public and private repositories'), 'Should explicitly state it works for both public and private repositories');
-  assert(!prompt.includes('PRIVATE repository'), 'Should NOT have private repo-specific warning');
-  assert(!prompt.includes('HTTP 404'), 'Should NOT mention HTTP 404 errors');
+  assert.ok(prompt.includes('works for both public and private repositories'), 'Should explicitly state it works for both public and private repositories');
+  assert.ok(!prompt.includes('PRIVATE repository'), 'Should NOT have private repo-specific warning');
+  assert.ok(!prompt.includes('HTTP 404'), 'Should NOT mention HTTP 404 errors');
 });
 
 test('No vision model → no screenshot section', () => {
@@ -112,12 +81,12 @@ test('No vision model → no screenshot section', () => {
     modelSupportsVision: false,
   });
 
-  assert(!prompt.includes('Visual UI work and screenshots'), 'Should not include screenshot section');
-  assert(!prompt.includes('github.com/test-owner/test-repo/blob/test-branch'), 'Should not include any screenshot URL');
+  assert.ok(!prompt.includes('Visual UI work and screenshots'), 'Should not include screenshot section');
+  assert.ok(!prompt.includes('github.com/test-owner/test-repo/blob/test-branch'), 'Should not include any screenshot URL');
 });
 
 // ===== Tests for agent.prompts.lib.mjs =====
-console.log(`\n${BLUE}📋 Tests for agent.prompts.lib.mjs${RESET}\n`);
+console.log('\n📋 Tests for agent.prompts.lib.mjs\n');
 
 test('[agent] Vision model → screenshot section uses github.com/blob/?raw=true URL format', () => {
   const prompt = agentBuildSystemPrompt({
@@ -125,10 +94,10 @@ test('[agent] Vision model → screenshot section uses github.com/blob/?raw=true
     modelSupportsVision: true,
   });
 
-  assert(prompt.includes('Visual UI work and screenshots'), 'Should include screenshot section header');
-  assert(prompt.includes('github.com/test-owner/test-repo/blob/test-branch'), 'Should include github.com/blob/ URL with correct owner/repo/branch');
-  assert(prompt.includes('?raw=true'), 'Should include ?raw=true suffix');
-  assert(!prompt.includes('raw.githubusercontent.com'), 'Should NOT use raw.githubusercontent.com (broken for private repos)');
+  assert.ok(prompt.includes('Visual UI work and screenshots'), 'Should include screenshot section header');
+  assert.ok(prompt.includes('github.com/test-owner/test-repo/blob/test-branch'), 'Should include github.com/blob/ URL with correct owner/repo/branch');
+  assert.ok(prompt.includes('?raw=true'), 'Should include ?raw=true suffix');
+  assert.ok(!prompt.includes('raw.githubusercontent.com'), 'Should NOT use raw.githubusercontent.com (broken for private repos)');
 });
 
 test('[agent] Vision model → screenshot section works universally (no private/public distinction)', () => {
@@ -137,8 +106,8 @@ test('[agent] Vision model → screenshot section works universally (no private/
     modelSupportsVision: true,
   });
 
-  assert(prompt.includes('works for both public and private repositories'), 'Should explicitly state it works for both public and private repositories');
-  assert(!prompt.includes('PRIVATE repository'), 'Should NOT have private repo-specific warning');
+  assert.ok(prompt.includes('works for both public and private repositories'), 'Should explicitly state it works for both public and private repositories');
+  assert.ok(!prompt.includes('PRIVATE repository'), 'Should NOT have private repo-specific warning');
 });
 
 test('[agent] No vision model → no screenshot section', () => {
@@ -147,64 +116,58 @@ test('[agent] No vision model → no screenshot section', () => {
     modelSupportsVision: false,
   });
 
-  assert(!prompt.includes('Visual UI work and screenshots'), 'Should not include screenshot section');
-  assert(!prompt.includes('github.com/test-owner/test-repo/blob/test-branch'), 'Should not include any screenshot URL');
+  assert.ok(!prompt.includes('Visual UI work and screenshots'), 'Should not include screenshot section');
+  assert.ok(!prompt.includes('github.com/test-owner/test-repo/blob/test-branch'), 'Should not include any screenshot URL');
 });
 
 // ===== Source code verification tests =====
-console.log(`\n${BLUE}📋 Source code verification tests${RESET}\n`);
+console.log('\n📋 Source code verification tests\n');
 
 test('claude.prompts.lib.mjs: uses github.com/blob/?raw=true URL format via screenshotRepoPath', () => {
   const claudePromptsPath = join(__dirname, '../src/claude.prompts.lib.mjs');
   const content = readFileSync(claudePromptsPath, 'utf-8');
-  assert(content.includes('github.com/${screenshotRepoPath}/blob/${branchName}'), 'Should use github.com/blob/ URL format with screenshotRepoPath');
-  assert(content.includes('?raw=true'), 'Should include ?raw=true suffix');
-  assert(!content.includes('raw.githubusercontent.com'), 'Should NOT use raw.githubusercontent.com');
+  assert.ok(content.includes('github.com/${screenshotRepoPath}/blob/${branchName}'), 'Should use github.com/blob/ URL format with screenshotRepoPath');
+  assert.ok(content.includes('?raw=true'), 'Should include ?raw=true suffix');
+  assert.ok(!content.includes('raw.githubusercontent.com'), 'Should NOT use raw.githubusercontent.com');
 });
 
 test('agent.prompts.lib.mjs: uses github.com/blob/?raw=true URL format via screenshotRepoPath', () => {
   const agentPromptsPath = join(__dirname, '../src/agent.prompts.lib.mjs');
   const content = readFileSync(agentPromptsPath, 'utf-8');
-  assert(content.includes('github.com/${screenshotRepoPath}/blob/${branchName}'), 'Should use github.com/blob/ URL format with screenshotRepoPath');
-  assert(content.includes('?raw=true'), 'Should include ?raw=true suffix');
-  assert(!content.includes('raw.githubusercontent.com'), 'Should NOT use raw.githubusercontent.com');
+  assert.ok(content.includes('github.com/${screenshotRepoPath}/blob/${branchName}'), 'Should use github.com/blob/ URL format with screenshotRepoPath');
+  assert.ok(content.includes('?raw=true'), 'Should include ?raw=true suffix');
+  assert.ok(!content.includes('raw.githubusercontent.com'), 'Should NOT use raw.githubusercontent.com');
 });
 
 test('claude.prompts.lib.mjs: does NOT have repoIsPrivate parameter (simplified approach)', () => {
   const claudePromptsPath = join(__dirname, '../src/claude.prompts.lib.mjs');
   const content = readFileSync(claudePromptsPath, 'utf-8');
-  assert(!content.includes('repoIsPrivate'), 'Should NOT have repoIsPrivate parameter (no longer needed)');
+  assert.ok(!content.includes('repoIsPrivate'), 'Should NOT have repoIsPrivate parameter (no longer needed)');
 });
 
 test('agent.prompts.lib.mjs: does NOT have repoIsPrivate parameter (simplified approach)', () => {
   const agentPromptsPath = join(__dirname, '../src/agent.prompts.lib.mjs');
   const content = readFileSync(agentPromptsPath, 'utf-8');
-  assert(!content.includes('repoIsPrivate'), 'Should NOT have repoIsPrivate parameter (no longer needed)');
+  assert.ok(!content.includes('repoIsPrivate'), 'Should NOT have repoIsPrivate parameter (no longer needed)');
 });
 
 test('claude.lib.mjs: does NOT import or use getRepoVisibility (simplified approach)', () => {
   const claudeLibPath = join(__dirname, '../src/claude.lib.mjs');
   const content = readFileSync(claudeLibPath, 'utf-8');
-  assert(!content.includes('getRepoVisibility'), 'claude.lib.mjs should NOT import getRepoVisibility (no longer needed)');
-  assert(!content.includes('repoIsPrivate'), 'claude.lib.mjs should NOT use repoIsPrivate');
+  assert.ok(!content.includes('getRepoVisibility'), 'claude.lib.mjs should NOT import getRepoVisibility (no longer needed)');
+  assert.ok(!content.includes('repoIsPrivate'), 'claude.lib.mjs should NOT use repoIsPrivate');
 });
 
 test('agent.lib.mjs: does NOT import or use getRepoVisibility (simplified approach)', () => {
   const agentLibPath = join(__dirname, '../src/agent.lib.mjs');
   const content = readFileSync(agentLibPath, 'utf-8');
-  assert(!content.includes('getRepoVisibility'), 'agent.lib.mjs should NOT import getRepoVisibility (no longer needed)');
-  assert(!content.includes('repoIsPrivate'), 'agent.lib.mjs should NOT use repoIsPrivate');
+  assert.ok(!content.includes('getRepoVisibility'), 'agent.lib.mjs should NOT import getRepoVisibility (no longer needed)');
+  assert.ok(!content.includes('repoIsPrivate'), 'agent.lib.mjs should NOT use repoIsPrivate');
 });
 
 // ===== Summary =====
-console.log('\n================================================================================');
-console.log(`Test Summary: ${GREEN}${passed} passed${RESET}, ${failed > 0 ? RED : ''}${failed} failed${RESET}`);
-console.log('================================================================================\n');
+printSummary(80);
 
-if (failed > 0) {
-  console.log(`${RED}❌ Tests FAILED${RESET}\n`);
+if (getFailCount() > 0) {
   process.exit(1);
-} else {
-  console.log(`${GREEN}✅ All tests PASSED${RESET}\n`);
-  process.exit(0);
 }

--- a/tests/test-private-repo-screenshots-1349.mjs
+++ b/tests/test-private-repo-screenshots-1349.mjs
@@ -7,7 +7,7 @@
  * 1. Vision model → screenshot instructions include github.com/blob/?raw=true URL pattern (works for both public and private repos)
  * 2. No vision model → no screenshot section in prompt
  * 3. URL format uses github.com/org/repo/blob/branch/path?raw=true (not raw.githubusercontent.com)
- * 4. Same behavior in both claude.prompts.lib.mjs and agent.prompts.lib.mjs
+ * 4. Same behavior in all prompt modules: claude, agent, codex, and opencode
  *
  * Run with: node tests/test-private-repo-screenshots-1349.mjs
  *
@@ -23,20 +23,20 @@ import { test, printSummary, getFailCount } from './test-helpers.mjs';
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
 
-// Import the prompt builder functions directly
-let claudePrompts;
-let agentPrompts;
+// Import all prompt builder functions
+let modules;
 
 try {
-  claudePrompts = await import('../src/claude.prompts.lib.mjs');
-  agentPrompts = await import('../src/agent.prompts.lib.mjs');
+  modules = {
+    claude: await import('../src/claude.prompts.lib.mjs'),
+    agent: await import('../src/agent.prompts.lib.mjs'),
+    codex: await import('../src/codex.prompts.lib.mjs'),
+    opencode: await import('../src/opencode.prompts.lib.mjs'),
+  };
 } catch (e) {
   console.error(`Failed to import prompt modules: ${e.message}`);
   process.exit(1);
 }
-
-const { buildSystemPrompt: claudeBuildSystemPrompt } = claudePrompts;
-const { buildSystemPrompt: agentBuildSystemPrompt } = agentPrompts;
 
 // Common base params for tests
 const baseParams = {
@@ -49,121 +49,60 @@ const baseParams = {
   argv: {},
 };
 
-// ===== Tests for claude.prompts.lib.mjs =====
-console.log('\n📋 Tests for claude.prompts.lib.mjs\n');
+// ===== Vision model screenshot URL tests for all prompt modules =====
+for (const [name, mod] of Object.entries(modules)) {
+  const buildSystemPrompt = mod.buildSystemPrompt;
 
-test('Vision model → screenshot section uses github.com/blob/?raw=true URL format', () => {
-  const prompt = claudeBuildSystemPrompt({
-    ...baseParams,
-    modelSupportsVision: true,
+  console.log(`\n📋 Tests for ${name}.prompts.lib.mjs\n`);
+
+  test(`[${name}] Vision model → screenshot section uses github.com/blob/?raw=true URL format`, () => {
+    const prompt = buildSystemPrompt({ ...baseParams, modelSupportsVision: true });
+    assert.ok(prompt.includes('Visual UI work and screenshots'), 'Should include screenshot section header');
+    assert.ok(prompt.includes('github.com/test-owner/test-repo/blob/test-branch'), 'Should include github.com/blob/ URL with correct owner/repo/branch');
+    assert.ok(prompt.includes('?raw=true'), 'Should include ?raw=true suffix');
+    assert.ok(!prompt.includes('raw.githubusercontent.com'), 'Should NOT use raw.githubusercontent.com (broken for private repos)');
   });
 
-  assert.ok(prompt.includes('Visual UI work and screenshots'), 'Should include screenshot section header');
-  assert.ok(prompt.includes('github.com/test-owner/test-repo/blob/test-branch'), 'Should include github.com/blob/ URL with correct owner/repo/branch');
-  assert.ok(prompt.includes('?raw=true'), 'Should include ?raw=true suffix');
-  assert.ok(!prompt.includes('raw.githubusercontent.com'), 'Should NOT use raw.githubusercontent.com (broken for private repos)');
-});
-
-test('Vision model → screenshot section works universally (no private/public distinction)', () => {
-  const prompt = claudeBuildSystemPrompt({
-    ...baseParams,
-    modelSupportsVision: true,
+  test(`[${name}] No vision model → no screenshot section`, () => {
+    const prompt = buildSystemPrompt({ ...baseParams, modelSupportsVision: false });
+    assert.ok(!prompt.includes('Visual UI work and screenshots'), 'Should not include screenshot section');
   });
+}
 
-  assert.ok(prompt.includes('works for both public and private repositories'), 'Should explicitly state it works for both public and private repositories');
-  assert.ok(!prompt.includes('PRIVATE repository'), 'Should NOT have private repo-specific warning');
-  assert.ok(!prompt.includes('HTTP 404'), 'Should NOT mention HTTP 404 errors');
-});
-
-test('No vision model → no screenshot section', () => {
-  const prompt = claudeBuildSystemPrompt({
-    ...baseParams,
-    modelSupportsVision: false,
+// Claude and agent have extra assertions about universal wording
+for (const name of ['claude', 'agent']) {
+  test(`[${name}] Vision model → screenshot section works universally (no private/public distinction)`, () => {
+    const prompt = modules[name].buildSystemPrompt({ ...baseParams, modelSupportsVision: true });
+    assert.ok(prompt.includes('works for both public and private repositories'), 'Should explicitly state it works for both public and private repositories');
+    assert.ok(!prompt.includes('PRIVATE repository'), 'Should NOT have private repo-specific warning');
   });
-
-  assert.ok(!prompt.includes('Visual UI work and screenshots'), 'Should not include screenshot section');
-  assert.ok(!prompt.includes('github.com/test-owner/test-repo/blob/test-branch'), 'Should not include any screenshot URL');
-});
-
-// ===== Tests for agent.prompts.lib.mjs =====
-console.log('\n📋 Tests for agent.prompts.lib.mjs\n');
-
-test('[agent] Vision model → screenshot section uses github.com/blob/?raw=true URL format', () => {
-  const prompt = agentBuildSystemPrompt({
-    ...baseParams,
-    modelSupportsVision: true,
-  });
-
-  assert.ok(prompt.includes('Visual UI work and screenshots'), 'Should include screenshot section header');
-  assert.ok(prompt.includes('github.com/test-owner/test-repo/blob/test-branch'), 'Should include github.com/blob/ URL with correct owner/repo/branch');
-  assert.ok(prompt.includes('?raw=true'), 'Should include ?raw=true suffix');
-  assert.ok(!prompt.includes('raw.githubusercontent.com'), 'Should NOT use raw.githubusercontent.com (broken for private repos)');
-});
-
-test('[agent] Vision model → screenshot section works universally (no private/public distinction)', () => {
-  const prompt = agentBuildSystemPrompt({
-    ...baseParams,
-    modelSupportsVision: true,
-  });
-
-  assert.ok(prompt.includes('works for both public and private repositories'), 'Should explicitly state it works for both public and private repositories');
-  assert.ok(!prompt.includes('PRIVATE repository'), 'Should NOT have private repo-specific warning');
-});
-
-test('[agent] No vision model → no screenshot section', () => {
-  const prompt = agentBuildSystemPrompt({
-    ...baseParams,
-    modelSupportsVision: false,
-  });
-
-  assert.ok(!prompt.includes('Visual UI work and screenshots'), 'Should not include screenshot section');
-  assert.ok(!prompt.includes('github.com/test-owner/test-repo/blob/test-branch'), 'Should not include any screenshot URL');
-});
+}
 
 // ===== Source code verification tests =====
 console.log('\n📋 Source code verification tests\n');
 
-test('claude.prompts.lib.mjs: uses github.com/blob/?raw=true URL format via screenshotRepoPath', () => {
-  const claudePromptsPath = join(__dirname, '../src/claude.prompts.lib.mjs');
-  const content = readFileSync(claudePromptsPath, 'utf-8');
-  assert.ok(content.includes('github.com/${screenshotRepoPath}/blob/${branchName}'), 'Should use github.com/blob/ URL format with screenshotRepoPath');
-  assert.ok(content.includes('?raw=true'), 'Should include ?raw=true suffix');
-  assert.ok(!content.includes('raw.githubusercontent.com'), 'Should NOT use raw.githubusercontent.com');
-});
+for (const name of Object.keys(modules)) {
+  test(`${name}.prompts.lib.mjs: uses github.com/blob/?raw=true URL format via screenshotRepoPath`, () => {
+    const content = readFileSync(join(__dirname, `../src/${name}.prompts.lib.mjs`), 'utf-8');
+    assert.ok(content.includes('github.com/${screenshotRepoPath}/blob/${branchName}'), 'Should use github.com/blob/ URL format with screenshotRepoPath');
+    assert.ok(content.includes('?raw=true'), 'Should include ?raw=true suffix');
+    assert.ok(!content.includes('raw.githubusercontent.com'), 'Should NOT use raw.githubusercontent.com');
+  });
 
-test('agent.prompts.lib.mjs: uses github.com/blob/?raw=true URL format via screenshotRepoPath', () => {
-  const agentPromptsPath = join(__dirname, '../src/agent.prompts.lib.mjs');
-  const content = readFileSync(agentPromptsPath, 'utf-8');
-  assert.ok(content.includes('github.com/${screenshotRepoPath}/blob/${branchName}'), 'Should use github.com/blob/ URL format with screenshotRepoPath');
-  assert.ok(content.includes('?raw=true'), 'Should include ?raw=true suffix');
-  assert.ok(!content.includes('raw.githubusercontent.com'), 'Should NOT use raw.githubusercontent.com');
-});
+  test(`${name}.prompts.lib.mjs: does NOT have repoIsPrivate parameter (simplified approach)`, () => {
+    const content = readFileSync(join(__dirname, `../src/${name}.prompts.lib.mjs`), 'utf-8');
+    assert.ok(!content.includes('repoIsPrivate'), 'Should NOT have repoIsPrivate parameter (no longer needed)');
+  });
+}
 
-test('claude.prompts.lib.mjs: does NOT have repoIsPrivate parameter (simplified approach)', () => {
-  const claudePromptsPath = join(__dirname, '../src/claude.prompts.lib.mjs');
-  const content = readFileSync(claudePromptsPath, 'utf-8');
-  assert.ok(!content.includes('repoIsPrivate'), 'Should NOT have repoIsPrivate parameter (no longer needed)');
-});
-
-test('agent.prompts.lib.mjs: does NOT have repoIsPrivate parameter (simplified approach)', () => {
-  const agentPromptsPath = join(__dirname, '../src/agent.prompts.lib.mjs');
-  const content = readFileSync(agentPromptsPath, 'utf-8');
-  assert.ok(!content.includes('repoIsPrivate'), 'Should NOT have repoIsPrivate parameter (no longer needed)');
-});
-
-test('claude.lib.mjs: does NOT import or use getRepoVisibility (simplified approach)', () => {
-  const claudeLibPath = join(__dirname, '../src/claude.lib.mjs');
-  const content = readFileSync(claudeLibPath, 'utf-8');
-  assert.ok(!content.includes('getRepoVisibility'), 'claude.lib.mjs should NOT import getRepoVisibility (no longer needed)');
-  assert.ok(!content.includes('repoIsPrivate'), 'claude.lib.mjs should NOT use repoIsPrivate');
-});
-
-test('agent.lib.mjs: does NOT import or use getRepoVisibility (simplified approach)', () => {
-  const agentLibPath = join(__dirname, '../src/agent.lib.mjs');
-  const content = readFileSync(agentLibPath, 'utf-8');
-  assert.ok(!content.includes('getRepoVisibility'), 'agent.lib.mjs should NOT import getRepoVisibility (no longer needed)');
-  assert.ok(!content.includes('repoIsPrivate'), 'agent.lib.mjs should NOT use repoIsPrivate');
-});
+// Lib files should not use getRepoVisibility
+for (const name of ['claude', 'agent']) {
+  test(`${name}.lib.mjs: does NOT import or use getRepoVisibility (simplified approach)`, () => {
+    const content = readFileSync(join(__dirname, `../src/${name}.lib.mjs`), 'utf-8');
+    assert.ok(!content.includes('getRepoVisibility'), `${name}.lib.mjs should NOT import getRepoVisibility (no longer needed)`);
+    assert.ok(!content.includes('repoIsPrivate'), `${name}.lib.mjs should NOT use repoIsPrivate`);
+  });
+}
 
 // ===== Summary =====
 printSummary(80);


### PR DESCRIPTION
## Summary

Fixes #1561

- When operating in fork mode, screenshot URLs in the system prompt now correctly point to the **fork repository** instead of the original repository
- Previously, the URL template used `${owner}/${repo}` which always resolved to the original repo, but the screenshot file was pushed to the fork — resulting in a broken image (GitHub returns 404 HTML)
- Now computes `screenshotRepoPath` that uses `forkedRepo` when `argv.fork` is active, falling back to `${owner}/${repo}` for non-fork mode
- Fix applied consistently across **all four prompt modules**: claude, agent, codex, and opencode

## Root Cause

The system prompt template in prompt modules contained:
```
https://github.com/${owner}/${repo}/blob/${branchName}/docs/screenshots/result.png?raw=true
```

When in fork mode, `owner/repo` = original repo (e.g., `Jhon-Crow/godot-topdown-MVP`), but code is pushed to the fork (e.g., `konard/Jhon-Crow-godot-topdown-MVP`). The branch only exists in the fork, so the URL returns a 404.

## Changes

- **`src/claude.prompts.lib.mjs`**: Extract `forkedRepo` from params, compute `screenshotRepoPath`, use it in URL template
- **`src/agent.prompts.lib.mjs`**: Same fix applied
- **`src/codex.prompts.lib.mjs`**: Same fix applied + added `modelSupportsVision` visual UI section
- **`src/opencode.prompts.lib.mjs`**: Same fix applied + added `modelSupportsVision` visual UI section
- **`tests/test-fork-screenshot-url-1561.mjs`**: 21 tests covering fork mode, non-fork mode, fallback behavior, source verification, and vision regression for all 4 modules
- **`tests/test-private-repo-screenshots-1349.mjs`**: Extended to cover all 4 prompt modules (codex, opencode added)
- **`docs/case-studies/issue-1561/case-study.md`**: Full case study with timeline, root cause analysis, and solution proposals

## Test plan

- [x] All 21 fork mode screenshot URL tests pass (all 4 modules)
- [x] All 20 private repo screenshot tests pass (regression, all 4 modules)
- [x] ESLint passes on all modified source files
- [x] jscpd duplication at 10.94% (under 11% threshold)
- [ ] Verify next fork-mode solve correctly generates screenshot URLs pointing to the fork

## Case Study

See [docs/case-studies/issue-1561/case-study.md](https://github.com/link-assistant/hive-mind/blob/issue-1561-3d3858b3890e/docs/case-studies/issue-1561/case-study.md) for the full investigation including:
- Timeline reconstruction of the broken screenshot incident
- Evidence chain tracing the bug from URL parsing through prompt generation
- Three root causes identified (critical: wrong repo path, medium: no URL validation, low: fragile branch-based URLs)
- Four proposed solutions with trade-offs

🤖 Generated with [Claude Code](https://claude.com/claude-code)