### PR TITLE
fix(ci): pre-install use-m @latest packages with retry to stop ENOTEMPTY flake

### DIFF
--- a/.changeset/issue-1724-preinstall-use-m-packages.md
+++ b/.changeset/issue-1724-preinstall-use-m-packages.md
@@ -1,0 +1,63 @@
+---
+'@link-assistant/hive-mind': patch
+---
+
+Fix flaky CI `test-suites` job caused by `use-m`'s no-retry global npm install
+— issue #1724.
+
+CI run [25109962685](https://github.com/link-assistant/hive-mind/actions/runs/25109962685/job/73581228475)
+on `main` failed in the `test-suites` job at the third test file
+(`tests/test-active-branch-runs-buffer-1722.mjs`) with:
+
+```
+Error: Failed to install command-stream@latest globally.
+  [cause]: Error: Command failed: npm install -g command-stream-v-latest@npm:command-stream@latest
+  npm error code ENOTEMPTY
+  npm error path /opt/hostedtoolcache/node/24.14.1/x64/lib/node_modules/command-stream-v-latest/js/src/commands
+```
+
+Root cause: `src/github.lib.mjs` and `src/playwright-mcp.lib.mjs` call
+`await use('command-stream')` at module top level (via `use-m`). Every test
+file that transitively imports either module re-runs
+`npm install -g command-stream-v-latest@npm:command-stream@latest`. `use-m`'s
+`ensurePackageInstalled` issues a single `npm install -g` with no retry, and
+npm intermittently fails with `ENOTEMPTY: directory not empty, rmdir` on
+GitHub-hosted Ubuntu runners (a long-standing npm rmdir race against itself
+when the previous global install left files behind).
+
+Fix:
+
+- New
+  [`scripts/preinstall-use-m-packages.mjs`](./scripts/preinstall-use-m-packages.mjs)
+  pre-installs every package the codebase loads through `use-m @latest`
+  (`command-stream`, `getenv`, `links-notation`, `@dotenvx/dotenvx`,
+  `telegraf`, `zx`, `yargs`) using the same alias scheme `use-m` does
+  (`<pkg-without-@-or-/>-v-latest`), with exponential-backoff retry on the
+  flake symptoms (`ENOTEMPTY` / `EBUSY` / `EPERM` / `ECONNRESET` / `ETIMEDOUT`
+  / `EAI_AGAIN` / `429` / `503`). After this step, `use-m`'s
+  `installedVersion === latestVersion` early-return path skips the install at
+  test time, so test imports never touch `npm install -g` again.
+- The script also satisfies the case-study "verbose mode for next iteration"
+  requirement via `PREINSTALL_USE_M_VERBOSE=1` (or `RUNNER_DEBUG=1`), which
+  logs each attempt's command, stdout, stderr, and backoff delay, and
+  recognizes "package present on disk after a flake" as recovered success.
+- Wires `node scripts/preinstall-use-m-packages.mjs` into the `test-suites`
+  and `test-execution` jobs in
+  [`.github/workflows/release.yml`](./.github/workflows/release.yml) right
+  after `npm install`, before any step that runs test files or `solve.mjs`.
+
+Tests:
+[`tests/test-preinstall-use-m-packages-1724.mjs`](./tests/test-preinstall-use-m-packages-1724.mjs)
+covers the alias scheme, retryable-error matcher, exponential backoff, and
+the four `installWithRetry` paths (first-success, retry-then-succeed,
+non-retryable-abort, recovered-from-disk) deterministically (no real npm
+calls). Marked `@hive-mind-test-suite default` so it runs in the same job
+that previously flaked.
+
+Documentation:
+[`docs/case-studies/issue-1724/`](./docs/case-studies/issue-1724/README.md)
+contains the timeline, verbatim error, downloaded failed-run logs, the
+no-retry snippet from the live `use-m` source
+(`logs/use-m-source.js`), the comparison with both pipeline templates
+(JS/Rust — neither template uses `use-m @latest` at module load yet, so the
+flake is hive-mind-specific until they do), and the implementation plan.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -271,6 +271,9 @@ jobs:
       - name: Install dependencies
         run: npm install
 
+      - name: Pre-install use-m packages (issue #1724)
+        run: node scripts/preinstall-use-m-packages.mjs
+
       - name: Run default test suite
         run: npm test
 
@@ -305,6 +308,9 @@ jobs:
 
       - name: Install dependencies
         run: npm install
+
+      - name: Pre-install use-m packages (issue #1724)
+        run: node scripts/preinstall-use-m-packages.mjs
 
       - name: Test solve.mjs execution
         run: |

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,2 +1,3 @@
 # .gitkeep file auto-generated at 2026-04-15T05:07:05.365Z for PR creation at branch issue-1603-d47eafcfffb1 for issue https://github.com/link-assistant/hive-mind/issues/1603
 # Updated: 2026-04-17T19:04:16.770Z
+# Updated: 2026-04-29T15:47:02.730Z

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,3 +1,2 @@
 # .gitkeep file auto-generated at 2026-04-15T05:07:05.365Z for PR creation at branch issue-1603-d47eafcfffb1 for issue https://github.com/link-assistant/hive-mind/issues/1603
 # Updated: 2026-04-17T19:04:16.770Z
-# Updated: 2026-04-29T15:47:02.730Z

--- a/.prettierignore
+++ b/.prettierignore
@@ -27,6 +27,7 @@ docs/case-studies/**/source-data/**/*.json
 docs/case-studies/**/working-session-logs/**/*.json
 docs/case-studies/**/logs/**/*.md
 docs/case-studies/issue-1639/data/
+docs/case-studies/issue-1724/data/use-m-source.js
 docs/case-studies/issue-731-unable-to-solve-space-compiler/commits-response.json
 docs/case-studies/issue-789-unrecognized-model-error/full-log.json
 

--- a/docs/case-studies/issue-1724/README.md
+++ b/docs/case-studies/issue-1724/README.md
@@ -1,0 +1,144 @@
+# Case Study: Issue #1724 — Fix CI/CD
+
+## Summary
+
+CI run [25109962685](https://github.com/link-assistant/hive-mind/actions/runs/25109962685/job/73581228475) on `main`
+failed in the `test-suites` job. The root cause is a **flaky `npm install -g` triggered by `use-m`** during test
+file imports — npm intermittently fails with `ENOTEMPTY: directory not empty, rmdir` when reinstalling a global
+package whose previous install left files behind.
+
+Tests do not actually need the package being installed (`command-stream`); the install is a side effect of importing
+production source files from a test file.
+
+## Timeline of Events
+
+| Time (UTC) | Event |
+| --- | --- |
+| 2026-04-29 12:53:01 | Push to `main` (sha `074a781d`) triggers run 25109962685. |
+| 2026-04-29 12:54:13 | `test-suites` job starts on `ubuntu-24.04`, Node 24.14.1, npm 11.11.0. |
+| 2026-04-29 12:54:33 | `npm install` finishes; `npm test` starts (`scripts/run-tests.mjs --suite default`). |
+| 2026-04-29 12:54:33 | `[1/75] tests/limits-display.test.mjs` — passes. |
+| 2026-04-29 12:54:36 | `[2/75] tests/<…>` — passes. |
+| 2026-04-29 12:54:37 | `[3/75] tests/test-active-branch-runs-buffer-1722.mjs` starts. |
+| 2026-04-29 12:54:39 | The test file imports `src/github-merge.lib.mjs` → `src/github.lib.mjs` (top-level `await use('command-stream')` via `use-m`). `npm install -g command-stream-v-latest@npm:command-stream@latest` fails with `ENOTEMPTY`. The whole test file aborts; `run-tests.mjs` exits 1; the job ends with `exit code 1`. |
+
+A previous run (25072975006, 2026-04-28 19:21) failed in the same step with a sibling symptom: `Failed to resolve the
+path to 'getenv' from '…/getenv-v-latest'` — also a `use-m` install path race, this time leaving a partial install.
+
+## Verbatim Error (run 25109962685)
+
+```
+[3/75] tests/test-active-branch-runs-buffer-1722.mjs
+<anonymous_script>:557
+        throw new Error(`Failed to install ${packageName}@${version} globally.`, { cause: error });
+
+Error: Failed to install command-stream@latest globally.
+    at ensurePackageInstalled (eval at <anonymous>
+        (file:///home/runner/work/hive-mind/hive-mind/src/playwright-mcp.lib.mjs:4:27),
+     <anonymous>:557:15)
+  [cause]: Error: Command failed: npm install -g command-stream-v-latest@npm:command-stream@latest
+  npm error code ENOTEMPTY
+  npm error syscall rmdir
+  npm error path /opt/hostedtoolcache/node/24.14.1/x64/lib/node_modules/command-stream-v-latest/js/src/commands
+  npm error errno -39
+  npm error ENOTEMPTY: directory not empty, rmdir '…/command-stream-v-latest/js/src/commands'
+```
+
+Full logs are in `data/run-25109962685-failed.txt` and `data/run-25072975006-failed.txt`. The current `use-m` source
+(`data/use-m-source.js`) shows that `ensurePackageInstalled` issues a single `npm install -g <alias>@npm:<pkg>@latest`
+with no retry.
+
+## Requirements (from the issue)
+
+1. Find the root cause of the failing CI run.
+2. Fix it.
+3. Apply the same kind of best practice across all GitHub workflow / CI scripts; if the same bug exists in the
+   templates, report it there.
+4. Compile data and a deep case study under `./docs/case-studies/issue-{id}`.
+5. If we can't pinpoint the root cause, add debug output / verbose mode for the next iteration.
+6. Where the cause is in another repo we can file issues against, file an issue with reproducer + workaround +
+   suggested fix.
+
+## Root Cause
+
+`use-m`'s `ensurePackageInstalled` runs `npm install -g <alias>@npm:<pkg>@<version>` for any
+`await use('<pkg>@latest')` call. Several modules in `src/` perform this at module top level
+(e.g. `src/github.lib.mjs`, `src/playwright-mcp.lib.mjs`):
+
+```js
+if (typeof globalThis.use === 'undefined')
+  globalThis.use = (await eval(await (await fetch('https://unpkg.com/use-m/use.js')).text())).use;
+const { $ } = await use('command-stream');
+```
+
+Therefore **every test file that transitively imports one of those modules triggers an `npm install -g` of
+`command-stream@latest` (and friends)** — even when the test never uses `$`.
+
+`npm install -g` of an existing global package occasionally fails with `ENOTEMPTY` on Ubuntu runners. This is a
+long-standing npm rmdir race when contents of `node_modules/<pkg>/<…>` are still being written or held open while npm
+tries to remove the previous install (npm/cli#4825 and similar). `use-m` does **not** retry; the first failure ends
+the test file with exit 1.
+
+## Why It's Hard to Reproduce
+
+- Only happens when the package is already present from a previous test or job, so first invocation passes.
+- `--depth=1` checkouts and the GitHub-hosted runner cache make timing non-deterministic.
+- Tests run sequentially in `scripts/run-tests.mjs`, so the failing import is the same in every run, but the npm race
+  may or may not fire.
+
+## Solution
+
+Two complementary mitigations:
+
+1. **Pre-install `use-m` "latest" packages once with retries before running tests.**
+   `use-m` keys the early-return on `installedVersion === latestVersion`. If we pre-install
+   `command-stream@latest`, `getenv@latest`, `@dotenvx/dotenvx@latest`, `links-notation@latest`,
+   `telegraf@latest`, `yargs@latest`, `zx@latest` with a retry loop, every later `await use('<pkg>')` in tests is a
+   no-op and never touches `npm install -g`.
+
+2. **Wire that step into `test-suites` and `test-execution`** workflow jobs (the two CI jobs that hit `npm test` /
+   `solve.mjs`).
+
+The retry script also gives us a single place to add verbose logging for future failures (requirement #5 above).
+
+## Why Not Patch `use-m`
+
+`use-m` is a separate project (link-foundation/use-m). The right place to add retry behaviour is upstream, but our CI
+must not depend on a synchronous fix there. We address that separately (see "Upstream Issue" below).
+
+## Implementation Plan
+
+| Step | File | Change |
+| --- | --- | --- |
+| 1 | `scripts/preinstall-use-m-packages.mjs` (new) | Pre-install the `latest` packages used by `use-m` with retry on `ENOTEMPTY`/`EBUSY`/network errors; emit verbose progress. |
+| 2 | `package.json` | Add a `preinstall:use-m` npm script that calls the above. |
+| 3 | `.github/workflows/release.yml` | Run `node scripts/preinstall-use-m-packages.mjs` after `npm install` in `test-suites` and `test-execution`, before `npm test`. |
+| 4 | `tests/test-preinstall-use-m-packages.mjs` (new) | Unit-test the retry helper deterministically (no real npm calls). |
+| 5 | `docs/case-studies/issue-1724/` | This case study. |
+
+## Templates
+
+Both `link-foundation/js-ai-driven-development-pipeline-template` (saved under `templates/js-template/`) and
+`link-foundation/rust-ai-driven-development-pipeline-template` (`templates/rust-template/`) define their `test`
+jobs with `npm install` then `npm test` and **do not** pre-install `use-m` packages. That's correct for them today
+because their template code does not currently use `use-m` `@latest` aliases at module load time (the rust template
+doesn't run JS tests at all). The flake is hive-mind-specific until those templates start using `use-m`.
+
+If/when those templates adopt the same `await use('<pkg>@latest')` pattern at module load, the same fix should be
+back-ported. We are **not** opening template issues now to avoid noise; this case study documents the trigger
+condition for future maintainers.
+
+## Upstream Issue
+
+A separate issue should be filed against `link-foundation/use-m` proposing a built-in retry on `ENOTEMPTY`/`EBUSY`
+errors with exponential backoff (3 attempts is sufficient based on observed behaviour). That issue is tracked as
+follow-up; this PR fixes the symptom in hive-mind without waiting on upstream.
+
+## Files in This Case Study
+
+- `README.md` — this document
+- `data/run-25109962685-failed.txt` — full failed-step log for the run named in issue #1724
+- `data/run-25072975006-failed.txt` — earlier failure with sibling symptom (`getenv-v-latest`)
+- `data/use-m-source.js` — snapshot of `https://unpkg.com/use-m/use.js` showing the no-retry install path
+- `templates/js-template/release.yml` — JS template workflow as of investigation
+- `templates/rust-template/release.yml` — Rust template workflow as of investigation

--- a/docs/case-studies/issue-1724/README.md
+++ b/docs/case-studies/issue-1724/README.md
@@ -12,14 +12,14 @@ production source files from a test file.
 
 ## Timeline of Events
 
-| Time (UTC) | Event |
-| --- | --- |
-| 2026-04-29 12:53:01 | Push to `main` (sha `074a781d`) triggers run 25109962685. |
-| 2026-04-29 12:54:13 | `test-suites` job starts on `ubuntu-24.04`, Node 24.14.1, npm 11.11.0. |
-| 2026-04-29 12:54:33 | `npm install` finishes; `npm test` starts (`scripts/run-tests.mjs --suite default`). |
-| 2026-04-29 12:54:33 | `[1/75] tests/limits-display.test.mjs` — passes. |
-| 2026-04-29 12:54:36 | `[2/75] tests/<…>` — passes. |
-| 2026-04-29 12:54:37 | `[3/75] tests/test-active-branch-runs-buffer-1722.mjs` starts. |
+| Time (UTC)          | Event                                                                                                                                                                                                                                                                                                           |
+| ------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| 2026-04-29 12:53:01 | Push to `main` (sha `074a781d`) triggers run 25109962685.                                                                                                                                                                                                                                                       |
+| 2026-04-29 12:54:13 | `test-suites` job starts on `ubuntu-24.04`, Node 24.14.1, npm 11.11.0.                                                                                                                                                                                                                                          |
+| 2026-04-29 12:54:33 | `npm install` finishes; `npm test` starts (`scripts/run-tests.mjs --suite default`).                                                                                                                                                                                                                            |
+| 2026-04-29 12:54:33 | `[1/75] tests/limits-display.test.mjs` — passes.                                                                                                                                                                                                                                                                |
+| 2026-04-29 12:54:36 | `[2/75] tests/<…>` — passes.                                                                                                                                                                                                                                                                                    |
+| 2026-04-29 12:54:37 | `[3/75] tests/test-active-branch-runs-buffer-1722.mjs` starts.                                                                                                                                                                                                                                                  |
 | 2026-04-29 12:54:39 | The test file imports `src/github-merge.lib.mjs` → `src/github.lib.mjs` (top-level `await use('command-stream')` via `use-m`). `npm install -g command-stream-v-latest@npm:command-stream@latest` fails with `ENOTEMPTY`. The whole test file aborts; `run-tests.mjs` exits 1; the job ends with `exit code 1`. |
 
 A previous run (25072975006, 2026-04-28 19:21) failed in the same step with a sibling symptom: `Failed to resolve the
@@ -66,8 +66,7 @@ with no retry.
 (e.g. `src/github.lib.mjs`, `src/playwright-mcp.lib.mjs`):
 
 ```js
-if (typeof globalThis.use === 'undefined')
-  globalThis.use = (await eval(await (await fetch('https://unpkg.com/use-m/use.js')).text())).use;
+if (typeof globalThis.use === 'undefined') globalThis.use = (await eval(await (await fetch('https://unpkg.com/use-m/use.js')).text())).use;
 const { $ } = await use('command-stream');
 ```
 
@@ -108,13 +107,13 @@ must not depend on a synchronous fix there. We address that separately (see "Ups
 
 ## Implementation Plan
 
-| Step | File | Change |
-| --- | --- | --- |
-| 1 | `scripts/preinstall-use-m-packages.mjs` (new) | Pre-install the `latest` packages used by `use-m` with retry on `ENOTEMPTY`/`EBUSY`/network errors; emit verbose progress. |
-| 2 | `package.json` | Add a `preinstall:use-m` npm script that calls the above. |
-| 3 | `.github/workflows/release.yml` | Run `node scripts/preinstall-use-m-packages.mjs` after `npm install` in `test-suites` and `test-execution`, before `npm test`. |
-| 4 | `tests/test-preinstall-use-m-packages.mjs` (new) | Unit-test the retry helper deterministically (no real npm calls). |
-| 5 | `docs/case-studies/issue-1724/` | This case study. |
+| Step | File                                             | Change                                                                                                                         |
+| ---- | ------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------ |
+| 1    | `scripts/preinstall-use-m-packages.mjs` (new)    | Pre-install the `latest` packages used by `use-m` with retry on `ENOTEMPTY`/`EBUSY`/network errors; emit verbose progress.     |
+| 2    | `package.json`                                   | Add a `preinstall:use-m` npm script that calls the above.                                                                      |
+| 3    | `.github/workflows/release.yml`                  | Run `node scripts/preinstall-use-m-packages.mjs` after `npm install` in `test-suites` and `test-execution`, before `npm test`. |
+| 4    | `tests/test-preinstall-use-m-packages.mjs` (new) | Unit-test the retry helper deterministically (no real npm calls).                                                              |
+| 5    | `docs/case-studies/issue-1724/`                  | This case study.                                                                                                               |
 
 ## Templates
 

--- a/docs/case-studies/issue-1724/data/run-25072975006-failed.txt
+++ b/docs/case-studies/issue-1724/data/run-25072975006-failed.txt
@@ -1,0 +1,256 @@
+test-suites	UNKNOWN STEP	﻿2026-04-28T19:23:21.0552465Z Current runner version: '2.334.0'
+test-suites	UNKNOWN STEP	2026-04-28T19:23:21.0587067Z ##[group]Runner Image Provisioner
+test-suites	UNKNOWN STEP	2026-04-28T19:23:21.0588281Z Hosted Compute Agent
+test-suites	UNKNOWN STEP	2026-04-28T19:23:21.0589154Z Version: 20260422.526
+test-suites	UNKNOWN STEP	2026-04-28T19:23:21.0590079Z Commit: e1a9e573f4d0838b3a7c1b07401aeb29ed3635a9
+test-suites	UNKNOWN STEP	2026-04-28T19:23:21.0591321Z Build Date: 2026-04-22T09:31:31Z
+test-suites	UNKNOWN STEP	2026-04-28T19:23:21.0592377Z Worker ID: {ae15e9d2-b62f-40d2-b98e-142697149bba}
+test-suites	UNKNOWN STEP	2026-04-28T19:23:21.0593477Z Azure Region: northcentralus
+test-suites	UNKNOWN STEP	2026-04-28T19:23:21.0594569Z ##[endgroup]
+test-suites	UNKNOWN STEP	2026-04-28T19:23:21.0596758Z ##[group]Operating System
+test-suites	UNKNOWN STEP	2026-04-28T19:23:21.0597648Z Ubuntu
+test-suites	UNKNOWN STEP	2026-04-28T19:23:21.0598585Z 24.04.4
+test-suites	UNKNOWN STEP	2026-04-28T19:23:21.0599250Z LTS
+test-suites	UNKNOWN STEP	2026-04-28T19:23:21.0599965Z ##[endgroup]
+test-suites	UNKNOWN STEP	2026-04-28T19:23:21.0601191Z ##[group]Runner Image
+test-suites	UNKNOWN STEP	2026-04-28T19:23:21.0602060Z Image: ubuntu-24.04
+test-suites	UNKNOWN STEP	2026-04-28T19:23:21.0602860Z Version: 20260426.100.1
+test-suites	UNKNOWN STEP	2026-04-28T19:23:21.0604890Z Included Software: https://github.com/actions/runner-images/blob/ubuntu24/20260426.100/images/ubuntu/Ubuntu2404-Readme.md
+test-suites	UNKNOWN STEP	2026-04-28T19:23:21.0607717Z Image Release: https://github.com/actions/runner-images/releases/tag/ubuntu24%2F20260426.100
+test-suites	UNKNOWN STEP	2026-04-28T19:23:21.0609244Z ##[endgroup]
+test-suites	UNKNOWN STEP	2026-04-28T19:23:21.0613668Z ##[group]GITHUB_TOKEN Permissions
+test-suites	UNKNOWN STEP	2026-04-28T19:23:21.0617205Z Actions: write
+test-suites	UNKNOWN STEP	2026-04-28T19:23:21.0618091Z ArtifactMetadata: write
+test-suites	UNKNOWN STEP	2026-04-28T19:23:21.0618935Z Attestations: write
+test-suites	UNKNOWN STEP	2026-04-28T19:23:21.0619931Z Checks: write
+test-suites	UNKNOWN STEP	2026-04-28T19:23:21.0620740Z Contents: write
+test-suites	UNKNOWN STEP	2026-04-28T19:23:21.0621477Z Deployments: write
+test-suites	UNKNOWN STEP	2026-04-28T19:23:21.0622424Z Discussions: write
+test-suites	UNKNOWN STEP	2026-04-28T19:23:21.0622985Z Issues: write
+test-suites	UNKNOWN STEP	2026-04-28T19:23:21.0623457Z Metadata: read
+test-suites	UNKNOWN STEP	2026-04-28T19:23:21.0624066Z Models: read
+test-suites	UNKNOWN STEP	2026-04-28T19:23:21.0624614Z Packages: write
+test-suites	UNKNOWN STEP	2026-04-28T19:23:21.0625100Z Pages: write
+test-suites	UNKNOWN STEP	2026-04-28T19:23:21.0626131Z PullRequests: write
+test-suites	UNKNOWN STEP	2026-04-28T19:23:21.0626725Z RepositoryProjects: write
+test-suites	UNKNOWN STEP	2026-04-28T19:23:21.0627372Z SecurityEvents: write
+test-suites	UNKNOWN STEP	2026-04-28T19:23:21.0627918Z Statuses: write
+test-suites	UNKNOWN STEP	2026-04-28T19:23:21.0628500Z VulnerabilityAlerts: read
+test-suites	UNKNOWN STEP	2026-04-28T19:23:21.0629161Z ##[endgroup]
+test-suites	UNKNOWN STEP	2026-04-28T19:23:21.0631236Z Secret source: Actions
+test-suites	UNKNOWN STEP	2026-04-28T19:23:21.0632325Z Prepare workflow directory
+test-suites	UNKNOWN STEP	2026-04-28T19:23:21.1127268Z Prepare all required actions
+test-suites	UNKNOWN STEP	2026-04-28T19:23:21.1179216Z Getting action download info
+test-suites	UNKNOWN STEP	2026-04-28T19:23:21.4751346Z Download action repository 'actions/checkout@v5' (SHA:93cb6efe18208431cddfb8368fd83d5badbf9bfd)
+test-suites	UNKNOWN STEP	2026-04-28T19:23:21.6006935Z Download action repository 'actions/setup-node@v5' (SHA:a0853c24544627f65ddf259abe73b1d18a591444)
+test-suites	UNKNOWN STEP	2026-04-28T19:23:21.8973745Z Complete job name: test-suites
+test-suites	UNKNOWN STEP	2026-04-28T19:23:21.9701328Z ##[group]Run actions/checkout@v5
+test-suites	UNKNOWN STEP	2026-04-28T19:23:21.9702179Z with:
+test-suites	UNKNOWN STEP	2026-04-28T19:23:21.9702653Z   repository: link-assistant/hive-mind
+test-suites	UNKNOWN STEP	2026-04-28T19:23:21.9703433Z   token: ***
+test-suites	UNKNOWN STEP	2026-04-28T19:23:21.9703865Z   ssh-strict: true
+test-suites	UNKNOWN STEP	2026-04-28T19:23:21.9704295Z   ssh-user: git
+test-suites	UNKNOWN STEP	2026-04-28T19:23:21.9704741Z   persist-credentials: true
+test-suites	UNKNOWN STEP	2026-04-28T19:23:21.9705430Z   clean: true
+test-suites	UNKNOWN STEP	2026-04-28T19:23:21.9705869Z   sparse-checkout-cone-mode: true
+test-suites	UNKNOWN STEP	2026-04-28T19:23:21.9706430Z   fetch-depth: 1
+test-suites	UNKNOWN STEP	2026-04-28T19:23:21.9706874Z   fetch-tags: false
+test-suites	UNKNOWN STEP	2026-04-28T19:23:21.9707321Z   show-progress: true
+test-suites	UNKNOWN STEP	2026-04-28T19:23:21.9707776Z   lfs: false
+test-suites	UNKNOWN STEP	2026-04-28T19:23:21.9708190Z   submodules: false
+test-suites	UNKNOWN STEP	2026-04-28T19:23:21.9708632Z   set-safe-directory: true
+test-suites	UNKNOWN STEP	2026-04-28T19:23:21.9709320Z env:
+test-suites	UNKNOWN STEP	2026-04-28T19:23:21.9709782Z   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+test-suites	UNKNOWN STEP	2026-04-28T19:23:21.9710342Z ##[endgroup]
+test-suites	UNKNOWN STEP	2026-04-28T19:23:22.0744241Z Syncing repository: link-assistant/hive-mind
+test-suites	UNKNOWN STEP	2026-04-28T19:23:22.0747571Z ##[group]Getting Git version info
+test-suites	UNKNOWN STEP	2026-04-28T19:23:22.0748876Z Working directory is '/home/runner/work/hive-mind/hive-mind'
+test-suites	UNKNOWN STEP	2026-04-28T19:23:22.0750769Z [command]/usr/bin/git version
+test-suites	UNKNOWN STEP	2026-04-28T19:23:22.0788756Z git version 2.54.0
+test-suites	UNKNOWN STEP	2026-04-28T19:23:22.0810431Z ##[endgroup]
+test-suites	UNKNOWN STEP	2026-04-28T19:23:22.0826144Z Temporarily overriding HOME='/home/runner/work/_temp/903884da-68dc-4b8d-b4fd-6a3ce040dd28' before making global git config changes
+test-suites	UNKNOWN STEP	2026-04-28T19:23:22.0829432Z Adding repository directory to the temporary git global config as a safe directory
+test-suites	UNKNOWN STEP	2026-04-28T19:23:22.0831876Z [command]/usr/bin/git config --global --add safe.directory /home/runner/work/hive-mind/hive-mind
+test-suites	UNKNOWN STEP	2026-04-28T19:23:22.0879473Z Deleting the contents of '/home/runner/work/hive-mind/hive-mind'
+test-suites	UNKNOWN STEP	2026-04-28T19:23:22.0883072Z ##[group]Initializing the repository
+test-suites	UNKNOWN STEP	2026-04-28T19:23:22.0888099Z [command]/usr/bin/git init /home/runner/work/hive-mind/hive-mind
+test-suites	UNKNOWN STEP	2026-04-28T19:23:22.0996426Z hint: Using 'master' as the name for the initial branch. This default branch name
+test-suites	UNKNOWN STEP	2026-04-28T19:23:22.0998370Z hint: will change to "main" in Git 3.0. To configure the initial branch name
+test-suites	UNKNOWN STEP	2026-04-28T19:23:22.1000062Z hint: to use in all of your new repositories, which will suppress this warning,
+test-suites	UNKNOWN STEP	2026-04-28T19:23:22.1001350Z hint: call:
+test-suites	UNKNOWN STEP	2026-04-28T19:23:22.1002085Z hint:
+test-suites	UNKNOWN STEP	2026-04-28T19:23:22.1002960Z hint: 	git config --global init.defaultBranch <name>
+test-suites	UNKNOWN STEP	2026-04-28T19:23:22.1004038Z hint:
+test-suites	UNKNOWN STEP	2026-04-28T19:23:22.1005088Z hint: Names commonly chosen instead of 'master' are 'main', 'trunk' and
+test-suites	UNKNOWN STEP	2026-04-28T19:23:22.1007070Z hint: 'development'. The just-created branch can be renamed via this command:
+test-suites	UNKNOWN STEP	2026-04-28T19:23:22.1008375Z hint:
+test-suites	UNKNOWN STEP	2026-04-28T19:23:22.1009081Z hint: 	git branch -m <name>
+test-suites	UNKNOWN STEP	2026-04-28T19:23:22.1009916Z hint:
+test-suites	UNKNOWN STEP	2026-04-28T19:23:22.1011017Z hint: Disable this message with "git config set advice.defaultBranchName false"
+test-suites	UNKNOWN STEP	2026-04-28T19:23:22.1012923Z Initialized empty Git repository in /home/runner/work/hive-mind/hive-mind/.git/
+test-suites	UNKNOWN STEP	2026-04-28T19:23:22.1016338Z [command]/usr/bin/git remote add origin https://github.com/link-assistant/hive-mind
+test-suites	UNKNOWN STEP	2026-04-28T19:23:22.1058874Z ##[endgroup]
+test-suites	UNKNOWN STEP	2026-04-28T19:23:22.1060715Z ##[group]Disabling automatic garbage collection
+test-suites	UNKNOWN STEP	2026-04-28T19:23:22.1062608Z [command]/usr/bin/git config --local gc.auto 0
+test-suites	UNKNOWN STEP	2026-04-28T19:23:22.1093074Z ##[endgroup]
+test-suites	UNKNOWN STEP	2026-04-28T19:23:22.1094313Z ##[group]Setting up auth
+test-suites	UNKNOWN STEP	2026-04-28T19:23:22.1100739Z [command]/usr/bin/git config --local --name-only --get-regexp core\.sshCommand
+test-suites	UNKNOWN STEP	2026-04-28T19:23:22.1136879Z [command]/usr/bin/git submodule foreach --recursive sh -c "git config --local --name-only --get-regexp 'core\.sshCommand' && git config --local --unset-all 'core.sshCommand' || :"
+test-suites	UNKNOWN STEP	2026-04-28T19:23:22.1522953Z [command]/usr/bin/git config --local --name-only --get-regexp http\.https\:\/\/github\.com\/\.extraheader
+test-suites	UNKNOWN STEP	2026-04-28T19:23:22.1556560Z [command]/usr/bin/git submodule foreach --recursive sh -c "git config --local --name-only --get-regexp 'http\.https\:\/\/github\.com\/\.extraheader' && git config --local --unset-all 'http.https://github.com/.extraheader' || :"
+test-suites	UNKNOWN STEP	2026-04-28T19:23:22.1788832Z [command]/usr/bin/git config --local --name-only --get-regexp ^includeIf\.gitdir:
+test-suites	UNKNOWN STEP	2026-04-28T19:23:22.1822173Z [command]/usr/bin/git submodule foreach --recursive git config --local --show-origin --name-only --get-regexp remote.origin.url
+test-suites	UNKNOWN STEP	2026-04-28T19:23:22.2066319Z [command]/usr/bin/git config --local http.https://github.com/.extraheader AUTHORIZATION: basic ***
+test-suites	UNKNOWN STEP	2026-04-28T19:23:22.2101979Z ##[endgroup]
+test-suites	UNKNOWN STEP	2026-04-28T19:23:22.2102757Z ##[group]Fetching the repository
+test-suites	UNKNOWN STEP	2026-04-28T19:23:22.2111055Z [command]/usr/bin/git -c protocol.version=2 fetch --no-tags --prune --no-recurse-submodules --depth=1 origin +206602874c73fda859087fa82933c3a2ed492527:refs/remotes/origin/main
+test-suites	UNKNOWN STEP	2026-04-28T19:23:32.5893561Z From https://github.com/link-assistant/hive-mind
+test-suites	UNKNOWN STEP	2026-04-28T19:23:32.5894178Z  * [new ref]         206602874c73fda859087fa82933c3a2ed492527 -> origin/main
+test-suites	UNKNOWN STEP	2026-04-28T19:23:32.5926997Z ##[endgroup]
+test-suites	UNKNOWN STEP	2026-04-28T19:23:32.5927682Z ##[group]Determining the checkout info
+test-suites	UNKNOWN STEP	2026-04-28T19:23:32.5930550Z ##[endgroup]
+test-suites	UNKNOWN STEP	2026-04-28T19:23:32.5936405Z [command]/usr/bin/git sparse-checkout disable
+test-suites	UNKNOWN STEP	2026-04-28T19:23:32.5981380Z [command]/usr/bin/git config --local --unset-all extensions.worktreeConfig
+test-suites	UNKNOWN STEP	2026-04-28T19:23:32.6008356Z ##[group]Checking out the ref
+test-suites	UNKNOWN STEP	2026-04-28T19:23:32.6012357Z [command]/usr/bin/git checkout --progress --force -B main refs/remotes/origin/main
+test-suites	UNKNOWN STEP	2026-04-28T19:23:33.6878273Z Updating files:  48% (1238/2556)
+test-suites	UNKNOWN STEP	2026-04-28T19:23:33.6888760Z Updating files:  49% (1253/2556)
+test-suites	UNKNOWN STEP	2026-04-28T19:23:33.6941071Z Updating files:  50% (1278/2556)
+test-suites	UNKNOWN STEP	2026-04-28T19:23:33.6967911Z Updating files:  51% (1304/2556)
+test-suites	UNKNOWN STEP	2026-04-28T19:23:33.6984035Z Updating files:  52% (1330/2556)
+test-suites	UNKNOWN STEP	2026-04-28T19:23:33.7089213Z Updating files:  53% (1355/2556)
+test-suites	UNKNOWN STEP	2026-04-28T19:23:33.8945495Z Updating files:  54% (1381/2556)
+test-suites	UNKNOWN STEP	2026-04-28T19:23:33.9179374Z Updating files:  55% (1406/2556)
+test-suites	UNKNOWN STEP	2026-04-28T19:23:33.9276014Z Updating files:  56% (1432/2556)
+test-suites	UNKNOWN STEP	2026-04-28T19:23:33.9379219Z Updating files:  57% (1457/2556)
+test-suites	UNKNOWN STEP	2026-04-28T19:23:33.9660062Z Updating files:  58% (1483/2556)
+test-suites	UNKNOWN STEP	2026-04-28T19:23:33.9710041Z Updating files:  59% (1509/2556)
+test-suites	UNKNOWN STEP	2026-04-28T19:23:33.9842242Z Updating files:  60% (1534/2556)
+test-suites	UNKNOWN STEP	2026-04-28T19:23:33.9880922Z Updating files:  61% (1560/2556)
+test-suites	UNKNOWN STEP	2026-04-28T19:23:33.9968650Z Updating files:  62% (1585/2556)
+test-suites	UNKNOWN STEP	2026-04-28T19:23:34.0102403Z Updating files:  63% (1611/2556)
+test-suites	UNKNOWN STEP	2026-04-28T19:23:34.0134340Z Updating files:  64% (1636/2556)
+test-suites	UNKNOWN STEP	2026-04-28T19:23:34.0152460Z Updating files:  65% (1662/2556)
+test-suites	UNKNOWN STEP	2026-04-28T19:23:34.0164167Z Updating files:  66% (1687/2556)
+test-suites	UNKNOWN STEP	2026-04-28T19:23:34.0179280Z Updating files:  67% (1713/2556)
+test-suites	UNKNOWN STEP	2026-04-28T19:23:34.0213707Z Updating files:  68% (1739/2556)
+test-suites	UNKNOWN STEP	2026-04-28T19:23:34.0226975Z Updating files:  69% (1764/2556)
+test-suites	UNKNOWN STEP	2026-04-28T19:23:34.0240553Z Updating files:  70% (1790/2556)
+test-suites	UNKNOWN STEP	2026-04-28T19:23:34.0253607Z Updating files:  71% (1815/2556)
+test-suites	UNKNOWN STEP	2026-04-28T19:23:34.0266330Z Updating files:  72% (1841/2556)
+test-suites	UNKNOWN STEP	2026-04-28T19:23:34.0280955Z Updating files:  73% (1866/2556)
+test-suites	UNKNOWN STEP	2026-04-28T19:23:34.0295563Z Updating files:  74% (1892/2556)
+test-suites	UNKNOWN STEP	2026-04-28T19:23:34.0311291Z Updating files:  75% (1917/2556)
+test-suites	UNKNOWN STEP	2026-04-28T19:23:34.0325831Z Updating files:  76% (1943/2556)
+test-suites	UNKNOWN STEP	2026-04-28T19:23:34.0338849Z Updating files:  77% (1969/2556)
+test-suites	UNKNOWN STEP	2026-04-28T19:23:34.0352876Z Updating files:  78% (1994/2556)
+test-suites	UNKNOWN STEP	2026-04-28T19:23:34.0366657Z Updating files:  79% (2020/2556)
+test-suites	UNKNOWN STEP	2026-04-28T19:23:34.0381499Z Updating files:  80% (2045/2556)
+test-suites	UNKNOWN STEP	2026-04-28T19:23:34.0394380Z Updating files:  81% (2071/2556)
+test-suites	UNKNOWN STEP	2026-04-28T19:23:34.0408994Z Updating files:  82% (2096/2556)
+test-suites	UNKNOWN STEP	2026-04-28T19:23:34.0424454Z Updating files:  83% (2122/2556)
+test-suites	UNKNOWN STEP	2026-04-28T19:23:34.0438308Z Updating files:  84% (2148/2556)
+test-suites	UNKNOWN STEP	2026-04-28T19:23:34.0450817Z Updating files:  85% (2173/2556)
+test-suites	UNKNOWN STEP	2026-04-28T19:23:34.0469378Z Updating files:  86% (2199/2556)
+test-suites	UNKNOWN STEP	2026-04-28T19:23:34.0486432Z Updating files:  87% (2224/2556)
+test-suites	UNKNOWN STEP	2026-04-28T19:23:34.0508251Z Updating files:  88% (2250/2556)
+test-suites	UNKNOWN STEP	2026-04-28T19:23:34.0534564Z Updating files:  89% (2275/2556)
+test-suites	UNKNOWN STEP	2026-04-28T19:23:34.0565487Z Updating files:  90% (2301/2556)
+test-suites	UNKNOWN STEP	2026-04-28T19:23:34.0596636Z Updating files:  91% (2326/2556)
+test-suites	UNKNOWN STEP	2026-04-28T19:23:34.0621195Z Updating files:  92% (2352/2556)
+test-suites	UNKNOWN STEP	2026-04-28T19:23:34.0640810Z Updating files:  93% (2378/2556)
+test-suites	UNKNOWN STEP	2026-04-28T19:23:34.0661559Z Updating files:  94% (2403/2556)
+test-suites	UNKNOWN STEP	2026-04-28T19:23:34.0683995Z Updating files:  95% (2429/2556)
+test-suites	UNKNOWN STEP	2026-04-28T19:23:34.0703116Z Updating files:  96% (2454/2556)
+test-suites	UNKNOWN STEP	2026-04-28T19:23:34.0723100Z Updating files:  97% (2480/2556)
+test-suites	UNKNOWN STEP	2026-04-28T19:23:34.0741216Z Updating files:  98% (2505/2556)
+test-suites	UNKNOWN STEP	2026-04-28T19:23:34.0764863Z Updating files:  99% (2531/2556)
+test-suites	UNKNOWN STEP	2026-04-28T19:23:34.0765392Z Updating files: 100% (2556/2556)
+test-suites	UNKNOWN STEP	2026-04-28T19:23:34.0765779Z Updating files: 100% (2556/2556), done.
+test-suites	UNKNOWN STEP	2026-04-28T19:23:34.0807145Z Switched to a new branch 'main'
+test-suites	UNKNOWN STEP	2026-04-28T19:23:34.0810360Z branch 'main' set up to track 'origin/main'.
+test-suites	UNKNOWN STEP	2026-04-28T19:23:34.0872290Z ##[endgroup]
+test-suites	UNKNOWN STEP	2026-04-28T19:23:34.0918791Z [command]/usr/bin/git log -1 --format=%H
+test-suites	UNKNOWN STEP	2026-04-28T19:23:34.0946138Z 206602874c73fda859087fa82933c3a2ed492527
+test-suites	UNKNOWN STEP	2026-04-28T19:23:34.1201228Z ##[group]Run actions/setup-node@v5
+test-suites	UNKNOWN STEP	2026-04-28T19:23:34.1201577Z with:
+test-suites	UNKNOWN STEP	2026-04-28T19:23:34.1201761Z   node-version: 24.x
+test-suites	UNKNOWN STEP	2026-04-28T19:23:34.1201971Z   always-auth: false
+test-suites	UNKNOWN STEP	2026-04-28T19:23:34.1202171Z   check-latest: false
+test-suites	UNKNOWN STEP	2026-04-28T19:23:34.1202523Z   token: ***
+test-suites	UNKNOWN STEP	2026-04-28T19:23:34.1202740Z   package-manager-cache: true
+test-suites	UNKNOWN STEP	2026-04-28T19:23:34.1202979Z env:
+test-suites	UNKNOWN STEP	2026-04-28T19:23:34.1203187Z   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+test-suites	UNKNOWN STEP	2026-04-28T19:23:34.1203635Z ##[endgroup]
+test-suites	UNKNOWN STEP	2026-04-28T19:23:34.2675193Z Found in cache @ /opt/hostedtoolcache/node/24.15.0/x64
+test-suites	UNKNOWN STEP	2026-04-28T19:23:34.2679424Z (node:2314) [DEP0040] DeprecationWarning: The `punycode` module is deprecated. Please use a userland alternative instead.
+test-suites	UNKNOWN STEP	2026-04-28T19:23:34.2680267Z (Use `node --trace-deprecation ...` to show where the warning was created)
+test-suites	UNKNOWN STEP	2026-04-28T19:23:34.2682131Z ##[group]Environment details
+test-suites	UNKNOWN STEP	2026-04-28T19:23:34.6301371Z node: v24.15.0
+test-suites	UNKNOWN STEP	2026-04-28T19:23:34.6301764Z npm: 11.12.1
+test-suites	UNKNOWN STEP	2026-04-28T19:23:34.6302174Z yarn: 1.22.22
+test-suites	UNKNOWN STEP	2026-04-28T19:23:34.6302922Z ##[endgroup]
+test-suites	UNKNOWN STEP	2026-04-28T19:23:34.6458685Z ##[group]Run npm install
+test-suites	UNKNOWN STEP	2026-04-28T19:23:34.6458994Z [36;1mnpm install[0m
+test-suites	UNKNOWN STEP	2026-04-28T19:23:34.6579981Z shell: /usr/bin/bash -e {0}
+test-suites	UNKNOWN STEP	2026-04-28T19:23:34.6580250Z env:
+test-suites	UNKNOWN STEP	2026-04-28T19:23:34.6580474Z   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+test-suites	UNKNOWN STEP	2026-04-28T19:23:34.6580755Z ##[endgroup]
+test-suites	UNKNOWN STEP	2026-04-28T19:23:42.6926826Z 
+test-suites	UNKNOWN STEP	2026-04-28T19:23:42.6934825Z > @link-assistant/hive-mind@1.58.0 prepare
+test-suites	UNKNOWN STEP	2026-04-28T19:23:42.6935780Z > husky
+test-suites	UNKNOWN STEP	2026-04-28T19:23:42.6935954Z 
+test-suites	UNKNOWN STEP	2026-04-28T19:23:42.7504914Z 
+test-suites	UNKNOWN STEP	2026-04-28T19:23:42.7506156Z added 472 packages, and audited 473 packages in 8s
+test-suites	UNKNOWN STEP	2026-04-28T19:23:42.7506543Z 
+test-suites	UNKNOWN STEP	2026-04-28T19:23:42.7506814Z 97 packages are looking for funding
+test-suites	UNKNOWN STEP	2026-04-28T19:23:42.7514068Z   run `npm fund` for details
+test-suites	UNKNOWN STEP	2026-04-28T19:23:42.7702477Z 
+test-suites	UNKNOWN STEP	2026-04-28T19:23:42.7703219Z 10 vulnerabilities (6 moderate, 4 high)
+test-suites	UNKNOWN STEP	2026-04-28T19:23:42.7703927Z 
+test-suites	UNKNOWN STEP	2026-04-28T19:23:42.7704368Z To address all issues, run:
+test-suites	UNKNOWN STEP	2026-04-28T19:23:42.7704956Z   npm audit fix
+test-suites	UNKNOWN STEP	2026-04-28T19:23:42.7705491Z 
+test-suites	UNKNOWN STEP	2026-04-28T19:23:42.7705961Z Run `npm audit` for details.
+test-suites	UNKNOWN STEP	2026-04-28T19:23:42.8380625Z ##[group]Run npm test
+test-suites	UNKNOWN STEP	2026-04-28T19:23:42.8380902Z [36;1mnpm test[0m
+test-suites	UNKNOWN STEP	2026-04-28T19:23:42.8443443Z shell: /usr/bin/bash -e {0}
+test-suites	UNKNOWN STEP	2026-04-28T19:23:42.8443697Z env:
+test-suites	UNKNOWN STEP	2026-04-28T19:23:42.8443907Z   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+test-suites	UNKNOWN STEP	2026-04-28T19:23:42.8444188Z ##[endgroup]
+test-suites	UNKNOWN STEP	2026-04-28T19:23:42.9697011Z 
+test-suites	UNKNOWN STEP	2026-04-28T19:23:42.9697987Z > @link-assistant/hive-mind@1.58.0 test
+test-suites	UNKNOWN STEP	2026-04-28T19:23:42.9698532Z > node scripts/run-tests.mjs --suite default
+test-suites	UNKNOWN STEP	2026-04-28T19:23:42.9698759Z 
+test-suites	UNKNOWN STEP	2026-04-28T19:23:43.0471409Z Running 70 default test file(s)...
+test-suites	UNKNOWN STEP	2026-04-28T19:23:43.0472559Z 
+test-suites	UNKNOWN STEP	2026-04-28T19:23:43.0472833Z [1/70] tests/limits-display.test.mjs
+test-suites	UNKNOWN STEP	2026-04-28T19:23:44.1758707Z <anonymous_script>:567
+test-suites	UNKNOWN STEP	2026-04-28T19:23:44.1759640Z       throw new Error(`Failed to resolve the path to '${moduleSpecifier}' from '${packageModulePath}'.`);
+test-suites	UNKNOWN STEP	2026-04-28T19:23:44.1776514Z             ^
+test-suites	UNKNOWN STEP	2026-04-28T19:23:44.1776740Z 
+test-suites	UNKNOWN STEP	2026-04-28T19:23:44.1777678Z Error: Failed to resolve the path to 'getenv' from '/opt/hostedtoolcache/node/24.15.0/x64/lib/node_modules/getenv-v-latest'.
+test-suites	UNKNOWN STEP	2026-04-28T19:23:44.1778831Z     at npm (eval at <anonymous> (file:///home/runner/work/hive-mind/hive-mind/src/queue-config.lib.mjs:29:29), <anonymous>:567:13)
+test-suites	UNKNOWN STEP	2026-04-28T19:23:44.1779750Z     at async eval (eval at <anonymous> (file:///home/runner/work/hive-mind/hive-mind/src/queue-config.lib.mjs:29:29), <anonymous>:867:24)
+test-suites	UNKNOWN STEP	2026-04-28T19:23:44.1780548Z     at async file:///home/runner/work/hive-mind/hive-mind/src/queue-config.lib.mjs:39:22
+test-suites	UNKNOWN STEP	2026-04-28T19:23:44.1780879Z 
+test-suites	UNKNOWN STEP	2026-04-28T19:23:44.1780992Z Node.js v24.15.0
+test-suites	UNKNOWN STEP	2026-04-28T19:23:44.1828662Z 
+test-suites	UNKNOWN STEP	2026-04-28T19:23:44.1828947Z Failed test files:
+test-suites	UNKNOWN STEP	2026-04-28T19:23:44.1829399Z   - tests/limits-display.test.mjs (exit 1)
+test-suites	UNKNOWN STEP	2026-04-28T19:23:44.1973124Z ##[error]Process completed with exit code 1.
+test-suites	UNKNOWN STEP	2026-04-28T19:23:44.2094909Z Post job cleanup.
+test-suites	UNKNOWN STEP	2026-04-28T19:23:44.3014861Z [command]/usr/bin/git version
+test-suites	UNKNOWN STEP	2026-04-28T19:23:44.3056158Z git version 2.54.0
+test-suites	UNKNOWN STEP	2026-04-28T19:23:44.3094094Z Temporarily overriding HOME='/home/runner/work/_temp/c23fa41d-11bb-47b5-842d-0e3795bece63' before making global git config changes
+test-suites	UNKNOWN STEP	2026-04-28T19:23:44.3095674Z Adding repository directory to the temporary git global config as a safe directory
+test-suites	UNKNOWN STEP	2026-04-28T19:23:44.3100461Z [command]/usr/bin/git config --global --add safe.directory /home/runner/work/hive-mind/hive-mind
+test-suites	UNKNOWN STEP	2026-04-28T19:23:44.3140329Z [command]/usr/bin/git config --local --name-only --get-regexp core\.sshCommand
+test-suites	UNKNOWN STEP	2026-04-28T19:23:44.3177893Z [command]/usr/bin/git submodule foreach --recursive sh -c "git config --local --name-only --get-regexp 'core\.sshCommand' && git config --local --unset-all 'core.sshCommand' || :"
+test-suites	UNKNOWN STEP	2026-04-28T19:23:44.3429502Z [command]/usr/bin/git config --local --name-only --get-regexp http\.https\:\/\/github\.com\/\.extraheader
+test-suites	UNKNOWN STEP	2026-04-28T19:23:44.3457310Z http.https://github.com/.extraheader
+test-suites	UNKNOWN STEP	2026-04-28T19:23:44.3468291Z [command]/usr/bin/git config --local --unset-all http.https://github.com/.extraheader
+test-suites	UNKNOWN STEP	2026-04-28T19:23:44.3504330Z [command]/usr/bin/git submodule foreach --recursive sh -c "git config --local --name-only --get-regexp 'http\.https\:\/\/github\.com\/\.extraheader' && git config --local --unset-all 'http.https://github.com/.extraheader' || :"
+test-suites	UNKNOWN STEP	2026-04-28T19:23:44.3786735Z [command]/usr/bin/git config --local --name-only --get-regexp ^includeIf\.gitdir:
+test-suites	UNKNOWN STEP	2026-04-28T19:23:44.3819450Z [command]/usr/bin/git submodule foreach --recursive git config --local --show-origin --name-only --get-regexp remote.origin.url
+test-suites	UNKNOWN STEP	2026-04-28T19:23:44.4209176Z Cleaning up orphan processes

--- a/docs/case-studies/issue-1724/data/run-25109962685-failed.txt
+++ b/docs/case-studies/issue-1724/data/run-25109962685-failed.txt
@@ -1,0 +1,530 @@
+test-suites	UNKNOWN STEP	﻿2026-04-29T12:54:13.1280466Z Current runner version: '2.334.0'
+test-suites	UNKNOWN STEP	2026-04-29T12:54:13.1304720Z ##[group]Runner Image Provisioner
+test-suites	UNKNOWN STEP	2026-04-29T12:54:13.1305558Z Hosted Compute Agent
+test-suites	UNKNOWN STEP	2026-04-29T12:54:13.1306164Z Version: 20260213.493
+test-suites	UNKNOWN STEP	2026-04-29T12:54:13.1306829Z Commit: 5c115507f6dd24b8de37d8bbe0bb4509d0cc0fa3
+test-suites	UNKNOWN STEP	2026-04-29T12:54:13.1307566Z Build Date: 2026-02-13T00:28:41Z
+test-suites	UNKNOWN STEP	2026-04-29T12:54:13.1308245Z Worker ID: {fa5da172-2c6b-4090-968d-be28d844882d}
+test-suites	UNKNOWN STEP	2026-04-29T12:54:13.1309001Z Azure Region: eastus
+test-suites	UNKNOWN STEP	2026-04-29T12:54:13.1309887Z ##[endgroup]
+test-suites	UNKNOWN STEP	2026-04-29T12:54:13.1311453Z ##[group]Operating System
+test-suites	UNKNOWN STEP	2026-04-29T12:54:13.1312072Z Ubuntu
+test-suites	UNKNOWN STEP	2026-04-29T12:54:13.1312564Z 24.04.4
+test-suites	UNKNOWN STEP	2026-04-29T12:54:13.1313382Z LTS
+test-suites	UNKNOWN STEP	2026-04-29T12:54:13.1313938Z ##[endgroup]
+test-suites	UNKNOWN STEP	2026-04-29T12:54:13.1314461Z ##[group]Runner Image
+test-suites	UNKNOWN STEP	2026-04-29T12:54:13.1315015Z Image: ubuntu-24.04
+test-suites	UNKNOWN STEP	2026-04-29T12:54:13.1315576Z Version: 20260413.86.1
+test-suites	UNKNOWN STEP	2026-04-29T12:54:13.1316885Z Included Software: https://github.com/actions/runner-images/blob/ubuntu24/20260413.86/images/ubuntu/Ubuntu2404-Readme.md
+test-suites	UNKNOWN STEP	2026-04-29T12:54:13.1318433Z Image Release: https://github.com/actions/runner-images/releases/tag/ubuntu24%2F20260413.86
+test-suites	UNKNOWN STEP	2026-04-29T12:54:13.1319335Z ##[endgroup]
+test-suites	UNKNOWN STEP	2026-04-29T12:54:13.1322321Z ##[group]GITHUB_TOKEN Permissions
+test-suites	UNKNOWN STEP	2026-04-29T12:54:13.1324695Z Actions: write
+test-suites	UNKNOWN STEP	2026-04-29T12:54:13.1325396Z ArtifactMetadata: write
+test-suites	UNKNOWN STEP	2026-04-29T12:54:13.1325946Z Attestations: write
+test-suites	UNKNOWN STEP	2026-04-29T12:54:13.1326497Z Checks: write
+test-suites	UNKNOWN STEP	2026-04-29T12:54:13.1327064Z Contents: write
+test-suites	UNKNOWN STEP	2026-04-29T12:54:13.1327555Z Deployments: write
+test-suites	UNKNOWN STEP	2026-04-29T12:54:13.1328103Z Discussions: write
+test-suites	UNKNOWN STEP	2026-04-29T12:54:13.1328716Z Issues: write
+test-suites	UNKNOWN STEP	2026-04-29T12:54:13.1329409Z Metadata: read
+test-suites	UNKNOWN STEP	2026-04-29T12:54:13.1330312Z Models: read
+test-suites	UNKNOWN STEP	2026-04-29T12:54:13.1331163Z Packages: write
+test-suites	UNKNOWN STEP	2026-04-29T12:54:13.1331934Z Pages: write
+test-suites	UNKNOWN STEP	2026-04-29T12:54:13.1332724Z PullRequests: write
+test-suites	UNKNOWN STEP	2026-04-29T12:54:13.1333622Z RepositoryProjects: write
+test-suites	UNKNOWN STEP	2026-04-29T12:54:13.1334295Z SecurityEvents: write
+test-suites	UNKNOWN STEP	2026-04-29T12:54:13.1334824Z Statuses: write
+test-suites	UNKNOWN STEP	2026-04-29T12:54:13.1335450Z VulnerabilityAlerts: read
+test-suites	UNKNOWN STEP	2026-04-29T12:54:13.1336046Z ##[endgroup]
+test-suites	UNKNOWN STEP	2026-04-29T12:54:13.1338198Z Secret source: Actions
+test-suites	UNKNOWN STEP	2026-04-29T12:54:13.1339035Z Prepare workflow directory
+test-suites	UNKNOWN STEP	2026-04-29T12:54:13.1723310Z Prepare all required actions
+test-suites	UNKNOWN STEP	2026-04-29T12:54:13.1760637Z Getting action download info
+test-suites	UNKNOWN STEP	2026-04-29T12:54:13.5549190Z Download action repository 'actions/checkout@v5' (SHA:93cb6efe18208431cddfb8368fd83d5badbf9bfd)
+test-suites	UNKNOWN STEP	2026-04-29T12:54:13.7094171Z Download action repository 'actions/setup-node@v5' (SHA:a0853c24544627f65ddf259abe73b1d18a591444)
+test-suites	UNKNOWN STEP	2026-04-29T12:54:13.9597116Z Complete job name: test-suites
+test-suites	UNKNOWN STEP	2026-04-29T12:54:14.0295761Z ##[group]Run actions/checkout@v5
+test-suites	UNKNOWN STEP	2026-04-29T12:54:14.0296617Z with:
+test-suites	UNKNOWN STEP	2026-04-29T12:54:14.0297060Z   repository: link-assistant/hive-mind
+test-suites	UNKNOWN STEP	2026-04-29T12:54:14.0297810Z   token: ***
+test-suites	UNKNOWN STEP	2026-04-29T12:54:14.0298242Z   ssh-strict: true
+test-suites	UNKNOWN STEP	2026-04-29T12:54:14.0298678Z   ssh-user: git
+test-suites	UNKNOWN STEP	2026-04-29T12:54:14.0299112Z   persist-credentials: true
+test-suites	UNKNOWN STEP	2026-04-29T12:54:14.0299810Z   clean: true
+test-suites	UNKNOWN STEP	2026-04-29T12:54:14.0300248Z   sparse-checkout-cone-mode: true
+test-suites	UNKNOWN STEP	2026-04-29T12:54:14.0300780Z   fetch-depth: 1
+test-suites	UNKNOWN STEP	2026-04-29T12:54:14.0301210Z   fetch-tags: false
+test-suites	UNKNOWN STEP	2026-04-29T12:54:14.0301652Z   show-progress: true
+test-suites	UNKNOWN STEP	2026-04-29T12:54:14.0302097Z   lfs: false
+test-suites	UNKNOWN STEP	2026-04-29T12:54:14.0302515Z   submodules: false
+test-suites	UNKNOWN STEP	2026-04-29T12:54:14.0302962Z   set-safe-directory: true
+test-suites	UNKNOWN STEP	2026-04-29T12:54:14.0303630Z env:
+test-suites	UNKNOWN STEP	2026-04-29T12:54:14.0304063Z   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+test-suites	UNKNOWN STEP	2026-04-29T12:54:14.0304640Z ##[endgroup]
+test-suites	UNKNOWN STEP	2026-04-29T12:54:14.1334847Z Syncing repository: link-assistant/hive-mind
+test-suites	UNKNOWN STEP	2026-04-29T12:54:14.1337763Z ##[group]Getting Git version info
+test-suites	UNKNOWN STEP	2026-04-29T12:54:14.1339011Z Working directory is '/home/runner/work/hive-mind/hive-mind'
+test-suites	UNKNOWN STEP	2026-04-29T12:54:14.1341026Z [command]/usr/bin/git version
+test-suites	UNKNOWN STEP	2026-04-29T12:54:14.1366378Z git version 2.53.0
+test-suites	UNKNOWN STEP	2026-04-29T12:54:14.1385812Z ##[endgroup]
+test-suites	UNKNOWN STEP	2026-04-29T12:54:14.1402195Z Temporarily overriding HOME='/home/runner/work/_temp/699230fa-dd28-4de8-b749-9c0a44699601' before making global git config changes
+test-suites	UNKNOWN STEP	2026-04-29T12:54:14.1404652Z Adding repository directory to the temporary git global config as a safe directory
+test-suites	UNKNOWN STEP	2026-04-29T12:54:14.1407884Z [command]/usr/bin/git config --global --add safe.directory /home/runner/work/hive-mind/hive-mind
+test-suites	UNKNOWN STEP	2026-04-29T12:54:14.1445107Z Deleting the contents of '/home/runner/work/hive-mind/hive-mind'
+test-suites	UNKNOWN STEP	2026-04-29T12:54:14.1450236Z ##[group]Initializing the repository
+test-suites	UNKNOWN STEP	2026-04-29T12:54:14.1455397Z [command]/usr/bin/git init /home/runner/work/hive-mind/hive-mind
+test-suites	UNKNOWN STEP	2026-04-29T12:54:14.1566150Z hint: Using 'master' as the name for the initial branch. This default branch name
+test-suites	UNKNOWN STEP	2026-04-29T12:54:14.1567242Z hint: will change to "main" in Git 3.0. To configure the initial branch name
+test-suites	UNKNOWN STEP	2026-04-29T12:54:14.1568394Z hint: to use in all of your new repositories, which will suppress this warning,
+test-suites	UNKNOWN STEP	2026-04-29T12:54:14.1569448Z hint: call:
+test-suites	UNKNOWN STEP	2026-04-29T12:54:14.1570235Z hint:
+test-suites	UNKNOWN STEP	2026-04-29T12:54:14.1571051Z hint: 	git config --global init.defaultBranch <name>
+test-suites	UNKNOWN STEP	2026-04-29T12:54:14.1571715Z hint:
+test-suites	UNKNOWN STEP	2026-04-29T12:54:14.1572298Z hint: Names commonly chosen instead of 'master' are 'main', 'trunk' and
+test-suites	UNKNOWN STEP	2026-04-29T12:54:14.1573263Z hint: 'development'. The just-created branch can be renamed via this command:
+test-suites	UNKNOWN STEP	2026-04-29T12:54:14.1574016Z hint:
+test-suites	UNKNOWN STEP	2026-04-29T12:54:14.1574423Z hint: 	git branch -m <name>
+test-suites	UNKNOWN STEP	2026-04-29T12:54:14.1574909Z hint:
+test-suites	UNKNOWN STEP	2026-04-29T12:54:14.1575541Z hint: Disable this message with "git config set advice.defaultBranchName false"
+test-suites	UNKNOWN STEP	2026-04-29T12:54:14.1576548Z Initialized empty Git repository in /home/runner/work/hive-mind/hive-mind/.git/
+test-suites	UNKNOWN STEP	2026-04-29T12:54:14.1578416Z [command]/usr/bin/git remote add origin https://github.com/link-assistant/hive-mind
+test-suites	UNKNOWN STEP	2026-04-29T12:54:14.1619320Z ##[endgroup]
+test-suites	UNKNOWN STEP	2026-04-29T12:54:14.1620417Z ##[group]Disabling automatic garbage collection
+test-suites	UNKNOWN STEP	2026-04-29T12:54:14.1624538Z [command]/usr/bin/git config --local gc.auto 0
+test-suites	UNKNOWN STEP	2026-04-29T12:54:14.1656956Z ##[endgroup]
+test-suites	UNKNOWN STEP	2026-04-29T12:54:14.1657690Z ##[group]Setting up auth
+test-suites	UNKNOWN STEP	2026-04-29T12:54:14.1666268Z [command]/usr/bin/git config --local --name-only --get-regexp core\.sshCommand
+test-suites	UNKNOWN STEP	2026-04-29T12:54:14.1701846Z [command]/usr/bin/git submodule foreach --recursive sh -c "git config --local --name-only --get-regexp 'core\.sshCommand' && git config --local --unset-all 'core.sshCommand' || :"
+test-suites	UNKNOWN STEP	2026-04-29T12:54:14.2014743Z [command]/usr/bin/git config --local --name-only --get-regexp http\.https\:\/\/github\.com\/\.extraheader
+test-suites	UNKNOWN STEP	2026-04-29T12:54:14.2047362Z [command]/usr/bin/git submodule foreach --recursive sh -c "git config --local --name-only --get-regexp 'http\.https\:\/\/github\.com\/\.extraheader' && git config --local --unset-all 'http.https://github.com/.extraheader' || :"
+test-suites	UNKNOWN STEP	2026-04-29T12:54:14.2291832Z [command]/usr/bin/git config --local --name-only --get-regexp ^includeIf\.gitdir:
+test-suites	UNKNOWN STEP	2026-04-29T12:54:14.2324397Z [command]/usr/bin/git submodule foreach --recursive git config --local --show-origin --name-only --get-regexp remote.origin.url
+test-suites	UNKNOWN STEP	2026-04-29T12:54:14.2555973Z [command]/usr/bin/git config --local http.https://github.com/.extraheader AUTHORIZATION: basic ***
+test-suites	UNKNOWN STEP	2026-04-29T12:54:14.2592246Z ##[endgroup]
+test-suites	UNKNOWN STEP	2026-04-29T12:54:14.2600578Z ##[group]Fetching the repository
+test-suites	UNKNOWN STEP	2026-04-29T12:54:14.2602003Z [command]/usr/bin/git -c protocol.version=2 fetch --no-tags --prune --no-recurse-submodules --depth=1 origin +074a781d8874303e10b2e18217738688d1632550:refs/remotes/origin/main
+test-suites	UNKNOWN STEP	2026-04-29T12:54:24.5917823Z From https://github.com/link-assistant/hive-mind
+test-suites	UNKNOWN STEP	2026-04-29T12:54:24.5918655Z  * [new ref]         074a781d8874303e10b2e18217738688d1632550 -> origin/main
+test-suites	UNKNOWN STEP	2026-04-29T12:54:24.5944871Z ##[endgroup]
+test-suites	UNKNOWN STEP	2026-04-29T12:54:24.5945542Z ##[group]Determining the checkout info
+test-suites	UNKNOWN STEP	2026-04-29T12:54:24.5948161Z ##[endgroup]
+test-suites	UNKNOWN STEP	2026-04-29T12:54:24.5954238Z [command]/usr/bin/git sparse-checkout disable
+test-suites	UNKNOWN STEP	2026-04-29T12:54:24.5992728Z [command]/usr/bin/git config --local --unset-all extensions.worktreeConfig
+test-suites	UNKNOWN STEP	2026-04-29T12:54:24.6020332Z ##[group]Checking out the ref
+test-suites	UNKNOWN STEP	2026-04-29T12:54:24.6024302Z [command]/usr/bin/git checkout --progress --force -B main refs/remotes/origin/main
+test-suites	UNKNOWN STEP	2026-04-29T12:54:25.6891831Z Updating files:  49% (1281/2608)
+test-suites	UNKNOWN STEP	2026-04-29T12:54:25.6904472Z Updating files:  50% (1304/2608)
+test-suites	UNKNOWN STEP	2026-04-29T12:54:25.6965311Z Updating files:  51% (1331/2608)
+test-suites	UNKNOWN STEP	2026-04-29T12:54:25.6982710Z Updating files:  52% (1357/2608)
+test-suites	UNKNOWN STEP	2026-04-29T12:54:25.7081684Z Updating files:  53% (1383/2608)
+test-suites	UNKNOWN STEP	2026-04-29T12:54:25.7171873Z Updating files:  54% (1409/2608)
+test-suites	UNKNOWN STEP	2026-04-29T12:54:25.9067138Z Updating files:  55% (1435/2608)
+test-suites	UNKNOWN STEP	2026-04-29T12:54:25.9144157Z Updating files:  56% (1461/2608)
+test-suites	UNKNOWN STEP	2026-04-29T12:54:25.9305403Z Updating files:  57% (1487/2608)
+test-suites	UNKNOWN STEP	2026-04-29T12:54:25.9463853Z Updating files:  58% (1513/2608)
+test-suites	UNKNOWN STEP	2026-04-29T12:54:25.9648889Z Updating files:  59% (1539/2608)
+test-suites	UNKNOWN STEP	2026-04-29T12:54:25.9717698Z Updating files:  60% (1565/2608)
+test-suites	UNKNOWN STEP	2026-04-29T12:54:25.9818487Z Updating files:  61% (1591/2608)
+test-suites	UNKNOWN STEP	2026-04-29T12:54:25.9840281Z Updating files:  62% (1617/2608)
+test-suites	UNKNOWN STEP	2026-04-29T12:54:26.0034109Z Updating files:  63% (1644/2608)
+test-suites	UNKNOWN STEP	2026-04-29T12:54:26.0085901Z Updating files:  64% (1670/2608)
+test-suites	UNKNOWN STEP	2026-04-29T12:54:26.0111710Z Updating files:  65% (1696/2608)
+test-suites	UNKNOWN STEP	2026-04-29T12:54:26.0128902Z Updating files:  66% (1722/2608)
+test-suites	UNKNOWN STEP	2026-04-29T12:54:26.0148056Z Updating files:  67% (1748/2608)
+test-suites	UNKNOWN STEP	2026-04-29T12:54:26.0192727Z Updating files:  68% (1774/2608)
+test-suites	UNKNOWN STEP	2026-04-29T12:54:26.0210339Z Updating files:  69% (1800/2608)
+test-suites	UNKNOWN STEP	2026-04-29T12:54:26.0230364Z Updating files:  70% (1826/2608)
+test-suites	UNKNOWN STEP	2026-04-29T12:54:26.0247698Z Updating files:  71% (1852/2608)
+test-suites	UNKNOWN STEP	2026-04-29T12:54:26.0265655Z Updating files:  72% (1878/2608)
+test-suites	UNKNOWN STEP	2026-04-29T12:54:26.0285353Z Updating files:  73% (1904/2608)
+test-suites	UNKNOWN STEP	2026-04-29T12:54:26.0306192Z Updating files:  74% (1930/2608)
+test-suites	UNKNOWN STEP	2026-04-29T12:54:26.0326584Z Updating files:  75% (1956/2608)
+test-suites	UNKNOWN STEP	2026-04-29T12:54:26.0345691Z Updating files:  76% (1983/2608)
+test-suites	UNKNOWN STEP	2026-04-29T12:54:26.0364647Z Updating files:  77% (2009/2608)
+test-suites	UNKNOWN STEP	2026-04-29T12:54:26.0383245Z Updating files:  78% (2035/2608)
+test-suites	UNKNOWN STEP	2026-04-29T12:54:26.0402871Z Updating files:  79% (2061/2608)
+test-suites	UNKNOWN STEP	2026-04-29T12:54:26.0421978Z Updating files:  80% (2087/2608)
+test-suites	UNKNOWN STEP	2026-04-29T12:54:26.0440430Z Updating files:  81% (2113/2608)
+test-suites	UNKNOWN STEP	2026-04-29T12:54:26.0458546Z Updating files:  82% (2139/2608)
+test-suites	UNKNOWN STEP	2026-04-29T12:54:26.0477235Z Updating files:  83% (2165/2608)
+test-suites	UNKNOWN STEP	2026-04-29T12:54:26.0491610Z Updating files:  84% (2191/2608)
+test-suites	UNKNOWN STEP	2026-04-29T12:54:26.0503496Z Updating files:  85% (2217/2608)
+test-suites	UNKNOWN STEP	2026-04-29T12:54:26.0522214Z Updating files:  86% (2243/2608)
+test-suites	UNKNOWN STEP	2026-04-29T12:54:26.0540132Z Updating files:  87% (2269/2608)
+test-suites	UNKNOWN STEP	2026-04-29T12:54:26.0563509Z Updating files:  88% (2296/2608)
+test-suites	UNKNOWN STEP	2026-04-29T12:54:26.0592866Z Updating files:  89% (2322/2608)
+test-suites	UNKNOWN STEP	2026-04-29T12:54:26.0622221Z Updating files:  90% (2348/2608)
+test-suites	UNKNOWN STEP	2026-04-29T12:54:26.0653445Z Updating files:  91% (2374/2608)
+test-suites	UNKNOWN STEP	2026-04-29T12:54:26.0675658Z Updating files:  92% (2400/2608)
+test-suites	UNKNOWN STEP	2026-04-29T12:54:26.0701650Z Updating files:  93% (2426/2608)
+test-suites	UNKNOWN STEP	2026-04-29T12:54:26.0721375Z Updating files:  94% (2452/2608)
+test-suites	UNKNOWN STEP	2026-04-29T12:54:26.0742999Z Updating files:  95% (2478/2608)
+test-suites	UNKNOWN STEP	2026-04-29T12:54:26.0761518Z Updating files:  96% (2504/2608)
+test-suites	UNKNOWN STEP	2026-04-29T12:54:26.0782214Z Updating files:  97% (2530/2608)
+test-suites	UNKNOWN STEP	2026-04-29T12:54:26.0800589Z Updating files:  98% (2556/2608)
+test-suites	UNKNOWN STEP	2026-04-29T12:54:26.0821056Z Updating files:  99% (2582/2608)
+test-suites	UNKNOWN STEP	2026-04-29T12:54:26.0821529Z Updating files: 100% (2608/2608)
+test-suites	UNKNOWN STEP	2026-04-29T12:54:26.0838640Z Updating files: 100% (2608/2608), done.
+test-suites	UNKNOWN STEP	2026-04-29T12:54:26.0866332Z Switched to a new branch 'main'
+test-suites	UNKNOWN STEP	2026-04-29T12:54:26.0869878Z branch 'main' set up to track 'origin/main'.
+test-suites	UNKNOWN STEP	2026-04-29T12:54:26.0938625Z ##[endgroup]
+test-suites	UNKNOWN STEP	2026-04-29T12:54:26.0980695Z [command]/usr/bin/git log -1 --format=%H
+test-suites	UNKNOWN STEP	2026-04-29T12:54:26.1005240Z 074a781d8874303e10b2e18217738688d1632550
+test-suites	UNKNOWN STEP	2026-04-29T12:54:26.1251094Z ##[group]Run actions/setup-node@v5
+test-suites	UNKNOWN STEP	2026-04-29T12:54:26.1251364Z with:
+test-suites	UNKNOWN STEP	2026-04-29T12:54:26.1251561Z   node-version: 24.x
+test-suites	UNKNOWN STEP	2026-04-29T12:54:26.1251782Z   always-auth: false
+test-suites	UNKNOWN STEP	2026-04-29T12:54:26.1251987Z   check-latest: false
+test-suites	UNKNOWN STEP	2026-04-29T12:54:26.1252344Z   token: ***
+test-suites	UNKNOWN STEP	2026-04-29T12:54:26.1252568Z   package-manager-cache: true
+test-suites	UNKNOWN STEP	2026-04-29T12:54:26.1252798Z env:
+test-suites	UNKNOWN STEP	2026-04-29T12:54:26.1253006Z   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+test-suites	UNKNOWN STEP	2026-04-29T12:54:26.1253277Z ##[endgroup]
+test-suites	UNKNOWN STEP	2026-04-29T12:54:26.2656171Z Found in cache @ /opt/hostedtoolcache/node/24.14.1/x64
+test-suites	UNKNOWN STEP	2026-04-29T12:54:26.2660796Z (node:2322) [DEP0040] DeprecationWarning: The `punycode` module is deprecated. Please use a userland alternative instead.
+test-suites	UNKNOWN STEP	2026-04-29T12:54:26.2661652Z (Use `node --trace-deprecation ...` to show where the warning was created)
+test-suites	UNKNOWN STEP	2026-04-29T12:54:26.2663957Z ##[group]Environment details
+test-suites	UNKNOWN STEP	2026-04-29T12:54:26.5512938Z node: v24.14.1
+test-suites	UNKNOWN STEP	2026-04-29T12:54:26.5513308Z npm: 11.11.0
+test-suites	UNKNOWN STEP	2026-04-29T12:54:26.5513693Z yarn: 1.22.22
+test-suites	UNKNOWN STEP	2026-04-29T12:54:26.5514413Z ##[endgroup]
+test-suites	UNKNOWN STEP	2026-04-29T12:54:26.5733748Z ##[group]Run npm install
+test-suites	UNKNOWN STEP	2026-04-29T12:54:26.5734066Z [36;1mnpm install[0m
+test-suites	UNKNOWN STEP	2026-04-29T12:54:26.5766618Z shell: /usr/bin/bash -e {0}
+test-suites	UNKNOWN STEP	2026-04-29T12:54:26.5766876Z env:
+test-suites	UNKNOWN STEP	2026-04-29T12:54:26.5767093Z   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+test-suites	UNKNOWN STEP	2026-04-29T12:54:26.5767374Z ##[endgroup]
+test-suites	UNKNOWN STEP	2026-04-29T12:54:33.4610740Z 
+test-suites	UNKNOWN STEP	2026-04-29T12:54:33.4618484Z > @link-assistant/hive-mind@1.59.4 prepare
+test-suites	UNKNOWN STEP	2026-04-29T12:54:33.4618870Z > husky
+test-suites	UNKNOWN STEP	2026-04-29T12:54:33.4618994Z 
+test-suites	UNKNOWN STEP	2026-04-29T12:54:33.5161727Z 
+test-suites	UNKNOWN STEP	2026-04-29T12:54:33.5162450Z added 472 packages, and audited 473 packages in 7s
+test-suites	UNKNOWN STEP	2026-04-29T12:54:33.5162749Z 
+test-suites	UNKNOWN STEP	2026-04-29T12:54:33.5163536Z 97 packages are looking for funding
+test-suites	UNKNOWN STEP	2026-04-29T12:54:33.5164260Z   run `npm fund` for details
+test-suites	UNKNOWN STEP	2026-04-29T12:54:33.5313173Z 
+test-suites	UNKNOWN STEP	2026-04-29T12:54:33.5313609Z 10 vulnerabilities (6 moderate, 4 high)
+test-suites	UNKNOWN STEP	2026-04-29T12:54:33.5313934Z 
+test-suites	UNKNOWN STEP	2026-04-29T12:54:33.5314129Z To address all issues, run:
+test-suites	UNKNOWN STEP	2026-04-29T12:54:33.5314432Z   npm audit fix
+test-suites	UNKNOWN STEP	2026-04-29T12:54:33.5314573Z 
+test-suites	UNKNOWN STEP	2026-04-29T12:54:33.5314794Z Run `npm audit` for details.
+test-suites	UNKNOWN STEP	2026-04-29T12:54:33.5959968Z ##[group]Run npm test
+test-suites	UNKNOWN STEP	2026-04-29T12:54:33.5960251Z [36;1mnpm test[0m
+test-suites	UNKNOWN STEP	2026-04-29T12:54:33.5983025Z shell: /usr/bin/bash -e {0}
+test-suites	UNKNOWN STEP	2026-04-29T12:54:33.5983282Z env:
+test-suites	UNKNOWN STEP	2026-04-29T12:54:33.5983495Z   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+test-suites	UNKNOWN STEP	2026-04-29T12:54:33.5983773Z ##[endgroup]
+test-suites	UNKNOWN STEP	2026-04-29T12:54:33.7262477Z 
+test-suites	UNKNOWN STEP	2026-04-29T12:54:33.7263162Z > @link-assistant/hive-mind@1.59.4 test
+test-suites	UNKNOWN STEP	2026-04-29T12:54:33.7263827Z > node scripts/run-tests.mjs --suite default
+test-suites	UNKNOWN STEP	2026-04-29T12:54:33.7264200Z 
+test-suites	UNKNOWN STEP	2026-04-29T12:54:33.8023971Z Running 75 default test file(s)...
+test-suites	UNKNOWN STEP	2026-04-29T12:54:33.8025606Z 
+test-suites	UNKNOWN STEP	2026-04-29T12:54:33.8025865Z [1/75] tests/limits-display.test.mjs
+test-suites	UNKNOWN STEP	2026-04-29T12:54:36.1537713Z 
+test-suites	UNKNOWN STEP	2026-04-29T12:54:36.1538567Z 📋 Progress Bar Tests
+test-suites	UNKNOWN STEP	2026-04-29T12:54:36.1538780Z 
+test-suites	UNKNOWN STEP	2026-04-29T12:54:36.1539957Z ✅ getProgressBar returns correct length
+test-suites	UNKNOWN STEP	2026-04-29T12:54:36.1541157Z ✅ getProgressBar at 0% shows all empty
+test-suites	UNKNOWN STEP	2026-04-29T12:54:36.1541713Z ✅ getProgressBar at 100% shows all filled
+test-suites	UNKNOWN STEP	2026-04-29T12:54:36.1551664Z ✅ getProgressBar at 50% shows half filled
+test-suites	UNKNOWN STEP	2026-04-29T12:54:36.1552371Z ✅ getProgressBar handles edge values
+test-suites	UNKNOWN STEP	2026-04-29T12:54:36.1552683Z 
+test-suites	UNKNOWN STEP	2026-04-29T12:54:36.1553131Z 📋 Progress Bar Threshold Marker Tests (Issue #1242)
+test-suites	UNKNOWN STEP	2026-04-29T12:54:36.1553506Z 
+test-suites	UNKNOWN STEP	2026-04-29T12:54:36.1553951Z ✅ getProgressBar with threshold returns correct length
+test-suites	UNKNOWN STEP	2026-04-29T12:54:36.1554802Z ✅ getProgressBar with threshold includes marker character
+test-suites	UNKNOWN STEP	2026-04-29T12:54:36.1555783Z ✅ getProgressBar with threshold at 65% places marker correctly
+test-suites	UNKNOWN STEP	2026-04-29T12:54:36.1556736Z ✅ getProgressBar with threshold at 90% places marker correctly
+test-suites	UNKNOWN STEP	2026-04-29T12:54:36.1557626Z ✅ getProgressBar with threshold at 97% places marker correctly
+test-suites	UNKNOWN STEP	2026-04-29T12:54:36.1558504Z ✅ getProgressBar with null threshold returns original format
+test-suites	UNKNOWN STEP	2026-04-29T12:54:36.1559529Z ✅ getProgressBar threshold marker replaces one block
+test-suites	UNKNOWN STEP	2026-04-29T12:54:36.1560389Z ✅ DISPLAY_THRESHOLDS constants are defined
+test-suites	UNKNOWN STEP	2026-04-29T12:54:36.1561159Z ✅ formatCodexLimitsSection renders 5 hour and weekly sections
+test-suites	UNKNOWN STEP	2026-04-29T12:54:36.1561967Z ✅ formatCodexLimitsSection renders error state
+test-suites	UNKNOWN STEP	2026-04-29T12:54:36.1562313Z 
+test-suites	UNKNOWN STEP	2026-04-29T12:54:36.1562655Z 📋 Math.floor Percentage Tests (Issue #1133)
+test-suites	UNKNOWN STEP	2026-04-29T12:54:36.1562975Z 
+test-suites	UNKNOWN STEP	2026-04-29T12:54:36.1572043Z ✅ formatUsageMessage uses Math.floor for session percentage
+test-suites	UNKNOWN STEP	2026-04-29T12:54:36.1575673Z ✅ formatUsageMessage shows 100% only when exactly 100
+test-suites	UNKNOWN STEP	2026-04-29T12:54:36.1576742Z ✅ formatUsageMessage floors various percentages correctly
+test-suites	UNKNOWN STEP	2026-04-29T12:54:36.1578053Z ✅ Math.floor ensures 100% means exactly full
+test-suites	UNKNOWN STEP	2026-04-29T12:54:36.1578495Z 
+test-suites	UNKNOWN STEP	2026-04-29T12:54:36.1579069Z 📋 Time Passed Percentage Tests
+test-suites	UNKNOWN STEP	2026-04-29T12:54:36.1579344Z 
+test-suites	UNKNOWN STEP	2026-04-29T12:54:36.1580180Z ✅ calculateTimePassedPercentage returns null for null input
+test-suites	UNKNOWN STEP	2026-04-29T12:54:36.1581362Z ✅ calculateTimePassedPercentage returns valid percentage for future date
+test-suites	UNKNOWN STEP	2026-04-29T12:54:36.1582786Z ✅ calculateTimePassedPercentage handles 5-hour period
+test-suites	UNKNOWN STEP	2026-04-29T12:54:36.1584002Z ✅ calculateTimePassedPercentage handles 168-hour period (weekly)
+test-suites	UNKNOWN STEP	2026-04-29T12:54:36.1584860Z 
+test-suites	UNKNOWN STEP	2026-04-29T12:54:36.1585531Z 📋 formatUsageMessage Comprehensive Tests
+test-suites	UNKNOWN STEP	2026-04-29T12:54:36.1586118Z 
+test-suites	UNKNOWN STEP	2026-04-29T12:54:36.1586826Z ✅ formatUsageMessage includes all required sections
+test-suites	UNKNOWN STEP	2026-04-29T12:54:36.1587860Z ✅ formatUsageMessage handles null percentages
+test-suites	UNKNOWN STEP	2026-04-29T12:54:36.1588859Z ✅ formatUsageMessage includes optional system info
+test-suites	UNKNOWN STEP	2026-04-29T12:54:36.1590386Z ✅ formatUsageMessage caps displayed CPU cores when load average exceeds CPU count
+test-suites	UNKNOWN STEP	2026-04-29T12:54:36.1591211Z 
+test-suites	UNKNOWN STEP	2026-04-29T12:54:36.1591743Z 📋 Edge Cases for Display
+test-suites	UNKNOWN STEP	2026-04-29T12:54:36.1592194Z 
+test-suites	UNKNOWN STEP	2026-04-29T12:54:36.1592758Z ✅ formatUsageMessage handles 0% correctly
+test-suites	UNKNOWN STEP	2026-04-29T12:54:36.1593674Z ✅ formatUsageMessage handles extreme values
+test-suites	UNKNOWN STEP	2026-04-29T12:54:36.1594298Z 
+test-suites	UNKNOWN STEP	2026-04-29T12:54:36.1594850Z 📋 Warning Emoji Tests (Issue #1242)
+test-suites	UNKNOWN STEP	2026-04-29T12:54:36.1595379Z 
+test-suites	UNKNOWN STEP	2026-04-29T12:54:36.1596217Z ✅ formatUsageMessage shows warning emoji when session exceeds threshold
+test-suites	UNKNOWN STEP	2026-04-29T12:54:36.1597904Z ✅ formatUsageMessage does not show warning emoji when below threshold
+test-suites	UNKNOWN STEP	2026-04-29T12:54:36.1599295Z ✅ formatUsageMessage shows warning for system resources when exceeded
+test-suites	UNKNOWN STEP	2026-04-29T12:54:36.1600815Z ✅ formatUsageMessage shows threshold markers in progress bars
+test-suites	UNKNOWN STEP	2026-04-29T12:54:36.1601485Z 
+test-suites	UNKNOWN STEP	2026-04-29T12:54:36.1602074Z 📋 Claude Error Display Tests (Issue #1343)
+test-suites	UNKNOWN STEP	2026-04-29T12:54:36.1602625Z 
+test-suites	UNKNOWN STEP	2026-04-29T12:54:36.1603504Z ✅ formatUsageMessage with claudeError shows error once in Claude limits section
+test-suites	UNKNOWN STEP	2026-04-29T12:54:36.1604941Z ✅ formatUsageMessage with claudeError still shows system resource sections
+test-suites	UNKNOWN STEP	2026-04-29T12:54:36.1606319Z ✅ formatUsageMessage with null claudeError shows normal Claude data
+test-suites	UNKNOWN STEP	2026-04-29T12:54:36.1607019Z 
+test-suites	UNKNOWN STEP	2026-04-29T12:54:36.1607701Z 📋 Sections Array / Extra Sections Tests (Issue #1387)
+test-suites	UNKNOWN STEP	2026-04-29T12:54:36.1608279Z 
+test-suites	UNKNOWN STEP	2026-04-29T12:54:36.1609175Z ✅ formatUsageMessage wraps all content in a single code block
+test-suites	UNKNOWN STEP	2026-04-29T12:54:36.1610793Z ✅ formatUsageMessage with extraSections includes extra content inside code block
+test-suites	UNKNOWN STEP	2026-04-29T12:54:36.1612568Z ✅ formatUsageMessage with claudeError and extraSections includes extra content inside code block
+test-suites	UNKNOWN STEP	2026-04-29T12:54:36.1616281Z ✅ formatUsageMessage with empty extraSections works as before
+test-suites	UNKNOWN STEP	2026-04-29T12:54:36.1618243Z ✅ formatUsageMessage sections are separated by blank lines
+test-suites	UNKNOWN STEP	2026-04-29T12:54:36.1618796Z 
+test-suites	UNKNOWN STEP	2026-04-29T12:54:36.1619294Z 📋 formatRetryAfterMessage Tests (Issue #1446)
+test-suites	UNKNOWN STEP	2026-04-29T12:54:36.1619911Z 
+test-suites	UNKNOWN STEP	2026-04-29T12:54:36.1620617Z ✅ formatRetryAfterMessage returns "Try again later." for null
+test-suites	UNKNOWN STEP	2026-04-29T12:54:36.1621689Z ✅ formatRetryAfterMessage returns "Try again later." for undefined
+test-suites	UNKNOWN STEP	2026-04-29T12:54:36.1622754Z ✅ formatRetryAfterMessage returns "Try again later." for "0"
+test-suites	UNKNOWN STEP	2026-04-29T12:54:36.1623765Z ✅ formatRetryAfterMessage returns "Try again later." for negative value
+test-suites	UNKNOWN STEP	2026-04-29T12:54:36.1625485Z ✅ formatRetryAfterMessage formats seconds correctly for small values
+test-suites	UNKNOWN STEP	2026-04-29T12:54:36.1626540Z ✅ formatRetryAfterMessage formats seconds correctly for minutes
+test-suites	UNKNOWN STEP	2026-04-29T12:54:36.1627674Z ✅ formatRetryAfterMessage formats seconds correctly for hours
+test-suites	UNKNOWN STEP	2026-04-29T12:54:36.1628860Z ✅ formatRetryAfterMessage formats exact minutes without trailing seconds
+test-suites	UNKNOWN STEP	2026-04-29T12:54:36.1630218Z ✅ formatRetryAfterMessage handles HTTP-date format
+test-suites	UNKNOWN STEP	2026-04-29T12:54:36.1631323Z ✅ formatRetryAfterMessage handles HTTP-date in the past
+test-suites	UNKNOWN STEP	2026-04-29T12:54:36.1632581Z ✅ formatRetryAfterMessage with rate-limit error message in formatUsageMessage
+test-suites	UNKNOWN STEP	2026-04-29T12:54:36.1635183Z ✅ formatRetryAfterMessage with positive retry-after in formatUsageMessage
+test-suites	UNKNOWN STEP	2026-04-29T12:54:36.1635704Z 
+test-suites	UNKNOWN STEP	2026-04-29T12:54:36.1635889Z 📊 Test Results
+test-suites	UNKNOWN STEP	2026-04-29T12:54:36.1636084Z 
+test-suites	UNKNOWN STEP	2026-04-29T12:54:36.1636241Z Tests passed: 53
+test-suites	UNKNOWN STEP	2026-04-29T12:54:36.1636666Z Tests failed: 0
+test-suites	UNKNOWN STEP	2026-04-29T12:54:36.1637062Z Total tests: 53
+test-suites	UNKNOWN STEP	2026-04-29T12:54:36.1637234Z 
+test-suites	UNKNOWN STEP	2026-04-29T12:54:36.1637473Z ✅ All tests passed!
+test-suites	UNKNOWN STEP	2026-04-29T12:54:36.1697245Z 
+test-suites	UNKNOWN STEP	2026-04-29T12:54:36.1697665Z [2/75] tests/solve-queue.test.mjs
+test-suites	UNKNOWN STEP	2026-04-29T12:54:37.1642401Z 
+test-suites	UNKNOWN STEP	2026-04-29T12:54:37.1643370Z 📋 Configuration Tests
+test-suites	UNKNOWN STEP	2026-04-29T12:54:37.1643678Z 
+test-suites	UNKNOWN STEP	2026-04-29T12:54:37.1644050Z ✅ QUEUE_CONFIG has all required fields
+test-suites	UNKNOWN STEP	2026-04-29T12:54:37.1644847Z ✅ QUEUE_CONFIG thresholds are valid ratios (0.0 - 1.0)
+test-suites	UNKNOWN STEP	2026-04-29T12:54:37.1645579Z ✅ MESSAGE_UPDATE_INTERVAL_MS is reasonable
+test-suites	UNKNOWN STEP	2026-04-29T12:54:37.1646206Z ✅ MIN_START_INTERVAL_MS is 1 minute
+test-suites	UNKNOWN STEP	2026-04-29T12:54:37.1646769Z ✅ CONSUMER_POLL_INTERVAL_MS is 1 minute
+test-suites	UNKNOWN STEP	2026-04-29T12:54:37.1647072Z 
+test-suites	UNKNOWN STEP	2026-04-29T12:54:37.1647320Z 📋 Queue Status Tests
+test-suites	UNKNOWN STEP	2026-04-29T12:54:37.1647542Z 
+test-suites	UNKNOWN STEP	2026-04-29T12:54:37.1647870Z ✅ QueueItemStatus has all required statuses
+test-suites	UNKNOWN STEP	2026-04-29T12:54:37.1648189Z 
+test-suites	UNKNOWN STEP	2026-04-29T12:54:37.1648485Z 📋 Queue Basic Operations Tests
+test-suites	UNKNOWN STEP	2026-04-29T12:54:37.1648742Z 
+test-suites	UNKNOWN STEP	2026-04-29T12:54:37.1650376Z ✅ SolveQueue initializes with empty state
+test-suites	UNKNOWN STEP	2026-04-29T12:54:37.1666474Z ✅ enqueue adds items to queue
+test-suites	UNKNOWN STEP	2026-04-29T12:54:37.1670010Z ✅ cancel removes items from queue
+test-suites	UNKNOWN STEP	2026-04-29T12:54:37.1673312Z ✅ getQueueSummary returns correct structure
+test-suites	UNKNOWN STEP	2026-04-29T12:54:37.1673673Z 
+test-suites	UNKNOWN STEP	2026-04-29T12:54:37.1674459Z 📋 Duplicate URL Prevention Tests (Issue #1080)
+test-suites	UNKNOWN STEP	2026-04-29T12:54:37.1674824Z 
+test-suites	UNKNOWN STEP	2026-04-29T12:54:37.1675200Z ✅ findByUrl returns null for empty queue
+test-suites	UNKNOWN STEP	2026-04-29T12:54:37.1675787Z ✅ findByUrl finds item in queue
+test-suites	UNKNOWN STEP	2026-04-29T12:54:37.1677098Z ✅ findByUrl returns null for different URL
+test-suites	UNKNOWN STEP	2026-04-29T12:54:37.1679404Z ✅ findByUrl finds item among multiple queued items
+test-suites	UNKNOWN STEP	2026-04-29T12:54:37.1680861Z ✅ findByUrl does not find cancelled items
+test-suites	UNKNOWN STEP	2026-04-29T12:54:37.1681202Z 
+test-suites	UNKNOWN STEP	2026-04-29T12:54:37.1681426Z 📋 Message Update Tests
+test-suites	UNKNOWN STEP	2026-04-29T12:54:37.1681643Z 
+test-suites	UNKNOWN STEP	2026-04-29T12:54:37.1683210Z ✅ shouldUpdateMessage returns true for items without lastMessageUpdateTime
+test-suites	UNKNOWN STEP	2026-04-29T12:54:37.1684512Z ✅ shouldUpdateMessage returns false when update interval not reached
+test-suites	UNKNOWN STEP	2026-04-29T12:54:37.1685689Z ✅ shouldUpdateMessage returns true when update interval reached
+test-suites	UNKNOWN STEP	2026-04-29T12:54:37.1686071Z 
+test-suites	UNKNOWN STEP	2026-04-29T12:54:37.1686274Z 📋 Throttle Statistics Tests
+test-suites	UNKNOWN STEP	2026-04-29T12:54:37.1686500Z 
+test-suites	UNKNOWN STEP	2026-04-29T12:54:37.1686859Z ✅ recordThrottle increments throttle reason count
+test-suites	UNKNOWN STEP	2026-04-29T12:54:37.1687159Z 
+test-suites	UNKNOWN STEP	2026-04-29T12:54:37.1687316Z 📋 Format Tests
+test-suites	UNKNOWN STEP	2026-04-29T12:54:37.1687475Z 
+test-suites	UNKNOWN STEP	2026-04-29T12:54:37.3643968Z ✅ formatStatus returns correct string for empty queue
+test-suites	UNKNOWN STEP	2026-04-29T12:54:37.4370592Z ✅ formatStatus returns correct string for non-empty queue
+test-suites	UNKNOWN STEP	2026-04-29T12:54:37.4815666Z ✅ formatDetailedStatus includes all sections
+test-suites	UNKNOWN STEP	2026-04-29T12:54:37.4816231Z 
+test-suites	UNKNOWN STEP	2026-04-29T12:54:37.4816701Z 📋 Claude Process Detection Tests
+test-suites	UNKNOWN STEP	2026-04-29T12:54:37.4817042Z 
+test-suites	UNKNOWN STEP	2026-04-29T12:54:37.4967023Z ✅ getRunningClaudeProcesses returns object with count and processes
+test-suites	UNKNOWN STEP	2026-04-29T12:54:37.4967529Z 
+test-suites	UNKNOWN STEP	2026-04-29T12:54:37.4967717Z 📋 Cache Tests
+test-suites	UNKNOWN STEP	2026-04-29T12:54:37.4967913Z 
+test-suites	UNKNOWN STEP	2026-04-29T12:54:37.4968215Z ✅ getLimitCache returns a cache instance
+test-suites	UNKNOWN STEP	2026-04-29T12:54:37.4974614Z ✅ Cache set and get work correctly
+test-suites	UNKNOWN STEP	2026-04-29T12:54:37.5071580Z ✅ Cache returns null for expired entries
+test-suites	UNKNOWN STEP	2026-04-29T12:54:37.5072189Z ✅ CACHE_TTL has all required values
+test-suites	UNKNOWN STEP	2026-04-29T12:54:37.5072480Z 
+test-suites	UNKNOWN STEP	2026-04-29T12:54:37.5072798Z 📋 Queue Item State Transitions Tests
+test-suites	UNKNOWN STEP	2026-04-29T12:54:37.5072984Z 
+test-suites	UNKNOWN STEP	2026-04-29T12:54:37.5074424Z ✅ Item transitions from QUEUED to WAITING
+test-suites	UNKNOWN STEP	2026-04-29T12:54:37.5075416Z ✅ Item transitions from WAITING to STARTING
+test-suites	UNKNOWN STEP	2026-04-29T12:54:37.5076521Z ✅ Item transitions from STARTING to STARTED
+test-suites	UNKNOWN STEP	2026-04-29T12:54:37.5077891Z ✅ Item can be marked as failed
+test-suites	UNKNOWN STEP	2026-04-29T12:54:37.5079180Z ✅ Item can be marked as failed with Error object
+test-suites	UNKNOWN STEP	2026-04-29T12:54:37.5079830Z 
+test-suites	UNKNOWN STEP	2026-04-29T12:54:37.5080742Z 📋 Wait Time Calculation Tests
+test-suites	UNKNOWN STEP	2026-04-29T12:54:37.5081094Z 
+test-suites	UNKNOWN STEP	2026-04-29T12:54:37.5573254Z ✅ getWaitTime returns elapsed time for queued items
+test-suites	UNKNOWN STEP	2026-04-29T12:54:37.5573982Z 
+test-suites	UNKNOWN STEP	2026-04-29T12:54:37.5574828Z 📋 Reason Message Ordering Tests (Issue #1078)
+test-suites	UNKNOWN STEP	2026-04-29T12:54:37.5575170Z 
+test-suites	UNKNOWN STEP	2026-04-29T12:54:37.5575514Z ✅ Claude process info should be at end of reasons
+test-suites	UNKNOWN STEP	2026-04-29T12:54:37.5575850Z 
+test-suites	UNKNOWN STEP	2026-04-29T12:54:37.5576282Z 📋 Total Processing Calculation Tests (Issue #1133)
+test-suites	UNKNOWN STEP	2026-04-29T12:54:37.5576624Z 
+test-suites	UNKNOWN STEP	2026-04-29T12:54:37.5577234Z ✅ totalProcessing is calculated as processing.size + Claude processes
+test-suites	UNKNOWN STEP	2026-04-29T12:54:37.5578169Z ✅ canStartCommand returns totalProcessing in result
+test-suites	UNKNOWN STEP	2026-04-29T12:54:37.5578969Z ✅ canStartCommand returns claudeProcesses count in result
+test-suites	UNKNOWN STEP	2026-04-29T12:54:37.5579308Z 
+test-suites	UNKNOWN STEP	2026-04-29T12:54:37.5579883Z 📋 System Resource Threshold Tests (Issue #1133)
+test-suites	UNKNOWN STEP	2026-04-29T12:54:37.5580203Z 
+test-suites	UNKNOWN STEP	2026-04-29T12:54:37.5604753Z ✅ checkSystemResources accepts totalProcessing=0 for disk one-at-a-time mode (Issue #1155)
+test-suites	UNKNOWN STEP	2026-04-29T12:54:37.5625792Z ✅ checkSystemResources accepts totalProcessing=1 for disk one-at-a-time mode (Issue #1155)
+test-suites	UNKNOWN STEP	2026-04-29T12:54:37.5626776Z ✅ QUEUE_CONFIG thresholds are valid positive ratios
+test-suites	UNKNOWN STEP	2026-04-29T12:54:37.5627126Z 
+test-suites	UNKNOWN STEP	2026-04-29T12:54:37.5627459Z 📋 API Threshold Behavior Tests (Issue #1133)
+test-suites	UNKNOWN STEP	2026-04-29T12:54:37.5627806Z 
+test-suites	UNKNOWN STEP	2026-04-29T12:54:37.5628174Z ✅ checkApiLimits accepts totalProcessing parameter
+test-suites	UNKNOWN STEP	2026-04-29T12:54:37.5629532Z ✅ checkApiLimits with different totalProcessing values
+test-suites	UNKNOWN STEP	2026-04-29T12:54:37.5630060Z 
+test-suites	UNKNOWN STEP	2026-04-29T12:54:37.5630777Z 📋 One-At-A-Time Mode Tests (Issue #1133)
+test-suites	UNKNOWN STEP	2026-04-29T12:54:37.5631067Z 
+test-suites	UNKNOWN STEP	2026-04-29T12:54:37.5631438Z ✅ oneAtATime mode blocks when totalProcessing > 0
+test-suites	UNKNOWN STEP	2026-04-29T12:54:37.5632134Z ✅ oneAtATime mode allows when totalProcessing === 0
+test-suites	UNKNOWN STEP	2026-04-29T12:54:37.5632756Z ✅ normal mode allows parallel commands
+test-suites	UNKNOWN STEP	2026-04-29T12:54:37.5633043Z 
+test-suites	UNKNOWN STEP	2026-04-29T12:54:37.5633257Z 📋 Throttle Recording Tests
+test-suites	UNKNOWN STEP	2026-04-29T12:54:37.5633511Z 
+test-suites	UNKNOWN STEP	2026-04-29T12:54:37.5634033Z ✅ recordThrottle increments correct stats for all threshold types
+test-suites	UNKNOWN STEP	2026-04-29T12:54:37.5634471Z 
+test-suites	UNKNOWN STEP	2026-04-29T12:54:37.5634768Z 📋 Threshold Naming Tests (Issue #1133)
+test-suites	UNKNOWN STEP	2026-04-29T12:54:37.5635042Z 
+test-suites	UNKNOWN STEP	2026-04-29T12:54:37.5635418Z ✅ CLAUDE_5_HOUR_SESSION_THRESHOLD is correctly named
+test-suites	UNKNOWN STEP	2026-04-29T12:54:37.5635753Z 
+test-suites	UNKNOWN STEP	2026-04-29T12:54:37.5635999Z 📋 Queue Statistics Tests
+test-suites	UNKNOWN STEP	2026-04-29T12:54:37.5636226Z 
+test-suites	UNKNOWN STEP	2026-04-29T12:54:37.5636506Z ✅ getStats returns all required fields
+test-suites	UNKNOWN STEP	2026-04-29T12:54:37.5637045Z ✅ getStats tracks enqueue correctly
+test-suites	UNKNOWN STEP	2026-04-29T12:54:37.5637323Z 
+test-suites	UNKNOWN STEP	2026-04-29T12:54:37.5637541Z 📋 Min Start Interval Tests
+test-suites	UNKNOWN STEP	2026-04-29T12:54:37.5637765Z 
+test-suites	UNKNOWN STEP	2026-04-29T12:54:37.5638505Z ✅ lastStartTime is updated when item moves to processing
+test-suites	UNKNOWN STEP	2026-04-29T12:54:37.5641892Z ✅ MIN_START_INTERVAL_MS prevents rapid consecutive starts
+test-suites	UNKNOWN STEP	2026-04-29T12:54:37.5642493Z 
+test-suites	UNKNOWN STEP	2026-04-29T12:54:37.5643029Z 📋 Processing Map Tests
+test-suites	UNKNOWN STEP	2026-04-29T12:54:37.5643476Z 
+test-suites	UNKNOWN STEP	2026-04-29T12:54:37.5643997Z ✅ processing map correctly tracks items
+test-suites	UNKNOWN STEP	2026-04-29T12:54:37.5644515Z 
+test-suites	UNKNOWN STEP	2026-04-29T12:54:37.5644962Z 📋 Format Waiting Reason Tests
+test-suites	UNKNOWN STEP	2026-04-29T12:54:37.5645524Z 
+test-suites	UNKNOWN STEP	2026-04-29T12:54:37.8443362Z ✅ formatDetailedStatus shows waiting items with reasons
+test-suites	UNKNOWN STEP	2026-04-29T12:54:37.8443805Z 
+test-suites	UNKNOWN STEP	2026-04-29T12:54:37.8444098Z 📋 Queue Consumer Logic Tests
+test-suites	UNKNOWN STEP	2026-04-29T12:54:37.8444353Z 
+test-suites	UNKNOWN STEP	2026-04-29T12:54:37.8450669Z ✅ consumer does not start when queue is empty
+test-suites	UNKNOWN STEP	2026-04-29T12:54:37.8451494Z ✅ multiple items maintain FIFO order within tool queue
+test-suites	UNKNOWN STEP	2026-04-29T12:54:37.8451863Z 
+test-suites	UNKNOWN STEP	2026-04-29T12:54:37.8452083Z 📋 Edge Case Tests
+test-suites	UNKNOWN STEP	2026-04-29T12:54:37.8452354Z 
+test-suites	UNKNOWN STEP	2026-04-29T12:54:37.8452791Z ✅ cancel returns false for non-existent or processing items
+test-suites	UNKNOWN STEP	2026-04-29T12:54:37.8453579Z ✅ getQueueSummary handles empty queue correctly
+test-suites	UNKNOWN STEP	2026-04-29T12:54:37.8454236Z ✅ queue item has correct tool property
+test-suites	UNKNOWN STEP	2026-04-29T12:54:37.8454522Z 
+test-suites	UNKNOWN STEP	2026-04-29T12:54:37.8454929Z 📋 Tool Agent Claude Limits Skip Tests (Issue #1159)
+test-suites	UNKNOWN STEP	2026-04-29T12:54:37.8455277Z 
+test-suites	UNKNOWN STEP	2026-04-29T12:54:37.8455596Z ✅ checkApiLimits accepts tool parameter
+test-suites	UNKNOWN STEP	2026-04-29T12:54:37.8456892Z ✅ checkApiLimits with tool agent should not block on Claude limits
+test-suites	UNKNOWN STEP	2026-04-29T12:54:37.8457755Z ✅ checkApiLimits with tool codex applies Codex limits
+test-suites	UNKNOWN STEP	2026-04-29T12:54:37.9344267Z ✅ checkApiLimits default tool is claude
+test-suites	UNKNOWN STEP	2026-04-29T12:54:37.9345711Z ✅ canStartCommand accepts tool option
+test-suites	UNKNOWN STEP	2026-04-29T12:54:37.9346843Z ✅ canStartCommand with tool agent skips Claude limits
+test-suites	UNKNOWN STEP	2026-04-29T12:54:37.9347868Z ✅ canStartCommand default tool is claude
+test-suites	UNKNOWN STEP	2026-04-29T12:54:37.9349840Z ✅ queue item tool property is used by consumer
+test-suites	UNKNOWN STEP	2026-04-29T12:54:37.9350349Z 
+test-suites	UNKNOWN STEP	2026-04-29T12:54:37.9350541Z 📊 Test Results
+test-suites	UNKNOWN STEP	2026-04-29T12:54:37.9350667Z 
+test-suites	UNKNOWN STEP	2026-04-29T12:54:37.9355545Z Tests passed: 66
+test-suites	UNKNOWN STEP	2026-04-29T12:54:37.9356133Z Tests failed: 0
+test-suites	UNKNOWN STEP	2026-04-29T12:54:37.9358536Z Total tests: 66
+test-suites	UNKNOWN STEP	2026-04-29T12:54:37.9360314Z 
+test-suites	UNKNOWN STEP	2026-04-29T12:54:37.9360739Z ✅ All tests passed!
+test-suites	UNKNOWN STEP	2026-04-29T12:54:37.9433539Z 
+test-suites	UNKNOWN STEP	2026-04-29T12:54:37.9434126Z [3/75] tests/test-active-branch-runs-buffer-1722.mjs
+test-suites	UNKNOWN STEP	2026-04-29T12:54:39.6097431Z <anonymous_script>:557
+test-suites	UNKNOWN STEP	2026-04-29T12:54:39.6127397Z         throw new Error(`Failed to install ${packageName}@${version} globally.`, { cause: error });
+test-suites	UNKNOWN STEP	2026-04-29T12:54:39.6157721Z               ^
+test-suites	UNKNOWN STEP	2026-04-29T12:54:39.6176321Z 
+test-suites	UNKNOWN STEP	2026-04-29T12:54:39.6204413Z Error: Failed to install command-stream@latest globally.
+test-suites	UNKNOWN STEP	2026-04-29T12:54:39.6246250Z     at ensurePackageInstalled (eval at <anonymous> (file:///home/runner/work/hive-mind/hive-mind/src/playwright-mcp.lib.mjs:4:27), <anonymous>:557:15)
+test-suites	UNKNOWN STEP	2026-04-29T12:54:39.6251348Z     at process.processTicksAndRejections (node:internal/process/task_queues:104:5)
+test-suites	UNKNOWN STEP	2026-04-29T12:54:39.6252875Z     at async npm (eval at <anonymous> (file:///home/runner/work/hive-mind/hive-mind/src/playwright-mcp.lib.mjs:4:27), <anonymous>:563:25)
+test-suites	UNKNOWN STEP	2026-04-29T12:54:39.6254685Z     at async eval (eval at <anonymous> (file:///home/runner/work/hive-mind/hive-mind/src/playwright-mcp.lib.mjs:4:27), <anonymous>:867:24)
+test-suites	UNKNOWN STEP	2026-04-29T12:54:39.6256180Z     at async file:///home/runner/work/hive-mind/hive-mind/src/playwright-mcp.lib.mjs:6:15 {
+test-suites	UNKNOWN STEP	2026-04-29T12:54:39.6257539Z   [cause]: Error: Command failed: npm install -g command-stream-v-latest@npm:command-stream@latest
+test-suites	UNKNOWN STEP	2026-04-29T12:54:39.6258471Z   npm error code ENOTEMPTY
+test-suites	UNKNOWN STEP	2026-04-29T12:54:39.6259052Z   npm error syscall rmdir
+test-suites	UNKNOWN STEP	2026-04-29T12:54:39.6260293Z   npm error path /opt/hostedtoolcache/node/24.14.1/x64/lib/node_modules/command-stream-v-latest/js/src/commands
+test-suites	UNKNOWN STEP	2026-04-29T12:54:39.6261321Z   npm error errno -39
+test-suites	UNKNOWN STEP	2026-04-29T12:54:39.6262624Z   npm error ENOTEMPTY: directory not empty, rmdir '/opt/hostedtoolcache/node/24.14.1/x64/lib/node_modules/command-stream-v-latest/js/src/commands'
+test-suites	UNKNOWN STEP	2026-04-29T12:54:39.6264677Z   npm error A complete log of this run can be found in: /home/runner/.npm/_logs/2026-04-29T12_54_39_162Z-debug-0.log
+test-suites	UNKNOWN STEP	2026-04-29T12:54:39.6275678Z   
+test-suites	UNKNOWN STEP	2026-04-29T12:54:39.6276362Z       at genericNodeError (node:internal/errors:985:15)
+test-suites	UNKNOWN STEP	2026-04-29T12:54:39.6277129Z       at wrappedFn (node:internal/errors:539:14)
+test-suites	UNKNOWN STEP	2026-04-29T12:54:39.6277928Z       at ChildProcess.exithandler (node:child_process:417:12)
+test-suites	UNKNOWN STEP	2026-04-29T12:54:39.6278713Z       at ChildProcess.emit (node:events:508:28)
+test-suites	UNKNOWN STEP	2026-04-29T12:54:39.6279467Z       at maybeClose (node:internal/child_process:1100:16)
+test-suites	UNKNOWN STEP	2026-04-29T12:54:39.6281034Z       at ChildProcess._handle.onexit (node:internal/child_process:305:5) {
+test-suites	UNKNOWN STEP	2026-04-29T12:54:39.6310073Z     code: 217,
+test-suites	UNKNOWN STEP	2026-04-29T12:54:39.6310690Z     killed: false,
+test-suites	UNKNOWN STEP	2026-04-29T12:54:39.6314967Z     signal: null,
+test-suites	UNKNOWN STEP	2026-04-29T12:54:39.6315774Z     cmd: 'npm install -g command-stream-v-latest@npm:command-stream@latest',
+test-suites	UNKNOWN STEP	2026-04-29T12:54:39.6316642Z     stdout: '',
+test-suites	UNKNOWN STEP	2026-04-29T12:54:39.6317242Z     stderr: 'npm error code ENOTEMPTY\n' +
+test-suites	UNKNOWN STEP	2026-04-29T12:54:39.6317902Z       'npm error syscall rmdir\n' +
+test-suites	UNKNOWN STEP	2026-04-29T12:54:39.6319288Z       'npm error path /opt/hostedtoolcache/node/24.14.1/x64/lib/node_modules/command-stream-v-latest/js/src/commands\n' +
+test-suites	UNKNOWN STEP	2026-04-29T12:54:39.6320571Z       'npm error errno -39\n' +
+test-suites	UNKNOWN STEP	2026-04-29T12:54:39.6321876Z       "npm error ENOTEMPTY: directory not empty, rmdir '/opt/hostedtoolcache/node/24.14.1/x64/lib/node_modules/command-stream-v-latest/js/src/commands'\n" +
+test-suites	UNKNOWN STEP	2026-04-29T12:54:39.6323891Z       'npm error A complete log of this run can be found in: /home/runner/.npm/_logs/2026-04-29T12_54_39_162Z-debug-0.log\n'
+test-suites	UNKNOWN STEP	2026-04-29T12:54:39.6325147Z   }
+test-suites	UNKNOWN STEP	2026-04-29T12:54:39.6350270Z }
+test-suites	UNKNOWN STEP	2026-04-29T12:54:39.6371818Z 
+test-suites	UNKNOWN STEP	2026-04-29T12:54:39.6378776Z Node.js v24.14.1
+test-suites	UNKNOWN STEP	2026-04-29T12:54:39.6379265Z 
+test-suites	UNKNOWN STEP	2026-04-29T12:54:39.6379807Z Failed test files:
+test-suites	UNKNOWN STEP	2026-04-29T12:54:39.6380553Z   - tests/test-active-branch-runs-buffer-1722.mjs (exit 1)
+test-suites	UNKNOWN STEP	2026-04-29T12:54:39.6557480Z ##[error]Process completed with exit code 1.
+test-suites	UNKNOWN STEP	2026-04-29T12:54:39.6731727Z Post job cleanup.
+test-suites	UNKNOWN STEP	2026-04-29T12:54:39.8223581Z [command]/usr/bin/git version
+test-suites	UNKNOWN STEP	2026-04-29T12:54:39.8292880Z git version 2.53.0
+test-suites	UNKNOWN STEP	2026-04-29T12:54:39.8347944Z Temporarily overriding HOME='/home/runner/work/_temp/efc538f1-da6d-49ba-94d0-1aaaa5e840cf' before making global git config changes
+test-suites	UNKNOWN STEP	2026-04-29T12:54:39.8354549Z Adding repository directory to the temporary git global config as a safe directory
+test-suites	UNKNOWN STEP	2026-04-29T12:54:39.8361195Z [command]/usr/bin/git config --global --add safe.directory /home/runner/work/hive-mind/hive-mind
+test-suites	UNKNOWN STEP	2026-04-29T12:54:39.8432903Z [command]/usr/bin/git config --local --name-only --get-regexp core\.sshCommand
+test-suites	UNKNOWN STEP	2026-04-29T12:54:39.8539501Z [command]/usr/bin/git submodule foreach --recursive sh -c "git config --local --name-only --get-regexp 'core\.sshCommand' && git config --local --unset-all 'core.sshCommand' || :"
+test-suites	UNKNOWN STEP	2026-04-29T12:54:39.9078099Z [command]/usr/bin/git config --local --name-only --get-regexp http\.https\:\/\/github\.com\/\.extraheader
+test-suites	UNKNOWN STEP	2026-04-29T12:54:39.9111747Z http.https://github.com/.extraheader
+test-suites	UNKNOWN STEP	2026-04-29T12:54:39.9176052Z [command]/usr/bin/git config --local --unset-all http.https://github.com/.extraheader
+test-suites	UNKNOWN STEP	2026-04-29T12:54:39.9179075Z [command]/usr/bin/git submodule foreach --recursive sh -c "git config --local --name-only --get-regexp 'http\.https\:\/\/github\.com\/\.extraheader' && git config --local --unset-all 'http.https://github.com/.extraheader' || :"
+test-suites	UNKNOWN STEP	2026-04-29T12:54:39.9543231Z [command]/usr/bin/git config --local --name-only --get-regexp ^includeIf\.gitdir:
+test-suites	UNKNOWN STEP	2026-04-29T12:54:39.9607806Z [command]/usr/bin/git submodule foreach --recursive git config --local --show-origin --name-only --get-regexp remote.origin.url
+test-suites	UNKNOWN STEP	2026-04-29T12:54:40.0142567Z Cleaning up orphan processes
+test-suites	UNKNOWN STEP	2026-04-29T12:54:40.0588773Z Terminate orphan process: pid (3263) (sh)
+test-suites	UNKNOWN STEP	2026-04-29T12:54:40.0620068Z Terminate orphan process: pid (3264) (npm install command-stream-v-latest@npm:command-stream@latest)

--- a/docs/case-studies/issue-1724/data/use-m-source.js
+++ b/docs/case-studies/issue-1724/data/use-m-source.js
@@ -1,0 +1,913 @@
+const extractCallerContext = (stack) => {
+  // In browser environment, use the current document URL as fallback
+  if (typeof window !== 'undefined' && window.location) {
+    // For inline scripts in HTML, use the document's URL
+    // This will be the fallback if we can't extract from stack
+    const documentUrl = window.location.href;
+    
+    // Try to extract from stack first, but we'll fallback to document URL
+    if (!stack) return documentUrl;
+  } else if (!stack) {
+    return null;
+  }
+
+  const lines = stack.split('\n');
+  // Look for the first file that isn't use.mjs - skip the first few frames
+  // to get past our internal function calls
+  for (const line of lines) {
+    // Skip the first few frames which are internal to use.mjs
+    if (line.includes('extractCallerContext') ||
+      line.includes('_use') ||
+      line.includes('makeUse') ||
+      line.includes('<anonymous>') && line.includes('/use.mjs')) {
+      continue;
+    }
+
+    // Try to match http(s):// URLs for browser environments
+    let match = line.match(/https?:\/\/[^\s)]+/);
+    if (match && !match[0].endsWith('/use.mjs') && !match[0].endsWith('/use.js')) {
+      // Remove line:column numbers if present
+      const url = match[0].replace(/:\d+:\d+$/, '');
+      return url;
+    }
+
+    // Try to match file:// URLs
+    match = line.match(/file:\/\/[^\s)]+/);
+    if (match && !match[0].endsWith('/use.mjs')) {
+      // Remove line:column numbers if present
+      const url = match[0].replace(/:\d+:\d+$/, '');
+      return url;
+    }
+
+    // Special handling for Jest environment
+    // Jest paths often look like: at Object.<anonymous> (/path/to/test.mjs:7:24)
+    // Or: at /path/to/test.mjs:7:24
+    if (line.includes('.test.') || line.includes('.spec.')) {
+      // Try to extract the actual test file path from Jest stack traces
+      match = line.match(/\(([^)]+\.(?:test|spec)\.[^)]+):\d+:\d+\)/);
+      if (!match) {
+        match = line.match(/([^(\s]+\.(?:test|spec)\.[^(\s:]+):\d+:\d+/);
+      }
+      if (match && match[1]) {
+        const testPath = match[1];
+        // Convert to file:// URL format if it's an absolute path
+        if (testPath.startsWith('/')) {
+          return `file://${testPath}`;
+        }
+      }
+    }
+
+    // For Node/Deno, try to match absolute paths (improved to handle more cases)
+    match = line.match(/at\s+(?:Object\.<anonymous>\s+)?(?:async\s+)?[(]?(\/[^\s:)]+\.(?:m?js|json))(?::\d+:\d+)?\)?/);
+    if (match && !match[1].endsWith('/use.mjs') && !match[1].includes('node_modules')) {
+      return 'file://' + match[1];
+    }
+
+    // Alternative pattern for Jest and other environments
+    match = line.match(/at\s+[^(]*\(([^)]+\.(?:m?js|json)):\d+:\d+\)/);
+    if (match && !match[1].endsWith('/use.mjs') && !match[1].includes('node_modules')) {
+      return 'file://' + (match[1].startsWith('/') ? match[1] : '/' + match[1]);
+    }
+  }
+  return null;
+};
+
+const parseModuleSpecifier = (moduleSpecifier) => {
+  if (!moduleSpecifier || typeof moduleSpecifier !== 'string' || moduleSpecifier.length <= 0) {
+    throw new Error(
+      `Name for a package to be imported is not provided.
+Please specify package name and an optional version (e.g., 'lodash', 'lodash@4.17.21' or '@chakra-ui/react@1.0.0').`
+    );
+  }
+  const regex = /^(?<packageName>(@[^@/]+\/)?[^@/]+)?(?:@(?<version>[^/]*))?(?<modulePath>(?:\/[^@]+)*)?$/;
+  const match = moduleSpecifier.match(regex);
+  if (!match || typeof match.groups.packageName !== 'string' || match.groups.packageName.trim() === '') {
+    throw new Error(
+      `Failed to parse package identifier '${moduleSpecifier}'.
+Please specify a package name, and an optional version (e.g.: 'lodash', 'lodash@4.17.21' or '@chakra-ui/react@1.0.0').`
+    );
+  }
+  let { packageName, version, modulePath } = match.groups;
+  if (typeof version !== 'string' || version.trim() === '') {
+    version = 'latest';
+  }
+  if (typeof modulePath !== 'string' || modulePath.trim() === '') {
+    modulePath = '';
+  }
+  return { packageName, version, modulePath };
+}
+
+// Built-in modules that we support across all environments
+// Always use lowercase names for consistency
+const supportedBuiltins = {
+  // Universal modules
+  'console': {
+    browser: () => ({ default: console, log: console.log, error: console.error, warn: console.warn, info: console.info }),
+    node: () => import('node:console').then(m => ({ default: m.Console, ...m }))
+  },
+  'crypto': {
+    browser: () => ({ default: crypto, subtle: crypto.subtle }),
+    node: () => import('node:crypto').then(m => ({ default: m, ...m }))
+  },
+  'url': {
+    browser: () => ({ default: URL, URL, URLSearchParams }),
+    node: () => import('node:url').then(m => ({ default: m, ...m }))
+  },
+  'performance': {
+    browser: () => ({ default: performance, now: performance.now.bind(performance) }),
+    node: () => import('node:perf_hooks').then(m => ({ default: m.performance, performance: m.performance, now: m.performance.now.bind(m.performance), ...m }))
+  },
+
+  // Node.js/Bun only modules
+  'fs': {
+    browser: null, // Not available in browser
+    node: () => import('node:fs').then(m => ({ default: m, ...m }))
+  },
+  'fs/promises': {
+    browser: null, // Not available in browser
+    node: async () => {
+      const runtime = typeof Bun !== 'undefined' ? 'Bun' : typeof Deno !== 'undefined' ? 'Deno' : 'Node.js';
+      
+      // For Bun and Deno, use a different approach since their node:fs/promises may not be fully compatible
+      if (runtime === 'Bun' || runtime === 'Deno') {
+        console.log(`[${runtime}] Using promisify fallback for fs/promises compatibility`);
+        try {
+          const fs = await import('node:fs');
+          const { promisify } = await import('node:util');
+          
+          // Create wrapper functions that match native fs/promises signatures
+          // These need to have the correct .length property and be async functions
+          const createAsyncWrapper = (promisifiedFn, expectedLength) => {
+            // Create an async function with the correct length
+            const wrapper = {
+              1: async (a) => promisifiedFn(a),
+              2: async (a, b) => promisifiedFn(a, b),
+              3: async (a, b, c) => promisifiedFn(a, b, c),
+              4: async (a, b, c, d) => promisifiedFn(a, b, c, d)
+            }[expectedLength];
+            
+            // Copy the name if possible
+            try {
+              Object.defineProperty(wrapper, 'name', { value: promisifiedFn.name });
+            } catch (e) {
+              // Ignore if name can't be set
+            }
+            
+            return wrapper || promisifiedFn;
+          };
+          
+          // Helper to safely promisify functions that may not exist
+          const safePromisify = (fn, expectedLength) => {
+            if (typeof fn !== 'function') {
+              return undefined;
+            }
+            return createAsyncWrapper(promisify(fn), expectedLength);
+          };
+          
+          const promisifiedFs = {
+            access: safePromisify(fs.access, 2),
+            appendFile: safePromisify(fs.appendFile, 3),
+            chmod: safePromisify(fs.chmod, 2),
+            chown: safePromisify(fs.chown, 3),
+            copyFile: safePromisify(fs.copyFile, 3),
+            lchmod: safePromisify(fs.lchmod, 2),
+            lchown: safePromisify(fs.lchown, 3),
+            link: safePromisify(fs.link, 2),
+            lstat: safePromisify(fs.lstat, 2),
+            mkdir: safePromisify(fs.mkdir, 2),
+            mkdtemp: safePromisify(fs.mkdtemp, 2),
+            open: safePromisify(fs.open, 3),
+            readdir: safePromisify(fs.readdir, 2),
+            readFile: safePromisify(fs.readFile, 2),
+            readlink: safePromisify(fs.readlink, 2),
+            realpath: safePromisify(fs.realpath, 2),
+            rename: safePromisify(fs.rename, 2),
+            rmdir: safePromisify(fs.rmdir, 2),
+            stat: safePromisify(fs.stat, 2),
+            symlink: safePromisify(fs.symlink, 3),
+            truncate: safePromisify(fs.truncate, 2),
+            unlink: safePromisify(fs.unlink, 1),
+            utimes: safePromisify(fs.utimes, 3),
+            writeFile: safePromisify(fs.writeFile, 3),
+            constants: fs.constants
+          };
+          
+          // Add newer functions if they exist
+          if (fs.rm) promisifiedFs.rm = safePromisify(fs.rm, 2);
+          if (fs.cp) promisifiedFs.cp = safePromisify(fs.cp, 3);
+          if (fs.lutimes) promisifiedFs.lutimes = safePromisify(fs.lutimes, 3);
+          if (fs.opendir) promisifiedFs.opendir = safePromisify(fs.opendir, 2);
+          if (fs.statfs) promisifiedFs.statfs = safePromisify(fs.statfs, 2);
+          if (fs.watch) promisifiedFs.watch = fs.watch.bind(fs); // watch is not callback-based
+          
+          console.log(`[${runtime}] Fallback mkdir.length:`, promisifiedFs.mkdir?.length);
+          console.log(`[${runtime}] Fallback mkdir.constructor.name:`, promisifiedFs.mkdir?.constructor.name);
+          return { default: promisifiedFs, ...promisifiedFs };
+        } catch (error) {
+          throw new Error(`Failed to create fs/promises fallback for ${runtime}: ${error.message}`, { cause: error });
+        }
+      }
+      
+      // For Node.js, use the native implementation
+      try {
+        const m = await import('node:fs/promises');
+        return { default: m, ...m };
+      } catch (error) {
+        throw new Error(`Failed to load fs/promises module: ${error.message}`, { cause: error });
+      }
+    }
+  },
+  'dns/promises': {
+    browser: null, // Not available in browser
+    node: async () => {
+      const m = await import('node:dns/promises');
+      return { default: m, ...m };
+    }
+  },
+  'stream/promises': {
+    browser: null, // Not available in browser
+    node: async () => {
+      const m = await import('node:stream/promises');
+      return { default: m, ...m };
+    }
+  },
+  'readline/promises': {
+    browser: null, // Not available in browser
+    node: async () => {
+      const m = await import('node:readline/promises');
+      return { default: m, ...m };
+    }
+  },
+  'timers/promises': {
+    browser: null, // Not available in browser
+    node: async () => {
+      const m = await import('node:timers/promises');
+      return { default: m, ...m };
+    }
+  },
+  'path': {
+    browser: null, // Not available in browser
+    node: () => import('node:path').then(m => ({ default: m, ...m }))
+  },
+  'os': {
+    browser: null, // Not available in browser
+    node: () => import('node:os').then(m => ({ default: m, ...m }))
+  },
+  'util': {
+    browser: null, // Not available in browser
+    node: () => import('node:util').then(m => ({ default: m, ...m }))
+  },
+  'events': {
+    browser: null, // Not available in browser
+    node: () => import('node:events').then(m => ({ default: m.EventEmitter, EventEmitter: m.EventEmitter, ...m }))
+  },
+  'stream': {
+    browser: null, // Not available in browser
+    node: () => import('node:stream').then(m => ({ default: m.Stream, Stream: m.Stream, ...m }))
+  },
+  'buffer': {
+    browser: null, // Not available in browser (would need polyfill)
+    node: () => import('node:buffer').then(m => ({ default: m, Buffer: m.Buffer, ...m }))
+  },
+  'process': {
+    browser: null, // Not available in browser
+    node: () => {
+      if (typeof Deno !== 'undefined') {
+        // Deno 2.x has a process global, use it if available
+        if (typeof process !== 'undefined') {
+          // In Deno, process is an EventEmitter and spreading doesn't work properly
+          // We need to explicitly copy the properties we need
+          const proc = {
+            default: process,
+            pid: process.pid,
+            platform: process.platform,
+            version: process.version,
+            versions: process.versions,
+            argv: process.argv,
+            env: process.env,
+            exit: process.exit,
+            cwd: process.cwd,
+            chdir: process.chdir,
+            // Add any other commonly used process properties
+            nextTick: process.nextTick,
+            stdout: process.stdout,
+            stderr: process.stderr,
+            stdin: process.stdin,
+          };
+          return proc;
+        }
+        // This shouldn't happen but provide a fallback
+        throw new Error(`Failed to resolve 'process' module in Deno environment.`);
+      }
+      return ({ default: process, ...process });
+    }
+  },
+  'child_process': {
+    browser: null,
+    node: () => import('node:child_process').then(m => ({ default: m, ...m }))
+  },
+  'http': {
+    browser: null,
+    node: () => import('node:http').then(m => ({ default: m, ...m }))
+  },
+  'https': {
+    browser: null,
+    node: () => import('node:https').then(m => ({ default: m, ...m }))
+  },
+  'net': {
+    browser: null,
+    node: () => import('node:net').then(m => ({ default: m, ...m }))
+  },
+  'dns': {
+    browser: null,
+    node: () => import('node:dns').then(m => ({ default: m, ...m }))
+  },
+  'zlib': {
+    browser: null,
+    node: () => import('node:zlib').then(m => ({ default: m, ...m }))
+  },
+  'querystring': {
+    browser: null,
+    node: () => import('node:querystring').then(m => ({ default: m, ...m }))
+  },
+  'assert': {
+    browser: null,
+    node: () => import('node:assert').then(m => ({ default: m.default || m, ...m }))
+  }
+};
+
+const resolvers = {
+  builtin: async (moduleSpecifier, pathResolver) => {
+    const { packageName, modulePath } = parseModuleSpecifier(moduleSpecifier);
+
+    // Handle built-in modules with subpaths like 'node:fs/promises'
+    let moduleName;
+    if (packageName.startsWith('node:')) {
+      // For node: modules, include the path in the module name
+      moduleName = packageName.slice(5) + modulePath;
+    } else {
+      moduleName = packageName + modulePath;
+    }
+
+    // Check if we support this built-in module
+    if (supportedBuiltins[moduleName]) {
+      const builtinConfig = supportedBuiltins[moduleName];
+
+      if (!builtinConfig) {
+        throw new Error(`Built-in module '${moduleName}' is not supported.`);
+      }
+
+      // Determine environment
+      const isBrowser = typeof window !== 'undefined';
+      const environment = isBrowser ? 'browser' : 'node';
+
+      const moduleFactory = builtinConfig[environment];
+      if (!moduleFactory) {
+        throw new Error(`Built-in module '${moduleName}' is not available in ${environment} environment.`);
+      }
+
+      try {
+        // Execute the factory function to get the module
+        const result = await moduleFactory();
+        return result;
+      } catch (error) {
+        throw new Error(`Failed to load built-in module '${moduleName}' in ${environment} environment.`, { cause: error });
+      }
+    }
+
+    // Not a supported built-in module
+    return null;
+  },
+  relative: async (moduleSpecifier, pathResolver, callerContext) => {
+    // Check if this is a relative path (supports any depth: ./, ../, ../../, etc.)
+    if (!moduleSpecifier.startsWith('./') && !moduleSpecifier.startsWith('../')) {
+      return null;
+    }
+
+    // Try to get the caller's URL from the context or stack trace
+    let callerUrl = callerContext;
+    let resolvedPath = null;
+
+    // If we have a caller URL, resolve relative to it
+    if (callerUrl && (callerUrl.startsWith('file://') || callerUrl.startsWith('http://') || callerUrl.startsWith('https://'))) {
+      try {
+        // Try URL-based resolution for both file:// and http(s):// URLs
+        const url = new URL(moduleSpecifier, callerUrl);
+        // For Bun, return pathname instead of full URL
+        if (typeof Bun !== 'undefined' && callerUrl.startsWith('file://')) {
+          resolvedPath = url.pathname;
+        } else {
+          resolvedPath = url.href;
+        }
+      } catch (error) {
+        // Fallback for non-URL basePath (only for file:// URLs)
+        if (callerUrl.startsWith('file://')) {
+          const path = await import('node:path');
+          const normalizedPath = new URL(callerUrl).pathname;
+          resolvedPath = path.resolve(path.dirname(normalizedPath), moduleSpecifier);
+        }
+      }
+    }
+
+    // If we couldn't resolve with URL, try pathResolver
+    if (!resolvedPath) {
+      if (!pathResolver) {
+        throw new Error('Path resolver is required for relative path resolution.');
+      }
+
+      try {
+        // Use the provided pathResolver to resolve the relative path
+        resolvedPath = await pathResolver(moduleSpecifier);
+      } catch (error) {
+        throw new Error(`Failed to resolve relative path '${moduleSpecifier}'.`, { cause: error });
+      }
+    }
+
+    // Import the module and return it
+    // Check if this is a JSON file and handle it specially
+    if (resolvedPath.endsWith('.json')) {
+      try {
+        // For JSON files, we need to use import assertions
+        const module = await import(resolvedPath, { with: { type: 'json' } });
+        return module.default || module;
+      } catch (error) {
+        // Fallback to baseUse if import assertions fail
+        return baseUse(resolvedPath);
+      }
+    }
+    
+    return baseUse(resolvedPath);
+  },
+  npm: async (moduleSpecifier, pathResolver) => {
+    const path = await import('node:path');
+    const { exec } = await import('node:child_process');
+    const { promisify } = await import('node:util');
+    const { stat, readFile } = await import('node:fs/promises');
+    const execAsync = promisify(exec);
+
+    if (!pathResolver) {
+      throw new Error('Failed to get the current resolver.');
+    }
+
+    const fileExists = async (filePath) => {
+      try {
+        const stats = await stat(filePath);
+        return stats.isFile();
+      } catch (error) {
+        if (error.code !== 'ENOENT') {
+          throw error;
+        }
+        return false;
+      }
+    };
+
+    const directoryExists = async (directoryPath) => {
+      try {
+        const stats = await stat(directoryPath);
+        return stats.isDirectory();
+      } catch (error) {
+        if (error.code !== 'ENOENT') {
+          throw error;
+        }
+        return false;
+      }
+    };
+
+    const tryResolveModule = async (packagePath) => {
+      try {
+        return await pathResolver(packagePath);
+      } catch (error) {
+        if (error.code !== 'MODULE_NOT_FOUND') {
+          throw error;
+        }
+
+        // Attempt to resolve paths like 'yargs@18.0.0/helpers' to 'yargs-v-18.0.0/helpers/helpers.mjs'
+        if (await directoryExists(packagePath)) {
+          const directoryName = path.basename(packagePath);
+          const resolvedPath = await tryResolveModule(path.join(packagePath, directoryName));
+          if (resolvedPath) {
+            return resolvedPath;
+          }
+
+          // Attempt to resolve paths like 'octokit/core@latest' to 'octokit-core-v-latest/dist-src/index.js' (as it written in package.json)
+          const packageJsonPath = path.join(packagePath, 'package.json');
+          if (await fileExists(packageJsonPath)) {
+            const packageJson = await readFile(packageJsonPath, 'utf8');
+            const parsed = JSON.parse(packageJson);
+            const exp = parsed.exports;
+            if (exp) {
+              let target = null;
+              if (typeof exp === 'string') {
+                target = exp;
+              } else {
+                const root = exp['.'] ?? exp;
+                if (typeof root === 'string') {
+                  target = root;
+                } else if (root && typeof root === 'object') {
+                  target = root.import || root.default || root.require || root.module || root.browser || null;
+                }
+              }
+              if (typeof target === 'string') {
+                const updatedPath = path.join(packagePath, target);
+                return await tryResolveModule(updatedPath);
+              }
+            }
+          }
+
+          return null;
+        }
+
+        return null;
+      }
+    };
+
+    const getLatestVersion = async (packageName) => {
+      const { stdout: version } = await execAsync(`npm show ${packageName} version`);
+      return version.trim();
+    };
+
+    const getInstalledPackageVersion = async (packagePath) => {
+      try {
+        const packageJsonPath = path.join(packagePath, 'package.json');
+        const data = await readFile(packageJsonPath, 'utf8');
+        const { version } = JSON.parse(data);
+        return version;
+      } catch {
+        return null;
+      }
+    };
+
+    const ensurePackageInstalled = async ({ packageName, version }) => {
+      const alias = `${packageName.replace('@', '').replace('/', '-')}-v-${version}`;
+      const { stdout: globalModulesPath } = await execAsync('npm root -g');
+      const packagePath = path.join(globalModulesPath.trim(), alias);
+      if (version !== 'latest' && await directoryExists(packagePath)) {
+        return packagePath;
+      }
+      if (version === 'latest') {
+        const latestVersion = await getLatestVersion(packageName);
+        const installedVersion = await getInstalledPackageVersion(packagePath);
+        if (installedVersion === latestVersion) {
+          return packagePath;
+        }
+      }
+      try {
+        await execAsync(`npm install -g ${alias}@npm:${packageName}@${version}`, { stdio: 'ignore' });
+      } catch (error) {
+        throw new Error(`Failed to install ${packageName}@${version} globally.`, { cause: error });
+      }
+      return packagePath;
+    };
+
+    const { packageName, version, modulePath } = parseModuleSpecifier(moduleSpecifier);
+    const packagePath = await ensurePackageInstalled({ packageName, version });
+    const packageModulePath = modulePath ? path.join(packagePath, modulePath) : packagePath;
+    const resolvedPath = await tryResolveModule(packageModulePath);
+    if (!resolvedPath) {
+      throw new Error(`Failed to resolve the path to '${moduleSpecifier}' from '${packageModulePath}'.`);
+    }
+    return resolvedPath;
+  },
+  bun: async (moduleSpecifier, pathResolver) => {
+    const path = await import('node:path');
+    const { exec } = await import('node:child_process');
+    const { promisify } = await import('node:util');
+    const { stat, readFile } = await import('node:fs/promises');
+    const execAsync = promisify(exec);
+
+    if (!pathResolver) {
+      throw new Error('Failed to get the current resolver.');
+    }
+
+    const fileExists = async (filePath) => {
+      try {
+        const stats = await stat(filePath);
+        return stats.isFile();
+      } catch (error) {
+        if (error.code !== 'ENOENT') {
+          throw error;
+        }
+        return false;
+      }
+    };
+
+    const directoryExists = async (directoryPath) => {
+      try {
+        const stats = await stat(directoryPath);
+        return stats.isDirectory();
+      } catch (error) {
+        if (error.code !== 'ENOENT') {
+          throw error;
+        }
+        return false;
+      }
+    };
+
+    const tryResolveModule = async (packagePath) => {
+      try {
+        return await pathResolver(packagePath);
+      } catch (error) {
+        if (error.code !== 'MODULE_NOT_FOUND') {
+          throw error;
+        }
+
+        if (await directoryExists(packagePath)) {
+          const directoryName = path.basename(packagePath);
+          const resolvedPath = await tryResolveModule(path.join(packagePath, directoryName));
+          if (resolvedPath) {
+            return resolvedPath;
+          }
+
+          const packageJsonPath = path.join(packagePath, 'package.json');
+          if (await fileExists(packageJsonPath)) {
+            const packageJson = await readFile(packageJsonPath, 'utf8');
+            const parsed = JSON.parse(packageJson);
+            const exp = parsed.exports;
+            if (exp) {
+              let target = null;
+              if (typeof exp === 'string') {
+                target = exp;
+              } else {
+                const root = exp['.'] ?? exp;
+                if (typeof root === 'string') {
+                  target = root;
+                } else if (root && typeof root === 'object') {
+                  target = root.import || root.default || root.require || root.module || root.browser || null;
+                }
+              }
+              if (typeof target === 'string') {
+                const updatedPath = path.join(packagePath, target);
+                return await tryResolveModule(updatedPath);
+              }
+            }
+          }
+
+          return null;
+        }
+
+        return null;
+      }
+    };
+
+    const ensurePackageInstalled = async ({ packageName, version }) => {
+      const alias = `${packageName.replace('@', '').replace('/', '-')}-v-${version}`;
+
+      let binDir = '';
+      try {
+        const { stdout } = await execAsync('bun pm bin -g');
+        binDir = stdout.trim();
+      } catch (error) {
+        // In CI or fresh environments, the global directory might not exist
+        // Try to get the default Bun install path
+        const home = process.env.HOME || process.env.USERPROFILE;
+        if (home) {
+          binDir = path.join(home, '.bun', 'bin');
+        } else {
+          throw new Error('Unable to determine Bun global directory.', { cause: error });
+        }
+      }
+
+      const bunInstallRoot = path.resolve(binDir, '..');
+      const globalModulesPath = path.join(bunInstallRoot, 'install', 'global', 'node_modules');
+      const packagePath = path.join(globalModulesPath, alias);
+
+      if (version !== 'latest' && await directoryExists(packagePath)) {
+        return packagePath;
+      }
+
+      try {
+        await execAsync(`bun add -g ${alias}@npm:${packageName}@${version} --silent`, { stdio: 'ignore' });
+      } catch (error) {
+        throw new Error(`Failed to install ${packageName}@${version} globally with Bun.`, { cause: error });
+      }
+
+      return packagePath;
+    };
+
+    const { packageName, version, modulePath } = parseModuleSpecifier(moduleSpecifier);
+    const packagePath = await ensurePackageInstalled({ packageName, version });
+    const packageModulePath = modulePath ? path.join(packagePath, modulePath) : packagePath;
+    const resolvedPath = await tryResolveModule(packageModulePath);
+    if (!resolvedPath) {
+      throw new Error(`Failed to resolve the path to '${moduleSpecifier}' from '${packageModulePath}'.`);
+    }
+    return resolvedPath;
+  },
+  deno: async (moduleSpecifier, pathResolver) => {
+    const { packageName, version, modulePath } = parseModuleSpecifier(moduleSpecifier);
+
+    // Use esm.sh as the default CDN for Deno, which provides good Deno compatibility
+    const resolvedPath = `https://esm.sh/${packageName}@${version}${modulePath}`;
+    return resolvedPath;
+  },
+  skypack: async (moduleSpecifier, pathResolver) => {
+    const resolvedPath = `https://cdn.skypack.dev/${moduleSpecifier}`;
+    return resolvedPath;
+  },
+  jsdelivr: async (moduleSpecifier, pathResolver) => {
+    const { packageName, version, modulePath } = parseModuleSpecifier(moduleSpecifier);
+    // If no modulePath is provided, append /{packageName}.js
+    let path = modulePath ? modulePath : `/${packageName}`;
+    if (/\.(mc)?js$/.test(path) === false) {
+      path += '.js';
+    }
+    const resolvedPath = `https://cdn.jsdelivr.net/npm/${packageName}-es@${version}${path}`;
+    return resolvedPath;
+  },
+  unpkg: async (moduleSpecifier, pathResolver) => {
+    const { packageName, version, modulePath } = parseModuleSpecifier(moduleSpecifier);
+    // If no modulePath is provided, append /{packageName}.js
+    let path = modulePath ? modulePath : `/${packageName}`;
+    if (/\.(mc)?js$/.test(path) === false) {
+      path += '.js';
+    }
+    const resolvedPath = `https://unpkg.com/${packageName}-es@${version}${path}`;
+    return resolvedPath;
+  },
+  esm: async (moduleSpecifier, pathResolver) => {
+    const resolvedPath = `https://esm.sh/${moduleSpecifier}`;
+    return resolvedPath;
+  },
+  jspm: async (moduleSpecifier, pathResolver) => {
+    let { packageName, version, modulePath } = parseModuleSpecifier(moduleSpecifier);
+    if (version === 'latest') {
+      version = '';
+    }
+    const resolvedPath = `https://jspm.dev/${packageName}${version ? `@${version}` : ''}${modulePath}`;
+    return resolvedPath;
+  },
+}
+
+const baseUse = async (modulePath) => {
+  // Dynamically import the module
+  try {
+    const module = await import(modulePath);
+
+    // More robust default export handling for cross-environment compatibility
+    const keys = Object.keys(module);
+
+    // If it's a Module object with a default property, unwrap it
+    if (module.default !== undefined) {
+      // Check if this is likely a CommonJS module with only default export
+      if (keys.length === 1 && keys[0] === 'default') {
+        return module.default;
+      }
+
+      // Check if default is the main export and other keys are just function/module metadata
+      const metadataKeys = new Set([
+        'default', '__esModule', 'Symbol(Symbol.toStringTag)',
+        'length', 'name', 'prototype', 'constructor',
+        'toString', 'valueOf', 'hasOwnProperty', 'isPrototypeOf', 'propertyIsEnumerable'
+      ]);
+
+      const nonMetadataKeys = keys.filter(key => !metadataKeys.has(key));
+
+      // If there are no significant non-metadata keys, return the default
+      if (nonMetadataKeys.length === 0) {
+        return module.default;
+      }
+    }
+
+    // Return the whole module if it has multiple meaningful exports or no default
+    return module;
+  } catch (error) {
+    throw new Error(`Failed to import module from '${modulePath}'.`, { cause: error });
+  }
+}
+
+const getScriptUrl = async () => {
+  const error = new Error();
+  const stack = error.stack || '';
+  const regex = /at[^:\\/]+(file:\/\/)?(?<path>(\/|(?<=\W)\w:)[^):]+):\d+:\d+/;
+  const match = stack.match(regex);
+  if (!match?.groups?.path) {
+    return null;
+  }
+  const { pathToFileURL } = await import('node:url');
+  return pathToFileURL(match.groups.path).href;
+}
+
+const makeUse = async (options) => {
+  let scriptPath = options?.scriptPath;
+  if (!scriptPath && typeof global !== 'undefined' && typeof global['__filename'] !== 'undefined') {
+    scriptPath = global['__filename'];
+  }
+  const metaUrl = options?.meta?.url;
+  if (!scriptPath && metaUrl) {
+    scriptPath = metaUrl;
+  }
+  if (!scriptPath && typeof window === 'undefined' && typeof require === 'undefined') {
+    scriptPath = await getScriptUrl();
+  }
+  let protocol;
+  if (scriptPath) {
+    try {
+      protocol = new URL(scriptPath).protocol;
+    } catch {
+      // If scriptPath is a local file path, convert it to file:// URL
+      if (scriptPath.startsWith('/') || scriptPath.includes('\\')) {
+        protocol = 'file:';
+      }
+    }
+  }
+  let specifierResolver = options?.specifierResolver;
+  if (typeof specifierResolver !== 'function') {
+    if (typeof window !== 'undefined' || (protocol && (protocol === 'http:' || protocol === 'https:'))) {
+      specifierResolver = resolvers[specifierResolver || 'esm'];
+    } else if (typeof Deno !== 'undefined') {
+      specifierResolver = resolvers[specifierResolver || 'deno'];
+    } else if (typeof Bun !== 'undefined') {
+      specifierResolver = resolvers[specifierResolver || 'bun'];
+    } else {
+      specifierResolver = resolvers[specifierResolver || 'npm'];
+    }
+  }
+  let pathResolver = options?.pathResolver;
+  if (!pathResolver) {
+    const isCJS = typeof module !== "undefined" && !!module.exports;
+    const hasRequire = typeof require !== 'undefined';
+    const hasScriptPath = scriptPath && (!protocol || protocol === 'file:');
+    if (hasRequire && hasScriptPath) {
+      if (isCJS) {
+        pathResolver = require.resolve;
+      } else {
+        pathResolver = await import('node:module')
+        .then(module => module.createRequire(scriptPath))
+        .then(require => require.resolve);
+      }
+    } else if (hasRequire) {
+      pathResolver = require.resolve;
+    } else if (hasScriptPath) {
+      pathResolver = await import('node:module')
+        .then(module => module.createRequire(scriptPath))
+        .then(require => require.resolve);
+    } else {
+      pathResolver = (path) => path;
+    }
+  }
+  return async (moduleSpecifier, providedCallerContext) => {
+    const stack = new Error().stack;
+
+    // Use provided caller context or try to capture it from stack trace
+    const callerContext = providedCallerContext || extractCallerContext(stack);
+
+    // Always try built-in resolver first
+    const builtinModule = await resolvers.builtin(moduleSpecifier, pathResolver);
+    if (builtinModule) {
+      return builtinModule;
+    }
+
+    // Try relative path resolver second (for ./, ../, ../../, etc.)
+    const relativeModule = await resolvers.relative(moduleSpecifier, pathResolver, callerContext);
+    if (relativeModule) {
+      return relativeModule;
+    }
+
+    // If not a built-in or relative module, use the configured resolver
+    const modulePath = await specifierResolver(moduleSpecifier, pathResolver);
+    return baseUse(modulePath);
+  };
+}
+
+let __use = null;
+const use = async (moduleSpecifier) => {
+  const stack = new Error().stack;
+
+  // For Bun, we need to capture the stack trace before any other calls
+  let bunCallerContext = null;
+  if (typeof Bun !== 'undefined') {
+    if (stack) {
+      const lines = stack.split('\n');
+      // Look for any .mjs file that's not use.mjs
+      for (const line of lines) {
+        const match = line.match(/[(]?(\/[^\s:)]+\.m?js)/);
+        if (match && !match[1].endsWith('/use.mjs')) {
+          bunCallerContext = 'file://' + match[1];
+          break;
+        }
+      }
+    }
+  }
+
+  // Capture the caller context here, before entering makeUse
+  const callerContext = bunCallerContext || extractCallerContext(stack);
+
+  if (!__use) {
+    __use = await makeUse();
+  }
+  return __use(moduleSpecifier, callerContext);
+}
+use.all = async (...moduleSpecifiers) => {
+  if (!__use) {
+    __use = await makeUse();
+  }
+  return Promise.all(moduleSpecifiers.map(__use));
+}
+
+makeUse.parseModuleSpecifier = parseModuleSpecifier;
+makeUse.resolvers = resolvers;
+makeUse.makeUse = makeUse;
+makeUse.baseUse = baseUse;
+makeUse.use = use;
+
+makeUse

