### PR TITLE
fix(solve): restore tool-comment posting broken by v1.53.1 stdin regression

### DIFF
--- a/.changeset/fix-tool-comment-stdin-regression.md
+++ b/.changeset/fix-tool-comment-stdin-regression.md
@@ -1,0 +1,20 @@
+---
+'@link-assistant/hive-mind': patch
+---
+
+fix(solve): post tool-generated PR comments again after v1.53.1 regression
+
+`postTrackedComment()` in `src/tool-comments.lib.mjs` (added in #1626) was
+passing the comment body to `gh api --input -` via `$({ input: payload })`,
+but command-stream's option is `stdin`, not `input`. The misnamed key was
+silently ignored, so `gh` read from the parent's stdin, sent an empty POST
+body, and GitHub's edge returned `HTTP 400 "Whoa there!"`. Every tool-posted
+comment — `AI Work Session Started`, log-upload link, `Ready to merge`,
+`Auto-merged`, billing-limit notice, usage-limit notice — failed from this
+one call path starting with v1.53.1.
+
+Fix: use the documented `stdin` option so the JSON payload actually reaches
+the child's stdin. The regression test pins the option name so a future
+rename can't silently recur.
+
+Fixes #1631.

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,3 +1,2 @@
 # .gitkeep file auto-generated at 2026-04-15T05:07:05.365Z for PR creation at branch issue-1603-d47eafcfffb1 for issue https://github.com/link-assistant/hive-mind/issues/1603
 # Updated: 2026-04-17T19:04:16.770Z
-# Updated: 2026-04-17T21:04:39.557Z

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,2 +1,3 @@
 # .gitkeep file auto-generated at 2026-04-15T05:07:05.365Z for PR creation at branch issue-1603-d47eafcfffb1 for issue https://github.com/link-assistant/hive-mind/issues/1603
 # Updated: 2026-04-17T19:04:16.770Z
+# Updated: 2026-04-17T21:04:39.557Z

--- a/docs/case-studies/issue-1631/README.md
+++ b/docs/case-studies/issue-1631/README.md
@@ -1,0 +1,228 @@
+# Case Study: Issue #1631 — Solve.mjs can't post tool comments after #1626
+
+- **Issue**: [link-assistant/hive-mind#1631](https://github.com/link-assistant/hive-mind/issues/1631)
+- **Pull Request**: [link-assistant/hive-mind#1632](https://github.com/link-assistant/hive-mind/pull/1632)
+- **Regression introduced by**: [#1626](https://github.com/link-assistant/hive-mind/pull/1626) (merged 2026-04-17)
+- **Related Issue**: [#1625](https://github.com/link-assistant/hive-mind/issues/1625) (the feature that #1626 implemented)
+- **First released broken in**: `v1.53.1`
+- **Observed on external PR**: [Jhon-Crow/godot-topdown-MVP#1870](https://github.com/Jhon-Crow/godot-topdown-MVP/pull/1870)
+
+## Summary
+
+After merging PR #1626 (`v1.53.1`), every solve.mjs invocation that tried to
+post a tool-authored GitHub comment — `AI Work Session Started`, ready-to-merge,
+log-upload link, usage-limit notice, etc. — returned **HTTP 400 Bad Request**
+from `gh api`, accompanied by GitHub's generic `"Whoa there!"` HTML page (the
+anti-abuse/edge rejection page, served _before_ the API layer runs).
+
+Consequences observed across six user-supplied logs:
+
+- `AI Work Session Started` comment never posted at session start.
+- `Solution Draft Log` comment never posted at session end (log uploaded to
+  Gist successfully, but the PR comment linking to it failed).
+- `Ready to merge` and `Auto-merged` status comments never posted.
+- Subsequent retries of solve.mjs would sometimes eventually succeed after long
+  delays (7 – 45 minutes), creating the impression that "everything is
+  broken" — the user explicitly considered reverting to `v1.53.0`.
+
+## Timeline of events
+
+All times UTC. Version history from `git log`:
+
+| Time                 | Event                                                                                 | Source                                                            |
+| -------------------- | ------------------------------------------------------------------------------------- | ----------------------------------------------------------------- |
+| 2026-04-17T(pre)     | PR #1626 introduces `src/tool-comments.lib.mjs` with `postTrackedComment()` helper    | commit `8936a32f`                                                 |
+| 2026-04-17T(merge)   | PR #1626 merged to `main`                                                             | commit `186e5ded`                                                 |
+| 2026-04-17T(release) | `v1.53.1` tagged with the new helper                                                  | commit `5357f4fb`                                                 |
+| 2026-04-17T20:32:44Z | First user report: `gh: HTTP 400` on comment post (gist `29407cc`)                    | user log                                                          |
+| 2026-04-17T20:42:52Z | Second report: same 400, this time on log-upload comment (gist `f74f24d` / `cbc94f7`) | user log                                                          |
+| 2026-04-17T20:51:12Z | Third report: 400 on log-upload, succeeded eventually via retry (gist `9df13d5`)      | user log                                                          |
+| 2026-04-17T20:54:42Z | Fourth report: 400 on session-start comment, succeeded eventually 33 min later        | user log                                                          |
+| 2026-04-17T20:55:25Z | Fifth report: near-duplicate of the fourth                                            | user log                                                          |
+| 2026-04-17T21:04:18Z | Sixth report: 400 on log-upload, full failure — no comment posted (gist `32e805d`)    | user log                                                          |
+| 2026-04-17T21:10Z    | Issue #1631 opened                                                                    | [#1631](../../../issue-1631)                                      |
+| 2026-04-17T22:00:40Z | AI work session began on #1631                                                        | [PR #1632](https://github.com/link-assistant/hive-mind/pull/1632) |
+
+All six raw logs are referenced by gist URL in [`data/log-urls.json`](data/log-urls.json)
+(they are multi-MB and would bloat the repo). A focused excerpt around each
+HTTP 400 is checked in at [`data/log-excerpts.txt`](data/log-excerpts.txt).
+
+## Root cause
+
+`postTrackedComment()` in `src/tool-comments.lib.mjs` (introduced by #1626) posts
+the comment body to GitHub's `POST /repos/:o/:r/issues/:n/comments` endpoint by
+piping a JSON payload to `gh api … --input -` via command-stream's options bag:
+
+```js
+// src/tool-comments.lib.mjs — the buggy invocation
+const payload = JSON.stringify({ body });
+result = await $({ input: payload })`gh api ${apiPath} -X POST --input -`;
+```
+
+The command-stream library (`node_modules/command-stream`, v0.9.4) does **not**
+recognise an `input` option. Its documented option name is `stdin` — verified
+in the library README, in `$.process-runner-base.mjs` (`handleStdin()` only
+branches on `stdin === 'inherit' | 'ignore' | string | Buffer`), and in
+existing correct usage elsewhere in the repo:
+
+- `src/claude.lib.mjs:810` — `$({ cwd, stdin: prompt, mirror: false, env })\`${claudePath}…\``
+- `scripts/create-github-release.mjs:81` — `$\`gh api … --input -\`.run({ stdin: payload })`
+- `scripts/format-release-notes.mjs:233` — `$\`gh api … -X PATCH --input -\`.run({ stdin: payload })`
+
+With the misnamed `input:` option silently ignored, command-stream's `stdin`
+fell back to the default `'inherit'`. `handleInheritStdin()` then wired the
+child's stdin to the **parent process's** stdin — which for solve.mjs is
+either a TTY attached to the caller's shell or a pipe that has already been
+consumed/closed. `gh api --input -` therefore read an empty / already-closed /
+unrelated stream, produced an empty `POST` body, and GitHub's edge tier
+rejected the request with the generic `400 "Whoa there!"` HTML page. The JSON
+API layer never saw the request, which is why the error payload is HTML rather
+than the usual GitHub API JSON error.
+
+### Why it was missed
+
+`tests/test-solution-summary.mjs` (added alongside #1626) mocks `$` with a
+callable that ignores its options and returns a canned JSON response. The
+mock happily accepts `{ input: … }` because it never inspects the options bag
+— the exact same footgun documented in [`docs/case-studies/issue-1532/README.md`](../issue-1532/README.md)
+for `promisify(execFile)`'s ignored `input` option.
+
+## Requirements from the issue
+
+1. **Download all related logs and data to the repository** →
+   [`data/log-urls.json`](data/log-urls.json) catalogs every user-linked gist;
+   [`data/log-excerpts.txt`](data/log-excerpts.txt) contains the failure
+   excerpts from all six logs (the full multi-MB logs live in the referenced
+   gists to avoid bloating the repo).
+2. **Compile a case study** → this document.
+3. **Reconstruct timeline** → see "Timeline of events" above.
+4. **List all requirements from the issue** → this list.
+5. **Find root cause for each problem** → single root cause for all six logs:
+   the `input` vs `stdin` option-name mismatch in `postTrackedComment`.
+6. **Propose solution plan** → see "Fix" below.
+7. **Search online for existing components/libraries that solve a similar
+   problem** → see "Existing libraries / patterns surveyed".
+8. **If not enough data, add debug output / verbose mode** → the diagnostic
+   info was already sufficient to find the root cause (the logs showed `gh: HTTP 400`
+   plus the HTML body); no additional logging is required for this fix.
+9. **Report issues in other repositories that are affected** → command-stream's
+   silent ignore of unknown options is a usability trap worth documenting
+   upstream. See "Related upstream issues".
+
+## Fix
+
+`src/tool-comments.lib.mjs` now passes the JSON body via the documented
+`stdin` option:
+
+```js
+result = await $({ stdin: payload })`gh api ${apiPath} -X POST --input -`;
+```
+
+The patch is a one-line change plus inline documentation explaining the
+footgun. The regression test asserts the option name explicitly so a rename
+can't silently recur:
+
+```js
+// tests/test-solution-summary.mjs — new test
+assertTrue(Object.prototype.hasOwnProperty.call(capturedOptions, 'stdin'), 'options bag must include `stdin` key (command-stream ignores `input`)');
+assertFalse(Object.prototype.hasOwnProperty.call(capturedOptions, 'input'), 'options bag must NOT use legacy `input` key (silently ignored by command-stream)');
+```
+
+## Existing libraries / patterns surveyed
+
+- **command-stream** (in-repo, v0.9.4) — the library whose misused option
+  caused the bug. Documented option name: `stdin`.
+- **execa** — widely-used child-process library; its option is `{ input: … }`.
+  Adopting execa would make the original `{ input: payload }` line correct —
+  but would introduce a new runtime dependency just to avoid a one-line fix.
+  Not warranted.
+- **`node:child_process` `execFile`/`spawn`** — also uses `input` under
+  `promisify(execFile)`, which is exactly the trap documented in
+  [issue #1532](../issue-1532/README.md). Same class of bug, different
+  library.
+- **Direct `gh api` with `--field body=@-`** — an alternative that doesn't
+  require stdin piping. Rejected because the existing payload shape (`body`
+  as a JSON string, nothing else) is already minimal and the stdin path works
+  once the option name is correct.
+
+## Related upstream issues
+
+- **command-stream**: option-name typos are silently ignored. Recommend adding
+  an unknown-option warning under a debug flag, or documenting the list of
+  supported options prominently. Tracking as a follow-up — not blocking.
+- Internal note: future `{ … }` options to `$(…)` that differ from the
+  supported set (`stdin`, `cwd`, `env`, `mirror`, …) should be caught by a
+  repo-local ESLint rule or a lightweight validator. Listed in
+  "Follow-up tasks" below.
+
+## Follow-up tasks (not in this PR)
+
+- [ ] Add an ESLint rule (or a `tests/test-*` consistency check) that flags
+      `$({ input: …, … })`/`$(…).run({ input: … })` since `input` is never a
+      command-stream option.
+- [ ] File an upstream issue/PR on command-stream to warn about unknown
+      option keys.
+- [ ] Audit every `$({ … })` options-bag usage in the repository for other
+      silently-ignored keys.
+
+## Reproduction
+
+1. Check out any commit on or after `5357f4fb` (`v1.53.1`) and before the fix.
+2. Run solve.mjs against any PR with `--watch` or `--auto-continue` so
+   `startWorkSession()` is invoked:
+   ```bash
+   solve https://github.com/<owner>/<repo>/pull/<n> --tool claude --attach-logs --verbose --auto-continue
+   ```
+3. Observe the `gh: HTTP 400` line immediately after
+   `📝 Converting PR: Back to draft mode...` in the log.
+
+After the fix, the same invocation posts the session-start comment without
+error and the log-upload comment carries a valid comment `id`.
+
+## Evidence: raw log excerpts
+
+### Session-start comment fails (log 4 / 5)
+
+```
+[2026-04-17T20:55:14.094Z] [INFO] 🔄 Checking out PR branch:   issue-1817-44a1ed5736dd
+[2026-04-17T20:55:15.797Z] [INFO]   ✅ PR converted:           Now in draft mode
+[2026-04-17T20:55:25.869Z] [STDOUT]
+<html>… <h1>Whoa there!</h1> …</html>
+[2026-04-17T20:55:25.870Z] [STDERR] gh: HTTP 400
+[2026-04-17T21:28:13.119Z] [INFO]   💬 Posted:                 AI Work Session Started comment
+```
+
+The session start comment finally succeeded **33 minutes later** — a second,
+retry-triggered solve.mjs invocation got further (the retry was caused by the
+parent's CTRL+C handler re-entering the comment-post path under different
+stdin conditions).
+
+### Log-upload comment fails (logs 1 / 2 / 6)
+
+```
+[2026-04-17T21:04:57.207Z] [ERROR] ❌ Command failed: No messages processed
+[2026-04-17T21:04:57.209Z] [INFO] 📄 Attaching failure logs to Pull Request...
+[2026-04-17T21:05:01.442Z] [STDOUT] ✅ Gist created (🌐 public)
+[2026-04-17T21:05:01.442Z] [STDOUT] 🔗 https://gist.github.com/konard/19845c36ad1ae80f6b76207a550be9f4
+[2026-04-17T21:05:12.062Z] [STDOUT] <html>… <h1>Whoa there!</h1> …</html>
+[2026-04-17T21:05:12.062Z] [STDERR] gh: HTTP 400
+[2026-04-17T21:20:51.436Z] [INFO]   ❌ Failed to post comment with log link: gh: HTTP 400
+[2026-04-17T21:20:51.436Z] [INFO]   ⚠️  Failed to upload failure logs
+```
+
+The Gist itself uploaded fine (15-second round-trip). The comment on the PR
+linking to that Gist is what failed — and that comment goes through
+`postTrackedCommentFromFile` → `postTrackedComment` → the misnamed `input:`
+option. The "long delay before failure" pattern (20:51:12 → 21:26:28 on log 2,
+21:05:12 → 21:20:51 on log 6) is solve.mjs's upstream retry loop retrying the
+same broken code path until giving up.
+
+## Source files touched
+
+- `src/tool-comments.lib.mjs` — one-line fix: `input:` → `stdin:` in
+  `postTrackedComment()`.
+- `tests/test-solution-summary.mjs` — new regression test pinning the option
+  name.
+- `.changeset/` — patch-bump entry.
+- `docs/case-studies/issue-1631/` — this case study, with log excerpts and
+  full-log gist URLs under `data/`.

--- a/docs/case-studies/issue-1631/data/log-excerpts.txt
+++ b/docs/case-studies/issue-1631/data/log-excerpts.txt
@@ -1,0 +1,123 @@
+=== log-1 20:32:44 (HTTP 400 on comment) ===
+10294-  <body>
+10295-    <div class="c">
+10296:      <h1>Whoa there!</h1>
+10297-      <p>You have sent an invalid request. <br><br>
+10298-        Please do not send this request again.
+--
+10306-  </body>
+10307-</html>
+10308:[2026-04-17T20:35:49.669Z] [STDERR] gh: HTTP 400
+10309:[2026-04-17T21:25:16.958Z] [INFO]   ✅ Solution draft log uploaded to Pull Request as public Gist
+10310-[2026-04-17T21:25:16.959Z] [INFO]   🔗 Log URL: https://gist.githubusercontent.com/konard/b05ffaaaf2cfb3397929534c5ff541f6/raw/a45e1c40f3a54ab6e326df24fda8182a34edc092/solution-draft-log-pr-1776458134540.txt
+10311-[2026-04-17T21:25:16.960Z] [INFO]   📊 Log size: 6285KB
+
+=== log-2 20:42:52 ===
+715-[2026-04-17T20:43:24.296Z] [INFO] 
+716:[2026-04-17T20:43:24.296Z] [INFO] 📄 Attaching failure logs to Pull Request...
+717-[2026-04-17T20:43:25.182Z] [STDOUT] github.com
+--
+778-    <div class="c">
+779:      <h1>Whoa there!</h1>
+780-      <p>You have sent an invalid request. <br><br>
+--
+790-</html>
+791:[2026-04-17T20:43:38.735Z] [STDERR] gh: HTTP 400
+792:[2026-04-17T21:26:28.286Z] [INFO]   ✅ Solution draft log uploaded to Pull Request as public Gist
+793-[2026-04-17T21:26:28.287Z] [INFO]   🔗 Log URL: https://gist.githubusercontent.com/konard/90c41b7f3fbbfe9789dd7fa90ef011f7/raw/503a985d62ab5e4bcd700ff9160ee09799b53439/solution-draft-log-pr-1776458605589.txt
+
+=== log-3 20:51:12 ===
+18492-    <div class="c">
+18493:      <h1>Whoa there!</h1>
+18494-      <p>You have sent an invalid request. <br><br>
+--
+18504-</html>
+18505:[2026-04-17T20:58:06.899Z] [STDERR] gh: HTTP 400
+18506:[2026-04-17T21:00:47.235Z] [INFO]   ✅ Solution draft log uploaded to Pull Request as public Gist
+18507-[2026-04-17T21:00:47.236Z] [INFO]   🔗 Log URL: https://gist.githubusercontent.com/konard/d41e8699a6dc816b0e6e59b90a447155/raw/9a5ca26808f4fa906206275c3541f33718631918/solution-draft-log-pr-1776459469810.txt
+--
+18645-[2026-04-17T21:01:04.910Z] [INFO]   🔗 Raw URL: https://gist.githubusercontent.com/konard/3693c93b1fb747e21315451c88943ce5/raw/582e1129cddb568983edeb11d09e91383145f600/solution-draft-log-pr-1776459658983.txt
+18646:[2026-04-17T21:01:07.305Z] [INFO]   ✅ Solution draft log uploaded to Pull Request as public Gist
+18647-[2026-04-17T21:01:07.306Z] [INFO]   🔗 Log URL: https://gist.githubusercontent.com/konard/3693c93b1fb747e21315451c88943ce5/raw/582e1129cddb568983edeb11d09e91383145f600/solution-draft-log-pr-1776459658983.txt
+
+=== log-4 20:54:42 ===
+196-[2026-04-17T20:55:14.971Z] [STDOUT] false
+197:[2026-04-17T20:55:14.974Z] [INFO]   📝 Converting PR:          Back to draft mode...
+198-[2026-04-17T20:55:15.793Z] [STDERR] ✓ Pull request Jhon-Crow/godot-topdown-MVP#1864 is converted to "draft"
+--
+229-    <div class="c">
+230:      <h1>Whoa there!</h1>
+231-      <p>You have sent an invalid request. <br><br>
+--
+241-</html>
+242:[2026-04-17T20:55:25.870Z] [STDERR] gh: HTTP 400
+243:[2026-04-17T21:28:13.119Z] [INFO]   💬 Posted:                 AI Work Session Started comment
+244-[2026-04-17T21:28:13.428Z] [STDOUT] konard
+--
+665-[2026-04-17T21:28:29.551Z] [INFO]   ✅ PR body already contains issue reference
+666:[2026-04-17T21:28:29.552Z] [INFO]   🔄 Converting PR from draft to ready for review...
+667-[2026-04-17T21:28:29.738Z] [STDOUT] public
+--
+830-    <div class="c">
+831:      <h1>Whoa there!</h1>
+832-      <p>You have sent an invalid request. <br><br>
+--
+842-</html>
+843:[2026-04-17T21:28:43.102Z] [STDERR] gh: HTTP 400
+844-[2026-04-17T21:28:44.792Z] [STDOUT] 
+--
+873-    <div class="c">
+874:      <h1>Whoa there!</h1>
+875-      <p>You have sent an invalid request. <br><br>
+--
+885-</html>
+886:[2026-04-17T21:28:44.793Z] [STDERR] gh: HTTP 400
+887-[2026-04-17T21:28:46.986Z] [INFO]   ✅ Solution draft log uploaded to Pull Request as public Gist
+
+=== log-5 20:55:25 ===
+192-[2026-04-17T20:55:53.607Z] [STDOUT] false
+193:[2026-04-17T20:55:53.610Z] [INFO]   📝 Converting PR:          Back to draft mode...
+194-[2026-04-17T20:55:54.501Z] [STDERR] ✓ Pull request Jhon-Crow/godot-topdown-MVP#1661 is converted to "draft"
+--
+225-    <div class="c">
+226:      <h1>Whoa there!</h1>
+227-      <p>You have sent an invalid request. <br><br>
+--
+237-</html>
+238:[2026-04-17T20:56:04.579Z] [STDERR] gh: HTTP 400
+239:[2026-04-17T21:29:24.380Z] [INFO]   💬 Posted:                 AI Work Session Started comment
+240-[2026-04-17T21:29:24.710Z] [STDOUT] konard
+--
+664-[2026-04-17T21:29:33.428Z] [INFO]   ✅ PR body already contains issue reference
+665:[2026-04-17T21:29:33.429Z] [INFO]   🔄 Converting PR from draft to ready for review...
+666-[2026-04-17T21:29:33.561Z] [STDOUT] public
+--
+829-    <div class="c">
+830:      <h1>Whoa there!</h1>
+831-      <p>You have sent an invalid request. <br><br>
+--
+841-</html>
+842:[2026-04-17T21:29:46.603Z] [STDERR] gh: HTTP 400
+843-[2026-04-17T21:29:49.142Z] [STDOUT] 
+--
+872-    <div class="c">
+873:      <h1>Whoa there!</h1>
+874-      <p>You have sent an invalid request. <br><br>
+--
+884-</html>
+885:[2026-04-17T21:29:49.142Z] [STDERR] gh: HTTP 400
+886-[2026-04-17T21:29:49.840Z] [INFO]   ✅ Solution draft log uploaded to Pull Request as public Gist
+
+=== log-6 21:04:18 ===
+1502-[2026-04-17T21:04:57.209Z] [INFO] 
+1503:[2026-04-17T21:04:57.209Z] [INFO] 📄 Attaching failure logs to Pull Request...
+1504-[2026-04-17T21:04:58.046Z] [STDOUT] github.com
+--
+1565-    <div class="c">
+1566:      <h1>Whoa there!</h1>
+1567-      <p>You have sent an invalid request. <br><br>
+--
+1577-</html>
+1578:[2026-04-17T21:05:12.062Z] [STDERR] gh: HTTP 400
+1579:[2026-04-17T21:20:51.436Z] [INFO]   ❌ Failed to post comment with log link: gh: HTTP 400
+1580-[2026-04-17T21:20:51.436Z] [INFO] 

--- a/docs/case-studies/issue-1631/data/log-urls.json
+++ b/docs/case-studies/issue-1631/data/log-urls.json
@@ -1,0 +1,64 @@
+{
+  "_comment": "Full logs referenced by issue #1631. Stored as gist URLs because each log is MB-sized. Excerpts around the HTTP 400 failure are in data/log-excerpts.txt.",
+  "logs": [
+    {
+      "id": "log-1",
+      "timestamp": "2026-04-17T20:32:44Z",
+      "size_kb": 6300,
+      "url": "https://gist.githubusercontent.com/konard/29407ccfeed275236917d07212135fbb/raw/aba0b64a14f5d812e3b1882244fce7bb3a22e9c0/solve-2026-04-17T20-32-44-741Z.log",
+      "failure_site": "log-upload comment",
+      "observed": "gh: HTTP 400 at 20:35:49Z, eventual retry success at 21:25:16Z (50 min gap)"
+    },
+    {
+      "id": "log-2",
+      "timestamp": "2026-04-17T20:42:52Z",
+      "size_kb": 95,
+      "url": "https://gist.githubusercontent.com/konard/f74f24de4f03104a61815873e51bf61a/raw/81c1ab7187bee8e8164291648798928b1352508d/solve-2026-04-17T20-42-52-488Z.log",
+      "failure_site": "log-upload comment (claude native binary missing — solve.mjs still tried to attach failure log, comment post failed)",
+      "observed": "gh: HTTP 400 at 20:43:38Z, eventual retry success at 21:26:28Z (43 min gap)"
+    },
+    {
+      "id": "log-3",
+      "timestamp": "2026-04-17T20:51:12Z",
+      "size_kb": 12560,
+      "url": "https://gist.githubusercontent.com/konard/9df13d5296a8b9ea12f71935c3a1c35d/raw/1ea4883b7e8170458535724ffee49708aacd233d/solve-2026-04-17T20-51-12-297Z.log",
+      "failure_site": "log-upload comment",
+      "observed": "gh: HTTP 400 at 20:58:06Z, eventual retry success (CTRL+C re-entered the path)"
+    },
+    {
+      "id": "log-4",
+      "timestamp": "2026-04-17T20:54:42Z",
+      "size_kb": 260,
+      "url": "https://gist.githubusercontent.com/konard/86c66f5ffbd44abcdb5423bd2634b858/raw/77cc8dc5ed332082e670dc450a5ce751caf4a0ab/solve-2026-04-17T20-55-25-647Z.log",
+      "failure_site": "AI Work Session Started comment (session start path)",
+      "observed": "gh: HTTP 400 at 20:55:25Z, eventual success at 21:28:13Z (33 min gap)"
+    },
+    {
+      "id": "log-5",
+      "timestamp": "2026-04-17T20:55:25Z",
+      "size_kb": 275,
+      "url": "https://gist.githubusercontent.com/konard/cbc94f799b5b4b5e64837f0fc930103b/raw/07e5fc20062a4aa44590ad74cf15e571ddbb2a78/solve-2026-04-17T20-42-52-488Z.log",
+      "failure_site": "AI Work Session Started comment (near-duplicate of log-4)",
+      "observed": "gh: HTTP 400 at 20:56:04Z, eventual success (29 min gap)"
+    },
+    {
+      "id": "log-6",
+      "timestamp": "2026-04-17T21:04:18Z",
+      "size_kb": 120,
+      "url": "https://gist.githubusercontent.com/konard/32e805d6df301eced8991dfe0b00413f/raw/282524e4536612f6825fae47ee35f77b139faf8e/solve-2026-04-17T21-04-18-327Z.log",
+      "failure_site": "log-upload comment (full failure — no comment posted)",
+      "observed": "gh: HTTP 400 at 21:05:12Z, retry gave up at 21:20:51Z with 'Failed to upload failure logs'"
+    }
+  ],
+  "common_failure_mode": {
+    "http_status": 400,
+    "response_body": "GitHub edge-tier HTML \"Whoa there!\" (generic anti-abuse rejection page, not JSON)",
+    "gh_cli_stderr": "gh: HTTP 400",
+    "root_cause": "src/tool-comments.lib.mjs postTrackedComment passed `{ input: payload }` but command-stream's option key is `stdin`. The unknown option was silently ignored, stdin fell back to 'inherit', and `gh api --input -` read the parent process's stdin (empty/closed), sending an empty POST body."
+  },
+  "fix": {
+    "pr": "https://github.com/link-assistant/hive-mind/pull/1632",
+    "change": "src/tool-comments.lib.mjs: $({ input: payload }) → $({ stdin: payload })",
+    "regression_test": "tests/test-solution-summary.mjs — asserts the options bag has `stdin` and does NOT have `input`"
+  }
+}

--- a/src/tool-comments.lib.mjs
+++ b/src/tool-comments.lib.mjs
@@ -199,13 +199,14 @@ export const postTrackedComment = async ({ $, owner, repo, targetNumber, body })
   const apiPath = `repos/${owner}/${repo}/issues/${targetNumber}/comments`;
   const payload = JSON.stringify({ body });
 
-  // `gh api --input -` reads from stdin. command-stream supports .stdin(...)
-  // on the returned process handle (same API used in interactive-mode.lib.mjs
-  // via execFileAsync). We build the invocation through $ so callers can
-  // inject a mock.
+  // command-stream's options key is `stdin`, not `input` — unknown keys are
+  // silently ignored, which previously left stdin inherited from the parent
+  // and caused `gh api --input -` to POST an empty body. GitHub's edge
+  // replied with HTTP 400 "Whoa there!" *before* the API layer ran. See
+  // issue #1631.
   let result;
   try {
-    result = await $({ input: payload })`gh api ${apiPath} -X POST --input -`;
+    result = await $({ stdin: payload })`gh api ${apiPath} -X POST --input -`;
   } catch (err) {
     return { ok: false, commentId: null, stderr: err && err.message ? err.message : String(err) };
   }

--- a/tests/test-solution-summary.mjs
+++ b/tests/test-solution-summary.mjs
@@ -327,6 +327,42 @@ runTest('postTrackedComment throws if $ helper is missing', async () => {
   assertTrue(threw, 'missing $ must throw a clear error');
 });
 
+// Issue #1631: command-stream's options bag uses `stdin`, not `input`. Passing
+// `{ input: payload }` was silently ignored, so `gh api --input -` read the
+// parent process stdin and posted an empty/malformed POST — GitHub's edge
+// replied with HTTP 400 "Whoa there!". This test pins the option name so a
+// future rename can't silently regress the same footgun.
+runTest('postTrackedComment passes body via stdin option to command-stream (Issue #1631)', async () => {
+  const { postTrackedComment, resetTrackedToolCommentIds } = await import('../src/tool-comments.lib.mjs');
+  resetTrackedToolCommentIds();
+  let capturedOptions = null;
+  const fakeResult = { code: 0, stdout: JSON.stringify({ id: 1631001 }), stderr: '' };
+  const mock$ = (...args) => {
+    // When invoked as `$(options)` the first call receives the options bag
+    // and must return the tagged-template function. When invoked as `$\`…\``
+    // the first call receives the template strings array directly — we fall
+    // through to returning the result.
+    const first = args[0];
+    if (first && typeof first === 'object' && !Array.isArray(first)) {
+      capturedOptions = first;
+      const tagged = () => Promise.resolve(fakeResult);
+      return Object.assign(tagged, Promise.resolve(fakeResult));
+    }
+    const tagged = () => Promise.resolve(fakeResult);
+    return Object.assign(tagged, Promise.resolve(fakeResult));
+  };
+  const body = 'hello world — multi-line\n\nbody';
+  const { ok, commentId } = await postTrackedComment({ $: mock$, owner: 'o', repo: 'r', targetNumber: 1, body });
+  assertTrue(ok, 'postTrackedComment should succeed');
+  assertEqual(commentId, '1631001', 'comment ID should be extracted');
+  assertTrue(capturedOptions !== null, 'command-stream options bag should have been captured');
+  assertTrue(Object.prototype.hasOwnProperty.call(capturedOptions, 'stdin'), 'options bag must include `stdin` key (command-stream ignores `input`)');
+  assertFalse(Object.prototype.hasOwnProperty.call(capturedOptions, 'input'), 'options bag must NOT use legacy `input` key (silently ignored by command-stream)');
+  const expected = JSON.stringify({ body });
+  assertEqual(capturedOptions.stdin, expected, 'stdin should contain JSON.stringify({body}) exactly');
+  resetTrackedToolCommentIds();
+});
+
 runTest('Cross-module: comment bodies posted at each site embed the centralized marker', async () => {
   // Spot-check by substring that each known posting site's literal body text
   // references the corresponding marker constant (not an ad-hoc string copy).


### PR DESCRIPTION
## Summary

Fixes #1631 — the regression that broke every tool-posted PR comment since
v1.53.1.

`postTrackedComment()` in `src/tool-comments.lib.mjs` (introduced by #1626)
was passing the comment body via `$({ input: payload })`, but command-stream's
options-bag key for subprocess stdin is `stdin` — not `input`. The misnamed
key was silently ignored. `stdin` defaulted to `'inherit'`, so `gh api --input -`
read the parent process's stdin (empty/closed), sent an empty POST, and
GitHub's edge rejected the request with HTTP 400 "Whoa there!" (the anti-abuse
HTML page, served *before* the API layer ran — which is why the error payload
is HTML, not a JSON API error).

Every tool-posted comment routes through this one function:

- `AI Work Session Started` (session-start)
- `Solution Draft Log` (log-upload link after failure or success)
- `Ready to merge` / `Auto-merged` (auto-merge status)
- Usage-limit and billing-limit notices

All of them failed across the six user-supplied logs attached to #1631 — the
user explicitly considered reverting to v1.53.0.

## Root cause (verified)

- **command-stream v0.9.4** (`$.process-runner-base.mjs`, `handleStdin()`): only
  recognises `stdin`. Unknown option keys are silently dropped.
- **Existing correct usage in the repo** that proves the convention:
  - `src/claude.lib.mjs:810` — `$({ cwd, stdin: prompt, mirror: false, env })`
  - `scripts/create-github-release.mjs:81` — `\`gh api … --input -\`.run({ stdin })`
  - `scripts/format-release-notes.mjs:233` — same pattern
- **Why the unit tests missed it**: `tests/test-solution-summary.mjs` mocks `$`
  with a callable that ignores its options and returns a canned JSON response.
  The mock happily accepts `{ input: … }` because it never inspects the options
  bag — the exact same footgun previously documented in
  `docs/case-studies/issue-1532/README.md` for `promisify(execFile)`.

## The fix

One-line change (plus explanatory comment) in `src/tool-comments.lib.mjs`:

```diff
- result = await $({ input: payload })`gh api ${apiPath} -X POST --input -`;
+ result = await $({ stdin: payload })`gh api ${apiPath} -X POST --input -`;
```

## Test plan

- [x] `node tests/test-solution-summary.mjs` — 36/36 pass (35 pre-existing + 1 new).
- [x] New regression test asserts the options bag **has** `stdin` and **does not**
      have `input`, so a future rename can't silently recur.
- [x] `npm run lint` — clean.
- [x] `npx prettier --check` on touched files — clean.
- [x] `npm test` — full suite 41/41 pass.
- [ ] Next real-world solve.mjs run on v1.54.1 (post-fix) should post session-start,
      log-upload, and ready-to-merge comments without `gh: HTTP 400`.

## Case study

Full timeline, log excerpts, and a catalog of the six user-reported gist URLs
are committed under `docs/case-studies/issue-1631/` per the issue's request:

- `README.md` — timeline, root cause, fix, requirements checklist.
- `data/log-excerpts.txt` — focused excerpt around each `gh: HTTP 400` across
  all six logs.
- `data/log-urls.json` — structured catalog of the six gists with size,
  failure site, and observed behaviour.

## Follow-up (not in this PR)

- Audit every `$({ … })` options-bag usage in the repo for other silently-ignored
  keys.
- Consider an ESLint rule that flags `$({ input: … })` / `.run({ input: … })`.
- Upstream: open an issue on command-stream to warn about unknown options keys.

🤖 Generated with [Claude Code](https://claude.com/claude-code)