### PR TITLE
Fix auto-resume reset time parsing for month/day timestamps

### DIFF
--- a/.changeset/clever-rings-relax.md
+++ b/.changeset/clever-rings-relax.md
@@ -1,0 +1,5 @@
+---
+'@link-assistant/hive-mind': patch
+---
+
+Fix auto-resume reset time parsing when usage-limit output includes a month/day prefix such as `Apr 17, 4:00 AM`.

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,2 +1,1 @@
 # .gitkeep file auto-generated at 2026-04-15T05:07:05.365Z for PR creation at branch issue-1603-d47eafcfffb1 for issue https://github.com/link-assistant/hive-mind/issues/1603
-# Updated: 2026-04-15T18:55:03.032Z

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,1 +1,2 @@
 # .gitkeep file auto-generated at 2026-04-15T05:07:05.365Z for PR creation at branch issue-1603-d47eafcfffb1 for issue https://github.com/link-assistant/hive-mind/issues/1603
+# Updated: 2026-04-15T18:55:03.032Z

--- a/src/solve.validation.lib.mjs
+++ b/src/solve.validation.lib.mjs
@@ -371,10 +371,12 @@ export const parseUrlComponents = issueUrl => {
 export const parseResetTime = timeStr => {
   // Normalize and parse time formats like:
   // "5:30am", "11:45pm", "12:16 PM", "07:05 Am", "5am", "5 AM"
+  // Also accepts date+time forms like "Apr 17, 4:00 AM" and ignores the date portion.
   const normalized = (timeStr || '').toString().trim();
+  const timePortion = normalized.replace(/^(?:Jan(?:uary)?|Feb(?:ruary)?|Mar(?:ch)?|Apr(?:il)?|May|Jun(?:e)?|Jul(?:y)?|Aug(?:ust)?|Sep(?:t(?:ember)?)?|Oct(?:ober)?|Nov(?:ember)?|Dec(?:ember)?)\s+\d{1,2},\s+/i, '');
 
   // Accept both HH:MM am/pm and HH am/pm
-  let match = normalized.match(/^(\d{1,2})(?::(\d{2}))?\s*([ap]m)$/i);
+  let match = timePortion.match(/^(\d{1,2})(?::(\d{2}))?\s*([ap]m)$/i);
   if (!match) {
     throw new Error(`Invalid time format: ${timeStr}`);
   }

--- a/tests/test-solve-validation-reset-time.mjs
+++ b/tests/test-solve-validation-reset-time.mjs
@@ -1,0 +1,30 @@
+#!/usr/bin/env node
+
+import process from 'node:process';
+
+import { parseResetTime, calculateWaitTime } from '../src/solve.validation.lib.mjs';
+import { test, printSummary, getFailCount } from './test-helpers.mjs';
+
+test('parseResetTime accepts time-only format', () => {
+  const result = parseResetTime('5:30 AM');
+  if (result.hour !== 5 || result.minute !== 30) {
+    throw new Error(`Expected 05:30, got ${JSON.stringify(result)}`);
+  }
+});
+
+test('parseResetTime accepts date+time format from usage-limit output', () => {
+  const result = parseResetTime('Apr 17, 4:00 AM');
+  if (result.hour !== 4 || result.minute !== 0) {
+    throw new Error(`Expected 04:00, got ${JSON.stringify(result)}`);
+  }
+});
+
+test('calculateWaitTime accepts date+time format from usage-limit output', () => {
+  const waitMs = calculateWaitTime('Apr 17, 4:00 AM');
+  if (!Number.isFinite(waitMs) || waitMs <= 0) {
+    throw new Error(`Expected positive wait time, got ${waitMs}`);
+  }
+});
+
+printSummary();
+process.exit(getFailCount() > 0 ? 1 : 0);


### PR DESCRIPTION
## Summary

Fixes auto-resume parsing when usage-limit output includes a month/day prefix like `Apr 17, 4:00 AM`.

## Root Cause

`src/solve.validation.lib.mjs` used a time-only parser for auto-resume wait calculation. When the tool emitted a reset string with a date prefix, for example `Apr 17, 4:00 AM`, the parser rejected it with `Invalid time format` and auto-continue failed instead of waiting for the reset.

## Changes

- accept `Mon DD, HH:MM AM/PM` input in the auto-resume validation parser by stripping the optional date prefix before parsing the time portion
- add a regression test covering `parseResetTime('Apr 17, 4:00 AM')`
- add a regression test covering `calculateWaitTime('Apr 17, 4:00 AM')`

## Reproduction

1. Trigger a usage-limit response that prints `The limit will reset at: Apr 17, 4:00 AM`.
2. Run auto-continue / auto-resume flow.
3. Before this change, it failed with `Invalid time format: Apr 17, 4:00 AM`.

## Verification

- `node tests/test-solve-validation-reset-time.mjs`
- `npm run test:usage-limit`