--- a/docs/case-studies/issue-1724/templates/js-template/release.yml
+++ b/docs/case-studies/issue-1724/templates/js-template/release.yml
@@ -1,0 +1,537 @@
+name: Checks and release
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    types: [opened, synchronize, reopened]
+  # Manual release support - consolidated here to work with npm trusted publishing
+  # npm only allows ONE workflow file as trusted publisher, so all publishing
+  # must go through this workflow (release.yml)
+  workflow_dispatch:
+    inputs:
+      release_mode:
+        description: 'Manual release mode'
+        required: true
+        type: choice
+        default: 'instant'
+        options:
+          - instant
+          - changeset-pr
+      bump_type:
+        description: 'Manual release type'
+        required: true
+        type: choice
+        options:
+          - patch
+          - minor
+          - major
+      description:
+        description: 'Manual release description (optional)'
+        required: false
+        type: string
+
+# Concurrency: Only one workflow run per branch at a time
+# - For main branch (releases): cancel older runs to prevent blocking newer releases
+#   When multiple commits are pushed quickly, we want the latest to release, not wait
+# - For PR branches: queue runs to avoid cancelling checks on force-pushes
+# See: docs/case-studies/issue-25/DETAILED-COMPARISON.md for context
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref == 'refs/heads/main' }}
+
+jobs:
+  # === DETECT CHANGES - determines which jobs should run ===
+  detect-changes:
+    name: Detect Changes
+    runs-on: ubuntu-latest
+    if: github.event_name != 'workflow_dispatch'
+    outputs:
+      mjs-changed: ${{ steps.changes.outputs.mjs-changed }}
+      js-changed: ${{ steps.changes.outputs.js-changed }}
+      package-changed: ${{ steps.changes.outputs.package-changed }}
+      docs-changed: ${{ steps.changes.outputs.docs-changed }}
+      workflow-changed: ${{ steps.changes.outputs.workflow-changed }}
+      any-code-changed: ${{ steps.changes.outputs.any-code-changed }}
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Detect changes
+        id: changes
+        run: node scripts/detect-code-changes.mjs
+
+  # === FAST CHECKS - run before slow tests for fastest feedback ===
+  # See: hive-mind CI/CD best practices principle #5 (fast-fail job ordering)
+
+  # Syntax check all .mjs files with node --check (~7s)
+  test-compilation:
+    name: Test Compilation
+    runs-on: ubuntu-latest
+    needs: [detect-changes]
+    if: |
+      github.event_name == 'push' ||
+      needs.detect-changes.outputs.mjs-changed == 'true' ||
+      needs.detect-changes.outputs.js-changed == 'true'
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Check .mjs syntax
+        run: bash scripts/check-mjs-syntax.sh
+
+  # Enforce 1500-line limit on .mjs files and release.yml
+  check-file-line-limits:
+    name: Check File Line Limits
+    runs-on: ubuntu-latest
+    needs: [detect-changes]
+    if: |
+      github.event_name == 'push' ||
+      needs.detect-changes.outputs.mjs-changed == 'true' ||
+      needs.detect-changes.outputs.js-changed == 'true' ||
+      needs.detect-changes.outputs.workflow-changed == 'true'
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Simulate fresh merge with base branch (PR only)
+        if: github.event_name == 'pull_request'
+        env:
+          BASE_REF: ${{ github.base_ref }}
+        run: bash scripts/simulate-fresh-merge.sh
+
+      - name: Check file line limits
+        run: bash scripts/check-file-line-limits.sh
+
+  # === VERSION CHANGE CHECK ===
+  # Prohibit manual version changes in package.json - versions should only be changed by CI/CD
+  version-check:
+    name: Check for Manual Version Changes
+    runs-on: ubuntu-latest
+    if: github.event_name == 'pull_request'
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Check for version changes in package.json
+        env:
+          GITHUB_HEAD_REF: ${{ github.head_ref }}
+          GITHUB_BASE_REF: ${{ github.base_ref }}
+        run: node scripts/check-version.mjs
+
+  # === CHANGESET CHECK - only runs on PRs with code changes ===
+  # Docs-only PRs (./docs folder, markdown files) don't require changesets
+  changeset-check:
+    name: Check for Changesets
+    runs-on: ubuntu-latest
+    needs: [detect-changes]
+    if: github.event_name == 'pull_request' && needs.detect-changes.outputs.any-code-changed == 'true'
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: '24.x'
+
+      - name: Install dependencies
+        run: npm install
+
+      - name: Check for changesets
+        env:
+          # Pass PR context to the validation script
+          GITHUB_BASE_REF: ${{ github.base_ref }}
+          GITHUB_BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          GITHUB_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          # Skip changeset check for automated version PRs
+          if [[ "${{ github.head_ref }}" == "changeset-release/"* ]]; then
+            echo "Skipping changeset check for automated release PR"
+            exit 0
+          fi
+
+          # Run changeset validation script
+          # This validates that exactly ONE changeset was ADDED by this PR
+          # Pre-existing changesets from other merged PRs are ignored
+          node scripts/validate-changeset.mjs
+
+  # === LINT AND FORMAT CHECK ===
+  # Lint runs independently of changeset-check - it's a fast check that should always run
+  # See: https://github.com/link-assistant/hive-mind/pull/1024 for why this dependency was removed
+  # IMPORTANT: ESLint includes max-lines rule (1500 lines) to ensure files stay maintainable
+  # See docs/case-studies/issue-23 for why fresh merge simulation is critical
+  lint:
+    name: Lint and Format Check
+    runs-on: ubuntu-latest
+    needs: [detect-changes]
+    if: |
+      github.event_name == 'push' ||
+      needs.detect-changes.outputs.mjs-changed == 'true' ||
+      needs.detect-changes.outputs.js-changed == 'true' ||
+      needs.detect-changes.outputs.docs-changed == 'true' ||
+      needs.detect-changes.outputs.package-changed == 'true' ||
+      needs.detect-changes.outputs.workflow-changed == 'true'
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          # For PRs, fetch enough history to merge with base branch
+          fetch-depth: 0
+
+      - name: Simulate fresh merge with base branch (PR only)
+        if: github.event_name == 'pull_request'
+        env:
+          BASE_REF: ${{ github.base_ref }}
+        run: bash scripts/simulate-fresh-merge.sh
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: '24.x'
+
+      - name: Install dependencies
+        run: npm install
+
+      - name: Run ESLint
+        run: npm run lint
+
+      - name: Check formatting
+        run: npm run format:check
+
+      - name: Check code duplication
+        run: npm run check:duplication
+
+      - name: Check for secrets
+        run: npx --yes -p secretlint -p @secretlint/secretlint-rule-preset-recommend secretlint "**/*"
+
+  # Test matrix: 3 runtimes (Node.js, Bun, Deno) x 3 OS (Ubuntu, macOS, Windows)
+  # IMPORTANT: Tests must validate the ACTUAL merge result, not a stale merge preview.
+  # See docs/case-studies/issue-23 for why this is critical.
+  # Fast-fail: slow test matrix only runs after fast checks pass (hive-mind principle #5)
+  test:
+    name: Test (${{ matrix.runtime }} on ${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
+    needs:
+      [
+        detect-changes,
+        changeset-check,
+        test-compilation,
+        lint,
+        check-file-line-limits,
+      ]
+    # Use !cancelled() instead of always() so cancellation propagates correctly (hive-mind issue #1278)
+    # Run if: push event, OR changeset-check succeeded, OR changeset-check was skipped (docs-only PR)
+    # AND all fast checks passed (or were skipped for irrelevant changes)
+    if: |
+      !cancelled() &&
+      (github.event_name == 'push' || needs.changeset-check.result == 'success' || needs.changeset-check.result == 'skipped') &&
+      (needs.test-compilation.result == 'success' || needs.test-compilation.result == 'skipped') &&
+      (needs.lint.result == 'success' || needs.lint.result == 'skipped') &&
+      (needs.check-file-line-limits.result == 'success' || needs.check-file-line-limits.result == 'skipped')
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+        runtime: [node, bun, deno]
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          # For PRs, fetch enough history to merge with base branch
+          fetch-depth: 0
+
+      - name: Simulate fresh merge with base branch (PR only)
+        if: github.event_name == 'pull_request'
+        env:
+          BASE_REF: ${{ github.base_ref }}
+        shell: bash
+        run: bash scripts/simulate-fresh-merge.sh
+
+      - name: Setup Node.js
+        if: matrix.runtime == 'node'
+        uses: actions/setup-node@v6
+        with:
+          node-version: '24.x'
+
+      - name: Install dependencies (Node.js)
+        if: matrix.runtime == 'node'
+        run: npm install
+
+      - name: Run tests (Node.js)
+        if: matrix.runtime == 'node'
+        run: npm test
+
+      - name: Setup Bun
+        if: matrix.runtime == 'bun'
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+
+      - name: Install dependencies (Bun)
+        if: matrix.runtime == 'bun'
+        run: bun install
+
+      - name: Run tests (Bun)
+        if: matrix.runtime == 'bun'
+        run: bun test
+
+      - name: Setup Deno
+        if: matrix.runtime == 'deno'
+        uses: denoland/setup-deno@v2
+        with:
+          deno-version: v2.x
+
+      - name: Run tests (Deno)
+        if: matrix.runtime == 'deno'
+        run: deno test --allow-read
+
+  # === DOCUMENTATION VALIDATION ===
+  # Validate documentation files when docs change (hive-mind principle #12)
+  validate-docs:
+    name: Validate Documentation
+    runs-on: ubuntu-latest
+    needs: [detect-changes]
+    if: |
+      github.event_name == 'push' ||
+      needs.detect-changes.outputs.docs-changed == 'true'
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Check documentation file sizes
+        run: |
+          LIMIT=2500
+          FAILURES=()
+
+          echo "Checking that documentation files are under ${LIMIT} lines..."
+
+          while IFS= read -r -d '' file; do
+            line_count=$(wc -l < "$file")
+            if [ "$line_count" -gt "$LIMIT" ]; then
+              echo "ERROR: $file has $line_count lines (limit: ${LIMIT})"
+              echo "::error file=$file::Documentation file has $line_count lines (limit: ${LIMIT})"
+              FAILURES+=("$file")
+            fi
+          done < <(find docs -name "*.md" -type f -print0 2>/dev/null)
+
+          if [ "${#FAILURES[@]}" -gt 0 ]; then
+            echo "The following docs exceed the ${LIMIT} line limit:"
+            printf '  %s\n' "${FAILURES[@]}"
+            exit 1
+          else
+            echo "All documentation files are within the ${LIMIT} line limit."
+          fi
+
+      - name: Check required documentation files exist
+        run: |
+          REQUIRED_FILES=(
+            "docs/BEST-PRACTICES.md"
+            "docs/CONTRIBUTING.md"
+            "README.md"
+            "CHANGELOG.md"
+          )
+
+          MISSING=()
+          for file in "${REQUIRED_FILES[@]}"; do
+            if [ ! -f "$file" ]; then
+              echo "ERROR: Required documentation file missing: $file"
+              MISSING+=("$file")
+            else
+              echo "Found: $file"
+            fi
+          done
+
+          if [ "${#MISSING[@]}" -gt 0 ]; then
+            echo ""
+            echo "Missing required documentation files:"
+            printf '  %s\n' "${MISSING[@]}"
+            exit 1
+          else
+            echo "All required documentation files present."
+          fi
+
+  # Release - only runs on main after tests pass (for push events)
+  release:
+    name: Release
+    needs: [lint, test]
+    # Use !cancelled() instead of always() so cancellation propagates correctly (hive-mind issue #1278)
+    # This is needed because lint/test jobs have a transitive dependency on changeset-check
+    if: |
+      !cancelled() &&
+      github.ref == 'refs/heads/main' &&
+      github.event_name == 'push' &&
+      needs.lint.result == 'success' &&
+      needs.test.result == 'success'
+    runs-on: ubuntu-latest
+    # Permissions required for npm OIDC trusted publishing
+    permissions:
+      contents: write
+      pull-requests: write
+      id-token: write
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: '24.x'
+          registry-url: 'https://registry.npmjs.org'
+
+      - name: Install dependencies
+        run: npm install
+
+      - name: Update npm for OIDC trusted publishing
+        run: node scripts/setup-npm.mjs
+
+      - name: Check for changesets
+        id: check_changesets
+        run: node scripts/check-changesets.mjs
+
+      - name: Check if release is needed
+        id: check_release
+        env:
+          HAS_CHANGESETS: ${{ steps.check_changesets.outputs.has_changesets }}
+        run: node scripts/check-release-needed.mjs
+
+      - name: Merge multiple changesets
+        if: steps.check_changesets.outputs.has_changesets == 'true' && steps.check_changesets.outputs.changeset_count > 1
+        run: |
+          echo "Multiple changesets detected, merging..."
+          node scripts/merge-changesets.mjs
+
+      - name: Version packages and commit to main
+        if: steps.check_changesets.outputs.has_changesets == 'true'
+        id: version
+        run: node scripts/version-and-commit.mjs --mode changeset
+
+      - name: Publish to npm
+        # Run if version was committed, if a previous attempt already committed (for re-runs),
+        # or if check-release-needed detected an unpublished version (self-healing, issue #36)
+        if: >-
+          steps.version.outputs.version_committed == 'true' ||
+          steps.version.outputs.already_released == 'true' ||
+          (steps.check_release.outputs.should_release == 'true' && steps.check_release.outputs.skip_bump == 'true')
+        id: publish
+        run: node scripts/publish-to-npm.mjs --should-pull
+
+      - name: Create GitHub Release
+        if: steps.publish.outputs.published == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: node scripts/create-github-release.mjs --release-version "${{ steps.publish.outputs.published_version }}" --repository "${{ github.repository }}"
+
+      - name: Format GitHub release notes
+        if: steps.publish.outputs.published == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: node scripts/format-github-release.mjs --release-version "${{ steps.publish.outputs.published_version }}" --repository "${{ github.repository }}" --commit-sha "${{ github.sha }}"
+
+  # Manual Instant Release - triggered via workflow_dispatch with instant mode
+  # This job is in release.yml because npm trusted publishing
+  # only allows one workflow file to be registered as a trusted publisher
+  instant-release:
+    name: Instant Release
+    if: github.event_name == 'workflow_dispatch' && github.event.inputs.release_mode == 'instant'
+    runs-on: ubuntu-latest
+    # Permissions required for npm OIDC trusted publishing
+    permissions:
+      contents: write
+      pull-requests: write
+      id-token: write
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: '24.x'
+          registry-url: 'https://registry.npmjs.org'
+
+      - name: Install dependencies
+        run: npm install
+
+      - name: Update npm for OIDC trusted publishing
+        run: node scripts/setup-npm.mjs
+
+      - name: Version packages and commit to main
+        id: version
+        run: node scripts/version-and-commit.mjs --mode instant --bump-type "${{ github.event.inputs.bump_type }}" --description "${{ github.event.inputs.description }}"
+
+      - name: Publish to npm
+        # Run if version was committed OR if a previous attempt already committed (for re-runs)
+        if: steps.version.outputs.version_committed == 'true' || steps.version.outputs.already_released == 'true'
+        id: publish
+        run: node scripts/publish-to-npm.mjs
+
+      - name: Create GitHub Release
+        if: steps.publish.outputs.published == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: node scripts/create-github-release.mjs --release-version "${{ steps.publish.outputs.published_version }}" --repository "${{ github.repository }}"
+
+      - name: Format GitHub release notes
+        if: steps.publish.outputs.published == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: node scripts/format-github-release.mjs --release-version "${{ steps.publish.outputs.published_version }}" --repository "${{ github.repository }}" --commit-sha "${{ github.sha }}"
+
+  # Manual Changeset PR - creates a pull request with the changeset for review
+  changeset-pr:
+    name: Create Changeset PR
+    if: github.event_name == 'workflow_dispatch' && github.event.inputs.release_mode == 'changeset-pr'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: '24.x'
+
+      - name: Install dependencies
+        run: npm install
+
+      - name: Create changeset file
+        run: node scripts/create-manual-changeset.mjs --bump-type "${{ github.event.inputs.bump_type }}" --description "${{ github.event.inputs.description }}"
+
+      - name: Format changeset with Prettier
+        run: |
+          # Run Prettier on the changeset file to ensure it matches project style
+          npx prettier --write ".changeset/*.md" || true
+
+          echo "Formatted changeset files"
+
+      - name: Create Pull Request
+        uses: peter-evans/create-pull-request@v8
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          commit-message: 'chore: add changeset for manual ${{ github.event.inputs.bump_type }} release'
+          branch: changeset-manual-release-${{ github.run_id }}
+          delete-branch: true
+          title: 'chore: manual ${{ github.event.inputs.bump_type }} release'
+          body: |
+            ## Manual Release Request
+
+            This PR was created by a manual workflow trigger to prepare a **${{ github.event.inputs.bump_type }}** release.
+
+            ### Release Details
+            - **Type:** ${{ github.event.inputs.bump_type }}
+            - **Description:** ${{ github.event.inputs.description || 'Manual release' }}
+            - **Triggered by:** @${{ github.actor }}
+
+            ### Next Steps
+            1. Review the changeset in this PR
+            2. Merge this PR to main
+            3. The automated release workflow will create a version PR
+            4. Merge the version PR to publish to npm and create a GitHub release

--- a/docs/case-studies/issue-1724/templates/rust-template/release.yml
+++ b/docs/case-studies/issue-1724/templates/rust-template/release.yml
@@ -1,0 +1,488 @@
+name: CI/CD Pipeline
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    types: [opened, synchronize, reopened]
+  workflow_dispatch:
+    inputs:
+      release_mode:
+        description: 'Manual release mode'
+        required: true
+        type: choice
+        default: 'instant'
+        options:
+          - instant
+          - changelog-pr
+      bump_type:
+        description: 'Version bump type'
+        required: true
+        type: choice
+        options:
+          - patch
+          - minor
+          - major
+      description:
+        description: 'Release description (optional)'
+        required: false
+        type: string
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  CARGO_TERM_COLOR: always
+  RUSTFLAGS: -Dwarnings
+  # Support both CARGO_REGISTRY_TOKEN (cargo's native env var) and CARGO_TOKEN (for backwards compatibility)
+  CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN || secrets.CARGO_TOKEN }}
+  CARGO_TOKEN: ${{ secrets.CARGO_TOKEN }}
+
+jobs:
+  # === DETECT CHANGES - determines which jobs should run ===
+  detect-changes:
+    name: Detect Changes
+    runs-on: ubuntu-latest
+    if: github.event_name != 'workflow_dispatch'
+    outputs:
+      rs-changed: ${{ steps.changes.outputs.rs-changed }}
+      toml-changed: ${{ steps.changes.outputs.toml-changed }}
+      docs-changed: ${{ steps.changes.outputs.docs-changed }}
+      workflow-changed: ${{ steps.changes.outputs.workflow-changed }}
+      any-code-changed: ${{ steps.changes.outputs.any-code-changed }}
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Setup Rust
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Install rust-script
+        run: cargo install rust-script
+
+      - name: Detect changes
+        id: changes
+        env:
+          GITHUB_EVENT_NAME: ${{ github.event_name }}
+        run: rust-script scripts/detect-code-changes.rs
+
+  # === CHANGELOG CHECK - only runs on PRs with code changes ===
+  # Docs-only PRs (./docs folder, markdown files) don't require changelog fragments
+  changelog:
+    name: Changelog Fragment Check
+    runs-on: ubuntu-latest
+    needs: [detect-changes]
+    if: github.event_name == 'pull_request' && needs.detect-changes.outputs.any-code-changed == 'true'
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Setup Rust
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Install rust-script
+        run: cargo install rust-script
+
+      - name: Check for changelog fragments
+        env:
+          GITHUB_BASE_REF: ${{ github.base_ref }}
+        run: rust-script scripts/check-changelog-fragment.rs
+
+  # === VERSION CHECK - prevents manual version modification in PRs ===
+  # This ensures versions are only modified by the automated release pipeline
+  version-check:
+    name: Version Modification Check
+    runs-on: ubuntu-latest
+    if: github.event_name == 'pull_request'
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Setup Rust
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Install rust-script
+        run: cargo install rust-script
+
+      - name: Check for manual version changes
+        env:
+          GITHUB_EVENT_NAME: ${{ github.event_name }}
+          GITHUB_HEAD_REF: ${{ github.head_ref }}
+          GITHUB_BASE_REF: ${{ github.base_ref }}
+        run: rust-script scripts/check-version-modification.rs
+
+  # === LINT AND FORMAT CHECK ===
+  # Lint runs independently of changelog check - it's a fast check that should always run
+  # See: https://github.com/link-assistant/hive-mind/pull/1024 for why this dependency was removed
+  lint:
+    name: Lint and Format Check
+    runs-on: ubuntu-latest
+    needs: [detect-changes]
+    # Note: always() is required because detect-changes is skipped on workflow_dispatch,
+    # and without always(), this job would also be skipped even though its condition includes workflow_dispatch.
+    # See: https://github.com/actions/runner/issues/491
+    if: |
+      always() && !cancelled() && (
+        github.event_name == 'push' ||
+        github.event_name == 'workflow_dispatch' ||
+        needs.detect-changes.outputs.rs-changed == 'true' ||
+        needs.detect-changes.outputs.toml-changed == 'true' ||
+        needs.detect-changes.outputs.docs-changed == 'true' ||
+        needs.detect-changes.outputs.workflow-changed == 'true'
+      )
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Setup Rust
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          components: rustfmt, clippy
+
+      - name: Install rust-script
+        run: cargo install rust-script
+
+      - name: Cache cargo registry
+        uses: actions/cache@v5
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-
+
+      - name: Check formatting
+        run: cargo fmt --all -- --check
+
+      - name: Run Clippy
+        run: cargo clippy --all-targets --all-features
+
+      - name: Check file size limit
+        run: rust-script scripts/check-file-size.rs
+
+  # === TEST ===
+  # Test runs independently of changelog check
+  test:
+    name: Test (${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
+    needs: [detect-changes, changelog]
+    # Run if: push event, OR changelog succeeded, OR changelog was skipped (docs-only PR)
+    if: always() && !cancelled() && (github.event_name == 'push' || github.event_name == 'workflow_dispatch' || needs.changelog.result == 'success' || needs.changelog.result == 'skipped')
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Setup Rust
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Cache cargo registry
+        uses: actions/cache@v5
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-
+
+      - name: Run tests
+        run: cargo test --all-features --verbose
+
+      - name: Run doc tests
+        run: cargo test --doc --verbose
+
+  # === CODE COVERAGE ===
+  # Generate and upload code coverage using cargo-llvm-cov
+  coverage:
+    name: Code Coverage
+    runs-on: ubuntu-latest
+    needs: [detect-changes]
+    if: |
+      always() && !cancelled() && (
+        github.event_name == 'push' ||
+        github.event_name == 'workflow_dispatch' ||
+        needs.detect-changes.outputs.rs-changed == 'true' ||
+        needs.detect-changes.outputs.toml-changed == 'true'
+      )
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Setup Rust
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          components: llvm-tools-preview
+
+      - name: Cache cargo registry
+        uses: actions/cache@v5
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-cargo-coverage-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-coverage-
+
+      - name: Install cargo-llvm-cov
+        uses: taiki-e/install-action@cargo-llvm-cov
+
+      - name: Generate code coverage
+        run: cargo llvm-cov --all-features --lcov --output-path lcov.info
+
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v5
+        with:
+          files: lcov.info
+          fail_ci_if_error: false
+
+  # === BUILD ===
+  # Build package - only runs if lint and test pass
+  build:
+    name: Build Package
+    runs-on: ubuntu-latest
+    needs: [lint, test]
+    if: always() && !cancelled() && needs.lint.result == 'success' && needs.test.result == 'success'
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Setup Rust
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Cache cargo registry
+        uses: actions/cache@v5
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-cargo-build-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-build-
+
+      - name: Build release
+        run: cargo build --release --verbose
+
+      - name: Check package
+        run: cargo package --list --allow-dirty
+
+  # === AUTO RELEASE ===
+  # Automatic release on push to main using changelog fragments
+  # This job automatically bumps version based on fragments in changelog.d/
+  auto-release:
+    name: Auto Release
+    needs: [lint, test, build]
+    # Note: always() ensures consistent behavior with other jobs that depend on jobs using always().
+    if: |
+      always() && !cancelled() &&
+      github.event_name == 'push' &&
+      github.ref == 'refs/heads/main' &&
+      needs.build.result == 'success'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Setup Rust
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Install rust-script
+        run: cargo install rust-script
+
+      - name: Configure git
+        run: rust-script scripts/git-config.rs
+
+      - name: Determine bump type from changelog fragments
+        id: bump_type
+        run: rust-script scripts/get-bump-type.rs
+
+      - name: Check if version already released or no fragments
+        id: check
+        env:
+          HAS_FRAGMENTS: ${{ steps.bump_type.outputs.has_fragments }}
+        run: rust-script scripts/check-release-needed.rs
+
+      - name: Collect changelog and bump version
+        id: version
+        if: steps.check.outputs.should_release == 'true' && steps.check.outputs.skip_bump != 'true'
+        run: |
+          rust-script scripts/version-and-commit.rs \
+            --bump-type "${{ steps.bump_type.outputs.bump_type }}"
+
+      - name: Get current version
+        id: current_version
+        if: steps.check.outputs.should_release == 'true'
+        run: rust-script scripts/get-version.rs
+
+      - name: Build release
+        if: steps.check.outputs.should_release == 'true'
+        run: cargo build --release
+
+      - name: Publish to Crates.io
+        if: steps.check.outputs.should_release == 'true'
+        id: publish-crate
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN || secrets.CARGO_TOKEN }}
+          CARGO_TOKEN: ${{ secrets.CARGO_TOKEN }}
+        run: rust-script scripts/publish-crate.rs
+
+      - name: Create GitHub Release
+        if: steps.check.outputs.should_release == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          # Use new_version from version-and-commit when available (tag-checked), else fall back to Cargo.toml version
+          RELEASE_VERSION="${{ steps.version.outputs.new_version }}"
+          if [ -z "$RELEASE_VERSION" ]; then
+            RELEASE_VERSION="${{ steps.current_version.outputs.version }}"
+          fi
+          rust-script scripts/create-github-release.rs --release-version "$RELEASE_VERSION" --repository "${{ github.repository }}"
+
+  # === MANUAL INSTANT RELEASE ===
+  # Manual release via workflow_dispatch - only after CI passes
+  manual-release:
+    name: Instant Release
+    needs: [lint, test, build]
+    # Note: always() is required to evaluate the condition when dependencies use always().
+    # The build job ensures lint and test passed before this job runs.
+    if: |
+      always() && !cancelled() &&
+      github.event_name == 'workflow_dispatch' &&
+      github.event.inputs.release_mode == 'instant' &&
+      needs.build.result == 'success'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Setup Rust
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Install rust-script
+        run: cargo install rust-script
+
+      - name: Configure git
+        run: rust-script scripts/git-config.rs
+
+      - name: Collect changelog fragments
+        run: rust-script scripts/collect-changelog.rs
+
+      - name: Version and commit
+        id: version
+        env:
+          BUMP_TYPE: ${{ github.event.inputs.bump_type }}
+          DESCRIPTION: ${{ github.event.inputs.description }}
+        run: rust-script scripts/version-and-commit.rs --bump-type "${{ github.event.inputs.bump_type }}" --description "${{ github.event.inputs.description }}"
+
+      - name: Build release
+        if: steps.version.outputs.version_committed == 'true' || steps.version.outputs.already_released == 'true'
+        run: cargo build --release
+
+      - name: Publish to Crates.io
+        if: steps.version.outputs.version_committed == 'true' || steps.version.outputs.already_released == 'true'
+        id: publish-crate
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN || secrets.CARGO_TOKEN }}
+          CARGO_TOKEN: ${{ secrets.CARGO_TOKEN }}
+        run: rust-script scripts/publish-crate.rs
+
+      - name: Create GitHub Release
+        if: steps.version.outputs.version_committed == 'true' || steps.version.outputs.already_released == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: rust-script scripts/create-github-release.rs --release-version "${{ steps.version.outputs.new_version }}" --repository "${{ github.repository }}"
+
+  # === MANUAL CHANGELOG PR ===
+  changelog-pr:
+    name: Create Changelog PR
+    if: github.event_name == 'workflow_dispatch' && github.event.inputs.release_mode == 'changelog-pr'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Setup Rust
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Install rust-script
+        run: cargo install rust-script
+
+      - name: Create changelog fragment
+        env:
+          BUMP_TYPE: ${{ github.event.inputs.bump_type }}
+          DESCRIPTION: ${{ github.event.inputs.description }}
+        run: rust-script scripts/create-changelog-fragment.rs --bump-type "${{ github.event.inputs.bump_type }}" --description "${{ github.event.inputs.description }}"
+
+      - name: Create Pull Request
+        uses: peter-evans/create-pull-request@v8
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          commit-message: 'chore: add changelog for manual ${{ github.event.inputs.bump_type }} release'
+          branch: changelog-manual-release-${{ github.run_id }}
+          delete-branch: true
+          title: 'chore: manual ${{ github.event.inputs.bump_type }} release'
+          body: |
+            ## Manual Release Request
+
+            This PR was created by a manual workflow trigger to prepare a **${{ github.event.inputs.bump_type }}** release.
+
+            ### Release Details
+            - **Type:** ${{ github.event.inputs.bump_type }}
+            - **Description:** ${{ github.event.inputs.description || 'Manual release' }}
+            - **Triggered by:** @${{ github.actor }}
+
+            ### Next Steps
+            1. Review the changelog fragment in this PR
+            2. Merge this PR to main
+            3. The automated release workflow will publish to crates.io and create a GitHub release
+
+  # === DEPLOY DOCUMENTATION ===
+  # Deploy Rust API documentation to GitHub Pages after a successful release
+  deploy-docs:
+    name: Deploy Rust Documentation
+    needs: [auto-release, manual-release]
+    if: |
+      always() && !cancelled() && (
+        needs.auto-release.result == 'success' ||
+        needs.manual-release.result == 'success'
+      )
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          ref: main
+
+      - name: Setup Rust
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Build documentation
+        run: cargo doc --no-deps --all-features
+
+      - name: Deploy to GitHub Pages
+        uses: peaceiris/actions-gh-pages@v4
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: target/doc

