### PR TITLE
fix: make usage limit footer message consistent with auto-resume mode

### DIFF
--- a/.changeset/fix-usage-limit-footer-consistency-1569.md
+++ b/.changeset/fix-usage-limit-footer-consistency-1569.md
@@ -1,0 +1,9 @@
+---
+'@link-assistant/hive-mind': patch
+---
+
+fix: make usage limit footer message consistent with auto-resume mode (#1569)
+
+- Fix footer message in "Usage Limit Reached" GitHub comments to reflect auto-resume/auto-restart mode
+- Previously the footer always showed "You can resume once the limit resets." even when auto-resume was enabled
+- Now shows mode-specific messages: "The session will automatically resume when the limit resets." or "The session will automatically restart when the limit resets."

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,0 +1,1 @@
+# .gitkeep file auto-generated at 2026-04-11T01:50:14.516Z for PR creation at branch issue-1569-48971e5974a5 for issue https://github.com/link-assistant/hive-mind/issues/1569

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,1 +1,0 @@
-# .gitkeep file auto-generated at 2026-04-11T01:50:14.516Z for PR creation at branch issue-1569-48971e5974a5 for issue https://github.com/link-assistant/hive-mind/issues/1569

--- a/docs/case-studies/issue-1569/README.md
+++ b/docs/case-studies/issue-1569/README.md
@@ -1,0 +1,87 @@
+# Case Study: Issue #1569 — Inconsistent User-Facing Messages
+
+## Overview
+
+**Issue**: [#1569 — We should be clear with user in all messages](https://github.com/link-assistant/hive-mind/issues/1569)
+**PR**: [#1575](https://github.com/link-assistant/hive-mind/pull/1575)
+**Labels**: bug
+**Status**: Fixed
+
+## Timeline / Sequence of Events
+
+1. **Root cause identified**: The "Usage Limit Reached" GitHub comment has two separate sections:
+   - A "### 🔄 How to Continue" section that correctly distinguishes between auto-resume and manual-resume modes.
+   - A footer line that **always** says "You can resume once the limit resets." regardless of mode.
+
+2. **Problem observed**: When `isAutoResumeEnabled` is `true`, the "How to Continue" section says:
+
+   > "The session will automatically resume (with context preserved) when the limit resets."
+
+   But the footer says:
+
+   > "You can resume once the limit resets."
+
+   This is misleading — if auto-resume is on, the user doesn't need to do anything manually.
+
+3. **Secondary issue found**: In lines 494-498 of `github.lib.mjs`, there was a redundant `if/else` block that produced identical output regardless of whether `limitResetTime` was set. This dead code was simplified.
+
+## Root Causes
+
+### Root Cause 1: Static Footer Message
+
+The footer message at lines 531 and 716 of `src/github.lib.mjs` was hardcoded as:
+
+```
+*This session was interrupted due to usage limits. You can resume once the limit resets.*
+```
+
+This was never updated when auto-resume functionality was added (issue #1152). It always tells the user they can manually resume, even when the system will do it automatically.
+
+### Root Cause 2: Duplicate If/Else Branches
+
+Lines 494-498 had an `if (limitResetTime)` / `else` block that produced identical output for both branches:
+
+```js
+if (limitResetTime) {
+  logComment += `**Auto-${modeName} is enabled.** ${modeDescription}`;
+} else {
+  logComment += `**Auto-${modeName} is enabled.** ${modeDescription}`;
+}
+```
+
+Both branches were identical — dead code that adds complexity without value.
+
+## Requirements
+
+1. Footer message must be consistent with the "How to Continue" section.
+2. When `isAutoResumeEnabled` is true (resume mode): footer must say the session will automatically resume.
+3. When `isAutoResumeEnabled` is true (restart mode): footer must say the session will automatically restart.
+4. When `isAutoResumeEnabled` is false: footer must say the user can resume manually.
+5. Remove duplicate if/else branches where both branches produce identical output.
+
+## Affected Files
+
+- `src/github.lib.mjs` — Contains both inline log comment and uploaded log comment generation.
+
+## Solution
+
+Updated the footer in both code paths (inline log and uploaded log) to be conditional based on `isAutoResumeEnabled` and `autoResumeMode`:
+
+```js
+const footerNote = isAutoResumeEnabled ? (autoResumeMode === 'restart' ? '*This session was interrupted due to usage limits. The session will automatically restart when the limit resets.*' : '*This session was interrupted due to usage limits. The session will automatically resume when the limit resets.*') : '*This session was interrupted due to usage limits. You can resume once the limit resets.*';
+```
+
+Also removed the duplicate `if/else` branches that produced identical output regardless of `limitResetTime`.
+
+## Testing
+
+- No existing tests in the test suite directly test the footer message text.
+- The fix was verified by reading `src/github.lib.mjs` and tracing the logic for all three cases:
+  1. `isAutoResumeEnabled = false` → "You can resume once the limit resets."
+  2. `isAutoResumeEnabled = true`, `autoResumeMode = 'resume'` → "The session will automatically resume when the limit resets."
+  3. `isAutoResumeEnabled = true`, `autoResumeMode = 'restart'` → "The session will automatically restart when the limit resets."
+
+## Related Issues
+
+- [#1152](https://github.com/link-assistant/hive-mind/issues/1152) — Auto-resume/restart functionality was added here; the footer was not updated to match.
+- [#1567](https://github.com/link-assistant/hive-mind/issues/1567) — Related PR for reducing `telegram-bot.mjs` below 1500-line CI limit.

--- a/src/github.lib.mjs
+++ b/src/github.lib.mjs
@@ -491,11 +491,7 @@ The automated solution draft was interrupted because the ${toolName} usage limit
         const modeName = autoResumeMode === 'restart' ? 'restart' : 'resume';
         const modeDescription = autoResumeMode === 'restart' ? 'The session will automatically restart (fresh start) when the limit resets.' : 'The session will automatically resume (with context preserved) when the limit resets.';
 
-        if (limitResetTime) {
-          logComment += `**Auto-${modeName} is enabled.** ${modeDescription}`;
-        } else {
-          logComment += `**Auto-${modeName} is enabled.** ${modeDescription}`;
-        }
+        logComment += `**Auto-${modeName} is enabled.** ${modeDescription}`;
       } else {
         // Manual resume mode - show CLI commands
         if (limitResetTime) {
@@ -516,6 +512,8 @@ ${resumeCommand}
         }
       }
 
+      const footerNote = isAutoResumeEnabled ? (autoResumeMode === 'restart' ? '*This session was interrupted due to usage limits. The session will automatically restart when the limit resets.*' : '*This session was interrupted due to usage limits. The session will automatically resume when the limit resets.*') : '*This session was interrupted due to usage limits. You can resume once the limit resets.*';
+
       logComment += `${modelInfoString}
 
 <details>
@@ -528,7 +526,7 @@ ${logContent}
 </details>
 
 ---
-*This session was interrupted due to usage limits. You can resume once the limit resets.*`;
+${footerNote}`;
     } else if (errorMessage) {
       // Failure log format (non-usage-limit errors)
       logComment = `## 🚨 Solution Draft Failed
@@ -707,13 +705,15 @@ ${resumeCommand}
               }
             }
 
+            const uploadFooterNote = isAutoResumeEnabled ? (autoResumeMode === 'restart' ? '*This session was interrupted due to usage limits. The session will automatically restart when the limit resets.*' : '*This session was interrupted due to usage limits. The session will automatically resume when the limit resets.*') : '*This session was interrupted due to usage limits. You can resume once the limit resets.*';
+
             logUploadComment += `${modelInfoString}
 
 ### 📎 **Execution log uploaded as ${uploadTypeLabel}${chunkInfo}** (${Math.round(logStats.size / 1024)}KB)
 - [View complete execution log](${logUrl})
 
 ---
-*This session was interrupted due to usage limits. You can resume once the limit resets.*`;
+${uploadFooterNote}`;
           } else if (errorMessage) {
             // Failure log format (non-usage-limit errors)
             logUploadComment = `## 🚨 Solution Draft Failed


### PR DESCRIPTION
## Summary

Fixes #1569

- The footer of the "Usage Limit Reached" GitHub comment was always saying **"You can resume once the limit resets."** even when `isAutoResumeEnabled` was `true`, implying the user needed to take manual action when in fact the system would resume/restart automatically.
- Fixed both code paths: inline log comment and uploaded log comment (Gist).
- Removed a duplicate `if/else` block that produced identical output regardless of `limitResetTime`.

## Root Cause

When auto-resume/auto-restart functionality was added (issue #1152), the **"How to Continue" section** was correctly updated to show mode-specific messages. However, the **footer line** at the bottom of the comment was left as a static string and never updated to match the mode.

### Before

With auto-resume enabled, the comment showed:
- **How to Continue**: "The session will automatically resume (with context preserved) when the limit resets."
- **Footer**: "You can resume once the limit resets." ← inconsistent!

### After

With auto-resume enabled:
- **Footer**: "The session will automatically resume when the limit resets."

With auto-restart enabled:
- **Footer**: "The session will automatically restart when the limit resets."

With auto-resume disabled (manual mode):
- **Footer**: "You can resume once the limit resets." (unchanged)

## Test plan

- [x] All existing tests pass (`npm test` — 41 tests, 0 failures)
- [x] `eslint src/github.lib.mjs` — 0 errors, 0 warnings
- [x] Logic traced for all three cases: auto-resume, auto-restart, manual

## Case Study

Added `docs/case-studies/issue-1569/README.md` with full root cause analysis and timeline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)