### PR TITLE
Count draft linked PRs in /hive skip checks

### DIFF
--- a/.changeset/count-draft-linked-prs-1760.md
+++ b/.changeset/count-draft-linked-prs-1760.md
@@ -1,0 +1,5 @@
+---
+"@link-assistant/hive-mind": patch
+---
+
+Count open draft pull requests when `/hive --skip-issues-with-prs` checks linked solution drafts, preventing duplicate work while an existing PR is still in progress.

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,3 +1,2 @@
 # .gitkeep file auto-generated at 2026-04-15T05:07:05.365Z for PR creation at branch issue-1603-d47eafcfffb1 for issue https://github.com/link-assistant/hive-mind/issues/1603
 # Updated: 2026-04-17T19:04:16.770Z
-# Updated: 2026-05-08T19:32:14.471Z

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,2 +1,3 @@
 # .gitkeep file auto-generated at 2026-04-15T05:07:05.365Z for PR creation at branch issue-1603-d47eafcfffb1 for issue https://github.com/link-assistant/hive-mind/issues/1603
 # Updated: 2026-04-17T19:04:16.770Z
+# Updated: 2026-05-08T19:32:14.471Z

--- a/docs/case-studies/issue-1760/README.md
+++ b/docs/case-studies/issue-1760/README.md
@@ -1,0 +1,112 @@
+# Issue #1760 - /hive skipped an existing draft solution PR
+
+- Issue: https://github.com/link-assistant/hive-mind/issues/1760
+- Pull request: https://github.com/link-assistant/hive-mind/pull/1768
+- Filed: 2026-05-06T11:31:38Z
+- Affected command: `/hive --all-issues --once --skip-issues-with-prs`
+- Affected private repository: named in the public issue; raw private logs are not committed here.
+
+## TL;DR
+
+`/hive --skip-issues-with-prs` incorrectly treated open draft pull requests as absent. During the incident, issue `#110` already had pull request `#111`, but that PR was temporarily converted back to draft while an automated work session rechecked CI. The batch GraphQL checker filtered it out with `!item.source.isDraft`, so `/hive` queued the issue and created duplicate PR `#116`.
+
+The fix is to count every open linked PR that uses closing keywords, regardless of draft status. Draft PRs are work in progress, but they are still active solution drafts and must block duplicate work.
+
+## Files in this folder
+
+| File                                    | Contents                                                                           |
+| --------------------------------------- | ---------------------------------------------------------------------------------- |
+| `data/public-issue-1760.json`           | Public issue metadata with the private log URL/body summarized rather than copied. |
+| `data/pr-1768-initial.json`             | Prepared PR metadata before this fix replaced the placeholder title/body.          |
+| `data/sanitized-incident-timeline.json` | Reconstructed incident timeline with no private log body or source code.           |
+| `data/sanitized-evidence.md`            | Short sanitized excerpts from the raw execution log and GitHub API evidence.       |
+
+The raw gist log was inspected locally at `/tmp/hive-issue-1760/issue-1760-source-log.raw`. It is intentionally excluded from the repository because it contains private repository output, tool prompts, command output, uploaded-log URLs, and authentication context.
+
+## Requirements from the issue
+
+1. Download and inspect all related logs and data.
+2. Preserve only non-private, non-sensitive compiled evidence under `docs/case-studies/issue-1760`.
+3. Reconstruct the timeline and sequence of events.
+4. List each requirement and determine root causes.
+5. Propose solutions and solution plans for every requirement.
+6. Search online for additional facts and data.
+7. Add debug or verbose output if data is insufficient to find the root cause.
+8. Report issues to other projects only if another project is responsible.
+9. Complete the work in one pull request.
+
+## Reconstructed timeline
+
+| Time (UTC)           | Event                                                                                       |
+| -------------------- | ------------------------------------------------------------------------------------------- |
+| 2026-05-06T07:36:46Z | Private issue `#110` was created.                                                           |
+| 2026-05-06T07:37:44Z | PR `#111` was created for issue `#110`. Its body used a closing keyword for the issue.      |
+| 2026-05-06T07:37:45Z | GitHub issue timeline recorded the cross-reference from PR `#111` to issue `#110`.          |
+| 2026-05-06T07:58:03Z | PR `#111` was marked ready for review.                                                      |
+| 2026-05-06T11:15:55Z | A later automated work session on PR `#111` started and converted the PR to draft mode.     |
+| 2026-05-06T11:16:15Z | The reported `/hive` command started.                                                       |
+| 2026-05-06T11:16:25Z | `/hive` fetched five open issues and ran the batch GraphQL PR check.                        |
+| 2026-05-06T11:16:25Z | Batch PR check reported `0/5 issues have open PRs`, so issue `#110` was added to the queue. |
+| 2026-05-06T11:16:51Z | Worker recheck for issue `#110` again reported `0/1 issues have open PRs`.                  |
+| 2026-05-06T11:17:19Z | Duplicate PR `#116` was created for issue `#110`.                                           |
+| 2026-05-06T11:17:20Z | GitHub issue timeline recorded the cross-reference from PR `#116` to issue `#110`.          |
+| 2026-05-06T11:18:55Z | PR `#111` was marked ready for review again.                                                |
+| 2026-05-06T14:27:07Z | PR `#111` was merged.                                                                       |
+| 2026-05-06T14:27:09Z | Issue `#110` was closed by the merged linked PR.                                            |
+| 2026-05-06T18:57:29Z | Duplicate PR `#116` was closed unmerged.                                                    |
+
+## Root cause
+
+The duplicate was caused by this condition in `src/github.batch.lib.mjs`:
+
+```javascript
+item.source.state === 'OPEN' && !item.source.isDraft;
+```
+
+The surrounding logic was already correct in two important ways:
+
+- It queried GitHub issue timeline `CrossReferencedEvent` entries whose source was a pull request.
+- It required a real closing keyword such as `Fixes #110`, `Closes #110`, or `Resolves #110`, which avoids false positives from casual references.
+
+The draft exclusion was the defect. `/hive --skip-issues-with-prs` is documented and logged as skipping issues that have any open PRs. Draft PRs are open PRs, and in this project they explicitly represent an active automated solution draft. Excluding them allowed concurrent duplicate work during the window where PR `#111` was open but draft.
+
+## Why the final summary later found both PRs
+
+The same batch checker reported `5/5 issues have open PRs` at the end of the run and listed both PR `#111` and PR `#116`. That does not contradict the earlier failure. By then PR `#111` had already been marked ready for review again, so the old `!isDraft` filter no longer hid it.
+
+## Online research
+
+GitHub documents that linking a pull request to an issue shows collaborators that someone is working on the issue and can automatically close the issue when the linked PR is merged:
+https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue
+
+GitHub also documents draft pull requests as work-in-progress PRs that cannot be merged until marked ready for review:
+https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/about-pull-requests
+
+Taken together, the expected `/hive` behavior is to treat an open linked draft PR as active work, not as absence of work.
+
+## Fix
+
+Move the timeline parsing into `extractLinkedPullRequestsForIssue()` and count linked PRs when:
+
+1. The timeline source is a pull request.
+2. The PR state is `OPEN`.
+3. The PR body or title has a closing keyword for the issue.
+
+The helper returns `isDraft` in the linked PR metadata for visibility, but no longer excludes draft PRs.
+
+## Solution plan coverage
+
+| Requirement                            | Solution                                                                                    |
+| -------------------------------------- | ------------------------------------------------------------------------------------------- |
+| Preserve evidence without private data | Keep raw logs in `/tmp`; commit only sanitized summaries and short excerpts.                |
+| Find root cause                        | Compare raw `/hive` decisions with GitHub timeline state; isolate the `!isDraft` filter.    |
+| Prevent duplicate PR creation          | Count open draft PRs in the batch checker used by queue filtering and worker rechecks.      |
+| Preserve false-positive protection     | Keep the closing-keyword test from issue `#1094`; casual issue mentions still do not count. |
+| Add test coverage                      | Add a focused regression test for an open draft PR whose body contains `Resolves #110`.     |
+| Avoid unnecessary third-party reports  | No upstream GitHub or private-repo defect was found; behavior was internal to hive-mind.    |
+
+## Verification
+
+- The new regression test fails before the fix with `0 !== 1` for an open draft PR that resolves the issue.
+- After the fix, the same test passes and confirms non-closing draft PR mentions are still ignored.
+- Existing `prClosesIssue` coverage remains unchanged and verifies closing-keyword parsing.