--- a/scripts/preinstall-use-m-packages.mjs
+++ b/scripts/preinstall-use-m-packages.mjs
@@ -1,0 +1,120 @@
+#!/usr/bin/env node
+
+// Pre-install the @latest packages that src/ modules load via `use-m` at import
+// time. Without this, every test file that imports those modules races on
+// `npm install -g command-stream@latest` and friends, which intermittently
+// fails on GitHub-hosted runners with `ENOTEMPTY: directory not empty, rmdir`
+// (see issue #1724, run 25109962685). use-m has no retry of its own.
+//
+// Once a package is installed at the latest version, use-m's
+// ensurePackageInstalled returns early, so the test never touches `npm install`.
+
+import { exec, execSync } from 'node:child_process';
+import { promisify } from 'node:util';
+import { existsSync } from 'node:fs';
+import { join } from 'node:path';
+
+const execAsync = promisify(exec);
+
+const PACKAGES = [
+  'command-stream',
+  'getenv',
+  'links-notation',
+  '@dotenvx/dotenvx',
+  'telegraf',
+  'zx',
+  'yargs',
+];
+
+const MAX_ATTEMPTS = 3;
+const BASE_DELAY_MS = 1000;
+const VERBOSE = process.env.PREINSTALL_USE_M_VERBOSE === '1' || process.env.RUNNER_DEBUG === '1';
+
+const log = (message, ...rest) => {
+  process.stdout.write(`[preinstall-use-m] ${message}\n`);
+  if (rest.length) process.stdout.write(`${rest.join(' ')}\n`);
+};
+const debug = (message, ...rest) => {
+  if (!VERBOSE) return;
+  process.stdout.write(`[preinstall-use-m][debug] ${message}\n`);
+  if (rest.length) process.stdout.write(`${rest.join(' ')}\n`);
+};
+
+export const aliasForPackage = packageName => `${packageName.replace('@', '').replace('/', '-')}-v-latest`;
+
+export const isRetryableNpmError = error => {
+  if (!error) return false;
+  const haystack = `${error.stderr || ''}${error.stdout || ''}${error.message || ''}`;
+  return /ENOTEMPTY|EBUSY|EPERM|ENOENT.*rmdir|ECONNRESET|ETIMEDOUT|EAI_AGAIN|429|503/i.test(haystack);
+};
+
+export const computeBackoffMs = (attempt, baseDelayMs = BASE_DELAY_MS) => baseDelayMs * 2 ** (attempt - 1);
+
+const sleep = ms => new Promise(resolve => setTimeout(resolve, ms));
+
+export const installWithRetry = async ({ packageName, alias, globalRoot, runner = execAsync, attempts = MAX_ATTEMPTS, baseDelayMs = BASE_DELAY_MS, sleeper = sleep }) => {
+  const command = `npm install -g ${alias}@npm:${packageName}@latest`;
+  for (let attempt = 1; attempt <= attempts; attempt++) {
+    try {
+      debug(`attempt ${attempt}/${attempts}: ${command}`);
+      await runner(command);
+      log(`✅ installed ${packageName}@latest as ${alias} (attempt ${attempt})`);
+      return { ok: true, attempt };
+    } catch (error) {
+      const retryable = isRetryableNpmError(error);
+      const installed = globalRoot && existsSync(join(globalRoot, alias, 'package.json'));
+      log(`⚠️  attempt ${attempt}/${attempts} failed for ${packageName}: ${error.message?.split('\n')[0] || error}`);
+      debug('stderr:', error.stderr || '(none)');
+      debug('stdout:', error.stdout || '(none)');
+      if (installed) {
+        log(`ℹ️  ${alias} already present in ${globalRoot}; treating as success despite npm error`);
+        return { ok: true, attempt, recovered: true };
+      }
+      if (!retryable || attempt === attempts) {
+        log(`❌ giving up on ${packageName}@latest after ${attempt} attempt(s)`);
+        return { ok: false, attempt, error };
+      }
+      const delayMs = computeBackoffMs(attempt, baseDelayMs);
+      debug(`retrying in ${delayMs}ms`);
+      await sleeper(delayMs);
+    }
+  }
+  return { ok: false, attempt: attempts };
+};
+
+const getNpmGlobalRoot = () => {
+  try {
+    return execSync('npm root -g', { encoding: 'utf8' }).trim();
+  } catch (error) {
+    log(`⚠️  could not determine npm global root: ${error.message}`);
+    return '';
+  }
+};
+
+const main = async () => {
+  if (process.env.SKIP_PREINSTALL_USE_M === '1') {
+    log('skipping (SKIP_PREINSTALL_USE_M=1)');
+    return;
+  }
+  const globalRoot = getNpmGlobalRoot();
+  log(`global root: ${globalRoot || '(unknown)'}`);
+  const failures = [];
+  for (const packageName of PACKAGES) {
+    const alias = aliasForPackage(packageName);
+    const result = await installWithRetry({ packageName, alias, globalRoot });
+    if (!result.ok) failures.push({ packageName, error: result.error });
+  }
+  if (failures.length) {
+    log(`❌ ${failures.length} package(s) failed: ${failures.map(f => f.packageName).join(', ')}`);
+    process.exit(1);
+  }
+  log(`✅ all ${PACKAGES.length} use-m packages pre-installed`);
+};
+
+const isMain = import.meta.url === `file://${process.argv[1]}` || process.argv[1]?.endsWith('preinstall-use-m-packages.mjs');
+if (isMain) {
+  main().catch(error => {
+    log(`fatal: ${error.message}`);
+    process.exit(1);
+  });
+}

