### PR TITLE
fix: prevent push failures in auto-restart and cleanup by syncing with remote (#1572)

### DIFF
--- a/.changeset/fix-push-failures-auto-restart-1572.md
+++ b/.changeset/fix-push-failures-auto-restart-1572.md
@@ -4,6 +4,6 @@
 
 fix: prevent push failures in auto-restart and cleanup by syncing with remote (#1572)
 
-- Add `git pull --rebase` before restart sessions and cleanup push to prevent stale local state
+- Add `git pull` before restart sessions and cleanup push to prevent stale local state
 - Add `2>&1` to all `git push` commands so stderr is captured for proper error handling
 - Fix multi-line log message formatting to include timestamps on each line

--- a/.changeset/fix-push-failures-auto-restart-1572.md
+++ b/.changeset/fix-push-failures-auto-restart-1572.md
@@ -1,0 +1,9 @@
+---
+'@link-assistant/hive-mind': patch
+---
+
+fix: prevent push failures in auto-restart and cleanup by syncing with remote (#1572)
+
+- Add `git pull --rebase` before restart sessions and cleanup push to prevent stale local state
+- Add `2>&1` to all `git push` commands so stderr is captured for proper error handling
+- Fix multi-line log message formatting to include timestamps on each line

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,1 +1,0 @@
-# .gitkeep file auto-generated at 2026-04-11T02:25:09.049Z for PR creation at branch issue-1572-43723cd4ad2c for issue https://github.com/link-assistant/hive-mind/issues/1572

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,0 +1,1 @@
+# .gitkeep file auto-generated at 2026-04-11T02:25:09.049Z for PR creation at branch issue-1572-43723cd4ad2c for issue https://github.com/link-assistant/hive-mind/issues/1572

--- a/docs/case-studies/issue-1572/README.md
+++ b/docs/case-studies/issue-1572/README.md
@@ -9,24 +9,24 @@ Two bugs were identified from a failed solve run on `Jhon-Crow/godot-topdown-MVP
 
 ## Timeline of Events
 
-| Time (UTC) | Event | Session |
-|---|---|---|
-| 18:07:06 | Solve process starts for issue #1742 | — |
-| 18:07:32 | `.gitkeep` committed (`ff077c8b`) and pushed to `issue-1742-d13525cf93f4` | Session 1 (`27647682`) |
-| 18:07:39 | PR #1791 created | Session 1 |
-| 18:07:55 | Claude Session 1 starts (model: claude-sonnet-4-6) | Session 1 |
-| 18:12:59 | AI pushes commits (ff077c8b..b1b75c11) — **success** | Session 1 |
-| 18:13:41 | Session 1 completes, cost $1.28, 94K tokens | Session 1 |
-| 18:13:51 | Auto-restart-until-mergeable mode begins monitoring PR #1791 | �� |
-| 18:25:18 | Owner (Jhon-Crow) posts feedback comment on PR | — |
-| 18:26:01 | "AI Work Session Started" comment posted, PR converted to draft | — |
-| 18:29:50 | **RESTART TRIGGERED** — new comment detected from Jhon-Crow | — |
-| 18:29:54 | Claude Session 2 starts — **same working directory, NO `git pull`** | Session 2 (`990c6d46`) |
-| 18:37:19 | AI tries `git push` in Session 2 — **FAILS with "fetch first"** | Session 2 |
-| 18:38:15 | Session 2 ends with exit code 1 | Session 2 |
-| 18:38:22 | `.gitkeep` revert committed locally (1d008e66) | Cleanup |
-| 18:38:22 | `.gitkeep` revert push — **FAILS with "non-fast-forward"** | Cleanup |
-| 18:38:22 | Process ends | — |
+| Time (UTC) | Event                                                                     | Session                |
+| ---------- | ------------------------------------------------------------------------- | ---------------------- |
+| 18:07:06   | Solve process starts for issue #1742                                      | —                      |
+| 18:07:32   | `.gitkeep` committed (`ff077c8b`) and pushed to `issue-1742-d13525cf93f4` | Session 1 (`27647682`) |
+| 18:07:39   | PR #1791 created                                                          | Session 1              |
+| 18:07:55   | Claude Session 1 starts (model: claude-sonnet-4-6)                        | Session 1              |
+| 18:12:59   | AI pushes commits (ff077c8b..b1b75c11) — **success**                      | Session 1              |
+| 18:13:41   | Session 1 completes, cost $1.28, 94K tokens                               | Session 1              |
+| 18:13:51   | Auto-restart-until-mergeable mode begins monitoring PR #1791              | ��                     |
+| 18:25:18   | Owner (Jhon-Crow) posts feedback comment on PR                            | —                      |
+| 18:26:01   | "AI Work Session Started" comment posted, PR converted to draft           | —                      |
+| 18:29:50   | **RESTART TRIGGERED** — new comment detected from Jhon-Crow               | —                      |
+| 18:29:54   | Claude Session 2 starts — **same working directory, NO `git pull`**       | Session 2 (`990c6d46`) |
+| 18:37:19   | AI tries `git push` in Session 2 — **FAILS with "fetch first"**           | Session 2              |
+| 18:38:15   | Session 2 ends with exit code 1                                           | Session 2              |
+| 18:38:22   | `.gitkeep` revert committed locally (1d008e66)                            | Cleanup                |
+| 18:38:22   | `.gitkeep` revert push — **FAILS with "non-fast-forward"**                | Cleanup                |
+| 18:38:22   | Process ends                                                              | —                      |
 
 ## Root Cause Analysis
 
@@ -44,6 +44,7 @@ Two bugs were identified from a failed solve run on `Jhon-Crow/godot-topdown-MVP
 6. After Session 2 fails, the cleanup tries to push the `.gitkeep` revert — also fails because local is still behind remote
 
 **Code locations:**
+
 - `src/solve.auto-merge.lib.mjs:954-993` — restart trigger handler, no `git pull/fetch`
 - `src/solve.restart-shared.lib.mjs:174-290` — `executeToolIteration()`, no `git pull/fetch`
 - `src/solve.results.lib.mjs:324` — cleanup push that fails
@@ -55,14 +56,16 @@ Two bugs were identified from a failed solve run on `Jhon-Crow/godot-topdown-MVP
 **Root cause:** Several `git push` commands in the codebase lack `2>&1` redirection. While the stdio interceptor (`setupStdioLogInterceptor()` in `src/lib.mjs:186-228`) captures all terminal output including stderr in the log file, the absence of `2>&1` means `pushResult.stderr` is empty/undefined in the JavaScript code. This prevents proper error handling and logging of push failure reasons.
 
 **Affected locations (missing `2>&1`):**
+
 - `src/solve.mjs:576` — initial push
-- `src/solve.mjs:1346` — uncommitted changes push  
+- `src/solve.mjs:1346` — uncommitted changes push
 - `src/claude.lib.mjs:1452` — Claude post-push
 - `src/codex.lib.mjs:495` — Codex post-push
 - `src/opencode.lib.mjs:549` — OpenCode post-push
 - `src/agent.lib.mjs:1085` — Agent post-push
 
 **Already correct (have `2>&1`):**
+
 - `src/solve.auto-pr.lib.mjs:384` — initial PR push
 - `src/solve.results.lib.mjs:304,324,370,406` — cleanup pushes
 
@@ -73,8 +76,9 @@ Two bugs were identified from a failed solve run on `Jhon-Crow/godot-topdown-MVP
 **Root cause:** The `log()` function in `src/lib.mjs:77-121` prepends a timestamp only at the beginning of the message. When messages contain embedded `\n` (e.g., `\n📁 Keeping directory...`), the continuation lines appear in the log file without timestamps, breaking log parsing.
 
 **Example:**
+
 ```
-[2026-04-10T18:38:22.993Z] [INFO] 
+[2026-04-10T18:38:22.993Z] [INFO]
 📁 Keeping directory (--no-auto-cleanup): /tmp/gh-issue-solver-1775844437743
 ```
 

--- a/docs/case-studies/issue-1572/README.md
+++ b/docs/case-studies/issue-1572/README.md
@@ -49,7 +49,7 @@ Two bugs were identified from a failed solve run on `Jhon-Crow/godot-topdown-MVP
 - `src/solve.restart-shared.lib.mjs:174-290` — `executeToolIteration()`, no `git pull/fetch`
 - `src/solve.results.lib.mjs:324` — cleanup push that fails
 
-**Fix:** Add `git pull --rebase origin <branchName>` before launching the restarted AI session in the auto-merge restart flow. Also add it to the cleanup function before pushing the revert, as a defense-in-depth measure.
+**Fix:** Add `git pull origin <branchName>` before launching the restarted AI session in the auto-merge restart flow. Also add it to the cleanup function before pushing the revert, as a defense-in-depth measure. Use plain `git pull` (no rebase) since nobody else touches the solve-created branch, and fail if the pull is not possible.
 
 ### Issue 2: Log completeness — missing `2>&1` on push commands
 
@@ -92,12 +92,12 @@ In `src/solve.auto-merge.lib.mjs`, before calling `executeToolIteration()` after
 
 ```javascript
 // Sync local branch with remote before restart
-await $({ cwd: tempDir })`git pull --rebase origin ${branchName} 2>&1`;
+await $({ cwd: tempDir })`git pull origin ${branchName} 2>&1`;
 ```
 
 ### Solution 2: Add `git pull` in cleanup before push
 
-In `src/solve.results.lib.mjs`, before each `git push` in the cleanup function, add a `git pull --rebase` as defense-in-depth.
+In `src/solve.results.lib.mjs`, before each `git push` in the cleanup function, add a `git pull` as defense-in-depth.
 
 ### Solution 3: Add `2>&1` to all `git push` commands
 

--- a/docs/case-studies/issue-1572/README.md
+++ b/docs/case-studies/issue-1572/README.md
@@ -1,0 +1,111 @@
+# Case Study: Issue #1572 — `error: failed to push some refs`
+
+## Summary
+
+Two bugs were identified from a failed solve run on `Jhon-Crow/godot-topdown-MVP#1742`:
+
+1. **Push failure during `.gitkeep` cleanup** — the revert commit could not be pushed because the local branch was behind the remote
+2. **Log completeness gaps** — some push commands lack `2>&1` redirection, making error details unavailable to the code for proper handling; also multi-line log messages lose timestamps on continuation lines
+
+## Timeline of Events
+
+| Time (UTC) | Event | Session |
+|---|---|---|
+| 18:07:06 | Solve process starts for issue #1742 | — |
+| 18:07:32 | `.gitkeep` committed (`ff077c8b`) and pushed to `issue-1742-d13525cf93f4` | Session 1 (`27647682`) |
+| 18:07:39 | PR #1791 created | Session 1 |
+| 18:07:55 | Claude Session 1 starts (model: claude-sonnet-4-6) | Session 1 |
+| 18:12:59 | AI pushes commits (ff077c8b..b1b75c11) — **success** | Session 1 |
+| 18:13:41 | Session 1 completes, cost $1.28, 94K tokens | Session 1 |
+| 18:13:51 | Auto-restart-until-mergeable mode begins monitoring PR #1791 | �� |
+| 18:25:18 | Owner (Jhon-Crow) posts feedback comment on PR | — |
+| 18:26:01 | "AI Work Session Started" comment posted, PR converted to draft | — |
+| 18:29:50 | **RESTART TRIGGERED** — new comment detected from Jhon-Crow | — |
+| 18:29:54 | Claude Session 2 starts — **same working directory, NO `git pull`** | Session 2 (`990c6d46`) |
+| 18:37:19 | AI tries `git push` in Session 2 — **FAILS with "fetch first"** | Session 2 |
+| 18:38:15 | Session 2 ends with exit code 1 | Session 2 |
+| 18:38:22 | `.gitkeep` revert committed locally (1d008e66) | Cleanup |
+| 18:38:22 | `.gitkeep` revert push — **FAILS with "non-fast-forward"** | Cleanup |
+| 18:38:22 | Process ends | — |
+
+## Root Cause Analysis
+
+### Issue 1: Push failure during `.gitkeep` cleanup
+
+**Root cause:** The `auto-restart-until-mergeable` mode in `solve.auto-merge.lib.mjs` does NOT perform `git pull` or `git fetch` before launching a restarted AI session. When a restart is triggered (line 954), it calls `executeToolIteration()` (line 982) which directly launches a new Claude session in the same working directory.
+
+**Chain of events:**
+
+1. Session 1 pushed commits to `b1b75c11` at 18:12:59
+2. Between sessions, the auto-restart loop only checks PR state via GitHub API — no local git operations
+3. Session 2 starts at 18:29:54 in the same `tempDir` with a stale local state
+4. The restart prompt tells the AI to "Ensure to get latest version of default branch" but this relies on the AI executing `git pull` — which is unreliable and a design flaw
+5. Session 2 makes local commits but can't push because remote has diverged
+6. After Session 2 fails, the cleanup tries to push the `.gitkeep` revert — also fails because local is still behind remote
+
+**Code locations:**
+- `src/solve.auto-merge.lib.mjs:954-993` — restart trigger handler, no `git pull/fetch`
+- `src/solve.restart-shared.lib.mjs:174-290` — `executeToolIteration()`, no `git pull/fetch`
+- `src/solve.results.lib.mjs:324` — cleanup push that fails
+
+**Fix:** Add `git pull --rebase origin <branchName>` before launching the restarted AI session in the auto-merge restart flow. Also add it to the cleanup function before pushing the revert, as a defense-in-depth measure.
+
+### Issue 2: Log completeness — missing `2>&1` on push commands
+
+**Root cause:** Several `git push` commands in the codebase lack `2>&1` redirection. While the stdio interceptor (`setupStdioLogInterceptor()` in `src/lib.mjs:186-228`) captures all terminal output including stderr in the log file, the absence of `2>&1` means `pushResult.stderr` is empty/undefined in the JavaScript code. This prevents proper error handling and logging of push failure reasons.
+
+**Affected locations (missing `2>&1`):**
+- `src/solve.mjs:576` — initial push
+- `src/solve.mjs:1346` — uncommitted changes push  
+- `src/claude.lib.mjs:1452` — Claude post-push
+- `src/codex.lib.mjs:495` — Codex post-push
+- `src/opencode.lib.mjs:549` — OpenCode post-push
+- `src/agent.lib.mjs:1085` — Agent post-push
+
+**Already correct (have `2>&1`):**
+- `src/solve.auto-pr.lib.mjs:384` — initial PR push
+- `src/solve.results.lib.mjs:304,324,370,406` — cleanup pushes
+
+**Fix:** Add `2>&1` to all `git push` commands that lack it, ensuring stderr is captured in the command result for proper error handling.
+
+### Issue 2b: Log formatting — multi-line messages lose timestamps
+
+**Root cause:** The `log()` function in `src/lib.mjs:77-121` prepends a timestamp only at the beginning of the message. When messages contain embedded `\n` (e.g., `\n📁 Keeping directory...`), the continuation lines appear in the log file without timestamps, breaking log parsing.
+
+**Example:**
+```
+[2026-04-10T18:38:22.993Z] [INFO] 
+📁 Keeping directory (--no-auto-cleanup): /tmp/gh-issue-solver-1775844437743
+```
+
+**Fix:** The `log()` function should handle multi-line messages by prepending timestamps to each line, or callers should avoid embedding `\n` in messages.
+
+## Proposed Solutions
+
+### Solution 1: Add `git pull` before restart sessions
+
+In `src/solve.auto-merge.lib.mjs`, before calling `executeToolIteration()` after a restart trigger, add:
+
+```javascript
+// Sync local branch with remote before restart
+await $({ cwd: tempDir })`git pull --rebase origin ${branchName} 2>&1`;
+```
+
+### Solution 2: Add `git pull` in cleanup before push
+
+In `src/solve.results.lib.mjs`, before each `git push` in the cleanup function, add a `git pull --rebase` as defense-in-depth.
+
+### Solution 3: Add `2>&1` to all `git push` commands
+
+Ensure all `git push` template literals include `2>&1` for consistent stderr capture.
+
+### Solution 4: Fix multi-line log formatting
+
+Update `log()` in `src/lib.mjs` to split messages on `\n` and prefix each line with the timestamp.
+
+## Related Resources
+
+- Full process log: `docs/case-studies/issue-1572/full-process-log.txt` (31,768 lines)
+- Solution draft log: `docs/case-studies/issue-1572/solution-draft-log-public.txt` (31,643 lines)
+- Public gist: https://gist.github.com/konard/6a971df0d762ee96625179ede3216688
+- Private gist: https://gist.github.com/konard/a1a4193a4cd449bc1816981b73e98dcf

--- a/src/agent.lib.mjs
+++ b/src/agent.lib.mjs
@@ -1082,12 +1082,12 @@ export const checkForUncommittedChanges = async (tempDir, owner, repo, branchNam
             if (commitResult.code === 0) {
               await log('✅ Changes committed successfully');
 
-              const pushResult = await $({ cwd: tempDir })`git push origin ${branchName}`;
+              const pushResult = await $({ cwd: tempDir })`git push origin ${branchName} 2>&1`;
 
               if (pushResult.code === 0) {
                 await log('✅ Changes pushed successfully');
               } else {
-                await log(`⚠️ Warning: Could not push changes: ${pushResult.stderr?.toString().trim()}`, {
+                await log(`⚠️ Warning: Could not push changes: ${pushResult.stderr?.toString().trim() || pushResult.stdout?.toString().trim()}`, {
                   level: 'warning',
                 });
               }

--- a/src/claude.lib.mjs
+++ b/src/claude.lib.mjs
@@ -1449,11 +1449,11 @@ export const checkForUncommittedChanges = async (tempDir, owner, repo, branchNam
             if (commitResult.code === 0) {
               await log('✅ Changes committed successfully');
               await log('📤 Pushing changes to remote...');
-              const pushResult = await $({ cwd: tempDir })`git push origin ${branchName}`;
+              const pushResult = await $({ cwd: tempDir })`git push origin ${branchName} 2>&1`;
               if (pushResult.code === 0) {
                 await log('✅ Changes pushed successfully');
               } else {
-                await log(`⚠️ Warning: Could not push changes: ${pushResult.stderr?.toString().trim()}`, {
+                await log(`⚠️ Warning: Could not push changes: ${pushResult.stderr?.toString().trim() || pushResult.stdout?.toString().trim()}`, {
                   level: 'warning',
                 });
               }

--- a/src/codex.lib.mjs
+++ b/src/codex.lib.mjs
@@ -492,12 +492,12 @@ export const checkForUncommittedChanges = async (tempDir, owner, repo, branchNam
             if (commitResult.code === 0) {
               await log('✅ Changes committed successfully');
 
-              const pushResult = await $({ cwd: tempDir })`git push origin ${branchName}`;
+              const pushResult = await $({ cwd: tempDir })`git push origin ${branchName} 2>&1`;
 
               if (pushResult.code === 0) {
                 await log('✅ Changes pushed successfully');
               } else {
-                await log(`⚠️ Warning: Could not push changes: ${pushResult.stderr?.toString().trim()}`, {
+                await log(`⚠️ Warning: Could not push changes: ${pushResult.stderr?.toString().trim() || pushResult.stdout?.toString().trim()}`, {
                   level: 'warning',
                 });
               }

--- a/src/lib.mjs
+++ b/src/lib.mjs
@@ -83,8 +83,13 @@ export const log = async (message, options = {}) => {
   }
 
   // Write to file if log file is set
+  // Issue #1572: Handle multi-line messages by timestamping each line,
+  // so continuation lines don't appear without timestamps in the log file
   if (logFile) {
-    const logMessage = `[${new Date().toISOString()}] [${level.toUpperCase()}] ${message}`;
+    const timestamp = new Date().toISOString();
+    const prefix = `[${timestamp}] [${level.toUpperCase()}]`;
+    const lines = String(message).split('\n');
+    const logMessage = lines.map(line => `${prefix} ${line}`).join('\n');
     await fs.appendFile(logFile, logMessage + '\n').catch(error => {
       // Silent fail for file append errors to avoid infinite loop
       // but report to Sentry in verbose mode

--- a/src/opencode.lib.mjs
+++ b/src/opencode.lib.mjs
@@ -546,12 +546,12 @@ export const checkForUncommittedChanges = async (tempDir, owner, repo, branchNam
             if (commitResult.code === 0) {
               await log('✅ Changes committed successfully');
 
-              const pushResult = await $({ cwd: tempDir })`git push origin ${branchName}`;
+              const pushResult = await $({ cwd: tempDir })`git push origin ${branchName} 2>&1`;
 
               if (pushResult.code === 0) {
                 await log('✅ Changes pushed successfully');
               } else {
-                await log(`⚠️ Warning: Could not push changes: ${pushResult.stderr?.toString().trim()}`, {
+                await log(`⚠️ Warning: Could not push changes: ${pushResult.stderr?.toString().trim() || pushResult.stdout?.toString().trim()}`, {
                   level: 'warning',
                 });
               }

--- a/src/solve.auto-ensure.lib.mjs
+++ b/src/solve.auto-ensure.lib.mjs
@@ -76,6 +76,18 @@ export const runAutoEnsureRequirements = async ({ issueUrl, owner, repo, issueNu
   for (let ensureIteration = 1; ensureIteration <= finalizeCount; ensureIteration++) {
     await log(`🔄 FINALIZE iteration ${ensureIteration}/${finalizeCount}: Restarting to verify requirements...`);
 
+    // Issue #1572: Sync local branch with remote before each finalize iteration
+    try {
+      const pullResult = await $({ cwd: tempDir })`git pull --rebase origin ${branchName} 2>&1`;
+      if (pullResult.code === 0) {
+        await log(`   Synced local branch ${branchName} from remote`, { verbose: true });
+      } else {
+        await log(`   ⚠️  git pull --rebase failed (code ${pullResult.code}), continuing anyway`, { verbose: true });
+      }
+    } catch (pullError) {
+      await log(`   ⚠️  Could not sync local branch: ${pullError.message}`, { verbose: true });
+    }
+
     const ensureFeedbackLines = ['', '='.repeat(60), '🔍 FINALIZE REQUIREMENTS CHECK:', '='.repeat(60), '', 'We need to ensure all changes are correct, consistent, validated, tested, logged and fully meet all discussed requirements (check issue description and all comments in issue and in pull request). Ensure all CI/CD checks pass.', ''];
 
     const ensureResult = await executeToolIteration({

--- a/src/solve.auto-ensure.lib.mjs
+++ b/src/solve.auto-ensure.lib.mjs
@@ -77,15 +77,11 @@ export const runAutoEnsureRequirements = async ({ issueUrl, owner, repo, issueNu
     await log(`🔄 FINALIZE iteration ${ensureIteration}/${finalizeCount}: Restarting to verify requirements...`);
 
     // Issue #1572: Sync local branch with remote before each finalize iteration
-    try {
-      const pullResult = await $({ cwd: tempDir })`git pull --rebase origin ${branchName} 2>&1`;
-      if (pullResult.code === 0) {
-        await log(`   Synced local branch ${branchName} from remote`, { verbose: true });
-      } else {
-        await log(`   ⚠️  git pull --rebase failed (code ${pullResult.code}), continuing anyway`, { verbose: true });
-      }
-    } catch (pullError) {
-      await log(`   ⚠️  Could not sync local branch: ${pullError.message}`, { verbose: true });
+    const pullResult = await $({ cwd: tempDir })`git pull origin ${branchName} 2>&1`;
+    if (pullResult.code === 0) {
+      await log(`   Synced local branch ${branchName} from remote`, { verbose: true });
+    } else {
+      throw new Error(`git pull failed (code ${pullResult.code}): ${pullResult.stdout || pullResult.stderr || 'no output'}`);
     }
 
     const ensureFeedbackLines = ['', '='.repeat(60), '🔍 FINALIZE REQUIREMENTS CHECK:', '='.repeat(60), '', 'We need to ensure all changes are correct, consistent, validated, tested, logged and fully meet all discussed requirements (check issue description and all comments in issue and in pull request). Ensure all CI/CD checks pass.', ''];

--- a/src/solve.auto-merge.lib.mjs
+++ b/src/solve.auto-merge.lib.mjs
@@ -979,16 +979,11 @@ Once the billing issue is resolved, you can re-run the CI checks or push a new c
         // Issue #1572: Sync local branch with remote before restarting to avoid push failures.
         // Without this, the restarted session works on stale local state and can't push.
         const effectiveBranch = prBranch || branchName;
-        try {
-          const pullResult = await $({ cwd: tempDir })`git pull --rebase origin ${effectiveBranch} 2>&1`;
-          if (pullResult.code === 0) {
-            await log(formatAligned('🔄', 'Synced:', `Local branch ${effectiveBranch} updated from remote`));
-          } else {
-            await log(`   ⚠️  git pull --rebase failed (code ${pullResult.code}), continuing anyway`, { verbose: true });
-            await log(`   Output: ${pullResult.stdout || pullResult.stderr || 'no output'}`, { verbose: true });
-          }
-        } catch (pullError) {
-          await log(`   ⚠️  Could not sync local branch: ${pullError.message}`, { verbose: true });
+        const pullResult = await $({ cwd: tempDir })`git pull origin ${effectiveBranch} 2>&1`;
+        if (pullResult.code === 0) {
+          await log(formatAligned('🔄', 'Synced:', `Local branch ${effectiveBranch} updated from remote`));
+        } else {
+          throw new Error(`git pull failed (code ${pullResult.code}): ${pullResult.stdout || pullResult.stderr || 'no output'}`);
         }
 
         // Execute the AI tool using shared utility

--- a/src/solve.auto-merge.lib.mjs
+++ b/src/solve.auto-merge.lib.mjs
@@ -976,6 +976,21 @@ Once the billing issue is resolved, you can re-run the CI checks or push a new c
         const prStateResult = await $`gh api repos/${owner}/${repo}/pulls/${prNumber} --jq '.mergeStateStatus'`;
         const mergeStateStatus = prStateResult.code === 0 ? prStateResult.stdout.toString().trim() : null;
 
+        // Issue #1572: Sync local branch with remote before restarting to avoid push failures.
+        // Without this, the restarted session works on stale local state and can't push.
+        const effectiveBranch = prBranch || branchName;
+        try {
+          const pullResult = await $({ cwd: tempDir })`git pull --rebase origin ${effectiveBranch} 2>&1`;
+          if (pullResult.code === 0) {
+            await log(formatAligned('🔄', 'Synced:', `Local branch ${effectiveBranch} updated from remote`));
+          } else {
+            await log(`   ⚠️  git pull --rebase failed (code ${pullResult.code}), continuing anyway`, { verbose: true });
+            await log(`   Output: ${pullResult.stdout || pullResult.stderr || 'no output'}`, { verbose: true });
+          }
+        } catch (pullError) {
+          await log(`   ⚠️  Could not sync local branch: ${pullError.message}`, { verbose: true });
+        }
+
         // Execute the AI tool using shared utility
         await log(formatAligned('🔄', 'Restarting:', `Running ${argv.tool.toUpperCase()} to address issues...`));
 

--- a/src/solve.mjs
+++ b/src/solve.mjs
@@ -573,12 +573,12 @@ try {
       const mergeResult = await $({ cwd: tempDir })`git merge ${defaultBranch} --no-edit`;
       if (mergeResult.code === 0) {
         await log(`${formatAligned('✅', 'Merge successful:', 'Pushing merged branch...')}`);
-        const pushResult = await $({ cwd: tempDir })`git push origin ${branchName}`;
+        const pushResult = await $({ cwd: tempDir })`git push origin ${branchName} 2>&1`;
         if (pushResult.code === 0) {
           await log(`${formatAligned('✅', 'Push successful:', 'Branch updated with latest changes')}`);
         } else {
           await log(`${formatAligned('⚠️', 'Push failed:', 'Merge completed but push failed')}`, { level: 'warning' });
-          await log(`  Error: ${pushResult.stderr?.toString() || 'Unknown error'}`, { level: 'warning' });
+          await log(`  Error: ${pushResult.stderr?.toString() || pushResult.stdout?.toString() || 'Unknown error'}`, { level: 'warning' });
         }
       } else {
         // Merge failed - likely due to conflicts
@@ -1343,13 +1343,13 @@ try {
     await log('');
 
     try {
-      const pushResult = await $({ cwd: tempDir })`git push origin ${branchName}`;
+      const pushResult = await $({ cwd: tempDir })`git push origin ${branchName} 2>&1`;
       if (pushResult.code === 0) {
         await log('✅ Changes pushed successfully to remote branch');
         await log(`   Branch: ${branchName}`);
         await log('');
       } else {
-        const errorMsg = pushResult.stderr?.toString() || 'Unknown error';
+        const errorMsg = pushResult.stderr?.toString() || pushResult.stdout?.toString() || 'Unknown error';
         await log('⚠️  Push failed:', { level: 'error' });
         await log(`   ${errorMsg.trim()}`, { level: 'error' });
         await log('   Please push manually:', { level: 'error' });

--- a/src/solve.repository.lib.mjs
+++ b/src/solve.repository.lib.mjs
@@ -1113,12 +1113,12 @@ export const setupUpstreamAndSync = async (tempDir, forkedRepo, upstreamRemote, 
 
               // Step 3: Push the updated default branch to fork to keep it in sync
               await log(`${formatAligned('🔄', 'Pushing to fork:', `${upstreamDefaultBranch} branch`)}`);
-              const pushResult = await $({ cwd: tempDir })`git push origin ${upstreamDefaultBranch}`;
+              const pushResult = await $({ cwd: tempDir })`git push origin ${upstreamDefaultBranch} 2>&1`;
               if (pushResult.code === 0) {
                 await log(`${formatAligned('✅', 'Fork updated:', 'Default branch pushed to fork')}`);
               } else {
                 // Check if it's a non-fast-forward error (fork has diverged from upstream)
-                const errorMsg = pushResult.stderr ? pushResult.stderr.toString().trim() : '';
+                const errorMsg = (pushResult.stderr ? pushResult.stderr.toString().trim() : '') || (pushResult.stdout ? pushResult.stdout.toString().trim() : '');
                 const isNonFastForward = errorMsg.includes('non-fast-forward') || errorMsg.includes('rejected') || errorMsg.includes('tip of your current branch is behind');
 
                 if (isNonFastForward) {

--- a/src/solve.repository.lib.mjs
+++ b/src/solve.repository.lib.mjs
@@ -1147,7 +1147,7 @@ export const setupUpstreamAndSync = async (tempDir, forkedRepo, upstreamRemote, 
                     await log(`${formatAligned('🔄', 'Force pushing:', 'Syncing fork with upstream (--force-with-lease)')}`);
                     const forcePushResult = await $({
                       cwd: tempDir,
-                    })`git push --force-with-lease origin ${upstreamDefaultBranch}`;
+                    })`git push --force-with-lease origin ${upstreamDefaultBranch} 2>&1`;
 
                     if (forcePushResult.code === 0) {
                       await log(`${formatAligned('✅', 'Fork synced:', 'Successfully force-pushed to align with upstream')}`);

--- a/src/solve.results.lib.mjs
+++ b/src/solve.results.lib.mjs
@@ -271,15 +271,11 @@ export const cleanupClaudeFile = async (tempDir, branchName, claudeCommitHash = 
 
     // Issue #1572: Sync local branch with remote before cleanup to prevent push failures.
     // After auto-restart sessions, the local branch may be behind the remote.
-    try {
-      const pullResult = await $({ cwd: tempDir })`git pull --rebase origin ${branchName} 2>&1`;
-      if (pullResult.code === 0) {
-        await log(`   Synced local branch before cleanup`, { verbose: true });
-      } else {
-        await log(`   ⚠️  Pre-cleanup sync failed (code ${pullResult.code}), continuing anyway`, { verbose: true });
-      }
-    } catch (pullError) {
-      await log(`   ⚠️  Could not sync local branch before cleanup: ${pullError.message}`, { verbose: true });
+    const pullResult = await $({ cwd: tempDir })`git pull origin ${branchName} 2>&1`;
+    if (pullResult.code === 0) {
+      await log(`   Synced local branch before cleanup`, { verbose: true });
+    } else {
+      throw new Error(`git pull failed (code ${pullResult.code}): ${pullResult.stdout || pullResult.stderr || 'no output'}`);
     }
 
     const commitToRevert = claudeCommitHash;

--- a/src/solve.results.lib.mjs
+++ b/src/solve.results.lib.mjs
@@ -269,6 +269,19 @@ export const cleanupClaudeFile = async (tempDir, branchName, claudeCommitHash = 
     await log(formatAligned('🔄', 'Cleanup:', `Reverting ${fileName} commit`));
     await log(`   Using saved commit hash: ${claudeCommitHash.substring(0, 7)}...`, { verbose: true });
 
+    // Issue #1572: Sync local branch with remote before cleanup to prevent push failures.
+    // After auto-restart sessions, the local branch may be behind the remote.
+    try {
+      const pullResult = await $({ cwd: tempDir })`git pull --rebase origin ${branchName} 2>&1`;
+      if (pullResult.code === 0) {
+        await log(`   Synced local branch before cleanup`, { verbose: true });
+      } else {
+        await log(`   ⚠️  Pre-cleanup sync failed (code ${pullResult.code}), continuing anyway`, { verbose: true });
+      }
+    } catch (pullError) {
+      await log(`   ⚠️  Could not sync local branch before cleanup: ${pullError.message}`, { verbose: true });
+    }
+
     const commitToRevert = claudeCommitHash;
 
     // APPROACH 3: Check for modifications before reverting (proactive detection)

--- a/tests/test-issue-1572-push-sync.mjs
+++ b/tests/test-issue-1572-push-sync.mjs
@@ -123,11 +123,11 @@ console.log('\n--- Test: Auto-restart includes git pull before restart ---');
   // Find the RESTART TRIGGERED section and check that git pull appears before executeToolIteration
   const restartTriggeredIdx = autoMergeContent.indexOf('RESTART TRIGGERED');
   const executeToolIterationIdx = autoMergeContent.indexOf('executeToolIteration({', restartTriggeredIdx);
-  const gitPullIdx = autoMergeContent.indexOf('git pull --rebase origin', restartTriggeredIdx);
+  const gitPullIdx = autoMergeContent.indexOf('git pull origin', restartTriggeredIdx);
 
   assert(restartTriggeredIdx > 0, 'Found RESTART TRIGGERED in auto-merge code');
   assert(executeToolIterationIdx > 0, 'Found executeToolIteration call after restart trigger');
-  assert(gitPullIdx > 0, 'Found git pull --rebase in auto-merge restart path');
+  assert(gitPullIdx > 0, 'Found git pull in auto-merge restart path');
   assert(gitPullIdx < executeToolIterationIdx, 'git pull appears BEFORE executeToolIteration in restart path', `git pull at index ${gitPullIdx}, executeToolIteration at index ${executeToolIterationIdx}`);
 }
 
@@ -142,11 +142,11 @@ console.log('\n--- Test: Auto-ensure includes git pull before iterations ---');
 
   const forLoopIdx = autoEnsureContent.indexOf('for (let ensureIteration');
   const executeToolIterationIdx = autoEnsureContent.indexOf('executeToolIteration({', forLoopIdx);
-  const gitPullIdx = autoEnsureContent.indexOf('git pull --rebase origin', forLoopIdx);
+  const gitPullIdx = autoEnsureContent.indexOf('git pull origin', forLoopIdx);
 
   assert(forLoopIdx > 0, 'Found finalize loop in auto-ensure code');
   assert(executeToolIterationIdx > 0, 'Found executeToolIteration call in finalize loop');
-  assert(gitPullIdx > 0, 'Found git pull --rebase in auto-ensure path');
+  assert(gitPullIdx > 0, 'Found git pull in auto-ensure path');
   assert(gitPullIdx < executeToolIterationIdx, 'git pull appears BEFORE executeToolIteration in finalize path', `git pull at index ${gitPullIdx}, executeToolIteration at index ${executeToolIterationIdx}`);
 }
 
@@ -161,11 +161,11 @@ console.log('\n--- Test: Cleanup includes git pull before revert ---');
 
   const cleanupFnIdx = resultsContent.indexOf('export const cleanupClaudeFile');
   const gitRevertIdx = resultsContent.indexOf('git revert', cleanupFnIdx);
-  const gitPullIdx = resultsContent.indexOf('git pull --rebase origin', cleanupFnIdx);
+  const gitPullIdx = resultsContent.indexOf('git pull origin', cleanupFnIdx);
 
   assert(cleanupFnIdx > 0, 'Found cleanupClaudeFile function');
   assert(gitRevertIdx > 0, 'Found git revert in cleanup');
-  assert(gitPullIdx > 0, 'Found git pull --rebase in cleanup');
+  assert(gitPullIdx > 0, 'Found git pull in cleanup');
   assert(gitPullIdx < gitRevertIdx, 'git pull appears BEFORE git revert in cleanup', `git pull at index ${gitPullIdx}, git revert at index ${gitRevertIdx}`);
 }
 

--- a/tests/test-issue-1572-push-sync.mjs
+++ b/tests/test-issue-1572-push-sync.mjs
@@ -108,13 +108,7 @@ console.log('\n--- Test: git push commands include 2>&1 ---');
   }
 
   assert(totalPushCommands > 0, `Found git push commands in source (${totalPushCommands} total)`);
-  assert(
-    pushCommandsMissing2and1.length === 0,
-    'All git push template commands include 2>&1',
-    pushCommandsMissing2and1.length > 0
-      ? `Missing 2>&1 in:\n${pushCommandsMissing2and1.map(l => `      ${l}`).join('\n')}`
-      : '',
-  );
+  assert(pushCommandsMissing2and1.length === 0, 'All git push template commands include 2>&1', pushCommandsMissing2and1.length > 0 ? `Missing 2>&1 in:\n${pushCommandsMissing2and1.map(l => `      ${l}`).join('\n')}` : '');
 }
 
 // ============================================================
@@ -134,11 +128,7 @@ console.log('\n--- Test: Auto-restart includes git pull before restart ---');
   assert(restartTriggeredIdx > 0, 'Found RESTART TRIGGERED in auto-merge code');
   assert(executeToolIterationIdx > 0, 'Found executeToolIteration call after restart trigger');
   assert(gitPullIdx > 0, 'Found git pull --rebase in auto-merge restart path');
-  assert(
-    gitPullIdx < executeToolIterationIdx,
-    'git pull appears BEFORE executeToolIteration in restart path',
-    `git pull at index ${gitPullIdx}, executeToolIteration at index ${executeToolIterationIdx}`,
-  );
+  assert(gitPullIdx < executeToolIterationIdx, 'git pull appears BEFORE executeToolIteration in restart path', `git pull at index ${gitPullIdx}, executeToolIteration at index ${executeToolIterationIdx}`);
 }
 
 // ============================================================
@@ -157,11 +147,7 @@ console.log('\n--- Test: Auto-ensure includes git pull before iterations ---');
   assert(forLoopIdx > 0, 'Found finalize loop in auto-ensure code');
   assert(executeToolIterationIdx > 0, 'Found executeToolIteration call in finalize loop');
   assert(gitPullIdx > 0, 'Found git pull --rebase in auto-ensure path');
-  assert(
-    gitPullIdx < executeToolIterationIdx,
-    'git pull appears BEFORE executeToolIteration in finalize path',
-    `git pull at index ${gitPullIdx}, executeToolIteration at index ${executeToolIterationIdx}`,
-  );
+  assert(gitPullIdx < executeToolIterationIdx, 'git pull appears BEFORE executeToolIteration in finalize path', `git pull at index ${gitPullIdx}, executeToolIteration at index ${executeToolIterationIdx}`);
 }
 
 // ============================================================
@@ -180,11 +166,7 @@ console.log('\n--- Test: Cleanup includes git pull before revert ---');
   assert(cleanupFnIdx > 0, 'Found cleanupClaudeFile function');
   assert(gitRevertIdx > 0, 'Found git revert in cleanup');
   assert(gitPullIdx > 0, 'Found git pull --rebase in cleanup');
-  assert(
-    gitPullIdx < gitRevertIdx,
-    'git pull appears BEFORE git revert in cleanup',
-    `git pull at index ${gitPullIdx}, git revert at index ${gitRevertIdx}`,
-  );
+  assert(gitPullIdx < gitRevertIdx, 'git pull appears BEFORE git revert in cleanup', `git pull at index ${gitPullIdx}, git revert at index ${gitRevertIdx}`);
 }
 
 // ============================================================

--- a/tests/test-issue-1572-push-sync.mjs
+++ b/tests/test-issue-1572-push-sync.mjs
@@ -1,0 +1,200 @@
+#!/usr/bin/env node
+
+/**
+ * Unit tests for Issue #1572 fixes:
+ * 1. Multi-line log messages get timestamps on each line
+ * 2. All git push commands include 2>&1 for stderr capture
+ * 3. Auto-restart and cleanup flows include git pull before push
+ *
+ * References:
+ * - Issue #1572: https://github.com/link-assistant/hive-mind/issues/1572
+ * - Root cause: auto-restart-until-mergeable mode didn't sync local branch
+ *   with remote before launching new sessions, causing push failures
+ */
+
+// Use use-m to dynamically import modules
+if (typeof globalThis.use === 'undefined') {
+  globalThis.use = (await eval(await (await fetch('https://unpkg.com/use-m/use.js')).text())).use;
+}
+const use = globalThis.use;
+
+const fs = (await use('fs')).promises;
+const path = (await use('path')).default;
+
+let testsPassed = 0;
+let testsFailed = 0;
+
+function assert(condition, testName, details = '') {
+  if (condition) {
+    console.log(`✅ PASS: ${testName}`);
+    testsPassed++;
+  } else {
+    console.log(`❌ FAIL: ${testName}`);
+    if (details) {
+      console.log(`   Details: ${details}`);
+    }
+    testsFailed++;
+  }
+}
+
+// ============================================================
+// Test 1: Multi-line log messages get timestamps on each line
+// ============================================================
+
+console.log('\n--- Test: Multi-line log message formatting ---');
+
+{
+  const { log, setLogFile, getLogFile } = await import('../src/lib.mjs');
+  const os = (await use('os')).default;
+
+  const tempLogFile = path.join(os.tmpdir(), `test-log-1572-${Date.now()}.log`);
+  setLogFile(tempLogFile);
+
+  // Write a multi-line message
+  await log('Line 1\nLine 2\nLine 3');
+
+  // Wait a moment for async file write
+  await new Promise(resolve => setTimeout(resolve, 100));
+
+  const logContent = await fs.readFile(tempLogFile, 'utf8');
+  const lines = logContent.trim().split('\n');
+
+  assert(lines.length === 3, 'Multi-line message produces 3 log lines', `Got ${lines.length} lines: ${JSON.stringify(lines)}`);
+
+  for (let i = 0; i < lines.length; i++) {
+    const hasTimestamp = /^\[\d{4}-\d{2}-\d{2}T/.test(lines[i]);
+    assert(hasTimestamp, `Line ${i + 1} has timestamp prefix`, `Line content: "${lines[i]}"`);
+  }
+
+  assert(lines[0].includes('Line 1'), 'First line contains "Line 1"');
+  assert(lines[1].includes('Line 2'), 'Second line contains "Line 2"');
+  assert(lines[2].includes('Line 3'), 'Third line contains "Line 3"');
+
+  // Clean up
+  await fs.unlink(tempLogFile).catch(() => {});
+}
+
+// ============================================================
+// Test 2: All git push commands in source files include 2>&1
+// ============================================================
+
+console.log('\n--- Test: git push commands include 2>&1 ---');
+
+{
+  const srcDir = path.join(import.meta.dirname, '..', 'src');
+  const files = await fs.readdir(srcDir);
+  const jsFiles = files.filter(f => f.endsWith('.mjs') || f.endsWith('.js'));
+
+  let totalPushCommands = 0;
+  let pushCommandsMissing2and1 = [];
+
+  for (const file of jsFiles) {
+    const content = await fs.readFile(path.join(srcDir, file), 'utf8');
+    const lines = content.split('\n');
+
+    for (let i = 0; i < lines.length; i++) {
+      const line = lines[i];
+
+      // Match template literal git push commands in $() calls
+      // Pattern: `git push ... ` (template literal with git push, executed via $)
+      // Exclude: string variables (= `git push...`), comments, log statements
+      if (line.includes('`git push') && line.includes('$') && !line.includes('//') && !line.includes('log(') && !line.match(/const \w+ = `git push/)) {
+        totalPushCommands++;
+        if (!line.includes('2>&1')) {
+          pushCommandsMissing2and1.push(`${file}:${i + 1}: ${line.trim()}`);
+        }
+      }
+    }
+  }
+
+  assert(totalPushCommands > 0, `Found git push commands in source (${totalPushCommands} total)`);
+  assert(
+    pushCommandsMissing2and1.length === 0,
+    'All git push template commands include 2>&1',
+    pushCommandsMissing2and1.length > 0
+      ? `Missing 2>&1 in:\n${pushCommandsMissing2and1.map(l => `      ${l}`).join('\n')}`
+      : '',
+  );
+}
+
+// ============================================================
+// Test 3: Auto-merge restart includes git pull
+// ============================================================
+
+console.log('\n--- Test: Auto-restart includes git pull before restart ---');
+
+{
+  const autoMergeContent = await fs.readFile(path.join(import.meta.dirname, '..', 'src', 'solve.auto-merge.lib.mjs'), 'utf8');
+
+  // Find the RESTART TRIGGERED section and check that git pull appears before executeToolIteration
+  const restartTriggeredIdx = autoMergeContent.indexOf('RESTART TRIGGERED');
+  const executeToolIterationIdx = autoMergeContent.indexOf('executeToolIteration({', restartTriggeredIdx);
+  const gitPullIdx = autoMergeContent.indexOf('git pull --rebase origin', restartTriggeredIdx);
+
+  assert(restartTriggeredIdx > 0, 'Found RESTART TRIGGERED in auto-merge code');
+  assert(executeToolIterationIdx > 0, 'Found executeToolIteration call after restart trigger');
+  assert(gitPullIdx > 0, 'Found git pull --rebase in auto-merge restart path');
+  assert(
+    gitPullIdx < executeToolIterationIdx,
+    'git pull appears BEFORE executeToolIteration in restart path',
+    `git pull at index ${gitPullIdx}, executeToolIteration at index ${executeToolIterationIdx}`,
+  );
+}
+
+// ============================================================
+// Test 4: Auto-ensure includes git pull
+// ============================================================
+
+console.log('\n--- Test: Auto-ensure includes git pull before iterations ---');
+
+{
+  const autoEnsureContent = await fs.readFile(path.join(import.meta.dirname, '..', 'src', 'solve.auto-ensure.lib.mjs'), 'utf8');
+
+  const forLoopIdx = autoEnsureContent.indexOf('for (let ensureIteration');
+  const executeToolIterationIdx = autoEnsureContent.indexOf('executeToolIteration({', forLoopIdx);
+  const gitPullIdx = autoEnsureContent.indexOf('git pull --rebase origin', forLoopIdx);
+
+  assert(forLoopIdx > 0, 'Found finalize loop in auto-ensure code');
+  assert(executeToolIterationIdx > 0, 'Found executeToolIteration call in finalize loop');
+  assert(gitPullIdx > 0, 'Found git pull --rebase in auto-ensure path');
+  assert(
+    gitPullIdx < executeToolIterationIdx,
+    'git pull appears BEFORE executeToolIteration in finalize path',
+    `git pull at index ${gitPullIdx}, executeToolIteration at index ${executeToolIterationIdx}`,
+  );
+}
+
+// ============================================================
+// Test 5: Cleanup includes git pull before revert
+// ============================================================
+
+console.log('\n--- Test: Cleanup includes git pull before revert ---');
+
+{
+  const resultsContent = await fs.readFile(path.join(import.meta.dirname, '..', 'src', 'solve.results.lib.mjs'), 'utf8');
+
+  const cleanupFnIdx = resultsContent.indexOf('export const cleanupClaudeFile');
+  const gitRevertIdx = resultsContent.indexOf('git revert', cleanupFnIdx);
+  const gitPullIdx = resultsContent.indexOf('git pull --rebase origin', cleanupFnIdx);
+
+  assert(cleanupFnIdx > 0, 'Found cleanupClaudeFile function');
+  assert(gitRevertIdx > 0, 'Found git revert in cleanup');
+  assert(gitPullIdx > 0, 'Found git pull --rebase in cleanup');
+  assert(
+    gitPullIdx < gitRevertIdx,
+    'git pull appears BEFORE git revert in cleanup',
+    `git pull at index ${gitPullIdx}, git revert at index ${gitRevertIdx}`,
+  );
+}
+
+// ============================================================
+// Summary
+// ============================================================
+
+console.log('\n' + '='.repeat(50));
+console.log(`Results: ${testsPassed} passed, ${testsFailed} failed`);
+console.log('='.repeat(50));
+
+if (testsFailed > 0) {
+  process.exit(1);
+}


### PR DESCRIPTION
## Summary

Fixes #1572 — `error: failed to push some refs` during `.gitkeep` cleanup after auto-restart.

**Root cause:** The `auto-restart-until-mergeable` and `finalize` modes launch new AI sessions in the same working directory **without syncing** with the remote branch. When a previous session already pushed commits, the new session's local state is stale, causing all subsequent push operations (including cleanup) to fail with "non-fast-forward" rejections.

### Changes

1. **Add `git pull` before restart sessions** (`solve.auto-merge.lib.mjs`, `solve.auto-ensure.lib.mjs`)
   - Syncs local branch with remote before each restart/finalize iteration
   - Prevents stale local state that causes push failures
   - Uses plain `git pull` (no rebase) since nobody else touches the solve-created branch
   - Fails immediately if the pull is not possible

2. **Add `git pull` before cleanup push** (`solve.results.lib.mjs`)
   - Defense-in-depth: syncs before `.gitkeep`/`CLAUDE.md` revert and push
   - Handles cases where cleanup runs after failed restart sessions

3. **Add `2>&1` to all `git push` commands** (6 files)
   - Ensures stderr is captured in `pushResult.stderr` for proper error handling
   - Fixes "Unknown error" messages when push fails
   - Files: `solve.mjs`, `claude.lib.mjs`, `codex.lib.mjs`, `opencode.lib.mjs`, `agent.lib.mjs`, `solve.repository.lib.mjs`

4. **Fix multi-line log message formatting** (`lib.mjs`)
   - Multi-line messages now get timestamps on each line
   - Prevents continuation lines from appearing without timestamps in log files

### Case Study

Detailed timeline reconstruction and root cause analysis in `docs/case-studies/issue-1572/README.md`, including:
- Event timeline from the failed solve run
- Root cause chain for the push failure
- All affected code locations identified

## Test plan

- [x] New test `tests/test-issue-1572-push-sync.mjs` (21 assertions):
  - Multi-line log formatting produces timestamps on each line
  - All `git push` template commands include `2>&1`
  - `git pull` appears before `executeToolIteration` in auto-merge restart
  - `git pull` appears before `executeToolIteration` in auto-ensure finalize
  - `git pull` appears before `git revert` in cleanup function

🤖 Generated with [Claude Code](https://claude.com/claude-code)