--- a/docs/case-studies/issue-1760/data/pr-1768-initial.json
+++ b/docs/case-studies/issue-1760/data/pr-1768-initial.json
@@ -1,0 +1,12 @@
+{
+  "number": 1768,
+  "url": "https://github.com/link-assistant/hive-mind/pull/1768",
+  "state": "OPEN",
+  "isDraft": true,
+  "baseRefName": "main",
+  "headRefName": "issue-1760-6e261031c17a",
+  "createdAt": "2026-05-08T19:32:21Z",
+  "updatedAt": "2026-05-08T19:32:23Z",
+  "initialTitleSummary": "[WIP] /hive command incorrectly detected a private repository issue as issue with no pull requests",
+  "initialBodySummary": "Generated placeholder solution draft body for issue #1760."
+}

--- a/docs/case-studies/issue-1760/data/public-issue-1760.json
+++ b/docs/case-studies/issue-1760/data/public-issue-1760.json
@@ -1,0 +1,11 @@
+{
+  "number": 1760,
+  "title": "/hive command incorrectly detected a private repository issue as issue with no pull requests",
+  "url": "https://github.com/link-assistant/hive-mind/issues/1760",
+  "state": "OPEN",
+  "createdAt": "2026-05-06T11:31:38Z",
+  "updatedAt": "2026-05-06T19:20:46Z",
+  "labels": ["bug"],
+  "bodySummary": ["A /hive run against a private repository used --skip-issues-with-prs.", "One private issue was incorrectly detected as having no pull requests.", "As a result, two pull requests were created for the same issue.", "The reporter provided a raw execution log and requested a sanitized case study without committing private or sensitive data."],
+  "privacyNote": "The original issue body names the private repository and links a raw gist log. This file intentionally summarizes that body instead of copying the raw private log URL or contents."
+}

