### PR TITLE
docs: document real codex setup and persistence flow

### DIFF
--- a/.gitkeep
+++ b/.gitkeep
@@ -1,0 +1,1 @@
+# .gitkeep file auto-generated at 2026-04-15T05:07:05.365Z for PR creation at branch issue-1603-d47eafcfffb1 for issue https://github.com/link-assistant/hive-mind/issues/1603

--- a/README.md
+++ b/README.md
@@ -195,25 +195,23 @@ docker attach hive-mind
 
 # --- Persisting auth data across restarts ---
 
-# Extract auth data from a running (or stopped) container to the host:
-mkdir -p ~/.hive-mind
-docker cp hive-mind:/workspace/.claude ~/.hive-mind/claude
-docker cp hive-mind:/workspace/.claude.json ~/.hive-mind/claude.json
-docker cp hive-mind:/workspace/.config/gh ~/.hive-mind/gh
+# On the host, create the directories used by the current Docker workflow:
+mkdir -p /root/.hive-mind/claude /root/.hive-mind/codex /root/.hive-mind/gh
+touch -a /root/.hive-mind/claude.json
 
-# Fix ownership to match the sandbox user inside the container:
-SANDBOX_UID=$(docker exec hive-mind id -u sandbox)
-chown -R $SANDBOX_UID:$SANDBOX_UID ~/.hive-mind/claude ~/.hive-mind/gh
-chown $SANDBOX_UID:$SANDBOX_UID ~/.hive-mind/claude.json
-
-# On subsequent runs, mount the auth data to keep it between restarts:
-docker run -dit \
-  --name hive-mind \
-  --restart unless-stopped \
+# In our Docker images HOME=/workspace, so Codex stores its data in /workspace/.codex.
+# Mount the full Codex directory so auth.json, config.toml, and sessions survive restarts.
+docker run -dit --user sandbox --name hive-mind --restart unless-stopped \
   -v /root/.hive-mind/claude:/workspace/.claude \
+  -v /root/.hive-mind/codex:/workspace/.codex \
   -v /root/.hive-mind/claude.json:/workspace/.claude.json \
   -v /root/.hive-mind/gh:/workspace/.config/gh \
