### PR TITLE
feat: replace deprecated qwen3.6-plus-free default with nemotron-3-super-free (#1563)

### DIFF
--- a/.changeset/replace-default-model-1563.md
+++ b/.changeset/replace-default-model-1563.md
@@ -1,0 +1,10 @@
+---
+'@link-assistant/hive-mind': minor
+---
+
+feat: replace deprecated qwen3.6-plus-free default with nemotron-3-super-free for --tool agent (#1563)
+
+- Change default agent model from `qwen3.6-plus-free` to `nemotron-3-super-free` (~262K context, NVIDIA hybrid Mamba-Transformer)
+- Move `qwen3.6-plus-free` to deprecated (free promotion ended April 2026, now requires OpenCode Go subscription)
+- Update documentation, tests, and model priority lists
+- Syncs with upstream agent PR #243

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,1 +1,0 @@
-# .gitkeep file auto-generated at 2026-04-10T19:31:17.191Z for PR creation at branch issue-1563-71a0bce8158e for issue https://github.com/link-assistant/hive-mind/issues/1563

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,0 +1,1 @@
+# .gitkeep file auto-generated at 2026-04-10T19:31:17.191Z for PR creation at branch issue-1563-71a0bce8158e for issue https://github.com/link-assistant/hive-mind/issues/1563

--- a/README.md
+++ b/README.md
@@ -445,9 +445,8 @@ Examples:
 /solve https://github.com/owner/repo/issues/123 --model opus --think max
 
 Free Models (with --tool agent):
-/solve https://github.com/owner/repo/issues/123 --tool agent --model qwen3.6-plus-free
-/solve https://github.com/owner/repo/issues/123 --tool agent --model opencode/qwen3.6-plus-free
 /solve https://github.com/owner/repo/issues/123 --tool agent --model nemotron-3-super-free
+/solve https://github.com/owner/repo/issues/123 --tool agent --model opencode/nemotron-3-super-free
 /solve https://github.com/owner/repo/issues/123 --tool agent --model minimax-m2.5-free
 /solve https://github.com/owner/repo/issues/123 --tool agent --model gpt-5-nano
 

--- a/docs/FREE_MODELS.md
+++ b/docs/FREE_MODELS.md
@@ -2,10 +2,11 @@
 
 This document provides comprehensive information about the free models supported by hive-mind when using the `--tool agent` option.
 
-> **Last Updated:** April 8, 2026
+> **Last Updated:** April 10, 2026
 > **Related:**
 >
 > - [Agent CLI FREE_MODELS.md](https://github.com/link-assistant/agent/blob/main/FREE_MODELS.md) - Upstream free models list (canonical source)
+> - [Agent PR #243](https://github.com/link-assistant/agent/pull/243) - Upstream: replace deprecated qwen3.6-plus-free with nemotron-3-super-free as default
 > - [Agent PR #234](https://github.com/link-assistant/agent/pull/234) - Upstream: qwen3.6-plus-free as default, add nemotron-3-super-free
 > - [Agent PR #209](https://github.com/link-assistant/agent/pull/209) - Upstream free model updates (minimax-m2.5-free as default)
 > - [Agent Issue #208](https://github.com/link-assistant/agent/issues/208) - kimi-k2.5-free removed from OpenCode Zen
@@ -14,32 +15,18 @@ This document provides comprehensive information about the free models supported
 
 Hive-mind supports free models from two providers:
 
-1. **OpenCode Zen** - 5 free models with `opencode/` prefix
+1. **OpenCode Zen** - 4 free models with `opencode/` prefix
 2. **Kilo Gateway** - 6 free models with `kilo/` prefix (Issue #1282)
 
 ---
 
 ## OpenCode Zen Free Models
 
-### 1. opencode/qwen3.6-plus-free **Default Model**
-
-- **Short Alias**: `qwen3.6-plus-free`
-- **Provider**: OpenCode Zen
-- **Status**: Fully Supported (Default for `--tool agent` as of Issue #1543)
-- **Features**: Reasoning, tool calling, temperature control
-- **Context Window**: ~1,000,000 tokens
-- **Output Limit**: 65,536 tokens
-- **Cost**: Free (no input/output charges)
-- **Knowledge Cutoff**: March 2025
-- **Release Date**: March 2026
-- **Open Weights**: Yes
-- **Notes**: Largest context window among free models (5x larger than minimax-m2.5-free)
-
-### 2. opencode/nemotron-3-super-free
+### 1. opencode/nemotron-3-super-free **Default Model**
 
 - **Short Alias**: `nemotron-3-super-free`
 - **Provider**: OpenCode Zen
-- **Status**: Fully Supported (Added in Issue #1543)
+- **Status**: Fully Supported (Default for `--tool agent` as of Issue #1563)
 - **Features**: Reasoning, tool calling, hybrid Mamba-Transformer architecture
 - **Context Window**: ~262,144 tokens
 - **Output Limit**: 262,144 tokens
@@ -49,11 +36,11 @@ Hive-mind supports free models from two providers:
 - **Open Weights**: Yes
 - **Notes**: NVIDIA hybrid Mamba-Transformer MoE, strong reasoning capabilities
 
-### 3. opencode/minimax-m2.5-free
+### 2. opencode/minimax-m2.5-free
 
 - **Short Alias**: `minimax-m2.5-free`
 - **Provider**: OpenCode Zen
-- **Status**: Fully Supported (Former default, Issue #1391)
+- **Status**: Fully Supported (Former default, Issues #1391, #1543)
 - **Features**: Reasoning, tool calling, temperature control
 - **Context Window**: 204,800 tokens
 - **Output Limit**: 131,072 tokens
@@ -62,7 +49,7 @@ Hive-mind supports free models from two providers:
 - **Release Date**: February 2026
 - **Open Weights**: Yes
 
-### 4. opencode/gpt-5-nano
+### 3. opencode/gpt-5-nano
 
 - **Short Alias**: `gpt-5-nano`
 - **Provider**: OpenCode Zen
@@ -73,7 +60,7 @@ Hive-mind supports free models from two providers:
 - **Cost**: Free (no input/output charges)
 - **Knowledge Cutoff**: January 2025
 
-### 5. opencode/big-pickle
+### 4. opencode/big-pickle
 
 - **Short Alias**: `big-pickle`
 - **Provider**: OpenCode Zen
@@ -92,6 +79,7 @@ The following models were previously free but are no longer available:
 
 | Model             | Former Model ID              | Status                                                                                                       |
 | ----------------- | ---------------------------- | ------------------------------------------------------------------------------------------------------------ |
+| Qwen 3.6 Plus Free | `opencode/qwen3.6-plus-free` | Free promotion ended (April 2026) — now requires OpenCode Go subscription. See [agent#242](https://github.com/link-assistant/agent/issues/242) |
 | Kimi K2.5 Free    | `opencode/kimi-k2.5-free`    | Removed from OpenCode Zen (March 2026) — see [agent#208](https://github.com/link-assistant/agent/issues/208) |
 | Grok Code Fast 1  | `opencode/grok-code`         | Discontinued January 2026                                                                                    |
 | MiniMax M2.1 Free | `opencode/minimax-m2.1-free` | Replaced by `opencode/minimax-m2.5-free`                                                                     |
@@ -198,12 +186,11 @@ The following Kilo models were previously the recommended free models but have b
 
 ```bash
 # OpenCode Zen models (short aliases without prefix)
-solve https://github.com/owner/repo/issues/123 --tool agent --model qwen3.6-plus-free
 solve https://github.com/owner/repo/issues/123 --tool agent --model nemotron-3-super-free
 hive https://github.com/owner/repo --tool agent --model minimax-m2.5-free
 
 # OpenCode Zen models (full model IDs)
-solve https://github.com/owner/repo/issues/123 --tool agent --model opencode/qwen3.6-plus-free
+solve https://github.com/owner/repo/issues/123 --tool agent --model opencode/nemotron-3-super-free
 hive https://github.com/owner/repo --tool agent --model opencode/big-pickle
 
 # Kilo Gateway models (full model IDs)
@@ -219,7 +206,6 @@ hive https://github.com/owner/repo --tool agent --model deepseek-r1-free
 
 ```bash
 # OpenCode Zen models (short aliases)
-/solve https://github.com/owner/repo/issues/123 --tool agent --model qwen3.6-plus-free
 /solve https://github.com/owner/repo/issues/123 --tool agent --model nemotron-3-super-free
 /solve https://github.com/owner/repo/issues/123 --tool agent --model minimax-m2.5-free
 
@@ -231,7 +217,7 @@ hive https://github.com/owner/repo --tool agent --model deepseek-r1-free
 /solve https://github.com/owner/repo/issues/123 --tool agent --model glm-5-free
 /hive https://github.com/owner/repo --tool agent --model glm-4.5-air-free
 
-# Default model (qwen3.6-plus-free via OpenCode Zen):
+# Default model (nemotron-3-super-free via OpenCode Zen):
 /solve https://github.com/owner/repo/issues/123 --tool agent
 ```
 
@@ -239,7 +225,6 @@ hive https://github.com/owner/repo --tool agent --model deepseek-r1-free
 
 ```bash
 # OpenCode Zen models
-echo "Your prompt here" | agent --model opencode/qwen3.6-plus-free
 echo "Your prompt here" | agent --model opencode/nemotron-3-super-free
 echo "Your prompt here" | agent --model opencode/minimax-m2.5-free
 
@@ -256,9 +241,8 @@ echo "Your prompt here" | agent --model kilo/deepseek-r1-free
 
 **Flagship Free Models**:
 
-- `opencode/qwen3.6-plus-free` - Largest context (~1M tokens), strong agent performance (OpenCode, default)
+- `opencode/nemotron-3-super-free` - NVIDIA hybrid Mamba-Transformer, strong reasoning (OpenCode, default)
 - `kilo/glm-5-free` - Z.AI flagship, matches Opus 4.5 on many tasks (Kilo)
-- `opencode/nemotron-3-super-free` - NVIDIA hybrid Mamba-Transformer, strong reasoning (OpenCode)
 
 **General Purpose & Reasoning**:
 
@@ -269,7 +253,6 @@ echo "Your prompt here" | agent --model kilo/deepseek-r1-free
 
 **For Large Context Tasks**:
 
-- `opencode/qwen3.6-plus-free` - Largest context (~1,000,000 tokens)
 - `opencode/gpt-5-nano` - Very large context (~400,000 tokens)
 - `opencode/nemotron-3-super-free` - Large context (~262,144 tokens)
 - `kilo/giga-potato-free` - Large context (256,000 tokens)
@@ -287,14 +270,14 @@ echo "Your prompt here" | agent --model kilo/deepseek-r1-free
 
 | Feature       | OpenCode Zen                                  | Kilo Gateway             |
 | ------------- | --------------------------------------------- | ------------------------ |
-| Free Models   | 5 models                                      | 6 models                 |
-| Default Model | qwen3.6-plus-free (~1M context)               | glm-5-free (recommended) |
+| Free Models   | 4 models                                      | 6 models                 |
+| Default Model | nemotron-3-super-free (~262K context)          | glm-5-free (recommended) |
 | API Format    | OpenAI-compatible                             | OpenAI-compatible        |
 | Free API Key  | `public`                                      | `public`                 |
 | Total Models  | 50+                                           | 500+                     |
-| Flagship Free | Qwen 3.6 Plus (~1M context)                   | GLM-5 (limited time)     |
+| Flagship Free | Nemotron 3 Super (~262K context)               | GLM-5 (limited time)     |
 | BYOK Support  | Yes                                           | Yes                      |
-| New Models    | Qwen 3.6 Plus, Nemotron 3 Super (Issue #1543) | DeepSeek R1, GLM 4.5 Air |
+| New Models    | Nemotron 3 Super (Issue #1543, #1563)          | DeepSeek R1, GLM 4.5 Air |
 
 ---
 
@@ -332,11 +315,12 @@ If you encounter issues with any of these models:
 - [Case Study: Issue #1391](./case-studies/issue-1391/README.md) - Free models update (minimax-m2.5-free as default, kimi-k2.5-free deprecated)
 - [Case Study: Issue #1473](./case-studies/issue-1473/README.md) - Model recognition fix and free models sync
 - [Case Study: Issue #1543](./case-studies/issue-1543/README.md) - Free models update (qwen3.6-plus-free as default, nemotron-3-super-free added)
+- [Case Study: Issue #1563](./case-studies/issue-1563/README.md) - Free models update (qwen3.6-plus-free deprecated, nemotron-3-super-free as default)
 - [OpenCode Zen Documentation](https://opencode.ai/docs/zen/) - OpenCode Zen provider details
 - [Kilo Gateway Documentation](https://kilo.ai/docs/gateway) - Kilo Gateway provider details
 
 ---
 
-**Last Updated**: April 8, 2026
-**Hive-Mind Version**: 1.46.9
-**Agent CLI Version**: Latest (with free model updates from PR #234)
+**Last Updated**: April 10, 2026
+**Hive-Mind Version**: 1.48.2
+**Agent CLI Version**: Latest (with free model updates from PR #243)

--- a/docs/FREE_MODELS.md
+++ b/docs/FREE_MODELS.md
@@ -77,13 +77,13 @@ Hive-mind supports free models from two providers:
 
 The following models were previously free but are no longer available:
 
-| Model             | Former Model ID              | Status                                                                                                       |
-| ----------------- | ---------------------------- | ------------------------------------------------------------------------------------------------------------ |
+| Model              | Former Model ID              | Status                                                                                                                                         |
+| ------------------ | ---------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------- |
 | Qwen 3.6 Plus Free | `opencode/qwen3.6-plus-free` | Free promotion ended (April 2026) — now requires OpenCode Go subscription. See [agent#242](https://github.com/link-assistant/agent/issues/242) |
-| Kimi K2.5 Free    | `opencode/kimi-k2.5-free`    | Removed from OpenCode Zen (March 2026) — see [agent#208](https://github.com/link-assistant/agent/issues/208) |
-| Grok Code Fast 1  | `opencode/grok-code`         | Discontinued January 2026                                                                                    |
-| MiniMax M2.1 Free | `opencode/minimax-m2.1-free` | Replaced by `opencode/minimax-m2.5-free`                                                                     |
-| GLM 4.7 Free      | `opencode/glm-4.7-free`      | No longer free on OpenCode Zen                                                                               |
+| Kimi K2.5 Free     | `opencode/kimi-k2.5-free`    | Removed from OpenCode Zen (March 2026) — see [agent#208](https://github.com/link-assistant/agent/issues/208)                                   |
+| Grok Code Fast 1   | `opencode/grok-code`         | Discontinued January 2026                                                                                                                      |
+| MiniMax M2.1 Free  | `opencode/minimax-m2.1-free` | Replaced by `opencode/minimax-m2.5-free`                                                                                                       |
+| GLM 4.7 Free       | `opencode/glm-4.7-free`      | No longer free on OpenCode Zen                                                                                                                 |
 
 > **Note:** See [OpenCode Zen Documentation](https://opencode.ai/docs/zen/) and [Agent CLI FREE_MODELS.md](https://github.com/link-assistant/agent/blob/main/FREE_MODELS.md) for the current list of free models.
 
@@ -268,16 +268,16 @@ echo "Your prompt here" | agent --model kilo/deepseek-r1-free
 
 ## Provider Comparison
 
-| Feature       | OpenCode Zen                                  | Kilo Gateway             |
-| ------------- | --------------------------------------------- | ------------------------ |
-| Free Models   | 4 models                                      | 6 models                 |
-| Default Model | nemotron-3-super-free (~262K context)          | glm-5-free (recommended) |
-| API Format    | OpenAI-compatible                             | OpenAI-compatible        |
-| Free API Key  | `public`                                      | `public`                 |
-| Total Models  | 50+                                           | 500+                     |
-| Flagship Free | Nemotron 3 Super (~262K context)               | GLM-5 (limited time)     |
-| BYOK Support  | Yes                                           | Yes                      |
-| New Models    | Nemotron 3 Super (Issue #1543, #1563)          | DeepSeek R1, GLM 4.5 Air |
+| Feature       | OpenCode Zen                          | Kilo Gateway             |
+| ------------- | ------------------------------------- | ------------------------ |
+| Free Models   | 4 models                              | 6 models                 |
+| Default Model | nemotron-3-super-free (~262K context) | glm-5-free (recommended) |
+| API Format    | OpenAI-compatible                     | OpenAI-compatible        |
+| Free API Key  | `public`                              | `public`                 |
+| Total Models  | 50+                                   | 500+                     |
+| Flagship Free | Nemotron 3 Super (~262K context)      | GLM-5 (limited time)     |
+| BYOK Support  | Yes                                   | Yes                      |
+| New Models    | Nemotron 3 Super (Issue #1543, #1563) | DeepSeek R1, GLM 4.5 Air |
 
 ---
 

--- a/docs/case-studies/issue-1563/README.md
+++ b/docs/case-studies/issue-1563/README.md
@@ -1,0 +1,72 @@
+# Case Study: Replace Deprecated `qwen3.6-plus-free` Default with `nemotron-3-super-free`
+
+**Issue:** [#1563](https://github.com/link-assistant/hive-mind/issues/1563)
+**Upstream PR:** [agent#243](https://github.com/link-assistant/agent/pull/243)
+**Upstream Issue:** [agent#242](https://github.com/link-assistant/agent/issues/242)
+
+## Problem Statement
+
+OpenCode Zen ended the free promotion for `qwen3.6-plus-free` (Qwen 3.6 Plus Free) in April 2026. The model now returns HTTP 401 with the following error:
+
+```json
+{
+  "type": "error",
+  "error": {
+    "type": "ModelError",
+    "message": "Free promotion has ended for Qwen3.6 Plus Free. You can continue using the model by subscribing to OpenCode Go - https://opencode.ai/go"
+  }
+}
+```
+
+This broke the default agent experience for all free-tier users of both the upstream agent CLI and hive-mind's `--tool agent` option, since `qwen3.6-plus-free` was the default model (set in Issue #1543).
+
+## Root Cause
+
+OpenCode Zen provider discontinued the free tier for `qwen3.6-plus-free`. The model requires an OpenCode Go subscription to continue using. This is an external provider decision, not a bug in hive-mind or the agent CLI.
+
+## Timeline
+
+1. **March 2026** - `qwen3.6-plus-free` added as free model (Issue #1543, agent PR #234)
+2. **April 8, 2026** - Hive-mind synced with upstream, set `qwen3.6-plus-free` as default (Issue #1543)
+3. **April 2026** - OpenCode Zen ends free promotion for `qwen3.6-plus-free`
+4. **April 10, 2026** - Agent CLI fixes the issue (agent PR #243), hive-mind syncs (this PR)
+
+## Solution
+
+### Default Model Change
+
+- **Before:** `qwen3.6-plus-free` (~1M context, now returns HTTP 401 for free users)
+- **After:** `nemotron-3-super-free` (~262K context, NVIDIA hybrid Mamba-Transformer, still free)
+
+### Changes Made
+
+| Area      | File                            | Change                                                                      |
+| --------- | ------------------------------- | --------------------------------------------------------------------------- |
+| **Core**  | `src/models/index.mjs`          | Change defaultModels.agent, move qwen3.6-plus-free to deprecated section    |
+| **Docs**  | `docs/FREE_MODELS.md`           | Move qwen3.6-plus-free to discontinued, update default references/examples  |
+| **Docs**  | `README.md`                     | Update free model examples                                                  |
+| **Tests** | `tests/test-free-models.mjs`    | Move qwen3.6-plus-free to deprecated models, update default model assertion |
+| **Docs**  | `docs/case-studies/issue-1563/` | This case study                                                             |
+
+### Backward Compatibility
+
+- `qwen3.6-plus-free` remains as a deprecated model alias (kept for backward compatibility)
+- Users who explicitly specify `--model qwen3.6-plus-free` will still have it resolved, but will get HTTP 401 from OpenCode Zen unless they have an OpenCode Go subscription
+- The only behavioral change is the default: users who don't specify `--model` with `--tool agent` will now get `nemotron-3-super-free` instead of `qwen3.6-plus-free`
+
+## Updated Free Models (OpenCode Zen, April 2026)
+
+| Model                 | Context    | Output  | Status                                    |
+| --------------------- | ---------- | ------- | ----------------------------------------- |
+| nemotron-3-super-free | ~262,144   | 262,144 | **New default**, NVIDIA hybrid Mamba-Transformer |
+| minimax-m2.5-free     | ~200,000   | 131,072 | Former default, general-purpose           |
+| gpt-5-nano            | ~400,000   | 128,000 | OpenAI, smallest GPT-5 variant            |
+| big-pickle            | ~200,000   | 128,000 | Stealth model, free during evaluation     |
+| ~~qwen3.6-plus-free~~ | ~~1,000,000~~ | ~~65,536~~ | **Discontinued** - free promotion ended |
+
+## References
+
+- [Agent PR #243](https://github.com/link-assistant/agent/pull/243) - Upstream fix
+- [Agent Issue #242](https://github.com/link-assistant/agent/issues/242) - Upstream issue
+- [Hive-mind Issue #1543](https://github.com/link-assistant/hive-mind/issues/1543) - Previous sync that added qwen3.6-plus-free
+- [Case Study: Issue #1543](../issue-1543/README.md) - Previous case study with model details

--- a/docs/case-studies/issue-1563/README.md
+++ b/docs/case-studies/issue-1563/README.md
@@ -56,13 +56,13 @@ OpenCode Zen provider discontinued the free tier for `qwen3.6-plus-free`. The mo
 
 ## Updated Free Models (OpenCode Zen, April 2026)
 
-| Model                 | Context    | Output  | Status                                    |
-| --------------------- | ---------- | ------- | ----------------------------------------- |
-| nemotron-3-super-free | ~262,144   | 262,144 | **New default**, NVIDIA hybrid Mamba-Transformer |
-| minimax-m2.5-free     | ~200,000   | 131,072 | Former default, general-purpose           |
-| gpt-5-nano            | ~400,000   | 128,000 | OpenAI, smallest GPT-5 variant            |
-| big-pickle            | ~200,000   | 128,000 | Stealth model, free during evaluation     |
-| ~~qwen3.6-plus-free~~ | ~~1,000,000~~ | ~~65,536~~ | **Discontinued** - free promotion ended |
+| Model                 | Context       | Output     | Status                                           |
+| --------------------- | ------------- | ---------- | ------------------------------------------------ |
+| nemotron-3-super-free | ~262,144      | 262,144    | **New default**, NVIDIA hybrid Mamba-Transformer |
+| minimax-m2.5-free     | ~200,000      | 131,072    | Former default, general-purpose                  |
+| gpt-5-nano            | ~400,000      | 128,000    | OpenAI, smallest GPT-5 variant                   |
+| big-pickle            | ~200,000      | 128,000    | Stealth model, free during evaluation            |
+| ~~qwen3.6-plus-free~~ | ~~1,000,000~~ | ~~65,536~~ | **Discontinued** - free promotion ended          |
 
 ## References
 

--- a/src/models/index.mjs
+++ b/src/models/index.mjs
@@ -47,7 +47,8 @@ export const claudeModels = {
 
 // Agent models (OpenCode API and Kilo Gateway via agent CLI)
 // Issue #1300: Updated free models to match agent PR #191
-// Issue #1543: Added qwen3.6-plus-free (new default) and nemotron-3-super-free per agent PR #234
+// Issue #1543: Added qwen3.6-plus-free (former default) and nemotron-3-super-free per agent PR #234
+// Issue #1563: qwen3.6-plus-free free promotion ended (April 2026), nemotron-3-super-free is now default per agent PR #243
 export const agentModels = {
   // OpenCode Zen free models (current)
   grok: 'opencode/grok-code',
@@ -56,8 +57,7 @@ export const agentModels = {
   'big-pickle': 'opencode/big-pickle',
   'gpt-5-nano': 'opencode/gpt-5-nano',
   'minimax-m2.5-free': 'opencode/minimax-m2.5-free', // Upgraded from M2.1 (Issue #1391)
-  'qwen3.6-plus-free': 'opencode/qwen3.6-plus-free', // New: ~1M context, default (Issue #1543)
-  'nemotron-3-super-free': 'opencode/nemotron-3-super-free', // New: NVIDIA hybrid Mamba-Transformer (Issue #1543)
+  'nemotron-3-super-free': 'opencode/nemotron-3-super-free', // Default: NVIDIA hybrid Mamba-Transformer (Issue #1563)
   // Kilo Gateway free models (Issue #1282, updated in #1300)
   // Short names for Kilo-exclusive models (Issue #1300)
   'glm-5-free': 'kilo/glm-5-free', // Kilo-exclusive
@@ -73,6 +73,7 @@ export const agentModels = {
   'kilo/giga-potato-free': 'kilo/giga-potato-free',
   'kilo/trinity-large-preview': 'kilo/trinity-large-preview',
   // Deprecated free models (kept for backward compatibility)
+  'qwen3.6-plus-free': 'opencode/qwen3.6-plus-free', // Deprecated: free promotion ended April 2026 (Issue #1563)
   'kimi-k2.5-free': 'opencode/kimi-k2.5-free', // Deprecated: not supported (Issue #1391)
   'glm-4.7-free': 'opencode/glm-4.7-free', // Deprecated: no longer free
   'minimax-m2.1-free': 'opencode/minimax-m2.1-free', // Deprecated: replaced by m2.5
@@ -115,7 +116,7 @@ export const codexModels = {
 // Default model for each tool (Issue #1473: centralized to avoid scattered hardcoded defaults)
 export const defaultModels = {
   claude: 'sonnet',
-  agent: 'qwen3.6-plus-free', // Issue #1543: changed from minimax-m2.5-free per agent PR #234
+  agent: 'nemotron-3-super-free', // Issue #1563: changed from qwen3.6-plus-free (free promotion ended) per agent PR #243
   opencode: 'grok-code-fast-1',
   codex: 'gpt-5',
 };
@@ -192,8 +193,8 @@ export const AGENT_MODELS = {
   'opencode/big-pickle': 'opencode/big-pickle',
   'opencode/gpt-5-nano': 'opencode/gpt-5-nano',
   'opencode/minimax-m2.5-free': 'opencode/minimax-m2.5-free',
-  'opencode/qwen3.6-plus-free': 'opencode/qwen3.6-plus-free', // Issue #1543
-  'opencode/nemotron-3-super-free': 'opencode/nemotron-3-super-free', // Issue #1543
+  'opencode/nemotron-3-super-free': 'opencode/nemotron-3-super-free', // Issue #1563: now default
+  'opencode/qwen3.6-plus-free': 'opencode/qwen3.6-plus-free', // Deprecated: free promotion ended (Issue #1563)
   'opencode/kimi-k2.5-free': 'opencode/kimi-k2.5-free', // Deprecated
   'opencode/glm-4.7-free': 'opencode/glm-4.7-free', // Deprecated
   'opencode/minimax-m2.1-free': 'opencode/minimax-m2.1-free', // Deprecated
@@ -304,7 +305,7 @@ export const primaryModelNames = {
   claude: ['opus', 'sonnet', 'haiku', 'opusplan'],
   opencode: ['grok', 'gpt4o'],
   codex: ['gpt5', 'gpt5-codex', 'o3'],
-  agent: ['qwen3.6-plus-free', 'nemotron-3-super-free', 'minimax-m2.5-free', 'big-pickle', 'gpt-5-nano', 'glm-5-free', 'deepseek-r1-free'],
+  agent: ['nemotron-3-super-free', 'minimax-m2.5-free', 'big-pickle', 'gpt-5-nano', 'glm-5-free', 'deepseek-r1-free'],
 };
 
 /**

--- a/tests/test-free-models.mjs
+++ b/tests/test-free-models.mjs
@@ -4,16 +4,17 @@
  * Comprehensive tests for all free models
  * Tests all 12 free models (6 OpenCode Zen + 6 Kilo Gateway) to ensure they work in hive-mind
  * Issue #1300: Updated free models - minimax-m2.5-free replaces m2.1, glm-4.7-free removed from OpenCode
- * Issue #1543: Added qwen3.6-plus-free (new default) and nemotron-3-super-free
+ * Issue #1543: Added qwen3.6-plus-free (former default) and nemotron-3-super-free
+ * Issue #1563: qwen3.6-plus-free deprecated (free promotion ended), nemotron-3-super-free is now default
  */
 
 import { strict as assert } from 'assert';
 import { validateModelName, AGENT_MODELS, mapModelForTool, isModelCompatibleWithTool, getValidModelsForTool, agentModels } from '../src/models/index.mjs';
 
 // OpenCode Zen free models (current - Issue #1300, Issue #1543)
-const OPENCODE_FREE_MODELS = ['opencode/big-pickle', 'opencode/gpt-5-nano', 'opencode/kimi-k2.5-free', 'opencode/minimax-m2.5-free', 'opencode/qwen3.6-plus-free', 'opencode/nemotron-3-super-free'];
+const OPENCODE_FREE_MODELS = ['opencode/big-pickle', 'opencode/gpt-5-nano', 'opencode/kimi-k2.5-free', 'opencode/minimax-m2.5-free', 'opencode/nemotron-3-super-free'];
 
-const OPENCODE_SHORT_ALIASES = ['big-pickle', 'gpt-5-nano', 'kimi-k2.5-free', 'minimax-m2.5-free', 'qwen3.6-plus-free', 'nemotron-3-super-free'];
+const OPENCODE_SHORT_ALIASES = ['big-pickle', 'gpt-5-nano', 'kimi-k2.5-free', 'minimax-m2.5-free', 'nemotron-3-super-free'];
 
 // Kilo Gateway free models (Issue #1282, updated in #1300)
 const KILO_FREE_MODELS = ['kilo/glm-5-free', 'kilo/glm-4.5-air-free', 'kilo/minimax-m2.5-free', 'kilo/deepseek-r1-free', 'kilo/giga-potato-free', 'kilo/trinity-large-preview'];
@@ -24,14 +25,14 @@ const KILO_SHORT_ALIASES = ['kilo/glm-5-free', 'kilo/glm-4.5-air-free', 'kilo/mi
 const KILO_EXCLUSIVE_SHORT_ALIASES = ['glm-5-free', 'glm-4.5-air-free', 'deepseek-r1-free', 'giga-potato-free', 'trinity-large-preview'];
 
 // Deprecated models (still work for backward compatibility but not recommended)
-const DEPRECATED_OPENCODE_MODELS = ['opencode/glm-4.7-free', 'opencode/minimax-m2.1-free'];
+const DEPRECATED_OPENCODE_MODELS = ['opencode/glm-4.7-free', 'opencode/minimax-m2.1-free', 'opencode/qwen3.6-plus-free'];
 const DEPRECATED_KILO_MODELS = ['kilo/glm-4.7-free', 'kilo/kimi-k2.5-free', 'kilo/minimax-m2.1-free'];
 
 // Combined lists
 const ALL_FREE_MODELS = [...OPENCODE_FREE_MODELS, ...KILO_FREE_MODELS];
 
 console.log('🧪 Running comprehensive free model tests...\n');
-console.log(`📊 Testing ${OPENCODE_FREE_MODELS.length} OpenCode Zen models (including 2 new: qwen3.6-plus-free, nemotron-3-super-free) and ${KILO_FREE_MODELS.length} Kilo Gateway models\n`);
+console.log(`📊 Testing ${OPENCODE_FREE_MODELS.length} OpenCode Zen models (nemotron-3-super-free is default) and ${KILO_FREE_MODELS.length} Kilo Gateway models\n`);
 
 // Test 1: OpenCode Zen model validation for full model IDs
 console.log('1️⃣ Testing OpenCode Zen full model ID validation...');
@@ -171,7 +172,7 @@ for (const invalidModel of invalidModels) {
 
 // Test 11: Case insensitive validation for OpenCode Zen
 console.log('\n1️⃣1️⃣ Testing OpenCode Zen case insensitive validation...');
-const opencodeVariants = ['OPENCODE/BIG-PICKLE', 'Opencode/Gpt-5-Nano', 'oPeNcOdE/kImI-k2.5-fReE', 'OPENCODE/minimax-m2.5-free', 'OPENCODE/QWEN3.6-PLUS-FREE', 'Opencode/Nemotron-3-Super-Free'];
+const opencodeVariants = ['OPENCODE/BIG-PICKLE', 'Opencode/Gpt-5-Nano', 'oPeNcOdE/kImI-k2.5-fReE', 'OPENCODE/minimax-m2.5-free', 'Opencode/Nemotron-3-Super-Free'];
 
 for (const caseVariant of opencodeVariants) {
   const result = validateModelName(caseVariant, 'agent');
@@ -250,11 +251,11 @@ for (const shortName of freeShortNames) {
   console.log(`✅ ${shortName} -> ${mappedByAgentLib}: Consistent (no moonshot/ prefix)`);
 }
 
-// Test 16: Default model qwen3.6-plus-free maps correctly through agent.lib.mjs (Issue #1543)
-console.log('\n1️⃣6️⃣ Testing default model (qwen3.6-plus-free) through agent.lib.mjs...');
-const defaultModel = 'qwen3.6-plus-free';
+// Test 16: Default model nemotron-3-super-free maps correctly through agent.lib.mjs (Issue #1563)
+console.log('\n1️⃣6️⃣ Testing default model (nemotron-3-super-free) through agent.lib.mjs...');
+const defaultModel = 'nemotron-3-super-free';
 const defaultMapped = mapModelToId(defaultModel);
-assert.strictEqual(defaultMapped, 'opencode/qwen3.6-plus-free', `Default model ${defaultModel} should map to opencode/qwen3.6-plus-free, got ${defaultMapped}`);
+assert.strictEqual(defaultMapped, 'opencode/nemotron-3-super-free', `Default model ${defaultModel} should map to opencode/nemotron-3-super-free, got ${defaultMapped}`);
 assert.ok(!defaultMapped.startsWith('moonshot/'), `Default model should NOT use moonshot/ prefix`);
 console.log(`✅ ${defaultModel} -> ${defaultMapped}: Default model maps correctly`);
 


### PR DESCRIPTION
## Summary

OpenCode Zen ended the free promotion for `qwen3.6-plus-free` (Qwen 3.6 Plus Free) in April 2026. The model now returns HTTP 401, breaking the default agent experience for all free-tier users.

- **Default model changed:** `qwen3.6-plus-free` → `nemotron-3-super-free` (~262K context, NVIDIA hybrid Mamba-Transformer)
- **Deprecated model:** `qwen3.6-plus-free` moved to deprecated (kept for backward compatibility)
- **Documentation updated:** FREE_MODELS.md, README.md updated with new default
- **Tests updated:** default model assertions and deprecated model lists
- **Case study added:** `docs/case-studies/issue-1563/` with root cause analysis
- **Changeset added:** minor version bump via changesets

### Root Cause

OpenCode Zen API now returns:
```json
{"type":"error","error":{"type":"ModelError","message":"Free promotion has ended for Qwen3.6 Plus Free. You can continue using the model by subscribing to OpenCode Go - https://opencode.ai/go"}}
```

### Files Changed

| File | Change |
| --- | --- |
| `src/models/index.mjs` | New default model, moved qwen3.6-plus-free to deprecated, updated priority lists |
| `docs/FREE_MODELS.md` | Moved qwen3.6-plus-free to discontinued, updated default references |
| `README.md` | Updated free model examples |
| `tests/test-free-models.mjs` | Updated default model assertions, deprecated model list |
| `.changeset/replace-default-model-1563.md` | Changeset for automated release |
| `docs/case-studies/issue-1563/README.md` | Case study with root cause analysis |

Fixes #1563
Syncs with upstream [agent PR #243](https://github.com/link-assistant/agent/pull/243)

## Test plan

- [x] All 16 free model tests pass (`node tests/test-free-models.mjs`)
- [x] ESLint passes (`npm run lint`)
- [x] Prettier formatting passes (`npm run format:check`)
- [x] Code duplication check passes (10.93%, under threshold)
- [ ] CI pipeline passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)