--- a/docs/case-studies/issue-1760/data/sanitized-evidence.md
+++ b/docs/case-studies/issue-1760/data/sanitized-evidence.md
@@ -1,0 +1,76 @@
+# Sanitized Evidence for Issue #1760
+
+This file contains short excerpts and derived facts. The raw execution log is not committed.
+
+## Raw log handling
+
+- Source inspected with `gh gist view ... --raw`.
+- Local path during investigation: `/tmp/hive-issue-1760/issue-1760-source-log.raw`.
+- Raw size: 102096 lines.
+- Repository policy for this case study: no full private logs, source code, command transcripts, uploaded-log gist URLs, or authentication context are committed.
+
+## Key sanitized excerpts from the raw `/hive` log
+
+```text
+Timestamp: 2026-05-06 11:16:15.532
+Command: hive <private repository> --tool claude --think max --concurrency 1 --all-issues --once --skip-issues-with-prs --attach-logs --verbose --no-tool-check
+Session: b59fc6e6-8600-494a-94aa-8558a3080c4a
+```
+
+```text
+Found 5 open issue(s)
+Checking for existing pull requests using batch GraphQL query...
+Batch checking PRs for 5 issues using GraphQL...
+Batch PR check complete: 0/5 issues have open PRs
+Added to queue: <private repo issue #110>
+Added to queue: <private repo issue #112>
+Added to queue: <private repo issue #113>
+Added to queue: <private repo issue #114>
+Added to queue: <private repo issue #115>
+```
+
+```text
+Worker 1 processing: <private repo issue #110>
+Rechecking conditions for issue #110...
+Issue is still open
+Batch checking PRs for 1 issues using GraphQL...
+Batch PR check complete: 0/1 issues have open PRs
+Issue still has no open PRs
+Executing solve for <private repo issue #110>...
+```
+
+```text
+gh pr create stdout: <private repo pull request #116>
+Created pull request for issue #110.
+```
+
+```text
+Issues with solution drafts:
+Batch checking PRs for 5 issues using GraphQL...
+Batch PR check complete: 5/5 issues have open PRs
+Issue #110 linked PRs:
+  PR #111
+  PR #116
+```
+
+## GitHub API facts used in the reconstruction
+
+| Fact                                                                                 | Evidence source                                            |
+| ------------------------------------------------------------------------------------ | ---------------------------------------------------------- |
+| Issue #110 had a cross-reference from PR #111 at 2026-05-06T07:37:45Z.               | `gh api repos/<private>/issues/110/timeline --paginate`    |
+| PR #111 was converted to draft by an automated work session at 2026-05-06T11:15:55Z. | PR #111 timeline comment and draft transition evidence.    |
+| The reported `/hive` command started at 2026-05-06 11:16:15.532 UTC.                 | Raw execution log header.                                  |
+| Duplicate PR #116 was created at 2026-05-06T11:17:19Z.                               | `gh pr view 116 --repo <private> --json createdAt`         |
+| PR #111 returned to ready-for-review at 2026-05-06T11:18:55Z.                        | PR #111 timeline.                                          |
+| PR #111 merged at 2026-05-06T14:27:07Z.                                              | `gh pr view 111 --repo <private> --json mergedAt`          |
+| Duplicate PR #116 closed unmerged at 2026-05-06T18:57:29Z.                           | `gh pr view 116 --repo <private> --json closedAt,mergedAt` |
+
+## Code evidence
+
+Before this fix, `src/github.batch.lib.mjs` only counted linked pull requests when the PR source was open and not draft:
+
+```javascript
+item.source.state === 'OPEN' && !item.source.isDraft;
+```
+
+That condition hid the original linked solution PR during the narrow draft window.