-  konard/hive-mind:latest
+  konard/hive-mind:latest bash -l -c 'bash /workspace/start-bot.sh'
+
+# After the first start, fix ownership to match the sandbox user inside the container:
+SANDBOX_UID=$(docker exec hive-mind id -u sandbox)
+chown -R $SANDBOX_UID:$SANDBOX_UID /root/.hive-mind/claude /root/.hive-mind/codex /root/.hive-mind/gh
+chown $SANDBOX_UID:$SANDBOX_UID /root/.hive-mind/claude.json
 ```
 
 **Benefits of Docker:**

--- a/coolify/README.md
+++ b/coolify/README.md
@@ -180,6 +180,7 @@ The docker-compose.yml configures several persistent volumes that Coolify will m
 | Volume            | Container Path          | Purpose                            |
 | ----------------- | ----------------------- | ---------------------------------- |
 | `./claude-config` | `/workspace/.claude`    | Claude authentication & settings   |
+| `./codex-config`  | `/workspace/.codex`     | Codex auth, config, and sessions   |
 | `./config`        | `/workspace/.config`    | General config (Claude Code, etc.) |
 | `./gh-config`     | `/workspace/.config/gh` | GitHub CLI config                  |
 | `./output`        | `/app/output`           | Generated PRs and code             |
@@ -187,6 +188,20 @@ The docker-compose.yml configures several persistent volumes that Coolify will m
 | `./sessions`      | `/app/claude-sessions`  | Session data                       |
 
 **Note**: These volumes are automatically created by Coolify and will persist across container updates and restarts.
+
+In our Docker-based deployments `HOME=/workspace`, so Codex stores its data in `/workspace/.codex`. Mount the full directory instead of individual files so these paths persist together:
+
+- `/workspace/.codex/auth.json`
+- `/workspace/.codex/config.toml`
+- `/workspace/.codex/sessions/`
+
+If you install or update Codex in the running container, use:
+
+```bash
+bun install -g @openai/codex@latest
+codex login --device-auth
+codex exec --model gpt-5.4-mini "hi"
+```
 
 ## Monitoring & Logs
 

--- a/docs/DOCKER.md
+++ b/docs/DOCKER.md
@@ -10,12 +10,20 @@ This document explains how to run Hive Mind in Docker containers.
 # Pull the latest image
 docker pull konard/hive-mind:latest
 
-# Run an interactive session
-docker run -it konard/hive-mind:latest
+# Create persistent host directories used by the current Docker workflow
+mkdir -p /root/.hive-mind/claude /root/.hive-mind/codex /root/.hive-mind/gh
+touch -a /root/.hive-mind/claude.json
 
-# IMPORTANT: Authentication is done AFTER the Docker image is installed
-# The installation script does NOT run gh auth login to avoid build timeouts
-# This allows the Docker build to complete successfully without interactive prompts
+# Run the container in detached mode with the same mounts we use locally
+docker run -dit --user sandbox --name hive-mind --restart unless-stopped \
+  -v /root/.hive-mind/claude:/workspace/.claude \
+  -v /root/.hive-mind/codex:/workspace/.codex \
+  -v /root/.hive-mind/claude.json:/workspace/.claude.json \
+  -v /root/.hive-mind/gh:/workspace/.config/gh \
+  konard/hive-mind:latest bash -l -c 'bash /workspace/start-bot.sh'
+
+# Open a shell in the running container
+docker exec -it hive-mind bash
 
 # Inside the container, authenticate with GitHub
 gh auth login -h github.com -s repo,workflow,user,read:org,gist
@@ -23,8 +31,17 @@ gh auth login -h github.com -s repo,workflow,user,read:org,gist
 # Authenticate with Claude
 claude
 
-# Now you can use hive and solve commands
-solve https://github.com/owner/repo/issues/123
+# Install or update Codex CLI
+bun install -g @openai/codex@latest
+
+# Log in to Codex using the current device auth flow
+codex login --device-auth
+
+# Verify Codex after login succeeds with "Successfully logged in"
+codex exec --model gpt-5.4-mini "hi"
+
+# Exit the shell when setup is complete
+exit
 ```
 
 ### Option 2: Building Locally
@@ -81,10 +98,37 @@ gh auth login -h github.com -s repo,workflow,user,read:org,gist
 claude
 ```
 
+### Codex Authentication
+
+Install or update Codex CLI inside the running container:
+
+```bash
+bun install -g @openai/codex@latest
+```
+
+Log in with the device auth flow we currently use:
+
+```bash
+codex login --device-auth
+```
+
+The command should finish with:
+
+```text
+Successfully logged in
+```
+
+Then run the current smoke test:
+
+```bash
+codex exec --model gpt-5.4-mini "hi"
+```
+
 This approach allows:
 
 - ✅ Multiple Docker instances with different GitHub accounts
 - ✅ Multiple Docker instances with different Claude subscriptions
+- ✅ Persistent Codex authentication and session data when `/workspace/.codex` is mounted
 - ✅ No credential leakage between containers
 - ✅ Each container has its own isolated authentication
 - ✅ Successful Docker builds without interactive authentication
@@ -112,26 +156,49 @@ This approach allows:
 
 ### Running with Persistent Storage
 
-To persist authentication and work between container restarts:
+To persist authentication and work between container restarts, mount the actual per-tool directories instead of a generic `/workspace` volume. In our Docker images `HOME=/workspace`, so Codex stores its data in `/workspace/.codex`.
 
 ```bash
-# Create a volume for the sandbox user's home directory
-docker volume create sandbox-home
+# Host directories used by the current local Docker workflow
+mkdir -p /root/.hive-mind/claude /root/.hive-mind/codex /root/.hive-mind/gh
+touch -a /root/.hive-mind/claude.json
 