--- a/scripts/preinstall-use-m-packages.mjs
+++ b/scripts/preinstall-use-m-packages.mjs
@@ -16,15 +16,7 @@ import { join } from 'node:path';
 
 const execAsync = promisify(exec);
 
-const PACKAGES = [
-  'command-stream',
-  'getenv',
-  'links-notation',
-  '@dotenvx/dotenvx',
-  'telegraf',
-  'zx',
-  'yargs',
-];
+const PACKAGES = ['command-stream', 'getenv', 'links-notation', '@dotenvx/dotenvx', 'telegraf', 'zx', 'yargs'];
 
 const MAX_ATTEMPTS = 3;
 const BASE_DELAY_MS = 1000;

--- a/tests/test-preinstall-use-m-packages-1724.mjs
+++ b/tests/test-preinstall-use-m-packages-1724.mjs
@@ -36,7 +36,7 @@ const test = (name, fn) => {
         err => {
           console.error(`❌ ${name}\n   ${err?.stack || err}`);
           failed++;
-        },
+        }
       );
     }
     console.log(`✅ ${name}`);

--- a/tests/test-preinstall-use-m-packages-1724.mjs
+++ b/tests/test-preinstall-use-m-packages-1724.mjs
@@ -1,0 +1,155 @@
+#!/usr/bin/env node
+/**
+ * Unit tests for scripts/preinstall-use-m-packages.mjs.
+ *
+ * Verifies:
+ *   - alias matches the use-m naming scheme so the pre-install step actually
+ *     primes the directory use-m looks up
+ *   - retry helper retries only on flaky npm errors (ENOTEMPTY/EBUSY/etc.)
+ *   - retry helper succeeds when later attempts work
+ *   - retry helper aborts immediately on non-retryable errors
+ *   - retry helper treats "package already present" as success after a flake
+ *
+ * Run with: node tests/test-preinstall-use-m-packages-1724.mjs
+ *
+ * @hive-mind-test-suite default
+ * @see https://github.com/link-assistant/hive-mind/issues/1724
+ */
+
+import assert from 'node:assert/strict';
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { aliasForPackage, computeBackoffMs, isRetryableNpmError, installWithRetry } from '../scripts/preinstall-use-m-packages.mjs';
+
+let passed = 0;
+let failed = 0;
+const test = (name, fn) => {
+  try {
+    const result = fn();
+    if (result && typeof result.then === 'function') {
+      return result.then(
+        () => {
+          console.log(`✅ ${name}`);
+          passed++;
+        },
+        err => {
+          console.error(`❌ ${name}\n   ${err?.stack || err}`);
+          failed++;
+        },
+      );
+    }
+    console.log(`✅ ${name}`);
+    passed++;
+  } catch (err) {
+    console.error(`❌ ${name}\n   ${err?.stack || err}`);
+    failed++;
+  }
+};
+
+await test('aliasForPackage strips @ and replaces / for scoped names', () => {
+  assert.equal(aliasForPackage('command-stream'), 'command-stream-v-latest');
+  assert.equal(aliasForPackage('@dotenvx/dotenvx'), 'dotenvx-dotenvx-v-latest');
+  assert.equal(aliasForPackage('links-notation'), 'links-notation-v-latest');
+});
+
+await test('isRetryableNpmError detects ENOTEMPTY and friends', () => {
+  assert.equal(isRetryableNpmError({ stderr: 'npm error code ENOTEMPTY' }), true);
+  assert.equal(isRetryableNpmError({ stderr: 'EBUSY: resource busy or locked' }), true);
+  assert.equal(isRetryableNpmError({ message: 'ECONNRESET while talking to registry' }), true);
+  assert.equal(isRetryableNpmError({ stderr: 'npm error code E404' }), false);
+  assert.equal(isRetryableNpmError(null), false);
+});
+
+await test('computeBackoffMs grows exponentially', () => {
+  assert.equal(computeBackoffMs(1, 100), 100);
+  assert.equal(computeBackoffMs(2, 100), 200);
+  assert.equal(computeBackoffMs(3, 100), 400);
+});
+
+await test('installWithRetry returns ok on first success', async () => {
+  let calls = 0;
+  const result = await installWithRetry({
+    packageName: 'command-stream',
+    alias: 'command-stream-v-latest',
+    globalRoot: '/tmp/nonexistent-root',
+    runner: async () => {
+      calls++;
+      return { stdout: '', stderr: '' };
+    },
+    sleeper: async () => {},
+  });
+  assert.deepEqual({ ok: result.ok, attempt: result.attempt, calls }, { ok: true, attempt: 1, calls: 1 });
+});
+
+await test('installWithRetry retries on ENOTEMPTY then succeeds', async () => {
+  let calls = 0;
+  const result = await installWithRetry({
+    packageName: 'command-stream',
+    alias: 'command-stream-v-latest',
+    globalRoot: '/tmp/nonexistent-root',
+    runner: async () => {
+      calls++;
+      if (calls < 3) {
+        const error = new Error('Command failed: npm install');
+        error.stderr = 'npm error code ENOTEMPTY\n';
+        throw error;
+      }
+      return { stdout: '', stderr: '' };
+    },
+    attempts: 4,
+    baseDelayMs: 1,
+    sleeper: async () => {},
+  });
+  assert.deepEqual({ ok: result.ok, attempt: result.attempt, calls }, { ok: true, attempt: 3, calls: 3 });
+});
+
+await test('installWithRetry aborts immediately on non-retryable error', async () => {
+  let calls = 0;
+  const result = await installWithRetry({
+    packageName: 'command-stream',
+    alias: 'command-stream-v-latest',
+    globalRoot: '/tmp/nonexistent-root',
+    runner: async () => {
+      calls++;
+      const error = new Error('Command failed: npm install');
+      error.stderr = 'npm error code E404 - Not Found\n';
+      throw error;
+    },
+    attempts: 4,
+    baseDelayMs: 1,
+    sleeper: async () => {},
+  });
+  assert.equal(result.ok, false);
+  assert.equal(calls, 1);
+});
+
+await test('installWithRetry treats package-present-on-disk as recovered success', async () => {
+  const tmp = mkdtempSync(join(tmpdir(), 'preinstall-1724-'));
+  try {
+    const alias = 'command-stream-v-latest';
+    mkdirSync(join(tmp, alias));
+    writeFileSync(join(tmp, alias, 'package.json'), JSON.stringify({ name: 'command-stream', version: '1.0.0' }));
+    let calls = 0;
+    const result = await installWithRetry({
+      packageName: 'command-stream',
+      alias,
+      globalRoot: tmp,
+      runner: async () => {
+        calls++;
+        const error = new Error('Command failed: npm install');
+        error.stderr = 'npm error code ENOTEMPTY\n';
+        throw error;
+      },
+      attempts: 3,
+      baseDelayMs: 1,
+      sleeper: async () => {},
+    });
+    assert.deepEqual({ ok: result.ok, recovered: result.recovered, calls }, { ok: true, recovered: true, calls: 1 });
+  } finally {
+    rmSync(tmp, { recursive: true, force: true });
+  }
+});
+
+console.log(`\nPassed: ${passed} / ${passed + failed}`);
+process.exit(failed === 0 ? 0 : 1);


