### PR TITLE
fix(solve): skip fork mode for private upstream with write access (#1716)

### DIFF
--- a/.changeset/issue-1716-skip-fork-private-upstream.md
+++ b/.changeset/issue-1716-skip-fork-private-upstream.md
@@ -1,0 +1,49 @@
+---
+'@link-assistant/hive-mind': patch
+---
+
+Fix `solve` to skip fork mode when the upstream repository is private and the
+user has direct write access — even when the existing PR was created from a
+fork (issue #1716).
+
+Previously, when a PR was originally created from a fork (e.g. the upstream
+repo was public and the user without write access used `--auto-fork`), but
+the upstream is now private and the user has direct write access, `solve`
+still tried to clone the fork. If the fork had been renamed, deleted, or was
+otherwise inaccessible (which is common after a public→private flip), repo
+setup failed with `Fork not accessible`.
+
+The auto-fork path already handled this correctly (logging
+_"Auto-fork: Write access detected to private repository, working directly on
+repository"_ and leaving `forkOwner = null`). The bug was that **continue
+mode** — both the auto-continue path and the direct PR-URL path — re-set
+`forkOwner` from the existing PR's head repository unconditionally,
+overriding the auto-fork bypass.
+
+Fix: in [`src/solve.mjs`](./src/solve.mjs):
+
+- Hoist `detectRepositoryVisibility(owner, repo)` out of the
+  `if (argv.autoCleanup === undefined)` block so `isRepoPublic` is
+  unconditionally available.
+- Compute one bypass flag,
+  `skipForkForPrivateUpstream = !isRepoPublic && !argv.fork && hasWriteAccess`.
+- Gate both fork-from-PR-data branches behind it. When set, log
+  _"Issue #1716: Working directly on the private upstream repository"_ and
+  leave `forkOwner = null` so the regular non-fork code path runs.
+- Gate the maintainer-modify auto-toggle on `forkOwner` being non-null so it
+  doesn't fire when the bypass triggered.
+
+Explicit `--fork` still wins (the bypass requires `!argv.fork`), and users
+with no write access on a private repo still hit the existing auto-fork
+private-repo guard (the bypass requires `hasWriteAccess`).
+
+Tests: [`tests/test-issue-1716-private-repo-skip-fork.mjs`](./tests/test-issue-1716-private-repo-skip-fork.mjs)
+locks the flag declaration, the exact condition formula, both
+fork-detection paths, and four scenario simulations
+(private+writeAccess → bypass; public → no bypass; explicit `--fork` → no
+bypass; no writeAccess → no bypass).
+
+Documentation: [`docs/case-studies/issue-1716/`](./docs/case-studies/issue-1716/README.md)
+contains the timeline reconstructed from the user's failure log, the
+distilled facts, the per-symptom root-cause analysis, and the implementation
+plan.

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,2 +1,3 @@
 # .gitkeep file auto-generated at 2026-04-15T05:07:05.365Z for PR creation at branch issue-1603-d47eafcfffb1 for issue https://github.com/link-assistant/hive-mind/issues/1603
 # Updated: 2026-04-17T19:04:16.770Z
+# Updated: 2026-04-29T10:11:17.712Z

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,3 +1,2 @@
 # .gitkeep file auto-generated at 2026-04-15T05:07:05.365Z for PR creation at branch issue-1603-d47eafcfffb1 for issue https://github.com/link-assistant/hive-mind/issues/1603
 # Updated: 2026-04-17T19:04:16.770Z
-# Updated: 2026-04-29T10:11:17.712Z

--- a/docs/case-studies/issue-1716/README.md
+++ b/docs/case-studies/issue-1716/README.md
@@ -1,0 +1,167 @@
+# Case Study: Issue #1716 — Skip Forks for Private Upstream Repositories
+
+**Issue:** [link-assistant/hive-mind#1716](https://github.com/link-assistant/hive-mind/issues/1716)
+**Pull Request:** [#1717](https://github.com/link-assistant/hive-mind/pull/1717)
+**Triggering log:** [Gist 37fecd1108eac139d3b893c7827c692a](https://gist.githubusercontent.com/konard/37fecd1108eac139d3b893c7827c692a/raw/6954ab0c86934aba6fb3a9a2b13a55fdea0d5637/3b06db69-75bb-4cbc-82b1-145606a7429a.log)
+**Labels:** `bug`
+**Reported by:** @konard on 2026-04-29
+**Status:** Implemented in PR #1717 — `solve` now bypasses fork mode when upstream is private and the user has write access.
+
+---
+
+## 1. Reported observation (verbatim from the issue)
+
+> Full log: <https://gist.githubusercontent.com/konard/37fecd1108eac139d3b893c7827c692a/raw/6954ab0c86934aba6fb3a9a2b13a55fdea0d5637/3b06db69-75bb-4cbc-82b1-145606a7429a.log>
+>
+> The repository may have been public, and made private. Anyway if repository private it does not matter if fork exists or not, even if it is broken.
+>
+> When repository is private we should always access it directly and use regular branches and pull requests without fork.
+
+The issue then asks for the standard case-study deliverables: download the data,
+reconstruct the timeline, list requirements, find root causes, propose
+solutions, add verbose output if anything is missing, and file upstream issues
+where applicable.
+
+---
+
+## 2. Source data captured for this case study
+
+| Path                                                                     | What it is                                                                                               |
+| ------------------------------------------------------------------------ | -------------------------------------------------------------------------------------------------------- |
+| [`data/issue-1716.json`](./data/issue-1716.json)                         | Raw GitHub issue JSON.                                                                                   |
+| [`data/solution-draft-log-1716.log`](./data/solution-draft-log-1716.log) | Full failure log linked from the issue (the user's `solve` invocation against `xlabtg/anti-corruption`). |
+| [`facts.md`](./facts.md)                                                 | Distilled facts from the log and codebase: who set what, which fork name was tried, why it failed.       |
+| [`root-causes.md`](./root-causes.md)                                     | Per-symptom root cause with file/line citations into `src/solve.mjs`.                                    |
+| [`solution-plans.md`](./solution-plans.md)                               | Plan adopted in PR #1717 plus alternatives considered.                                                   |
+
+---
+
+## 3. Timeline / sequence of events (from `data/solution-draft-log-1716.log`)
+
+| Timestamp (UTC)         | Event                                                                                                                                                                                           |
+| ----------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| 2026-04-29 10:04:28.358 | User runs `solve https://github.com/xlabtg/anti-corruption/pull/12 --model opus --tool claude --attach-logs --verbose --no-tool-check` (v1.58.0).                                               |
+| 2026-04-29 10:04:35     | URL validated as PR URL (`Is PR URL: true`).                                                                                                                                                    |
+| 2026-04-29 10:04:36     | `--auto-accept-invite` finds no pending invitations.                                                                                                                                            |
+| 2026-04-29 10:04:37     | `gh api repos/xlabtg/anti-corruption --jq .visibility` → `private`. `permissions.push: true`.                                                                                                   |
+| 2026-04-29 10:04:38     | Auto-fork prints: _"Write access detected to private repository, working directly on repository"_ — i.e. **auto-fork itself was bypassed.**                                                     |
+| 2026-04-29 10:04:39     | Repository write access confirmed (second probe).                                                                                                                                               |
+| 2026-04-29 10:04:40     | Auto-cleanup defaults to `true` (private repo). Continue mode activated for PR #12.                                                                                                             |
+| 2026-04-29 10:04:43     | `gh pr view 12 --json …` returns `headRepository.nameWithOwner = konard/anti-corruption` (a fork created when `xlabtg/anti-corruption` was public).                                             |
+| 2026-04-29 10:04:43     | `solve.mjs` logs: _"🍴 Detected fork PR from konard/anti-corruption … Will clone fork repository for continue mode"_. `forkOwner = konard`.                                                     |
+| 2026-04-29 10:04:44     | `setupRepository` builds standard fork name `konard/xlabtg-anti-corruption` (uses `${forkOwner}/${owner}-${repo}` because the fork's repo name differs from the base — a #1332-style scenario). |
+| 2026-04-29 10:04:45.400 | `gh repo view konard/xlabtg-anti-corruption` → 404. **Fork not accessible.** `Repository setup failed`. Exit code `1`.                                                                          |
+
+The fork named `konard/xlabtg-anti-corruption` does not exist; the original
+fork was `konard/anti-corruption`. Either way, **none of this matters**: the
+upstream `xlabtg/anti-corruption` is private and the user has `push: true` on
+it. The whole fork detour is unnecessary.
+
+---
+
+## 4. Requirements extracted from the issue
+
+| #   | Requirement                                                                                                                                                                       | Source phrase                                                                                                               |
+| --- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------- |
+| R1  | When the upstream repository is **private**, `solve` must operate directly on it (regular branches + PRs) and must **not** route through a fork — even if a fork was used before. | _"When repository is private we should always access it directly and use regular branches and pull requests without fork."_ |
+| R2  | The bypass must hold even if the head repository of the existing PR is a fork.                                                                                                    | _"if repository private it does not matter if fork exists or not, even if it is broken."_                                   |
+| R3  | Compile the case study to `./docs/case-studies/issue-1716`.                                                                                                                       | _"compile that data to `./docs/case-studies/issue-{id}` folder"_                                                            |
+| R4  | If data is insufficient, add debug/verbose output for the next iteration.                                                                                                         | _"add debug output and verbose mode if not present"_                                                                        |
+| R5  | If applicable, file reproducible upstream issues.                                                                                                                                 | _"If issue related to any other repository/project … please do so."_                                                        |
+
+---
+
+## 5. Findings at a glance
+
+> See [`root-causes.md`](./root-causes.md) for the full analysis.
+
+- **Root cause.** `src/solve.mjs` already special-cases `--auto-fork` for
+  private repos (line ~205: _"Write access detected to private repository,
+  working directly on repository"_) by setting `forkOwner = null`.
+  However, the **continue-mode fork detection** runs **after** that, in two
+  places — the auto-continue path
+  (`prCheckData.headRepositoryOwner.login`) and the direct PR-URL path
+  (`prData.headRepositoryOwner.login`). Both unconditionally set `forkOwner`
+  to whatever the existing PR's head is, even when the upstream is private and
+  the user has direct write access. Downstream, `setupRepository` then tries
+  to clone `forkOwner/<headRepoName>`, which (a) often fails when the upstream
+  was re-privated or the fork was renamed/deleted, and (b) is structurally
+  wrong — fork commits cannot be pushed to a private upstream PR anyway.
+
+- **Why the auto-fork bypass at line 205 didn't help.** That bypass only
+  guards `argv.autoFork`. Continue mode populates `forkOwner` from the **PR
+  data**, not from auto-fork logic, so the bypass never sees it.
+
+- **The ~$0 fix.** Compute `skipForkForPrivateUpstream = !isRepoPublic && !argv.fork && hasWriteAccess`
+  once (after the existing visibility probe), and gate **both**
+  fork-from-PR-data branches behind it. When set, log a clear message and
+  leave `forkOwner = null`, so the regular non-fork code path runs.
+
+---
+
+## 6. Solution plans (summary)
+
+> Detailed reasoning + alternatives in [`solution-plans.md`](./solution-plans.md).
+
+- **R1 / R2.** In `src/solve.mjs`:
+  1. Move the existing `detectRepositoryVisibility(owner, repo)` call out of
+     the `if (argv.autoCleanup === undefined)` block so `isRepoPublic` is
+     always available (it was only evaluated in the auto-cleanup path).
+  2. Compute `const skipForkForPrivateUpstream = !isRepoPublic && !argv.fork && hasWriteAccess;`.
+  3. In each of the two fork-from-PR-data branches, wrap the
+     `forkOwner = …; forkRepoName = …;` assignments in
+     `if (skipForkForPrivateUpstream) { log "Working directly on the private upstream repository"; }
+else { /* old assignment */ }`.
+  4. Gate the maintainer-modify auto-toggle on `forkOwner &&` so it only
+     activates when a fork is actually being used.
+  5. The explicit `--fork` flag still wins (the bypass requires `!argv.fork`).
+  6. The `hasWriteAccess` requirement keeps behaviour safe when the user has
+     no push permission — fork mode (auto-fork) remains the documented
+     fallback.
+
+- **R3.** ✅ This folder.
+- **R4.** Existing `--verbose` already prints visibility, write-access and
+  fork detection. The new bypass branch adds an explicit log line so future
+  runs make the decision visible without extra flags.
+- **R5.** No upstream component to file against — both the GitHub CLI and
+  Anthropic API behaved correctly in the failing run; the bug is entirely in
+  `solve.mjs`'s fork-detection logic.
+
+---
+
+## 7. Implementation status (PR #1717)
+
+The bypass is implemented in `src/solve.mjs` at the three places listed in
+plan §6. Tests are in
+[`tests/test-issue-1716-private-repo-skip-fork.mjs`](../../../tests/test-issue-1716-private-repo-skip-fork.mjs)
+(13 tests, all passing) — they cover:
+
+1. The flag declaration and exact condition formula.
+2. `detectRepositoryVisibility` runs unconditionally (not gated on autoCleanup).
+3. Both fork-detection paths consult the flag.
+4. `forkOwner` stays `null` when the bypass triggers.
+5. Maintainer-modify is gated by `forkOwner`.
+6. Scenario simulations: private+writeAccess → bypass; public → no bypass;
+   `--fork` → no bypass; no writeAccess → no bypass (auto-fork still applies).
+
+---
+
+## 8. Existing components / libraries reviewed
+
+| Need                         | Already in repo                                                                                 | Verdict                                                             |
+| ---------------------------- | ----------------------------------------------------------------------------------------------- | ------------------------------------------------------------------- |
+| Detect repository visibility | `detectRepositoryVisibility` in [`src/github.lib.mjs`](../../../src/github.lib.mjs) (line 1389) | ✅ Reuse — already returns `{ isPublic, visibility }`. No new call. |
+| Detect write access          | `checkRepositoryWritePermission` in [`src/github.lib.mjs`](../../../src/github.lib.mjs)         | ✅ `hasWriteAccess` is already computed by the auto-fork path.      |
+| Bypass auto-fork on private  | Existing branch in `src/solve.mjs` around the auto-fork block.                                  | ✅ Mirror the same logic for continue-mode fork detection.          |
+
+No new library is needed.
+
+---
+
+## 9. Quick reference: file:line citations
+
+- `src/solve.mjs` (auto-fork bypass for private) — already present, around the auto-fork block: _"Write access detected to private repository, working directly on repository"_.
+- `src/solve.mjs` (auto-continue PR-detection path) — `prCheckData.headRepositoryOwner.login` block, where `forkOwner` was unconditionally set.
+- `src/solve.mjs` (direct PR-URL path) — `prData.headRepositoryOwner.login` block, same pattern.
+- `src/solve.repository.lib.mjs:898` — emits the `Fork not accessible` error when the constructed fork URL 404s.
+- `src/github.lib.mjs:1389` — `detectRepositoryVisibility(owner, repo)` returns `{ isPublic, visibility }`.

--- a/docs/case-studies/issue-1716/data/issue-1716.json
+++ b/docs/case-studies/issue-1716/data/issue-1716.json
@@ -1,0 +1,10 @@
+{
+  "author": { "id": "MDQ6VXNlcjE0MzE5MDQ=", "is_bot": false, "login": "konard", "name": "Konstantin Diachenko" },
+  "body": "Full log: https://gist.githubusercontent.com/konard/37fecd1108eac139d3b893c7827c692a/raw/6954ab0c86934aba6fb3a9a2b13a55fdea0d5637/3b06db69-75bb-4cbc-82b1-145606a7429a.log\n\nThe repository may have been public, and made private. Anyway if repository private it does not matter if fork exists or not, even if it is broken.\n\nWhen repository is private we should always access it directly and use regular branches and pull requests without fork.\n\nWe need to download all logs and data related about the issue to this repository, make sure we compile that data to `./docs/case-studies/issue-{id}` folder, and use it to do deep case study analysis (also make sure to search online for additional facts and data), in which we will reconstruct timeline/sequence of events, list of each and all requirements from the issue, find root causes of the each problem, and propose possible solutions and solution plans for each requirement (we should also check known existing components/libraries, that solve similar problem or can help in solutions).\n\nIf there is not enough data to find actual root cause, add debug output and verbose mode if not present, that will allow us to find root cause on next iteration.\n\nIf issue related to any other repository/project, where we can report issues on GitHub, please do so. Each issue must contain reproducible examples, workarounds and suggestions for fix the issue in code.",
+  "comments": [],
+  "createdAt": "2026-04-29T10:10:31Z",
+  "labels": [{ "id": "LA_kwDOPUU0qc8AAAACGYm6iw", "name": "bug", "description": "Something isn't working", "color": "d73a4a" }],
+  "number": 1716,
+  "state": "OPEN",
+  "title": "When repository is private, we should not use forks, even if they existed before"
+}

--- a/docs/case-studies/issue-1716/data/solution-draft-log-1716.log
+++ b/docs/case-studies/issue-1716/data/solution-draft-log-1716.log
@@ -1,0 +1,97 @@
+=== Start Command Log ===
+Execution ID: 3b06db69-75bb-4cbc-82b1-145606a7429a
+Timestamp: 2026-04-29 10:04:28.358
+Command: solve https://github.com/xlabtg/anti-corruption/pull/12 --model opus --tool claude --attach-logs --verbose --no-tool-check
+Environment: screen
+Mode: detached
+Session: 8a4c0eb4-296b-4dc2-9ed4-652b771bbd20
+Platform: linux
+Node Version: v24.3.0
+Working Directory: /home/box
+==================================================
+
+Command started in detached screen session: 8a4c0eb4-296b-4dc2-9ed4-652b771bbd20
+Session will exit automatically after command completes.
+Reattach with: screen -r 8a4c0eb4-296b-4dc2-9ed4-652b771bbd20
+Live log: /tmp/start-command/logs/isolation/screen/3b06db69-75bb-4cbc-82b1-145606a7429a.log
+📁 Log file: /home/box/solve-2026-04-29T10-04-35-640Z.log
+   (All output will be logged here)
+
+🚀 solve v1.58.0
+🔧 Raw command executed:
+   /home/box/.nvm/versions/node/v20.20.2/bin/node /home/box/.bun/bin/solve https://github.com/xlabtg/anti-corruption/pull/12 --model opus --tool claude --attach-logs --verbose --no-tool-check
+
+
+⚠️  SECURITY WARNING: --attach-logs is ENABLED
+
+   This option will upload the complete solution draft log file to the Pull Request.
+   The log may contain sensitive information such as:
+   • API keys, tokens, or secrets
+   • File paths and directory structures
+   • Command outputs and error messages
+   • Internal system information
+
+   ⚠️  DO NOT use this option with public repositories or if the log
+       might contain sensitive data that should not be shared publicly.
+
+   Continuing in 5 seconds... (Press Ctrl+C to abort)
+
+   Countdown: 5 seconds remaining...   Countdown: 4 seconds remaining...   Countdown: 3 seconds remaining...   Countdown: 2 seconds remaining...   Countdown: 1 seconds remaining...   Proceeding with log attachment enabled.                    
+
+💾 Disk space check: 53501MB available (2048MB required) ✅
+🧠 Memory check: 10874MB available, swap: none, total: 10874MB (256MB required) ✅
+⏩ Skipping tool connection validation (dry-run mode or skip-tool-connection-check enabled)
+⏩ Skipping GitHub authentication check (dry-run mode or skip-tool-connection-check enabled)
+📋 URL validation:
+   Input URL: https://github.com/xlabtg/anti-corruption/pull/12
+   Is Issue URL: false
+   Is PR URL: true
+🔍 --auto-accept-invite: Checking for pending invitation to xlabtg/anti-corruption...
+   Found 2 total pending repo invitation(s)
+   No pending repository invitation found for xlabtg/anti-corruption
+   Found 0 total pending org invitation(s)
+   No pending organization invitation found for xlabtg
+ℹ️  --auto-accept-invite: No pending invitation found for xlabtg/anti-corruption or organization xlabtg
+🔍 Checking repository access for auto-fork...
+{"admin":false,"maintain":false,"pull":true,"push":true,"triage":true}
+private
+   Repository visibility: private
+✅ Auto-fork: Write access detected to private repository, working directly on repository
+🔍 Checking repository write permissions...
+{"admin":false,"maintain":false,"pull":true,"push":true,"triage":true}
+✅ Repository write access: Confirmed
+xlabtg
+xlabtg/anti-corruption
+{"number":12,"state":"OPEN"}
+private
+   Repository visibility: private
+   Auto-cleanup default: true (repository is private)
+🔄 Continue mode: Working with PR #12
+   Continue mode activated: PR URL provided directly
+   PR Number set to: 12
+   Will fetch PR details and linked issue
+{"body":"## 📋 Описание\n\nЭтот Pull Request реализует полноценный CI/CD пайплайн для автоматического тестирования и развертывания приложения на хостинг hostia.net с использованием GitHub Actions.\n\nFixes #11\n\n## 🚀 Реализованные функции\n\n### GitHub Actions Workflows\n\n1. **test.yml** - Автоматическое тестирование Pull Requests\n   - Установка PHP 8.1 и необходимых расширений\n   - Установка зависимостей Composer и NPM\n   - Сборка frontend assets\n   - Запуск миграций и тестов на SQLite\n   - Проверка стиля кода с помощью PHP-CS-Fixer\n\n2. **deploy-staging.yml** - Развертывание на staging\n   - Триггер: push в ветку `develop`\n   - Сборка production-оптимизированных assets\n   - Развертывание через FTP на staging сервер\n   - Автоматическая очистка кеша (если доступен SSH)\n\n3. **deploy-production.yml** - Развертывание на production\n   - Триггер: push в ветку `main`\n   - Проверка качества кода\n   - Создание backup перед развертыванием\n   - Развертывание через FTP на hostia.net\n   - Выполнение post-deploy команд (миграции, оптимизация кеша)\n   - Установка правильных прав доступа\n\n4. **release.yml** - Автоматическое создание релизов\n   - Триггер: push тега формата `v*.*.*`\n   - Генерация changelog из коммитов\n   - Создание GitHub Release с описанием\n   - Создание и прикрепление архива для развертывания\n\n### Конфигурация окружений\n\n- **.env.example** - Базовый шаблон конфигурации Laravel со всеми необходимыми переменными\n- **.env.staging** - Шаблон для staging окружения с комментариями\n- **.env.production** - Шаблон для production с оптимизациями для hostia.net\n\n### Документация\n\n- **DEPLOYMENT.md** - Подробное руководство по развертыванию, включающее:\n  - Пошаговые инструкции по настройке GitHub Secrets\n  - Описание каждого workflow и его использования\n  - Процесс развертывания на staging и production\n  - Процедуры отката изменений\n  - Решение типичных проблем\n  - Особенности работы с hostia.net shared hosting\n  - Чеклист перед первым развертыванием\n\n## 🔧 Особенности реализации\n\n### Оптимизация для shared-хостинга hostia.net\n\n- **FTP-развертывание** вместо SSH (подходит для shared hosting без полного SSH)\n- **Исключение больших директорий** из развертывания (node_modules, tests, .git)\n- **Автоматическое кеширование** конфигурации Laravel для повышения производительности\n- **Backup перед обновлением** с автоматической очисткой старых backup'ов (старше 7 дней)\n- **Fallback механизмы** для выполнения команд при ограниченном SSH доступе\n\n### Безопасность\n\n- Все учетные данные хранятся в GitHub Secrets\n- `.env` файлы с реальными данными исключены из VCS\n- Production окружение с отключенным debug режимом\n- Secure cookies и CSRF защита\n\n### Производительность\n\n- Кеширование Composer dependencies для ускорения сборки\n- Кеширование NPM packages\n- Оптимизация autoloader для production\n- Предварительная компиляция views, routes и config\n\n## 📝 Необходимые действия для запуска\n\n### 1. Настройка GitHub Secrets\n\nДобавьте следующие секреты в Settings → Secrets and variables → Actions:\n\n**Для Staging:**\n- `STAGING_FTP_HOST` - FTP хост\n- `STAGING_FTP_USER` - FTP пользователь\n- `STAGING_FTP_PASS` - FTP пароль\n\n**Для Production:**\n- `PRODUCTION_FTP_HOST` - FTP хост (hostia.net)\n- `PRODUCTION_FTP_USER` - FTP пользователь\n- `PRODUCTION_FTP_PASS` - FTP пароль\n- `PRODUCTION_SSH_HOST` - SSH хост (опционально)\n- `PRODUCTION_SSH_USER` - SSH пользователь (опционально)\n- `PRODUCTION_SSH_PASS` - SSH пароль (опционально)\n\n### 2. Настройка окружений\n\n1. Отредактируйте `.env.staging` и `.env.production`\n2. Замените все значения `REPLACE_WITH_*` на реальные\n3. Убедитесь, что эти файлы добавлены в `.gitignore`\n\n### 3. Создание ветки develop\n\n```bash\ngit checkout -b develop\ngit push origin develop\n```\n\n### 4. Тестирование\n\n1. Создайте тестовый PR - автоматически запустится `test.yml`\n2. Слейте в `develop` - автоматически развернется на staging\n3. Проверьте staging окружение\n4. Слейте в `main` - автоматически развернется на production\n\n## ✅ Чеклист\n\n- [x] Созданы все 4 GitHub Actions workflows\n- [x] Созданы шаблоны .env файлов для всех окружений\n- [x] Написана полная документация в DEPLOYMENT.md\n- [x] Реализована поддержка FTP-развертывания\n- [x] Добавлена поддержка SSH для post-deploy команд\n- [x] Реализован механизм backup перед production deploy\n- [x] Добавлены оптимизации для shared hosting\n- [x] Реализовано автоматическое создание релизов\n- [x] Добавлена проверка стиля кода\n- [x] Настроено кеширование для ускорения CI\n\n## 📊 Структура файлов\n\n```\n.github/\n└── workflows/\n    ├── test.yml                 # Тестирование PR\n    ├── deploy-staging.yml       # Развертывание на staging\n    ├── deploy-production.yml    # Развертывание на production\n    └── release.yml              # Создание релизов\n\n.env.example                     # Базовый шаблон\n.env.staging                     # Конфигурация staging\n.env.production                  # Конфигурация production\nDEPLOYMENT.md                    # Документация\n```\n\n## 🔄 Workflow процесса\n\n```mermaid\ngraph LR\n    A[Feature Branch] --> B[Pull Request]\n    B --> C{Tests Pass?}\n    C -->|Yes| D[Merge to develop]\n    C -->|No| B\n    D --> E[Deploy to Staging]\n    E --> F{Staging OK?}\n    F -->|Yes| G[Merge to main]\n    F -->|No| D\n    G --> H[Deploy to Production]\n    H --> I[Create Tag]\n    I --> J[Create Release]\n```\n\n## 📚 Дополнительная информация\n\nПолная документация по настройке и использованию CI/CD доступна в файле [DEPLOYMENT.md](./DEPLOYMENT.md).\n\n## 🧪 Тестирование\n\nДля локального тестирования workflow:\n\n```bash\n# Установка зависимостей\ncomposer install\nnpm ci\n\n# Сборка assets\nnpm run build\n\n# Запуск тестов\nphp artisan test\n\n# Проверка стиля кода\ncomposer require --dev friendsofphp/php-cs-fixer\nvendor/bin/php-cs-fixer fix --dry-run --diff\n```\n\n---\n\n**🤖 Этот PR был создан автоматически для решения issue #11**\n\nГотов к review и тестированию!","headRefName":"issue-11-892db3332ea8","headRepository":{"id":"R_kgDOQPr0aw","name":"anti-corruption","nameWithOwner":"konard/anti-corruption"},"headRepositoryOwner":{"id":"MDQ6VXNlcjE0MzE5MDQ=","name":"Konstantin Diachenko","login":"konard"},"mergeStateStatus":"UNKNOWN","number":12,"state":"OPEN"}
+🍴 Detected fork PR from konard/anti-corruption
+   Fork owner: konard
+   Will clone fork repository for continue mode
+📝 PR branch: issue-11-892db3332ea8
+🔗 Found linked issue #11
+
+Creating temporary directory: /tmp/gh-issue-solver-1777457084804
+
+🍴 Fork mode:                DETECTED from PR
+ Fork owner:               konard
+✅ Using fork:               konard/xlabtg-anti-corruption
+
+🔍 Verifying fork:           Checking accessibility...
+❌ Error:                    Fork not accessible
+ Fork tried:               konard/xlabtg-anti-corruption
+ Suggestion:               The fork's repo name may differ from the base repo name
+ Hint:                     Try running with --fork flag to create your own fork instead
+
+❌ Repository setup failed
+📁 Full log file: /home/box/solve-2026-04-29T10-04-35-640Z.log
+
+==================================================
+Finished: 2026-04-29 10:04:45.400
+Exit Code: 1

--- a/docs/case-studies/issue-1716/facts.md
+++ b/docs/case-studies/issue-1716/facts.md
@@ -1,0 +1,52 @@
+# Facts distilled from the failing run (`data/solution-draft-log-1716.log`)
+
+These are the **actual values** observed in the user's failing `solve` run for
+PR `xlabtg/anti-corruption#12`. They drive the test assertions and the
+case-study analysis.
+
+| Field                                          | Value                                                                           | Source line in log                       |
+| ---------------------------------------------- | ------------------------------------------------------------------------------- | ---------------------------------------- |
+| solve version                                  | `1.58.0`                                                                        | line 20                                  |
+| Input URL                                      | `https://github.com/xlabtg/anti-corruption/pull/12`                             | line 22                                  |
+| Is PR URL                                      | `true`                                                                          | line 48                                  |
+| `--auto-fork` enabled                          | implicit (default behaviour shown later)                                        | lines 55–59                              |
+| Upstream visibility                            | `private`                                                                       | lines 57–58, 66                          |
+| User permissions on upstream                   | `push: true, pull: true, triage: true, admin: false`                            | lines 56, 61                             |
+| Auto-fork decision                             | _"Write access detected to private repository, working directly on repository"_ | line 59                                  |
+| Auto-cleanup default                           | `true` (because private)                                                        | line 68                                  |
+| PR head repository                             | `konard/anti-corruption` (a fork created when upstream was public)              | line 73 (`headRepository.nameWithOwner`) |
+| Fork detected by continue-mode                 | _"🍴 Detected fork PR from konard/anti-corruption"_                             | line 74                                  |
+| Fork name **constructed** by `setupRepository` | `konard/xlabtg-anti-corruption`                                                 | line 84 (`Using fork:`)                  |
+| Outcome                                        | `Fork not accessible` → `Repository setup failed`                               | lines 87–92                              |
+| Exit code                                      | `1`                                                                             | line 97                                  |
+| Total wall-clock time                          | ~10 s (10:04:35 → 10:04:45)                                                     | lines 17, 96                             |
+
+## Reconciliation
+
+- The fork name `konard/xlabtg-anti-corruption` is derived in
+  `src/solve.repository.lib.mjs` as `${forkOwner}/${owner}-${headRepoName}`
+  where `headRepoName = forkRepoName || repo`. The actual fork is at
+  `konard/anti-corruption`, so the constructed URL legitimately 404s — but the
+  point of this issue is that **the constructed URL should not have been
+  attempted at all**, because:
+  - Upstream `xlabtg/anti-corruption` is **private** and
+  - The user has **`push: true`** on it.
+
+- The auto-fork code path **already** does the right thing
+  (line 59: _"Write access detected to private repository, working directly on
+  repository"_). The bug is that **continue mode** ignores that decision and
+  re-introduces a fork from the PR's head repository.
+
+## Reproducer
+
+Without write access to a private repo this can't be reproduced end-to-end,
+but the **decision logic** is fully covered by
+[`tests/test-issue-1716-private-repo-skip-fork.mjs`](../../../tests/test-issue-1716-private-repo-skip-fork.mjs),
+which simulates each scenario:
+
+| Scenario                            | `isRepoPublic` | `argv.fork` | `hasWriteAccess` | Expected `skipForkForPrivateUpstream` |
+| ----------------------------------- | -------------- | ----------- | ---------------- | ------------------------------------- |
+| Private + write access (this issue) | `false`        | `false`     | `true`           | **`true`** (bypass fork)              |
+| Public repo                         | `true`         | `false`     | `true`           | `false`                               |
+| Private but explicit `--fork`       | `false`        | `true`      | `true`           | `false`                               |
+| Private but no write access         | `false`        | `false`     | `false`          | `false` (auto-fork still applies)     |

--- a/docs/case-studies/issue-1716/root-causes.md
+++ b/docs/case-studies/issue-1716/root-causes.md
@@ -1,0 +1,110 @@
+# Root causes — Issue #1716
+
+The failure has a single root cause but it surfaces in two execution paths in
+`src/solve.mjs`. Both are addressed by the same fix.
+
+## Root cause (one sentence)
+
+**Continue-mode fork detection sets `forkOwner` from the existing PR's head
+repository unconditionally, ignoring the same "private upstream + write
+access" bypass that `--auto-fork` already honours.**
+
+## Walkthrough
+
+### 1. The auto-fork path already does the right thing
+
+`src/solve.mjs` contains a block (around the auto-fork detection) that probes
+visibility + permissions, and when:
+
+```text
+visibility === 'private'  &&  push: true
+```
+
+it logs:
+
+> Auto-fork: Write access detected to private repository, working directly on repository
+
+and **does not** set up fork mode — it leaves `forkOwner = null`.
+
+Concretely, the failing run's log shows this happening (line 59):
+
+```
+✅ Auto-fork: Write access detected to private repository, working directly on repository
+```
+
+So far so good.
+
+### 2. Continue-mode then re-introduces a fork from the PR data
+
+A few hundred lines later in `solve.mjs`, when continue mode parses the
+existing PR (`gh pr view 12 --json …`), it has two near-identical branches:
+
+- **Auto-continue path** — runs when `processAutoContinueForIssue` finds an
+  existing PR for the issue. Reads `prCheckData.headRepositoryOwner.login` /
+  `prCheckData.headRepository.name`.
+- **Direct PR-URL path** — runs when the user passes a PR URL directly (this
+  issue's scenario). Reads `prData.headRepositoryOwner.login` /
+  `prData.headRepository.name`.
+
+Both branches **unconditionally** set:
+
+```js
+forkOwner = detectedForkOwner;
+forkRepoName = detectedForkRepoName;
+```
+
+even when:
+
+1. `argv.fork` is **false** (no explicit fork request),
+2. the upstream is **private**, and
+3. the user has **push** on it.
+
+That assignment overrides the auto-fork bypass from step 1.
+
+### 3. Downstream: setupRepository tries to clone the fork
+
+`setupRepository` (in `src/solve.repository.lib.mjs`) sees `forkOwner !== null`
+and enters its "Priority 2" branch where it:
+
+1. Constructs `standardForkName = '${forkOwner}/${headRepoName}'` (or the
+   prefixed form `${forkOwner}/${owner}-${headRepoName}`),
+2. Calls `gh repo view <forkName>`,
+3. On 404, fails the whole run with **"Fork not accessible"**
+   (`solve.repository.lib.mjs:898`).
+
+In the failing run the fork is at `konard/anti-corruption` (different repo
+name — same shape as #1332). The tool tried `konard/xlabtg-anti-corruption`
+and got a 404. **But this whole branch should have been skipped: the upstream
+is private, and the user has direct write access.**
+
+### 4. Why `--auto-cleanup`'s visibility detection didn't help
+
+The existing `detectRepositoryVisibility` call sat **inside** the
+`if (argv.autoCleanup === undefined)` block. That meant `isRepoPublic` was
+only computed when the user had not pinned `--auto-cleanup` explicitly, and
+even when computed it was scoped to that block — invisible to the
+fork-detection branches that ran later.
+
+## Citations (post-fix line numbers)
+
+- `src/solve.mjs` — `detectRepositoryVisibility` is now hoisted above the
+  `if (argv.autoCleanup === undefined)` block so `isRepoPublic` is
+  unconditionally available.
+- `src/solve.mjs` — `const skipForkForPrivateUpstream = !isRepoPublic && !argv.fork && hasWriteAccess;`
+  is computed once.
+- `src/solve.mjs` — auto-continue path: `if (skipForkForPrivateUpstream) { … }
+else { forkOwner = detectedForkOwner; forkRepoName = detectedForkRepoName; }`.
+- `src/solve.mjs` — direct PR-URL path: same shape.
+- `src/solve.mjs` — `if (forkOwner && argv.allowToPushToContributorsPullRequestsAsMaintainer && argv.autoFork)`
+  now requires `forkOwner` so it doesn't fire under the bypass.
+- `src/solve.repository.lib.mjs:898` — unchanged; this is where the
+  pre-fix failure surfaced.
+
+## Why the fix is safe
+
+| Concern                                      | Mitigation                                                                                                                                                                       |
+| -------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| User explicitly passed `--fork`              | Bypass requires `!argv.fork`, so explicit fork mode wins.                                                                                                                        |
+| User has no write access on private upstream | `hasWriteAccess` is `false`, so bypass does not trigger; auto-fork's "no fork for private" rule applies and the run still fails clearly.                                         |
+| Public upstream where fork is correct        | `isRepoPublic === true` → bypass does not trigger; existing behaviour preserved.                                                                                                 |
+| Maintainer-modify auto-toggle                | The `argv.allowToPushToContributorsPullRequestsAsMaintainer && argv.autoFork` block is now also gated on `forkOwner` being non-null, so it is a no-op when the bypass triggered. |

--- a/docs/case-studies/issue-1716/solution-plans.md
+++ b/docs/case-studies/issue-1716/solution-plans.md
@@ -1,0 +1,97 @@
+# Solution plans — Issue #1716
+
+This document records the plan adopted in PR #1717 and the alternatives that
+were considered and rejected.
+
+## Plan A (adopted) — single bypass flag, gated at fork-detection points
+
+Compute one flag once, reuse it at the two existing fork-detection branches.
+
+```js
+const { isPublic: isRepoPublic } = await detectRepositoryVisibility(owner, repo);
+// (was previously inside the autoCleanup default block)
+
+if (argv.autoCleanup === undefined) {
+  argv.autoCleanup = !isRepoPublic;
+}
+
+// Issue #1716: when upstream is private and the user has direct write access,
+// skip fork mode regardless of the PR's head repository — work directly on
+// the upstream repository using regular branches.
+const skipForkForPrivateUpstream = !isRepoPublic && !argv.fork && hasWriteAccess;
+```
+
+Then in each fork-from-PR-data branch:
+
+```js
+if (skipForkForPrivateUpstream) {
+  await log(`   Issue #1716: Working directly on the private upstream repository (skipping fork ${detectedForkOwner}/${detectedForkRepoName ?? ''})`);
+} else {
+  forkOwner = detectedForkOwner;
+  forkRepoName = detectedForkRepoName;
+}
+```
+
+…and gate the maintainer-modify auto-toggle on `forkOwner` so it doesn't fire
+when the bypass triggered:
+
+```js
+if (forkOwner && argv.allowToPushToContributorsPullRequestsAsMaintainer && argv.autoFork) {
+  // …
+}
+```
+
+### Why this plan
+
+- **Minimal blast radius.** The change is local to `src/solve.mjs`. No
+  signature changes in `setupRepositoryAndClone` or `setupRepository`.
+- **Reuses existing detection.** `detectRepositoryVisibility` and
+  `hasWriteAccess` are already computed by the auto-fork path; we just lift
+  visibility a few lines so it is in scope where we need it.
+- **Composes with `--fork`.** The bypass requires `!argv.fork`, so users who
+  explicitly want fork mode keep it.
+- **Composes with `--auto-fork`.** The bypass shares the same intent as the
+  existing private-upstream branch in auto-fork — they reach the same
+  conclusion (`forkOwner = null`).
+
+## Plan B (considered, rejected) — push the bypass into `setupRepository`
+
+Move the visibility check into `src/solve.repository.lib.mjs` and have
+`setupRepository` ignore `forkOwner` when the upstream is private and the
+user has write access.
+
+**Rejected because:** `setupRepository` is also reused by paths that may
+legitimately want the fork even on private repos in the future
+(e.g. cross-org workflows). Keeping the bypass in `solve.mjs` keeps the
+contract of `setupRepository` honest — when it receives a `forkOwner`, that's
+what it operates on.
+
+## Plan C (considered, rejected) — refuse to run + tell user to retry without continue mode
+
+Detect the situation and ask the user to re-run without the PR URL. This is
+strictly worse UX: the tool already has all the information it needs to do
+the right thing.
+
+## Verbose output (R4)
+
+`--verbose` already logs:
+
+- visibility (line 58 of the failing log: `Repository visibility: private`),
+- write-access probe (line 56),
+- the auto-fork decision (line 59),
+- continue-mode fork detection (line 74).
+
+The new bypass branch adds one more log line:
+
+```
+   Issue #1716: Working directly on the private upstream repository (skipping fork konard/anti-corruption)
+```
+
+This makes the decision visible **without** extra flags, satisfying R4.
+
+## Upstream reports (R5)
+
+None applicable. The bug is entirely inside `src/solve.mjs`'s fork-detection
+logic. The GitHub CLI and Anthropic API both behaved correctly in the failing
+run (`gh repo view <fork>` correctly returned 404; the failure is that we
+asked the question at all).

--- a/src/solve.fork-detection.lib.mjs
+++ b/src/solve.fork-detection.lib.mjs
@@ -1,0 +1,126 @@
+#!/usr/bin/env node
+
+/**
+ * Fork-detection helpers for solve.mjs
+ *
+ * Extracted from solve.mjs to keep the file under the 1500-line CI limit.
+ * - handleAutoForkOption: implements the --auto-fork detection branch.
+ * - handleMaintainerForkAccess: handles the
+ *   --allow-to-push-to-contributors-pull-requests-as-maintainer follow-up
+ *   that runs after a fork PR has been detected.
+ *
+ * Tests for Issue #1716 grep solve.mjs textually, so the *call sites* there
+ * still hold the canonical condition checks; only the bodies live here.
+ */
+
+if (typeof globalThis.use === 'undefined') {
+  globalThis.use = (await eval(await (await fetch('https://unpkg.com/use-m/use.js')).text())).use;
+}
+const use = globalThis.use;
+const { $ } = await use('command-stream');
+
+const lib = await import('./lib.mjs');
+const { log, ghCmdRetry } = lib;
+const githubLib = await import('./github.lib.mjs');
+
+/**
+ * Handle the --auto-fork option: when the user lacks write access to a public
+ * repository, automatically enable fork mode; when the repository is private,
+ * fail with an actionable error.
+ *
+ * Mutates argv.fork in place when fork mode is enabled.
+ *
+ * @param {object} params
+ * @param {string} params.owner
+ * @param {string} params.repo
+ * @param {object} params.argv - CLI arguments (mutated: argv.fork may be set)
+ * @param {(code: number, reason?: string) => Promise<void>} params.safeExit
+ */
+export async function handleAutoForkOption({ owner, repo, argv, safeExit }) {
+  if (!argv.autoFork || argv.fork) return;
+
+  const { detectRepositoryVisibility } = githubLib;
+  await log('🔍 Checking repository access for auto-fork...');
+  const permResult = await ghCmdRetry(() => $`gh api repos/${owner}/${repo} --jq .permissions`, { label: 'auto-fork perms' });
+
+  if (permResult.code === 0) {
+    const permissions = JSON.parse(permResult.stdout.toString().trim());
+    const hasWriteAccess = permissions.push === true || permissions.admin === true || permissions.maintain === true;
+
+    if (!hasWriteAccess) {
+      const { isPublic } = await detectRepositoryVisibility(owner, repo);
+
+      if (!isPublic) {
+        await log('');
+        await log("❌ --auto-fork failed: Repository is private and you don't have write access", { level: 'error' });
+        await log('');
+        await log('   🔍 What happened:', { level: 'error' });
+        await log(`      Repository ${owner}/${repo} is private`, { level: 'error' });
+        await log("      You don't have write access to this repository", { level: 'error' });
+        await log('      --auto-fork cannot create a fork of a private repository you cannot access', { level: 'error' });
+        await log('');
+        await log('   💡 Solution:', { level: 'error' });
+        await log('      • Request collaborator access from the repository owner', { level: 'error' });
+        await log(`        https://github.com/${owner}/${repo}/settings/access`, { level: 'error' });
+        await log('');
+        await safeExit(1, 'Auto-fork failed - private repository without access');
+        return;
+      }
+
+      await log('✅ Auto-fork: No write access detected, enabling fork mode');
+      argv.fork = true;
+    } else {
+      const { isPublic } = await detectRepositoryVisibility(owner, repo);
+      await log(`✅ Auto-fork: Write access detected to ${isPublic ? 'public' : 'private'} repository, working directly on repository`);
+    }
+  } else {
+    const { isPublic } = await detectRepositoryVisibility(owner, repo);
+
+    if (!isPublic) {
+      await log('');
+      await log('❌ --auto-fork failed: Could not verify permissions for private repository', { level: 'error' });
+      await log('');
+      await log('   🔍 What happened:', { level: 'error' });
+      await log(`      Repository ${owner}/${repo} is private`, { level: 'error' });
+      await log('      Could not check your permissions to this repository', { level: 'error' });
+      await log('');
+      await log('   💡 Solutions:', { level: 'error' });
+      await log('      • Check your GitHub CLI authentication: gh auth status', { level: 'error' });
+      await log("      • Request collaborator access if you don't have it yet", { level: 'error' });
+      await log(`        https://github.com/${owner}/${repo}/settings/access`, { level: 'error' });
+      await log('');
+      await safeExit(1, 'Auto-fork failed - cannot verify private repository permissions');
+      return;
+    }
+
+    await log('⚠️  Auto-fork: Could not check permissions, enabling fork mode for public repository');
+    argv.fork = true;
+  }
+}
+
+/**
+ * After a fork PR is detected, optionally check whether the maintainer can
+ * push directly to the contributor's fork. If not, request access.
+ *
+ * @param {object} params
+ * @param {string} params.owner
+ * @param {string} params.repo
+ * @param {string|number} params.prNumber
+ */
+export async function handleMaintainerForkAccess({ owner, repo, prNumber }) {
+  const { checkMaintainerCanModifyPR, requestMaintainerAccess } = githubLib;
+  const { canModify } = await checkMaintainerCanModifyPR(owner, repo, prNumber);
+
+  if (canModify) {
+    await log('✅ Maintainer can push to fork: Enabled by contributor');
+    await log("   Will push changes directly to contributor's fork instead of creating own fork");
+    return;
+  }
+
+  await log('⚠️  Maintainer cannot push to fork: "Allow edits by maintainers" is not enabled', { level: 'warning' });
+  await log('   Posting comment to request access...', { level: 'warning' });
+  await requestMaintainerAccess(owner, repo, prNumber);
+  await log('   Comment posted. Proceeding with own fork instead.', { level: 'warning' });
+}
+
+export default { handleAutoForkOption, handleMaintainerForkAccess };

--- a/src/solve.mjs
+++ b/src/solve.mjs
@@ -296,19 +296,26 @@ if (!entityCheck.valid) {
   await safeExit(1, `GitHub entity not found (${entityCheck.level})`);
 }
 
-// Detect repository visibility and set auto-cleanup default if not explicitly set
+// Detect repository visibility once and reuse for downstream decisions
+// (auto-cleanup default + Issue #1716 private-repo fork bypass)
+const { detectRepositoryVisibility } = githubLib;
+const { isPublic: isRepoPublic } = await detectRepositoryVisibility(owner, repo);
 if (argv.autoCleanup === undefined) {
-  const { detectRepositoryVisibility } = githubLib;
-  const { isPublic } = await detectRepositoryVisibility(owner, repo);
   // For public repos: keep temp directories (default false)
   // For private repos: clean up temp directories (default true)
-  argv.autoCleanup = !isPublic;
+  argv.autoCleanup = !isRepoPublic;
   if (argv.verbose) {
-    await log(`   Auto-cleanup default: ${argv.autoCleanup} (repository is ${isPublic ? 'public' : 'private'})`, {
+    await log(`   Auto-cleanup default: ${argv.autoCleanup} (repository is ${isRepoPublic ? 'public' : 'private'})`, {
       verbose: true,
     });
   }
 }
+// Issue #1716: When the upstream repository is private and the user has direct
+// write access, fork-based workflows should be skipped — even if the existing
+// PR was originally created from a fork. Forks of private repositories often
+// become inaccessible (renamed, deleted, parent re-private'd) and there's no
+// reason to use them when we can push branches and PRs to the upstream repo.
+const skipForkForPrivateUpstream = !isRepoPublic && !argv.fork && hasWriteAccess;
 // Determine mode and get issue details
 let issueNumber;
 let prNumber;
@@ -345,17 +352,25 @@ if (autoContinueResult.isContinueMode) {
           await log(`   Merge status: ${mergeStateStatus || 'UNKNOWN'}`, { verbose: true });
         }
         if (prCheckData.headRepositoryOwner && prCheckData.headRepositoryOwner.login !== owner) {
-          forkOwner = prCheckData.headRepositoryOwner.login;
-          // Get actual fork repository name (may be prefixed) and store for use in setupRepository
-          forkRepoName = prCheckData.headRepository && prCheckData.headRepository.name ? prCheckData.headRepository.name : null;
-          await log(`🍴 Detected fork PR from ${forkOwner}/${forkRepoName || repo}`);
-          if (argv.verbose) {
-            await log(`   Fork owner: ${forkOwner}`, { verbose: true });
-            await log('   Will clone fork repository for continue mode', { verbose: true });
+          const detectedForkOwner = prCheckData.headRepositoryOwner.login;
+          const detectedForkRepoName = prCheckData.headRepository && prCheckData.headRepository.name ? prCheckData.headRepository.name : null;
+          // Issue #1716: Skip fork mode for private upstream repos with write access.
+          if (skipForkForPrivateUpstream) {
+            await log(`🔒 Detected fork PR from ${detectedForkOwner}/${detectedForkRepoName || repo}, but upstream ${owner}/${repo} is private and you have write access.`);
+            await log('   Working directly on the private upstream repository (Issue #1716).');
+          } else {
+            forkOwner = detectedForkOwner;
+            // Get actual fork repository name (may be prefixed) and store for use in setupRepository
+            forkRepoName = detectedForkRepoName;
+            await log(`🍴 Detected fork PR from ${forkOwner}/${forkRepoName || repo}`);
+            if (argv.verbose) {
+              await log(`   Fork owner: ${forkOwner}`, { verbose: true });
+              await log('   Will clone fork repository for continue mode', { verbose: true });
+            }
           }
 
           // Check if maintainer can push to the fork when --allow-to-push-to-contributors-pull-requests-as-maintainer is enabled
-          if (argv.allowToPushToContributorsPullRequestsAsMaintainer && argv.autoFork) {
+          if (forkOwner && argv.allowToPushToContributorsPullRequestsAsMaintainer && argv.autoFork) {
             const { checkMaintainerCanModifyPR, requestMaintainerAccess } = githubLib;
             const { canModify } = await checkMaintainerCanModifyPR(owner, repo, prNumber);
 
@@ -425,17 +440,25 @@ if (isPrUrl) {
     prState = prData.state;
     // Check if this is a fork PR
     if (prData.headRepositoryOwner && prData.headRepositoryOwner.login !== owner) {
-      forkOwner = prData.headRepositoryOwner.login;
-      // Get actual fork repository name and store for use in setupRepository
-      forkRepoName = prData.headRepository && prData.headRepository.name ? prData.headRepository.name : null;
-      await log(`🍴 Detected fork PR from ${forkOwner}/${forkRepoName || repo}`);
-      if (argv.verbose) {
-        await log(`   Fork owner: ${forkOwner}`, { verbose: true });
-        await log('   Will clone fork repository for continue mode', { verbose: true });
+      const detectedForkOwner = prData.headRepositoryOwner.login;
+      const detectedForkRepoName = prData.headRepository && prData.headRepository.name ? prData.headRepository.name : null;
+      // Issue #1716: Skip fork mode for private upstream repos with write access.
+      if (skipForkForPrivateUpstream) {
+        await log(`🔒 Detected fork PR from ${detectedForkOwner}/${detectedForkRepoName || repo}, but upstream ${owner}/${repo} is private and you have write access.`);
+        await log('   Working directly on the private upstream repository (Issue #1716).');
+      } else {
+        forkOwner = detectedForkOwner;
+        // Get actual fork repository name and store for use in setupRepository
+        forkRepoName = detectedForkRepoName;
+        await log(`🍴 Detected fork PR from ${forkOwner}/${forkRepoName || repo}`);
+        if (argv.verbose) {
+          await log(`   Fork owner: ${forkOwner}`, { verbose: true });
+          await log('   Will clone fork repository for continue mode', { verbose: true });
+        }
       }
 
       // Check if maintainer can push to the fork when --allow-to-push-to-contributors-pull-requests-as-maintainer is enabled
-      if (argv.allowToPushToContributorsPullRequestsAsMaintainer && argv.autoFork) {
+      if (forkOwner && argv.allowToPushToContributorsPullRequestsAsMaintainer && argv.autoFork) {
         const { checkMaintainerCanModifyPR, requestMaintainerAccess } = githubLib;
         const { canModify } = await checkMaintainerCanModifyPR(owner, repo, prNumber);
 

--- a/src/solve.mjs
+++ b/src/solve.mjs
@@ -58,6 +58,7 @@ const { postTrackedComment, USAGE_LIMIT_REACHED_MARKER } = await import('./tool-
 const { prepareFeedbackAndTimestamps, checkUncommittedChanges, checkForkActions } = await import('./solve.preparation.lib.mjs');
 const { validateAndExitOnInvalidModel } = await import('./models/index.mjs');
 const { autoAcceptInviteForRepo } = await import('./solve.accept-invite.lib.mjs');
+const { handleAutoForkOption, handleMaintainerForkAccess } = await import('./solve.fork-detection.lib.mjs');
 // Initialize log file early (before argument parsing) to capture all output
 const logFile = await initializeLogFile(null);
 // Log version and raw command IMMEDIATELY after log file initialization
@@ -209,73 +210,7 @@ if (argv.autoAcceptInvite) {
   await autoAcceptInviteForRepo(owner, repo, log, argv.verbose);
 }
 // Handle --auto-fork option: automatically fork public repositories without write access
-if (argv.autoFork && !argv.fork) {
-  const { detectRepositoryVisibility } = githubLib;
-  // Check if we have write access first (issue #1536: retry on transient network errors)
-  await log('🔍 Checking repository access for auto-fork...');
-  const permResult = await lib.ghCmdRetry(() => $`gh api repos/${owner}/${repo} --jq .permissions`, { label: 'auto-fork perms' });
-
-  if (permResult.code === 0) {
-    const permissions = JSON.parse(permResult.stdout.toString().trim());
-    const hasWriteAccess = permissions.push === true || permissions.admin === true || permissions.maintain === true;
-
-    if (!hasWriteAccess) {
-      // No write access - check if repository is public before enabling fork mode
-      const { isPublic } = await detectRepositoryVisibility(owner, repo);
-
-      if (!isPublic) {
-        // Private repository without write access - cannot fork
-        await log('');
-        await log("❌ --auto-fork failed: Repository is private and you don't have write access", { level: 'error' });
-        await log('');
-        await log('   🔍 What happened:', { level: 'error' });
-        await log(`      Repository ${owner}/${repo} is private`, { level: 'error' });
-        await log("      You don't have write access to this repository", { level: 'error' });
-        await log('      --auto-fork cannot create a fork of a private repository you cannot access', {
-          level: 'error',
-        });
-        await log('');
-        await log('   💡 Solution:', { level: 'error' });
-        await log('      • Request collaborator access from the repository owner', { level: 'error' });
-        await log(`        https://github.com/${owner}/${repo}/settings/access`, { level: 'error' });
-        await log('');
-        await safeExit(1, 'Auto-fork failed - private repository without access');
-      }
-
-      // Public repository without write access - automatically enable fork mode
-      await log('✅ Auto-fork: No write access detected, enabling fork mode');
-      argv.fork = true;
-    } else {
-      // Has write access - work directly on the repo (works for both public and private repos)
-      const { isPublic } = await detectRepositoryVisibility(owner, repo);
-      await log(`✅ Auto-fork: Write access detected to ${isPublic ? 'public' : 'private'} repository, working directly on repository`);
-    }
-  } else {
-    // Could not check permissions - assume no access and try to fork if public
-    const { isPublic } = await detectRepositoryVisibility(owner, repo);
-
-    if (!isPublic) {
-      // Cannot determine permissions for private repo - fail safely
-      await log('');
-      await log('❌ --auto-fork failed: Could not verify permissions for private repository', { level: 'error' });
-      await log('');
-      await log('   🔍 What happened:', { level: 'error' });
-      await log(`      Repository ${owner}/${repo} is private`, { level: 'error' });
-      await log('      Could not check your permissions to this repository', { level: 'error' });
-      await log('');
-      await log('   💡 Solutions:', { level: 'error' });
-      await log('      • Check your GitHub CLI authentication: gh auth status', { level: 'error' });
-      await log("      • Request collaborator access if you don't have it yet", { level: 'error' });
-      await log(`        https://github.com/${owner}/${repo}/settings/access`, { level: 'error' });
-      await log('');
-      await safeExit(1, 'Auto-fork failed - cannot verify private repository permissions');
-    }
-
-    // Public repository but couldn't check permissions - assume no access and fork
-    await log('⚠️  Auto-fork: Could not check permissions, enabling fork mode for public repository');
-    argv.fork = true;
-  }
-}
+await handleAutoForkOption({ owner, repo, argv, safeExit });
 // Permission check BEFORE entity validation (#1552): avoids false 404 on private repos without access
 const { checkRepositoryWritePermission } = githubLib;
 const hasWriteAccess = await checkRepositoryWritePermission(owner, repo, {
@@ -371,21 +306,7 @@ if (autoContinueResult.isContinueMode) {
 
           // Check if maintainer can push to the fork when --allow-to-push-to-contributors-pull-requests-as-maintainer is enabled
           if (forkOwner && argv.allowToPushToContributorsPullRequestsAsMaintainer && argv.autoFork) {
-            const { checkMaintainerCanModifyPR, requestMaintainerAccess } = githubLib;
-            const { canModify } = await checkMaintainerCanModifyPR(owner, repo, prNumber);
-
-            if (canModify) {
-              await log('✅ Maintainer can push to fork: Enabled by contributor');
-              await log("   Will push changes directly to contributor's fork instead of creating own fork");
-              // Don't disable fork mode, but we'll use the contributor's fork
-            } else {
-              await log('⚠️  Maintainer cannot push to fork: "Allow edits by maintainers" is not enabled', {
-                level: 'warning',
-              });
-              await log('   Posting comment to request access...', { level: 'warning' });
-              await requestMaintainerAccess(owner, repo, prNumber);
-              await log('   Comment posted. Proceeding with own fork instead.', { level: 'warning' });
-            }
+            await handleMaintainerForkAccess({ owner, repo, prNumber });
           }
         }
       }
@@ -459,21 +380,7 @@ if (isPrUrl) {
 
       // Check if maintainer can push to the fork when --allow-to-push-to-contributors-pull-requests-as-maintainer is enabled
       if (forkOwner && argv.allowToPushToContributorsPullRequestsAsMaintainer && argv.autoFork) {
-        const { checkMaintainerCanModifyPR, requestMaintainerAccess } = githubLib;
-        const { canModify } = await checkMaintainerCanModifyPR(owner, repo, prNumber);
-
-        if (canModify) {
-          await log('✅ Maintainer can push to fork: Enabled by contributor');
-          await log("   Will push changes directly to contributor's fork instead of creating own fork");
-          // Don't disable fork mode, but we'll use the contributor's fork
-        } else {
-          await log('⚠️  Maintainer cannot push to fork: "Allow edits by maintainers" is not enabled', {
-            level: 'warning',
-          });
-          await log('   Posting comment to request access...', { level: 'warning' });
-          await requestMaintainerAccess(owner, repo, prNumber);
-          await log('   Comment posted. Proceeding with own fork instead.', { level: 'warning' });
-        }
+        await handleMaintainerForkAccess({ owner, repo, prNumber });
       }
     }
     await log(`📝 PR branch: ${prBranch}`);

--- a/tests/test-issue-1332-fork-name-from-pr-data.mjs
+++ b/tests/test-issue-1332-fork-name-from-pr-data.mjs
@@ -48,8 +48,12 @@ runTest('solve.mjs declares forkRepoName at outer scope', () => {
 runTest('solve.mjs stores forkRepoName from headRepository in auto-continue path', () => {
   const content = execSync(`cat ${srcDir}/solve.mjs`, { encoding: 'utf8' });
 
-  // Check for the assignment (not declaration with const)
-  if (!content.includes('forkRepoName = prCheckData.headRepository && prCheckData.headRepository.name ? prCheckData.headRepository.name : null;')) {
+  // After the Issue #1716 refactor, the value is read into a local
+  // `detectedForkRepoName` first and then assigned to `forkRepoName` in the
+  // non-bypass branch. Either form satisfies #1332.
+  const oldShape = content.includes('forkRepoName = prCheckData.headRepository && prCheckData.headRepository.name ? prCheckData.headRepository.name : null;');
+  const newShape = content.includes('detectedForkRepoName = prCheckData.headRepository && prCheckData.headRepository.name ? prCheckData.headRepository.name : null;') && content.includes('forkRepoName = detectedForkRepoName;');
+  if (!oldShape && !newShape) {
     throw new Error('forkRepoName not stored from prCheckData.headRepository.name in auto-continue path');
   }
 });
@@ -58,7 +62,9 @@ runTest('solve.mjs stores forkRepoName from headRepository in auto-continue path
 runTest('solve.mjs stores forkRepoName from headRepository in PR URL path', () => {
   const content = execSync(`cat ${srcDir}/solve.mjs`, { encoding: 'utf8' });
 
-  if (!content.includes('forkRepoName = prData.headRepository && prData.headRepository.name ? prData.headRepository.name : null;')) {
+  const oldShape = content.includes('forkRepoName = prData.headRepository && prData.headRepository.name ? prData.headRepository.name : null;');
+  const newShape = content.includes('detectedForkRepoName = prData.headRepository && prData.headRepository.name ? prData.headRepository.name : null;') && content.includes('forkRepoName = detectedForkRepoName;');
+  if (!oldShape && !newShape) {
     throw new Error('forkRepoName not stored from prData.headRepository.name in PR URL path');
   }
 });

--- a/tests/test-issue-1716-private-repo-skip-fork.mjs
+++ b/tests/test-issue-1716-private-repo-skip-fork.mjs
@@ -1,0 +1,177 @@
+#!/usr/bin/env node
+// @hive-mind-test-suite default
+
+/**
+ * Test suite for Issue #1716 fix: Skip fork when upstream repository is private
+ *
+ * Bug: When a PR was originally created from a fork (e.g., the upstream repo
+ * was public at the time and the user without write access used --auto-fork),
+ * but the upstream is now private and the user has direct write access, the
+ * tool still tries to clone the fork. If the fork is renamed or no longer
+ * accessible, repository setup fails.
+ *
+ * Fix: When the upstream repository is private and the user has write access,
+ * skip fork mode regardless of the PR's head repository — work directly on the
+ * upstream repository using regular branches.
+ */
+
+import { execSync } from 'child_process';
+import { fileURLToPath } from 'url';
+import { dirname, join } from 'path';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+const srcDir = join(__dirname, '..', 'src');
+
+let testsPassed = 0;
+let testsFailed = 0;
+
+function runTest(name, testFn) {
+  process.stdout.write(`Testing ${name}... `);
+  try {
+    testFn();
+    console.log('✅ PASSED');
+    testsPassed++;
+  } catch (error) {
+    console.log(`❌ FAILED: ${error.message}`);
+    testsFailed++;
+  }
+}
+
+const solveContent = execSync(`cat ${srcDir}/solve.mjs`, { encoding: 'utf8' });
+
+// Test 1: solve.mjs computes a single visibility-aware bypass flag
+runTest('solve.mjs computes skipForkForPrivateUpstream flag', () => {
+  if (!solveContent.includes('const skipForkForPrivateUpstream =')) {
+    throw new Error('skipForkForPrivateUpstream flag not declared in solve.mjs');
+  }
+});
+
+// Test 2: bypass requires private upstream + no explicit --fork + write access
+runTest('bypass requires !isRepoPublic && !argv.fork && hasWriteAccess', () => {
+  if (!solveContent.includes('!isRepoPublic && !argv.fork && hasWriteAccess')) {
+    throw new Error('skipForkForPrivateUpstream condition is not (!isRepoPublic && !argv.fork && hasWriteAccess)');
+  }
+});
+
+// Test 3: visibility detection is performed unconditionally (not gated on autoCleanup)
+runTest('visibility detection runs unconditionally', () => {
+  // The fix moves the detectRepositoryVisibility call out of the `if (argv.autoCleanup === undefined)` block
+  if (!solveContent.includes('const { isPublic: isRepoPublic } = await detectRepositoryVisibility(owner, repo);')) {
+    throw new Error('isRepoPublic not detected unconditionally before fork-detection paths');
+  }
+});
+
+// Test 4: bypass references issue #1716 in code comments
+runTest('bypass references issue #1716', () => {
+  if (!solveContent.includes('Issue #1716')) {
+    throw new Error('Bypass should reference Issue #1716 for traceability');
+  }
+});
+
+// Test 5: bypass message mentions working directly on upstream
+runTest('bypass logs working directly on private upstream', () => {
+  if (!solveContent.includes('Working directly on the private upstream repository')) {
+    throw new Error('Bypass should log a message about working on upstream directly');
+  }
+});
+
+// Test 6: bypass is applied in the auto-continue / processAutoContinueForIssue path
+runTest('bypass applied in auto-continue PR-detection path', () => {
+  // Ensure the detected fork variables are gated by skipForkForPrivateUpstream
+  // in the auto-continue branch (where prCheckData is parsed)
+  const autoContinueIdx = solveContent.indexOf('prCheckData.headRepositoryOwner.login');
+  const skipFlagIdxAfter = solveContent.indexOf('if (skipForkForPrivateUpstream)', autoContinueIdx);
+  if (autoContinueIdx === -1 || skipFlagIdxAfter === -1) {
+    throw new Error('Auto-continue path does not consult skipForkForPrivateUpstream');
+  }
+});
+
+// Test 7: bypass is applied in the direct PR-URL path
+runTest('bypass applied in direct PR URL path', () => {
+  // The path that uses prData.headRepositoryOwner — must also consult the flag
+  const prDataIdx = solveContent.indexOf('prData.headRepositoryOwner.login');
+  const skipFlagIdxAfter = solveContent.indexOf('if (skipForkForPrivateUpstream)', prDataIdx);
+  if (prDataIdx === -1 || skipFlagIdxAfter === -1) {
+    throw new Error('Direct PR-URL path does not consult skipForkForPrivateUpstream');
+  }
+});
+
+// Test 8: when bypass triggers, forkOwner remains null
+runTest('bypass leaves forkOwner null', () => {
+  // In the bypass branch, we should NOT assign to forkOwner
+  // We verify this structurally by ensuring the assignment to forkOwner is
+  // inside an `else` of skipForkForPrivateUpstream, not a sibling.
+  const pattern = /if \(skipForkForPrivateUpstream\) \{[\s\S]*?\} else \{\s*forkOwner = detectedForkOwner;/g;
+  const matches = solveContent.match(pattern);
+  if (!matches || matches.length < 2) {
+    throw new Error('forkOwner assignment is not gated behind the !skipForkForPrivateUpstream branch in both fork-detection paths');
+  }
+});
+
+// Test 9: maintainer-modify check is gated by forkOwner being set
+runTest('maintainer-modify check requires forkOwner', () => {
+  // After the fix, the `if (argv.allowToPushToContributorsPullRequestsAsMaintainer && argv.autoFork)`
+  // block must require forkOwner so it doesn't run when bypass triggered
+  const occurrences = solveContent.split('if (forkOwner && argv.allowToPushToContributorsPullRequestsAsMaintainer && argv.autoFork)').length - 1;
+  if (occurrences < 2) {
+    throw new Error('maintainer-modify branch does not require forkOwner in both fork-detection paths');
+  }
+});
+
+// Test 10: scenario simulation — private repo, user has write access, PR from fork
+runTest('scenario: private upstream + write access + fork PR → bypass', () => {
+  const isRepoPublic = false; // private
+  const hasWriteAccess = true;
+  const argvFork = false; // user did not pass --fork explicitly
+
+  const skipForkForPrivateUpstream = !isRepoPublic && !argvFork && hasWriteAccess;
+  if (!skipForkForPrivateUpstream) {
+    throw new Error('Expected bypass to trigger for private upstream with write access and no --fork');
+  }
+});
+
+// Test 11: scenario simulation — public repo with fork PR should NOT bypass
+runTest('scenario: public upstream + fork PR → no bypass', () => {
+  const isRepoPublic = true;
+  const hasWriteAccess = true;
+  const argvFork = false;
+
+  const skipForkForPrivateUpstream = !isRepoPublic && !argvFork && hasWriteAccess;
+  if (skipForkForPrivateUpstream) {
+    throw new Error('Bypass should NOT trigger for public upstream repositories');
+  }
+});
+
+// Test 12: scenario — explicit --fork should NOT bypass
+runTest('scenario: explicit --fork on private repo → no bypass', () => {
+  const isRepoPublic = false;
+  const hasWriteAccess = true;
+  const argvFork = true;
+
+  const skipForkForPrivateUpstream = !isRepoPublic && !argvFork && hasWriteAccess;
+  if (skipForkForPrivateUpstream) {
+    throw new Error('Bypass should NOT trigger when --fork was passed explicitly');
+  }
+});
+
+// Test 13: scenario — private repo without write access (auto-fork failure case) → no bypass
+runTest('scenario: private upstream + no write access → no bypass', () => {
+  const isRepoPublic = false;
+  const hasWriteAccess = false;
+  const argvFork = false;
+
+  const skipForkForPrivateUpstream = !isRepoPublic && !argvFork && hasWriteAccess;
+  if (skipForkForPrivateUpstream) {
+    throw new Error('Bypass should NOT trigger when user lacks write access (no fallback would be possible)');
+  }
+});
+
+// Summary
+console.log('\n' + '='.repeat(60));
+console.log('Test Results for Issue #1716 (Skip fork for private upstream):');
+console.log(`  ✅ Passed: ${testsPassed}`);
+console.log(`  ❌ Failed: ${testsFailed}`);
+console.log('='.repeat(60));
+
+process.exit(testsFailed > 0 ? 1 : 0);


### PR DESCRIPTION
## Summary

- **Root cause.** `src/solve.mjs` already bypasses `--auto-fork` when upstream is private and the user has write access, but **continue-mode fork detection** (both auto-continue via `prCheckData.headRepository*` and direct PR-URL via `prData.headRepository*`) unconditionally re-set `forkOwner` from the existing PR's head, overriding that bypass. Downstream, `setupRepository` then tried to clone a fork that may have been renamed, deleted, or never existed — producing **"Fork not accessible"** even though the upstream is fully writable.
- **Fix.** Hoist `detectRepositoryVisibility(owner, repo)` out of the `if (argv.autoCleanup === undefined)` block so `isRepoPublic` is always in scope. Compute `skipForkForPrivateUpstream = !isRepoPublic && !argv.fork && hasWriteAccess` once, and gate **both** fork-from-PR-data branches behind it. When the bypass triggers, log a clear message and leave `forkOwner = null`, so the regular non-fork code path runs against the private upstream. Also gate the maintainer-modify auto-toggle on `forkOwner &&` so it doesn't fire when the bypass triggered.
- **Scope.** Minimal blast radius — change is local to `src/solve.mjs`; no signature changes in `setupRepositoryAndClone` / `setupRepository`. Reuses existing `detectRepositoryVisibility` and `hasWriteAccess`. The explicit `--fork` flag still wins. When the user has no write access, `hasWriteAccess` is `false` and the bypass does not trigger — auto-fork's existing rules apply.

## How to reproduce

1. Create a fork of a public repo, open a PR from the fork.
2. Make the upstream **private**, grant the user **push** access.
3. Run `solve <PR URL>`.
   - **Before:** `setupRepository` constructs `forkOwner/<headRepoName>`, calls `gh repo view`, gets 404 if the fork was renamed/deleted/re-privated → **"Fork not accessible"** + exit 1.
   - **After:** logs `Issue #1716: Working directly on the private upstream repository (skipping fork ...)`, leaves `forkOwner = null`, and clones the upstream directly.

## Test plan

- [x] New: `tests/test-issue-1716-private-repo-skip-fork.mjs` — 13 tests, all passing. Covers flag declaration, exact condition formula, unconditional visibility detection, the bypass log message, both fork-detection paths, `forkOwner` gating on maintainer-modify, and scenario simulations (private+writeAccess → bypass; public → no bypass; `--fork` → no bypass; no writeAccess → no bypass).
- [x] Existing: `tests/test-issue-1332-fork-name-from-pr-data.mjs` — 14/14 passing (tests #2 and #3 updated to accept the refactored `detectedForkRepoName` local).
- [x] Existing: `tests/test-fork-parent-validation.mjs` (23 tests), `tests/test-fork-screenshot.mjs` (21 tests) — all passing.
- [x] `npm run lint` — passing.
- [x] `npm run format:check` — passing.
- [x] Case study compiled to `docs/case-studies/issue-1716/` per R3 (README, facts, root-causes, solution-plans, raw issue JSON, full failure log).
- [x] Changeset added: `.changeset/issue-1716-skip-fork-private-upstream.md` (patch bump).

Fixes #1716