--- a/docs/case-studies/issue-1760/data/sanitized-incident-timeline.json
+++ b/docs/case-studies/issue-1760/data/sanitized-incident-timeline.json
@@ -1,0 +1,57 @@
+[
+  {
+    "time": "2026-05-06T07:36:46Z",
+    "event": "issue_created",
+    "details": "Private issue #110 was created."
+  },
+  {
+    "time": "2026-05-06T07:37:44Z",
+    "event": "original_pr_created",
+    "details": "PR #111 was created for private issue #110 with a closing keyword."
+  },
+  {
+    "time": "2026-05-06T07:37:45Z",
+    "event": "original_pr_cross_reference",
+    "details": "GitHub recorded a cross-reference from PR #111 to issue #110."
+  },
+  {
+    "time": "2026-05-06T11:15:55Z",
+    "event": "original_pr_converted_to_draft",
+    "details": "Automated work session converted PR #111 to draft while rechecking CI."
+  },
+  {
+    "time": "2026-05-06T11:16:15Z",
+    "event": "hive_run_started",
+    "details": "/hive started with --all-issues --once --skip-issues-with-prs."
+  },
+  {
+    "time": "2026-05-06T11:16:25Z",
+    "event": "batch_check_false_negative",
+    "details": "Batch PR check reported 0/5 issues had open PRs."
+  },
+  {
+    "time": "2026-05-06T11:16:51Z",
+    "event": "worker_recheck_false_negative",
+    "details": "Worker recheck for issue #110 reported 0/1 issues had open PRs."
+  },
+  {
+    "time": "2026-05-06T11:17:19Z",
+    "event": "duplicate_pr_created",
+    "details": "Duplicate PR #116 was created for issue #110."
+  },
+  {
+    "time": "2026-05-06T11:18:55Z",
+    "event": "original_pr_ready_again",
+    "details": "PR #111 was marked ready for review again."
+  },
+  {
+    "time": "2026-05-06T14:27:07Z",
+    "event": "original_pr_merged",
+    "details": "PR #111 was merged."
+  },
+  {
+    "time": "2026-05-06T18:57:29Z",
+    "event": "duplicate_pr_closed",
+    "details": "Duplicate PR #116 was closed unmerged."
+  }
+]

--- a/src/github-linking.lib.mjs
+++ b/src/github-linking.lib.mjs
@@ -26,6 +26,58 @@ export function getGitHubLinkingKeywords() {
   return ['close', 'closes', 'closed', 'fix', 'fixes', 'fixed', 'resolve', 'resolves', 'resolved'];
 }
 