-# Run with the volume mounted
-docker run -it -v sandbox-home:/workspace konard/hive-mind:latest
+# Run with persistent mounts
+docker run -dit --user sandbox --name hive-mind --restart unless-stopped \
+  -v /root/.hive-mind/claude:/workspace/.claude \
+  -v /root/.hive-mind/codex:/workspace/.codex \
+  -v /root/.hive-mind/claude.json:/workspace/.claude.json \
+  -v /root/.hive-mind/gh:/workspace/.config/gh \
+  konard/hive-mind:latest bash -l -c 'bash /workspace/start-bot.sh'
+
+# Fix ownership after the container starts
+SANDBOX_UID=$(docker exec hive-mind id -u sandbox)
+chown -R $SANDBOX_UID:$SANDBOX_UID /root/.hive-mind/claude /root/.hive-mind/codex /root/.hive-mind/gh
+chown $SANDBOX_UID:$SANDBOX_UID /root/.hive-mind/claude.json
 ```
+
+The mounted Codex directory keeps the files we rely on:
+
+- `/workspace/.codex/auth.json`
+- `/workspace/.codex/config.toml`
+- `/workspace/.codex/sessions/`
 
 ### Running in Detached Mode
 
 ```bash
-# Start a detached container
-docker run -d --name hive-worker -v sandbox-home:/workspace konard/hive-mind:latest sleep infinity
+# Start a detached container with persistent auth mounts
+docker run -dit --user sandbox --name hive-worker --restart unless-stopped \
+  -v /root/.hive-mind/claude:/workspace/.claude \
+  -v /root/.hive-mind/codex:/workspace/.codex \
+  -v /root/.hive-mind/claude.json:/workspace/.claude.json \
+  -v /root/.hive-mind/gh:/workspace/.config/gh \
+  konard/hive-mind:latest bash -l -c 'bash /workspace/start-bot.sh'
 
 # Execute commands in the running container
 docker exec -it hive-worker bash
 
 # Inside the container, run your commands
+codex exec --model gpt-5.4-mini "hi"
 solve https://github.com/owner/repo/issues/123
 ```
 

--- a/docs/UBUNTU-SERVER.md
+++ b/docs/UBUNTU-SERVER.md
@@ -120,12 +120,32 @@ The following instructions describe the legacy bare-metal installation on Ubuntu
 ssh -L 1455:localhost:1455 root@123.123.123.123
 ```
 
-2. Start codex login oAuth server:
+2. Install or update Codex CLI:
 
 ```bash
-codex login
+bun install -g @openai/codex@latest
 ```
 
-The oAuth callback server on 1455 port will be started, and the link to oAuth will be printed, copy the link.
+3. Start the current Codex device auth flow:
 
-3. Use your browser on machine where you started the tunnel from, paste there the link from `codex login` command, and go there using your browser. Once redirected to localhost:1455 you will see successful login page, and in `codex login` you will see `Successfully logged in`. After that `codex login` command will complete, and you can use `codex` command as usual to verify. It should also be working with `--tool codex` in `solve` and `hive` commands.
+```bash
+codex login --device-auth
+```
+
+4. Finish login in your browser. The command should end with:
+
+```text
+Successfully logged in
+```
+
+5. Verify the Codex CLI with the same smoke test used in the Docker workflow:
+
+```bash
+codex exec --model gpt-5.4-mini "hi"
+```
+
+Codex stores its data in `~/.codex` on a regular server. The most important paths are:
+
+- `~/.codex/auth.json`
+- `~/.codex/config.toml`
+- `~/.codex/sessions/`