### PR DESCRIPTION
## Summary

- Fixes the flaky `test-suites` job seen in run [25109962685](https://github.com/link-assistant/hive-mind/actions/runs/25109962685/job/73581228475), which aborted on the third test file with `npm error code ENOTEMPTY` while `use-m` reinstalled `command-stream-v-latest` for the umpteenth time.
- Adds [`scripts/preinstall-use-m-packages.mjs`](./scripts/preinstall-use-m-packages.mjs) that pre-installs every package the codebase loads via `use-m @latest` (`command-stream`, `getenv`, `links-notation`, `@dotenvx/dotenvx`, `telegraf`, `zx`, `yargs`) using the same alias scheme `use-m` does, with exponential-backoff retry on `ENOTEMPTY/EBUSY/EPERM/ECONNRESET/ETIMEDOUT/EAI_AGAIN/429/503`. After this step runs, `use-m`'s `installedVersion === latestVersion` early-return path skips the install at test time, so test imports never touch `npm install -g` again.
- Wires that step into the `test-suites` and `test-execution` jobs in [`.github/workflows/release.yml`](./.github/workflows/release.yml) right after `npm install`.
- Adds a verbose-mode toggle (`PREINSTALL_USE_M_VERBOSE=1` or `RUNNER_DEBUG=1`) so the next iteration has actionable diagnostics, satisfying the issue's requirement #5.

Closes #1724.

## Root cause

`src/github.lib.mjs` and `src/playwright-mcp.lib.mjs` call `await use('command-stream')` at module top level via `use-m`. Every test file that transitively imports either module re-runs `npm install -g command-stream-v-latest@npm:command-stream@latest`. The live `use-m` source (snapshot in [`docs/case-studies/issue-1724/data/use-m-source.js`](./docs/case-studies/issue-1724/data/use-m-source.js)) issues a single `npm install -g` with no retry. npm intermittently fails with `ENOTEMPTY: directory not empty, rmdir` on Ubuntu runners — the well-known npm self-rmdir race when the previous global install left files behind.

Full timeline, verbatim error, downloaded failed-run logs (this run plus the earlier sibling failure where the symptom was `Failed to resolve the path to 'getenv' from '…/getenv-v-latest'`), and a comparison with both pipeline templates are in [`docs/case-studies/issue-1724/README.md`](./docs/case-studies/issue-1724/README.md).

## Templates

Both `link-foundation/js-ai-driven-development-pipeline-template` and `link-foundation/rust-ai-driven-development-pipeline-template` use `npm install` then `npm test` with no preinstall warmup. Their workflows are saved under [`docs/case-studies/issue-1724/templates/`](./docs/case-studies/issue-1724/templates/) for reference. Neither template currently uses `use-m @latest` at module load, so the bug doesn't fire there yet — no template issue is filed at this time. The case-study README documents the trigger condition for future maintainers.

## Why not patch use-m

`use-m` is a separate project (`link-foundation/use-m`) and the right place for retry is upstream, but CI cannot wait on a synchronous fix there. An upstream issue proposing built-in retry on `ENOTEMPTY/EBUSY` with exponential backoff is tracked as a follow-up in the case study.

## Test plan

- [x] `node tests/test-preinstall-use-m-packages-1724.mjs` — 7/7 pass locally (alias scheme, retryable-error matcher, exponential backoff, four `installWithRetry` paths: first-success, retry-then-succeed, non-retryable-abort, recovered-from-disk).
- [x] `bash scripts/check-file-line-limits.sh` — passes.
- [x] `node scripts/run-tests.mjs --list --suite default` includes `tests/test-preinstall-use-m-packages-1724.mjs` (so it runs in the job that previously flaked).
- [x] `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/release.yml'))"` — workflow still parses; both `test-suites` and `test-execution` get the new step right after `Install dependencies`.
- [ ] `npm test` in CI on this branch (expected: green, with `[preinstall-use-m] ✅ all 7 use-m packages pre-installed` near the top of the `test-suites` log).
- [ ] If CI flakes again with `ENOTEMPTY`, set `PREINSTALL_USE_M_VERBOSE=1` (or `RUNNER_DEBUG=1`) in the workflow env and re-run for full attempt-by-attempt diagnostics.