+function escapeRegExp(value) {
+  return String(value).replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+function buildClosingReferencePatterns(keyword, issueNumber, owner = null, repo = null) {
+  const issueNumStr = escapeRegExp(issueNumber);
+  const separator = String.raw`(?:\s+|\s*:\s*)`;
+  const prefix = String.raw`\b${keyword}${separator}`;
+  const references = [String.raw`#${issueNumStr}\b`];
+
+  if (owner && repo) {
+    references.push(`${escapeRegExp(owner)}/${escapeRegExp(repo)}#${issueNumStr}\\b`);
+    references.push(`https://github\\.com/${escapeRegExp(owner)}/${escapeRegExp(repo)}/issues/${issueNumStr}\\b`);
+  }
+
+  references.push(String.raw`[\w.-]+/[\w.-]+#${issueNumStr}\b`);
+  references.push(`https://github\\.com/[^/\\s]+/[^/\\s]+/issues/${issueNumStr}\\b`);
+
+  return references.map(reference => new RegExp(`${prefix}${reference}`, 'i'));
+}
+
+/**
+ * Check whether text contains a GitHub closing keyword for a specific issue.
+ *
+ * This is the shared parser used by solve and hive code paths so they agree on
+ * which PR body/title references are real closing links.
+ *
+ * @param {string} text - Pull request body or title text
+ * @param {string|number} issueNumber - Issue number to check for
+ * @param {string} [owner] - Repository owner for exact owner/repo references
+ * @param {string} [repo] - Repository name for exact owner/repo references
+ * @returns {boolean} True if a valid closing reference is found
+ */
+export function prClosesIssue(text, issueNumber, owner = null, repo = null) {
+  if (!text || typeof text !== 'string' || issueNumber === null || issueNumber === undefined || String(issueNumber).trim() === '') {
+    return false;
+  }
+
+  const issueNumStr = String(issueNumber).trim();
+
+  for (const keyword of getGitHubLinkingKeywords()) {
+    const patterns = buildClosingReferencePatterns(keyword, issueNumStr, owner, repo);
+    for (const pattern of patterns) {
+      if (pattern.test(text)) {
+        return true;
+      }
+    }
+  }
+
+  return false;
+}
+
 /**
  * Check if PR body contains a valid GitHub linking keyword for the given issue
  *
@@ -36,54 +88,7 @@ export function getGitHubLinkingKeywords() {
  * @returns {boolean} True if a valid linking keyword is found
  */
 export function hasGitHubLinkingKeyword(prBody, issueNumber, owner = null, repo = null) {
-  if (!prBody || !issueNumber) {
-    return false;
-  }
-
-  const keywords = getGitHubLinkingKeywords();
-  const issueNumStr = issueNumber.toString();
-
-  // Build regex patterns for each valid format:
-  // 1. KEYWORD #123
-  // 2. KEYWORD owner/repo#123
-  // 3. KEYWORD https://github.com/owner/repo/issues/123
-
-  for (const keyword of keywords) {
-    // Pattern 1: KEYWORD #123
-    // Must have word boundary before keyword and # immediately before number
-    const pattern1 = new RegExp(`\\b${keyword}\\s+#${issueNumStr}\\b`, 'i');
-
-    if (pattern1.test(prBody)) {
-      return true;
-    }
-
-    // Pattern 2: KEYWORD owner/repo#123 (for cross-repo or fork references)
-    if (owner && repo) {
-      const pattern2 = new RegExp(`\\b${keyword}\\s+${owner}/${repo}#${issueNumStr}\\b`, 'i');
-
-      if (pattern2.test(prBody)) {
-        return true;
-      }
-    }
-
-    // Pattern 3: KEYWORD https://github.com/owner/repo/issues/123
-    if (owner && repo) {
-      const pattern3 = new RegExp(`\\b${keyword}\\s+https://github\\.com/${owner}/${repo}/issues/${issueNumStr}\\b`, 'i');
-
-      if (pattern3.test(prBody)) {
-        return true;
-      }
-    }
-
-    // Pattern 4: Also check for any URL format (generic)
-    const pattern4 = new RegExp(`\\b${keyword}\\s+https://github\\.com/[^/]+/[^/]+/issues/${issueNumStr}\\b`, 'i');
-
-    if (pattern4.test(prBody)) {
-      return true;
-    }
-  }
-
-  return false;
+  return prClosesIssue(prBody, issueNumber, owner, repo);
 }
 
 /**

--- a/src/github.batch.lib.mjs
+++ b/src/github.batch.lib.mjs
@@ -10,54 +10,10 @@ if (typeof globalThis.use === 'undefined') {
 // Import dependencies
 import { log, cleanErrorMessage } from './lib.mjs';
 import { githubLimits, timeouts } from './config.lib.mjs';
+import { prClosesIssue } from './github-linking.lib.mjs';
 
 import { wrapDollarWithGhRetry as _wrapDollarWithGhRetry, execGhWithRetry } from './github-rate-limit.lib.mjs'; // rate-limit marker (#1726): gh API calls flow through $ wrapped by caller. execGhWithRetry adds transient-network retry (#1756).
-/**
- * Check if a PR body/title indicates it fixes/closes/resolves a specific issue number
- * GitHub auto-closes issues when PR body contains keywords like "fixes #123", "closes #123", "resolves #123"
- * See: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
- * @param {string} text - PR body or title text
- * @param {number} issueNumber - Issue number to check for
- * @returns {boolean} True if the text contains a closing keyword for this issue
- */
-export function prClosesIssue(text, issueNumber) {
-  if (!text || typeof text !== 'string') {
-    return false;
-  }
-
-  // GitHub closing keywords (case-insensitive)
-  // Supports: fix, fixes, fixed, close, closes, closed, resolve, resolves, resolved
-  // Also supports variations with repository prefix like "fixes owner/repo#123"
-  const closingKeywords = ['fix', 'fixes', 'fixed', 'close', 'closes', 'closed', 'resolve', 'resolves', 'resolved'];
-
-  // Build regex pattern that matches any of the keywords followed by #N or repo#N
-  // Examples matched:
-  //   - "fixes #123"
-  //   - "Closes #123"
-  //   - "RESOLVED #123"
-  //   - "fixes owner/repo#123"
-  //   - "fix: #123" (common commit style)
-  const issueNum = issueNumber.toString();
-
-  for (const keyword of closingKeywords) {
-    // Pattern: keyword + optional colon/space + optional repo prefix + # + issue number
-    // Must be followed by word boundary (not part of larger number)
-    const patterns = [
-      // Standard format: "fixes #123"
-      new RegExp(`\\b${keyword}\\s*:?\\s*#${issueNum}\\b`, 'i'),
-      // With repo prefix: "fixes owner/repo#123"
-      new RegExp(`\\b${keyword}\\s*:?\\s*[\\w.-]+/[\\w.-]+#${issueNum}\\b`, 'i'),
-    ];
-
-    for (const pattern of patterns) {
-      if (pattern.test(text)) {
-        return true;
-      }
-    }
-  }
-
-  return false;
-}
+export { prClosesIssue };
 
 /**
  * Extract open pull requests that are linked to an issue with closing keywords.

--- a/src/github.batch.lib.mjs
+++ b/src/github.batch.lib.mjs
@@ -60,6 +60,43 @@ export function prClosesIssue(text, issueNumber) {
 }
 
 /**
+ * Extract open pull requests that are linked to an issue with closing keywords.
+ * Draft pull requests are still open in-progress solution drafts, so they must
+ * count for /hive --skip-issues-with-prs.
+ * @param {Object} issueData - GraphQL issue node with timelineItems
+ * @param {number} issueNum - Issue number to check
+ * @param {Function} logger - Async logger, defaults to shared log helper
+ * @returns {Promise<Array<Object>>} Linked open PRs that close the issue
+ */
+export async function extractLinkedPullRequestsForIssue(issueData, issueNum, logger = log) {
+  const linkedPRs = [];
+
+  for (const item of issueData.timelineItems?.nodes || []) {
+    if (item?.source && item.source.state === 'OPEN') {
+      // Check if PR actually closes this issue (has "fixes #N", "closes #N", or "resolves #N")
+      const prBody = item.source.body || '';
+      const prTitle = item.source.title || '';
+      const closesThisIssue = prClosesIssue(prBody, issueNum) || prClosesIssue(prTitle, issueNum);
+
+      if (closesThisIssue) {
+        linkedPRs.push({
+          number: item.source.number,
+          title: item.source.title,
+          state: item.source.state,
+          isDraft: Boolean(item.source.isDraft),
+          url: item.source.url,
+        });
+      } else {
+        // Log that we're skipping a PR that only mentions the issue
+        await logger(`      ℹ️  PR #${item.source.number} mentions issue #${issueNum} but doesn't close it (no fixes/closes/resolves keyword)`, { verbose: true });
+      }
+    }
+  }
+
+  return linkedPRs;
+}
+
+/**
  * Batch fetch pull request information for multiple issues using GraphQL
  * @param {string} owner - Repository owner
  * @param {string} repo - Repository name
@@ -140,31 +177,11 @@ export async function batchCheckPullRequestsForIssues(owner, repo, issueNumbers)
         for (const issueNum of batch) {
           const issueData = data.data?.repository?.[`issue${issueNum}`];
           if (issueData) {
-            const linkedPRs = [];
-
-            // Extract linked PRs from timeline items
+            // Extract linked PRs from timeline items, including draft PRs.
             // Issue #1094: Only count PRs that explicitly fix/close/resolve this issue
             // This prevents false positives from PRs that only mention issues without solving them
-            for (const item of issueData.timelineItems?.nodes || []) {
-              if (item?.source && item.source.state === 'OPEN' && !item.source.isDraft) {
-                // Check if PR actually closes this issue (has "fixes #N", "closes #N", or "resolves #N")
-                const prBody = item.source.body || '';
-                const prTitle = item.source.title || '';
-                const closesThisIssue = prClosesIssue(prBody, issueNum) || prClosesIssue(prTitle, issueNum);
-
-                if (closesThisIssue) {
-                  linkedPRs.push({
-                    number: item.source.number,
-                    title: item.source.title,
-                    state: item.source.state,
-                    url: item.source.url,
-                  });
-                } else {
-                  // Log that we're skipping a PR that only mentions the issue
-                  await log(`      ℹ️  PR #${item.source.number} mentions issue #${issueNum} but doesn't close it (no fixes/closes/resolves keyword)`, { verbose: true });
-                }
-              }
-            }
+            // Issue #1760: Draft PRs are still active solution drafts and must block duplicate work
+            const linkedPRs = await extractLinkedPullRequestsForIssue(issueData, issueNum);
 
             results[issueNum] = {
               title: issueData.title,
@@ -337,6 +354,7 @@ export async function batchCheckArchivedRepositories(repositories) {
 // Export all functions as default object too
 export default {
   prClosesIssue,
+  extractLinkedPullRequestsForIssue,
   batchCheckPullRequestsForIssues,
   batchCheckArchivedRepositories,
 };

--- a/tests/pr-closes-issue.test.mjs
+++ b/tests/pr-closes-issue.test.mjs
@@ -11,7 +11,7 @@
  */
 
 import assert from 'node:assert/strict';
-import { prClosesIssue } from '../src/github.batch.lib.mjs';
+import { prClosesIssue } from '../src/github-linking.lib.mjs';
 
 // Test utilities
 let testsPassed = 0;

--- a/tests/test-github-linking.mjs
+++ b/tests/test-github-linking.mjs
@@ -67,6 +67,7 @@ const validFormats = [
   { prBody: 'This PR FIXES #515', issueNumber: '515', desc: 'All caps FIXES #N' },
   { prBody: 'Closes #42', issueNumber: '42', desc: 'closes #N' },
   { prBody: 'Resolves #123', issueNumber: '123', desc: 'Resolves #N' },
+  { prBody: 'fixes: #515', issueNumber: '515', desc: 'Commit-style fixes: #N' },
   { prBody: 'Fix #99', issueNumber: '99', desc: 'Fix #N' },
   { prBody: 'Close #88', issueNumber: '88', desc: 'Close #N' },
   { prBody: 'Resolve #77', issueNumber: '77', desc: 'Resolve #N' },
@@ -80,6 +81,11 @@ const validFormats = [
     owner: 'link-assistant',
     repo: 'hive-mind',
     desc: 'Fixes owner/repo#N',
+  },
+  {
+    prBody: 'Fixes labtgbot/marketcap#110',
+    issueNumber: '110',
+    desc: 'Fixes generic owner/repo#N',
   },
   {
     prBody: 'Resolves https://github.com/link-assistant/hive-mind/issues/515',

--- a/tests/test-issue-1760-draft-linked-prs.mjs
+++ b/tests/test-issue-1760-draft-linked-prs.mjs
@@ -1,0 +1,90 @@
+#!/usr/bin/env node
+
+import assert from 'node:assert/strict';
+import { extractLinkedPullRequestsForIssue } from '../src/github.batch.lib.mjs';
+
+const silentLog = async () => {};
+
+function issueDataWith(nodes) {
+  return {
+    timelineItems: {
+      nodes,
+    },
+  };
+}
+
+function prSource(overrides = {}) {
+  return {
+    source: {
+      number: 111,
+      title: 'Add multi-language localization',
+      body: 'Resolves #110',
+      state: 'OPEN',
+      isDraft: false,
+      url: 'https://github.example.test/example/repo/pull/111',
+      ...overrides,
+    },
+  };
+}
+
+async function test(name, fn) {
+  try {
+    await fn();
+    console.log(`PASS ${name}`);
+  } catch (error) {
+    console.error(`FAIL ${name}`);
+    console.error(error);
+    process.exitCode = 1;
+  }
+}
+
+await test('counts open draft PRs that close the issue', async () => {
+  const linkedPRs = await extractLinkedPullRequestsForIssue(
+    issueDataWith([
+      prSource({
+        isDraft: true,
+      }),
+    ]),
+    110,
+    silentLog
+  );
+
+  assert.equal(linkedPRs.length, 1);
+  assert.deepEqual(linkedPRs[0], {
+    number: 111,
+    title: 'Add multi-language localization',
+    state: 'OPEN',
+    isDraft: true,
+    url: 'https://github.example.test/example/repo/pull/111',
+  });
+});
+
+await test('ignores draft PRs that only mention the issue', async () => {
+  const linkedPRs = await extractLinkedPullRequestsForIssue(
+    issueDataWith([
+      prSource({
+        body: 'Related to #110',
+        isDraft: true,
+      }),
+    ]),
+    110,
+    silentLog
+  );
+
+  assert.equal(linkedPRs.length, 0);
+});
+
+await test('ignores closed PRs even when they have closing keywords', async () => {
+  const linkedPRs = await extractLinkedPullRequestsForIssue(
+    issueDataWith([
+      prSource({
+        state: 'CLOSED',
+        isDraft: true,
+      }),
+    ]),
+    110,
+    silentLog
+  );
+
+  assert.equal(linkedPRs.length, 0);
+});


### PR DESCRIPTION
## Summary

Fixes #1760 by making `/hive --skip-issues-with-prs` count open draft pull requests as active linked solution drafts.

## Root Cause

The batch GraphQL issue-to-PR checker only counted linked PRs when the pull request was open and not draft:

```js
item.source.state === 'OPEN' && !item.source.isDraft
```

During the incident, the original linked PR was temporarily converted to draft while an automated work session rechecked CI. `/hive` therefore treated the issue as having no PR and created a duplicate.

## Changes

- Extracted timeline parsing into `extractLinkedPullRequestsForIssue()`.
- Counted all open linked PRs with closing keywords, including drafts.
- Preserved the existing closing-keyword guard so casual issue mentions do not block work.
- Moved closing-keyword parsing into shared `github-linking.lib.mjs` code so solve and hive paths use the same issue-link detector.
- Added regression coverage for an open draft PR with `Resolves #110`.
- Added parser coverage for commit-style `fixes: #N` and generic `owner/repo#N` references.
- Added sanitized case-study material under `docs/case-studies/issue-1760/`; raw private logs remain excluded.

## Verification

- `node tests/test-issue-1760-draft-linked-prs.mjs`
- `node tests/pr-closes-issue.test.mjs`
- `node tests/test-github-linking.mjs`
- `node tests/test-issue-1616-pr-issue-link-preservation.mjs`
- `node tests/test-issue-1763-per-iteration-pr-issue-link.mjs`
- `npm run lint`
- `npm run format:check`
- `npm test`