--- a/docs/case-studies/issue-1603/README.md
+++ b/docs/case-studies/issue-1603/README.md
@@ -1,0 +1,89 @@
+# Case Study: Issue #1603 — Document Codex setup, auth, updates, and persistent data mounting
+
+## Issue Summary
+
+**Issue**: [#1603](https://github.com/link-assistant/hive-mind/issues/1603)
+**Type**: Documentation / Docker deployment
+
+The issue reported that Hive Mind documentation did not match the actual Codex setup currently used with the project, especially in Docker-based deployments. The docs still described an older `codex login` flow and omitted the full `/workspace/.codex` persistence pattern that is required to keep Codex auth, config, and sessions across container restarts.
+
+## Timeline
+
+- **2026-04-15**: Issue #1603 opened with explicit required commands and Docker mount examples.
+- **2026-04-15**: Maintainer comment requested a local case-study record under `docs/case-studies/issue-1603/`.
+- **2026-04-15**: Repository inspection confirmed outdated Codex guidance in `README.md`, `docs/DOCKER.md`, and `docs/UBUNTU-SERVER.md`.
+
+## Requirements
+
+1. Document the actual Codex install/update command:
+   `bun install -g @openai/codex@latest`
+2. Document the actual login command:
+   `codex login --device-auth`
+3. Mention the success message:
+   `Successfully logged in`
+4. Document Codex data storage:
+   `~/.codex`
+5. Document the Docker-specific location when `HOME=/workspace`:
+   `/workspace/.codex`
+6. Recommend mounting the full Codex directory, not individual files.
+7. Document the current host directories created by the Docker workflow:
+   `/root/.hive-mind/claude`
+   `/root/.hive-mind/codex`
+   `/root/.hive-mind/gh`
+   `/root/.hive-mind/claude.json`
+8. Document the current Docker mount pattern and detached `docker run` shape.
+9. Document the ownership fix using `docker exec ... id -u sandbox` and `chown`.
+10. Document the real smoke test:
+    `codex exec --model gpt-5.4-mini "hi"`
+
+## Evidence Collected
+
+### Issue-provided facts
+
+The issue body included the exact commands and mount layout currently used by the maintainers. That is the strongest source of truth for this task.
+
+### Repository drift found during inspection
+
+- `README.md` documented persistence for `.claude`, `.claude.json`, and GitHub config, but not `.codex`.
+- `docs/DOCKER.md` documented generic `/workspace` persistence and no Codex-specific auth or mount flow.
+- `docs/UBUNTU-SERVER.md` still documented `codex login` instead of `codex login --device-auth`.
+- `coolify/README.md` documented persistent Claude and GitHub storage, but not Codex storage.
+
+## Root Cause
+
+The documentation evolved around Claude-oriented flows first, then Codex support was added incrementally without updating the Docker and server setup guides to match the current operational workflow. As a result:
+
+- the login command drifted from the actual `--device-auth` flow,
+- persistence guidance stayed incomplete for Codex,
+- the exact detached Docker run command used in practice was not recorded in the main docs,
+- the smoke-test command for Codex was not documented alongside setup.
+
+This was a documentation consistency problem rather than a runtime code bug.
+
+## Solution Applied
+
+Updated the primary setup docs to describe the actual Codex workflow now used with Hive Mind:
+
+- `README.md`
+- `docs/DOCKER.md`
+- `docs/UBUNTU-SERVER.md`
+- `coolify/README.md`
+
+The updates align the docs on:
+
+- installing/updating Codex with `bun install -g @openai/codex@latest`,
+- authenticating with `codex login --device-auth`,
+- verifying successful login with `Successfully logged in`,
+- persisting `/workspace/.codex` in Docker deployments,
+- using the actual host directories and mount arguments from the issue,
+- running `codex exec --model gpt-5.4-mini "hi"` as the smoke test.
+
+## Residual Gaps / Follow-up
+
+- The translated docs (`*.ru.md`, `*.hi.md`, `*.zh.md`) still contain the older Codex login wording and were not updated as part of this issue.
+- If the project wants full cross-language consistency, the same doc changes should be propagated to translated Docker and Ubuntu server guides.
+
+## Verification
+
+- Reviewed changed docs to confirm the requested commands, directories, mount points, and verification command are now present.
+- Confirmed the case-study record exists at `docs/case-studies/issue-1603/README.md`.


### PR DESCRIPTION
## Summary
- update Codex setup docs to use `bun install -g @openai/codex@latest`
- document the real `codex login --device-auth` flow and smoke test
- document `/workspace/.codex` persistence and the current Docker mount layout
- add a case study for issue #1603 under `docs/case-studies/issue-1603/`

## Testing
- reviewed the changed docs and diff locally for command, path, and mount consistency

## Issue
Fixes #1603
