### PR TITLE
feat(queue): per-(tool, model) concurrency mode for solve queue (closes #1474)

### DIFF
--- a/.changeset/issue-1474-agent-concurrency.md
+++ b/.changeset/issue-1474-agent-concurrency.md
@@ -1,0 +1,5 @@
+---
+"@link-assistant/hive-mind": patch
+---
+
+Add per-tool concurrency mode to the solve queue. The `--tool agent` queue now defaults to **global one-at-a-time** so free-tier providers (OpenCode Zen, Kilo Gateway) aren't rate-limited by parallel runs. The new mode `per-free-model-one-at-a-time` runs one task at a time per free model (e.g. one `minimax-m2.5-free`) while letting different free models (e.g. `gpt-5-nano-free`) run in parallel. Configurable for every queue via env vars (`HIVE_MIND_<TOOL>_CONCURRENCY`) and the existing `HIVE_MIND_QUEUE_CONFIG` links notation (`(agent-concurrency per-free-model-one-at-a-time)`). Other tools (claude/codex/qwen/gemini) keep their previous behavior by defaulting to `off`. Closes #1474.

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,3 +1,2 @@
 # .gitkeep file auto-generated at 2026-04-15T05:07:05.365Z for PR creation at branch issue-1603-d47eafcfffb1 for issue https://github.com/link-assistant/hive-mind/issues/1603
 # Updated: 2026-04-17T19:04:16.770Z
-# Updated: 2026-05-13T07:30:47.162Z

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,2 +1,3 @@
 # .gitkeep file auto-generated at 2026-04-15T05:07:05.365Z for PR creation at branch issue-1603-d47eafcfffb1 for issue https://github.com/link-assistant/hive-mind/issues/1603
 # Updated: 2026-04-17T19:04:16.770Z
+# Updated: 2026-05-13T07:30:47.162Z

--- a/docs/case-studies/issue-1474/README.md
+++ b/docs/case-studies/issue-1474/README.md
@@ -1,0 +1,159 @@
+# Case Study: Issue #1474 — Per-free-model `1-at-a-time` mode for `--tool agent`
+
+## Issue
+
+[Issue #1474](https://github.com/link-assistant/hive-mind/issues/1474) — _"For all free models in queue of `--tool agent` please use mode `1 at time` for each specific free model."_
+
+## Problem statement (verbatim, condensed)
+
+> For example for `minimax-m2.5-free` we cannot execute more than 1 task at a time, due to high risk of getting into rate limit.
+> But if task for `minimax-m2.5-free` is executing, we still can execute 1 task for `gpt-5-nano`, that is also free model, but we expect it to have separate rate limit.
+>
+> As we now testing `--tool agent` mostly with free limits, the entire agent queue should be working in 1 task at a time mode. And yet it should be configurable for all queues, just that they should have different defaults, at the moment the `--tool agent` should be the only queue with 1 at time mode globally and unconditionally.
+
+The author also notes a dependency on [#380](https://github.com/link-assistant/hive-mind/issues/380) (tracking finish of a solve command end-to-end). With separate-tool queues already in place per [#1159](https://github.com/link-assistant/hive-mind/issues/1159) and the existing `dequeue-one-at-a-time` strategy from [#1253](https://github.com/link-assistant/hive-mind/issues/1253), we can deliver per-free-model gating without waiting on #380 — `this.processing` in the in-memory queue is already a good enough proxy for "command running" inside the bot process. (External pgrep is still consulted via `getExternalProcessingSnapshot`, so detached screen sessions also count.)
+
+## Requirements
+
+Numbered for traceability:
+
+1. **R1** — The `--tool agent` queue MUST default to globally and unconditionally 1-at-a-time concurrency (one in-flight task at a time across the entire agent queue).
+2. **R2** — Each specific **free** agent model (e.g. `minimax-m2.5-free`, `gpt-5-nano`, `nemotron-3-super-free`, `deepseek-r1-free`, …) MUST have its own _1-at-a-time_ slot, so different free models execute in parallel.
+3. **R3** — Configurability: every queue (claude, agent, codex, qwen, gemini) MUST have a tunable concurrency mode (global one-at-a-time, per-model one-at-a-time, off) via the existing `HIVE_MIND_QUEUE_CONFIG` (links notation) **and** discrete env vars. The agent queue MUST default to "global one-at-a-time" today.
+4. **R4** — Free model detection MUST cover both providers (OpenCode Zen `opencode/...-free` and Kilo Gateway `kilo/...-free`) and aliases.
+5. **R5** — Other tools (claude/codex/qwen/gemini) MUST remain unaffected unless explicitly configured.
+6. **R6** — Behavior MUST be covered by automated tests (queue gating logic) and documented in a case study + PR description.
+7. **R7** — No regressions in existing queue behavior (rate limits, reject strategy, parallel cross-tool starts).
+
+## Data collected
+
+### Files that participate in the queue / rate-limiting flow
+
+| Path                               | Role                                                                                                                                       |
+| ---------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------ |
+| `src/telegram-solve-queue.lib.mjs` | The queue. Holds `SolveQueueItem`, `SolveQueue`, `findStartableItems()`, `canStartCommand()`, `getProcessingCountByTool()`.                |
+| `src/queue-config.lib.mjs`         | `QUEUE_CONFIG` thresholds, strategies, `parseQueueConfig` (links notation).                                                                |
+| `src/telegram-bot.mjs`             | The producer. Parses `--tool` and `--model` from args and calls `solveQueue.enqueue(...)`.                                                 |
+| `src/models/index.mjs`             | `agentModels`, `defaultModels.agent`, `freeToBaseModelMap`, `mapModelForTool()`.                                                           |
+| `src/agent.lib.mjs`                | Tool runner. Has `getBaseModelForPricing()` which already classifies a model as "free" using `freeToBaseModelMap` plus the `-free` suffix. |
+| `tests/solve-queue*.mjs`           | Test suite for the queue.                                                                                                                  |
+
+### Already-existing primitives we can reuse
+
+- **Per-tool queues** (PR #1160 / issue #1159) — `this.queues[tool]` and `getProcessingCountByTool(tool)` already exist and isolate tools from each other. We just need a per-`(tool, model)` counter and gate.
+- **Strategy framework** (#1253) — `THRESHOLD_STRATEGIES` already includes `dequeue-one-at-a-time`. Reused for naming consistency, but the new concurrency mode is conceptually different from threshold-driven strategies, so we add a separate config under `QUEUE_CONFIG.concurrency`.
+- **Free-model classifier** — `getBaseModelForPricing()` in `src/agent.lib.mjs` already encodes the truth about "what counts as a free agent model": `freeToBaseModelMap` membership OR ends with `-free`. We lift that logic into a shared helper so the queue can call it too.
+- **Links notation parser** (#1242 / #1253) — `parseQueueConfig()` already accepts arbitrary metric names and validates against `THRESHOLD_STRATEGIES`. We extend the surface but keep the same parser.
+
+### How `enqueue()` is currently called from the bot
+
+From `src/telegram-bot.mjs:877`:
+
+```js
+const queueItem = solveQueue.enqueue({
+  url: normalizedUrl,
+  args: argsWithLocale,
+  ctx,
+  requester,
+  infoBlock,
+  tool: solveTool, // 'agent', 'claude', …
+  perCommandIsolation: effectiveSolveIsolation,
+  urlContext: solveUrlContext,
+  showLimits: solveShowLimits,
+  limitsAtStart: solveLimitsAtStart,
+  locale: solveLocale,
+});
+```
+
+`solveTool` is parsed by walking `args` looking for `--tool`/`--tool=`. The user's `--model` is in `args` but is currently _not_ extracted at the queue boundary. We need to extract it the same way `solveTool` is.
+
+## Research: prior art / online review
+
+- **#1159 (separate tool queues)** establishes the exact pattern of "FIFO per dimension, independent rate limits per dimension". Our extension is one dimension deeper: per `(tool, model)` for the gated case.
+- **#1253 (strategy framework)** introduces `THRESHOLD_STRATEGIES = ['reject', 'enqueue', 'dequeue-one-at-a-time']` and the `HIVE_MIND_QUEUE_CONFIG` links notation. We reuse this exact vocabulary so users do not have to learn a new config language.
+- **`p-limit` / `bottleneck` / `async-mutex`** (npm) — these solve per-key concurrency well but our queue is already integrated with status messages, Telegram updates, and `findStartableItems`; bringing in a third-party scheduler would force a refactor without obvious gain. The implementation below is ~30 lines in the existing class.
+- **OpenCode Zen / Kilo Gateway free tier rate limits** — both providers rate-limit per-model (per API key) rather than per-account-aggregated, which is exactly why the issue requires per-model gating instead of "free-vs-paid" gating.
+
+## Proposed solution
+
+### Concurrency configuration model
+
+Add a `QUEUE_CONFIG.concurrency` map, keyed by tool:
+
+```jsonc
+{
+  "claude": { "mode": "off" }, // unchanged default
+  "agent": { "mode": "global-one-at-a-time" }, // R1: agent default
+  "codex": { "mode": "off" },
+  "qwen": { "mode": "off" },
+  "gemini": { "mode": "off" },
+}
+```
+
+Where `mode` is one of:
+
+- `'off'` — no concurrency cap from this layer (existing rate-limit strategies still apply).
+- `'global-one-at-a-time'` — at most 1 in-flight item per tool, regardless of model.
+- `'per-free-model-one-at-a-time'` — for _free_ models, at most 1 in-flight item per `(tool, model)`. Non-free models in the same tool run with `'off'` semantics.
+- `'per-model-one-at-a-time'` — at most 1 in-flight item per `(tool, model)`, for all models.
+
+Per the issue text: ship `agent = 'global-one-at-a-time'` as the default. The `'per-free-model-one-at-a-time'` mode is the natural switch users will flip when they want different free models to run in parallel (R2 + R3).
+
+### Configuration surface
+
+1. **Env var per tool** — `HIVE_MIND_AGENT_CONCURRENCY=per-free-model-one-at-a-time` (and same for `CLAUDE`, `CODEX`, `QWEN`, `GEMINI`).
+2. **Links notation** — extend `HIVE_MIND_QUEUE_CONFIG`:
+   ```
+   (
+     (agent-concurrency per-free-model-one-at-a-time)
+     (claude-concurrency global-one-at-a-time)
+   )
+   ```
+3. **Built-in defaults** — `agent: global-one-at-a-time`, all others `off`.
+
+### Plumbing the model into the queue
+
+- `SolveQueueItem` gains a `model` field (alias preserved; we don't need to map to a full provider ID for gating — the alias is unique enough and matches what users specify).
+- `solveQueue.enqueue({ ..., model })` accepts it; the telegram bot extracts `--model`/`-m`/`--model=` from `args` the same way it extracts `--tool`.
+- New helper `getProcessingCountByToolAndModel(tool, model)` symmetrical with `getProcessingCountByTool(tool)`.
+- New helper `isFreeAgentModel(model)` lifted from `agent.lib.mjs`'s `getBaseModelForPricing()`.
+- `findStartableItems()` consults `QUEUE_CONFIG.concurrency[tool].mode` to gate the head of each tool queue.
+
+### Why not gate on the `dequeue-one-at-a-time` strategy via a synthetic threshold?
+
+That mechanism is keyed off live metrics (RAM/CPU/Claude limits) — it kicks in only when a threshold is exceeded. R1 demands unconditional 1-at-a-time for agent, so a metric-driven gate is the wrong primitive. The simpler, more honest model is "concurrency cap", parallel to "threshold strategy".
+
+## Implementation plan (atomic commits)
+
+1. **Add free-model classifier helper** — export `isFreeAgentModel(model)` from `src/models/index.mjs` so both `agent.lib.mjs` and the queue can use it.
+2. **Add concurrency config** — extend `src/queue-config.lib.mjs`: parse `*-concurrency` keys (lino + env vars), add `QUEUE_CONFIG.concurrency`, defaults `{ agent: 'global-one-at-a-time', others: 'off' }`.
+3. **Wire model through queue** — `SolveQueueItem.model`, `enqueue({...,model})`, `getProcessingCountByToolAndModel`, update `findStartableItems()` to gate per-tool mode.
+4. **Producer side** — extract `--model` in `src/telegram-bot.mjs` and pass into `enqueue(...)`.
+5. **Tests** — extend `tests/solve-queue-tool-tracking.test.mjs` (or a new file) covering: agent default = global one-at-a-time; per-free-model mode allows two different free models to start in parallel; non-free models bypass per-free gating; claude/codex unaffected.
+6. **Changeset** — patch bump describing the user-visible change.
+7. **Case study** — this document.
+8. **PR update** — title, description with R-checklist.
+
+## Acceptance criteria (mapped to requirements)
+
+| R#  | Verification                                                                                                                                                           |
+| --- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| R1  | Default config has `concurrency.agent = 'global-one-at-a-time'`. Test: enqueue 2 agent items, only 1 startable.                                                        |
+| R2  | With `concurrency.agent = 'per-free-model-one-at-a-time'`: two items with same free model → 1 startable; two items with different free models → both startable.        |
+| R3  | Env var + lino config override defaults; tests cover both paths.                                                                                                       |
+| R4  | `isFreeAgentModel` returns true for `*-free` suffix and for entries of `freeToBaseModelMap`. Resolution works for aliases (e.g. `minimax-m2.5-free` → still detected). |
+| R5  | Default `claude/codex/qwen/gemini` concurrency is `'off'`; existing tests continue to pass.                                                                            |
+| R6  | New tests in `tests/solve-queue-concurrency.test.mjs`; this case study.                                                                                                |
+| R7  | Full `npm test` green; no behavior change for current rate limits / reject strategy.                                                                                   |
+
+## Open questions / future work
+
+- Concurrency cap > 1 (e.g. "max 3 per model") is straightforward to add later — the helper is parameterized. Out of scope for this PR per the issue text.
+- Cross-process coordination (multiple bot instances sharing free-model rate limits via a shared store) is out of scope; this PR remains in-memory.
+- Per-(tool, model) reject strategy could also be useful but isn't requested.
+
+## References
+
+- Issue: https://github.com/link-assistant/hive-mind/issues/1474
+- Pull request: https://github.com/link-assistant/hive-mind/pull/1797
+- Related: #380, #1159, #1253, #1242, #1543, #1563

--- a/experiments/debug-concurrency-second-pass.mjs
+++ b/experiments/debug-concurrency-second-pass.mjs
@@ -1,0 +1,67 @@
+#!/usr/bin/env node
+/**
+ * Diagnose why the second findStartableItems() pass returns 0 items
+ * in the per-free-model parallel test.
+ */
+import { SolveQueue, QUEUE_CONFIG, resetSolveQueue } from '../src/telegram-solve-queue.lib.mjs';
+import { resetLimitCache } from '../src/limits.lib.mjs';
+
+resetSolveQueue();
+resetLimitCache();
+
+const queue = new SolveQueue({
+  verbose: true,
+  autoStart: false,
+  getRunningProcesses: async () => ({ count: 0, processes: [] }),
+  getRunningIsolatedSessions: async () => ({ count: 0, sessions: [], byTool: {} }),
+});
+
+// Force concurrency
+QUEUE_CONFIG.concurrency.agent = 'per-free-model-one-at-a-time';
+
+queue.enqueue({ url: 'https://github.com/test/repo/issues/1', args: '', requester: 'u', infoBlock: 'i', tool: 'agent', model: 'minimax-m2.5-free' });
+queue.enqueue({ url: 'https://github.com/test/repo/issues/2', args: '', requester: 'u', infoBlock: 'i', tool: 'agent', model: 'gpt-5-nano-free' });
+
+console.log('--- BEFORE first pass ---');
+console.log('agent queue length:', queue.getToolQueue('agent').length);
+console.log('processing size:', queue.processing.size);
+
+const first = await queue.findStartableItems();
+console.log('first pass startable count:', first.length);
+console.log(
+  'first pass details:',
+  first.map(s => ({ tool: s.tool, model: s.item.model }))
+);
+
+// Simulate move first to processing
+queue.processing.set(first[0].item.id, first[0].item);
+queue.getToolQueue('agent').shift();
+
+console.log('\n--- BEFORE second pass ---');
+console.log('agent queue length:', queue.getToolQueue('agent').length);
+console.log('processing size:', queue.processing.size);
+console.log('head of agent queue:', queue.getToolQueue('agent')[0] ? { tool: queue.getToolQueue('agent')[0].tool, model: queue.getToolQueue('agent')[0].model } : null);
+
+// What does canStartCommand say?
+const head = queue.getToolQueue('agent')[0];
+const check = await queue.canStartCommand({ tool: 'agent', locale: null });
+console.log('\ncanStartCommand result:', {
+  canStart: check.canStart,
+  rejected: check.rejected,
+  rejectReason: check.rejectReason,
+  reasons: check.reasons,
+  oneAtATime: check.oneAtATime,
+  totalProcessing: check.totalProcessing,
+});
+
+const ok = queue.canStartUnderConcurrencyMode('agent', head);
+console.log('\ncanStartUnderConcurrencyMode("agent", head):', ok);
+
+const second = await queue.findStartableItems();
+console.log('\nsecond pass startable count:', second.length);
+console.log(
+  'second pass details:',
+  second.map(s => ({ tool: s.tool, model: s.item.model }))
+);
+
+queue.stop();

--- a/experiments/debug-r1.mjs
+++ b/experiments/debug-r1.mjs
@@ -1,0 +1,63 @@
+#!/usr/bin/env node
+import { SolveQueue, QUEUE_CONFIG, resetSolveQueue } from '../src/telegram-solve-queue.lib.mjs';
+import { resetLimitCache } from '../src/limits.lib.mjs';
+
+resetSolveQueue();
+resetLimitCache();
+
+function buildQueue() {
+  const queue = new SolveQueue({
+    verbose: false,
+    autoStart: false,
+    getRunningProcesses: async () => ({ count: 0, processes: [] }),
+    getRunningIsolatedSessions: async () => ({ count: 0, sessions: [], byTool: {} }),
+  });
+  const okCheck = { ok: true, reasons: [], oneAtATime: false, rejected: false, rejectReason: null };
+  queue.checkSystemResources = async () => ({ ...okCheck });
+  queue.checkApiLimits = async () => ({ ...okCheck });
+  return queue;
+}
+
+const queue = buildQueue();
+queue.enqueue({ url: 'https://github.com/test/repo/issues/1', args: '', requester: 'u', infoBlock: 'i', tool: 'agent', model: 'minimax-m2.5-free' });
+queue.enqueue({ url: 'https://github.com/test/repo/issues/2', args: '', requester: 'u', infoBlock: 'i', tool: 'agent', model: 'gpt-5-nano' });
+
+console.log('QUEUE_CONFIG.concurrency:', QUEUE_CONFIG.concurrency);
+
+const first = await queue.findStartableItems();
+console.log(
+  'first pass:',
+  first.length,
+  first.map(s => ({ tool: s.tool, model: s.item.model }))
+);
+
+queue.processing.set(first[0].item.id, first[0].item);
+const aq = queue.getToolQueue('agent');
+const idx = aq.findIndex(i => i.id === first[0].item.id);
+if (idx !== -1) aq.splice(idx, 1);
+
+console.log(
+  'agent queue after shift:',
+  aq.map(i => ({ tool: i.tool, model: i.model }))
+);
+console.log('processing size:', queue.processing.size);
+console.log(
+  'processing items:',
+  [...queue.processing.values()].map(i => ({ id: i.id, tool: i.tool }))
+);
+
+const head = aq[0];
+console.log('head:', { tool: head.tool, model: head.model });
+console.log('getProcessingCountByTool("agent"):', queue.getProcessingCountByTool('agent'));
+console.log('canStartUnderConcurrencyMode:', queue.canStartUnderConcurrencyMode('agent', head));
+
+const check = await queue.canStartCommand({ tool: 'agent' });
+console.log('canStartCommand check:', { canStart: check.canStart, oneAtATime: check.oneAtATime });
+
+const second = await queue.findStartableItems();
+console.log(
+  'second pass:',
+  second.length,
+  second.map(s => ({ tool: s.tool, model: s.item.model }))
+);
+queue.stop();

--- a/experiments/reproduce-r2-failing.mjs
+++ b/experiments/reproduce-r2-failing.mjs
@@ -1,0 +1,60 @@
+#!/usr/bin/env node
+import { SolveQueue, QUEUE_CONFIG, resetSolveQueue } from '../src/telegram-solve-queue.lib.mjs';
+import { resetLimitCache } from '../src/limits.lib.mjs';
+
+function buildQueue() {
+  return new SolveQueue({
+    verbose: true,
+    autoStart: false,
+    getRunningProcesses: async () => ({ count: 0, processes: [] }),
+    getRunningIsolatedSessions: async () => ({ count: 0, sessions: [], byTool: {} }),
+  });
+}
+
+function withConcurrency(overrides, fn) {
+  const saved = { ...QUEUE_CONFIG.concurrency };
+  try {
+    Object.assign(QUEUE_CONFIG.concurrency, overrides);
+    return fn();
+  } finally {
+    for (const k of Object.keys(QUEUE_CONFIG.concurrency)) delete QUEUE_CONFIG.concurrency[k];
+    Object.assign(QUEUE_CONFIG.concurrency, saved);
+  }
+}
+
+resetSolveQueue();
+resetLimitCache();
+const queue = buildQueue();
+
+await withConcurrency({ agent: 'per-free-model-one-at-a-time' }, async () => {
+  queue.enqueue({ url: 'https://github.com/test/repo/issues/1', args: '', requester: 'u', infoBlock: 'i', tool: 'agent', model: 'minimax-m2.5-free' });
+  queue.enqueue({ url: 'https://github.com/test/repo/issues/2', args: '', requester: 'u', infoBlock: 'i', tool: 'agent', model: 'gpt-5-nano-free' });
+
+  console.log('\n[during fn] concurrency.agent =', QUEUE_CONFIG.concurrency.agent);
+
+  const first = await queue.findStartableItems();
+  console.log(
+    'first pass:',
+    first.length,
+    first.map(s => s.item.model)
+  );
+  console.log('[after first await] concurrency.agent =', QUEUE_CONFIG.concurrency.agent);
+
+  queue.processing.set(first[0].item.id, first[0].item);
+  queue.getToolQueue('agent').shift();
+
+  console.log('\n[before second pass] concurrency.agent =', QUEUE_CONFIG.concurrency.agent);
+  console.log('agent queue length:', queue.getToolQueue('agent').length);
+  console.log('processing size:', queue.processing.size);
+  console.log('head:', queue.getToolQueue('agent')[0] ? { tool: queue.getToolQueue('agent')[0].tool, model: queue.getToolQueue('agent')[0].model } : null);
+
+  const second = await queue.findStartableItems();
+  console.log(
+    'second pass:',
+    second.length,
+    second.map(s => s.item.model)
+  );
+});
+
+console.log('\n[after withConcurrency] concurrency.agent =', QUEUE_CONFIG.concurrency.agent);
+queue.stop();

--- a/experiments/verify-finally-bug.mjs
+++ b/experiments/verify-finally-bug.mjs
@@ -1,0 +1,19 @@
+const state = { mode: 'off' };
+
+function withConcurrency(override, fn) {
+  const saved = state.mode;
+  try {
+    state.mode = override;
+    return fn();
+  } finally {
+    state.mode = saved;
+  }
+}
+
+await withConcurrency('per-free-model-one-at-a-time', async () => {
+  console.log('inside async fn, state.mode =', state.mode);
+  // Simulate async work
+  await new Promise(r => setTimeout(r, 0));
+  console.log('after await, state.mode =', state.mode);
+});
+console.log('after withConcurrency, state.mode =', state.mode);

--- a/src/models/index.mjs
+++ b/src/models/index.mjs
@@ -209,6 +209,30 @@ export const freeToBaseModelMap = {
   'trinity-large-preview-free': 'trinity-large-preview',
 };
 
+// Issue #1474: classify whether an agent model is a free variant that needs
+// per-model concurrency gating. Accepts either a short alias (e.g.
+// 'minimax-m2.5-free') or a fully-mapped id (e.g. 'opencode/minimax-m2.5-free',
+// 'kilo/glm-5-free'). Lifted from agent.lib.mjs::getBaseModelForPricing so the
+// queue can call it without importing the agent runner.
+export const isFreeAgentModel = model => {
+  if (!model || typeof model !== 'string') return false;
+  const tail = model.includes('/') ? model.split('/').pop() : model;
+  if (!tail) return false;
+  if (freeToBaseModelMap[tail]) return true;
+  return tail.endsWith('-free');
+};
+
+// Issue #1474: normalize an agent model alias to a stable key for per-model
+// concurrency tracking. We use the fully-mapped id when available so that
+// `minimax-m2.5-free` and `opencode/minimax-m2.5-free` share a slot (they hit
+// the same provider rate limit), while `kilo/minimax-m2.5-free` (different
+// provider) gets its own slot.
+export const normalizeAgentModelKey = model => {
+  if (!model || typeof model !== 'string') return '';
+  const mapped = agentModels[model];
+  return mapped || model;
+};
+
 // ─── VALIDATION-EXTENDED MODEL MAPS ──────────────────────────────────────────
 // These extend the base maps with full model ID identity entries for validation
 // (e.g., 'claude-sonnet-4-5-20250929' → 'claude-sonnet-4-5-20250929')

--- a/src/queue-config.lib.mjs
+++ b/src/queue-config.lib.mjs
@@ -54,6 +54,25 @@ const LinoParser = linoModule.Parser || linoModule.default?.Parser;
 export const THRESHOLD_STRATEGIES = Object.freeze(['reject', 'enqueue', 'dequeue-one-at-a-time']);
 
 /**
+ * Valid per-tool concurrency modes (Issue #1474).
+ *
+ * - 'off' — no extra concurrency cap from the queue layer (default for
+ *   claude/codex/qwen/gemini).
+ * - 'global-one-at-a-time' — at most one in-flight item across the tool's
+ *   entire queue, regardless of model. Default for the agent queue today
+ *   because most testing happens with free models that share rate limits.
+ * - 'per-free-model-one-at-a-time' — for free models (see isFreeAgentModel),
+ *   at most one in-flight item per (tool, model). Non-free models run with
+ *   'off' semantics. Designed for the case where each free model has its own
+ *   provider-side rate limit.
+ * - 'per-model-one-at-a-time' — at most one in-flight item per (tool, model)
+ *   for every model.
+ *
+ * @type {readonly ['off', 'global-one-at-a-time', 'per-free-model-one-at-a-time', 'per-model-one-at-a-time']}
+ */
+export const CONCURRENCY_MODES = Object.freeze(['off', 'global-one-at-a-time', 'per-free-model-one-at-a-time', 'per-model-one-at-a-time']);
+
+/**
  * Validate a threshold strategy value
  * @param {string} strategy - The strategy to validate
  * @param {string} defaultStrategy - Default strategy if invalid
@@ -64,6 +83,19 @@ function validateStrategy(strategy, defaultStrategy = 'enqueue') {
     return defaultStrategy;
   }
   return strategy;
+}
+
+/**
+ * Validate a per-tool concurrency mode (Issue #1474).
+ * @param {string} mode - The mode to validate
+ * @param {string} defaultMode - Default mode if invalid
+ * @returns {string} Valid mode
+ */
+function validateConcurrencyMode(mode, defaultMode = 'off') {
+  if (!mode || !CONCURRENCY_MODES.includes(mode)) {
+    return defaultMode;
+  }
+  return mode;
 }
 
 /**
@@ -89,11 +121,17 @@ function normalizeMetricName(name) {
  *   (claude-5-hour (65% dequeue-one-at-a-time))
  *   (claude-weekly (97% dequeue-one-at-a-time))
  *   (github-api (50% enqueue))
+ *   (agent-concurrency per-free-model-one-at-a-time)
+ *   (claude-concurrency global-one-at-a-time)
  * )
  * ```
  *
+ * Issue #1474: `*-concurrency` entries set per-tool concurrency mode.
+ * They are returned under the special `concurrency` key, e.g.
+ * `{ concurrency: { agent: 'per-free-model-one-at-a-time' } }`.
+ *
  * @param {string} linoConfig - Configuration in links notation format
- * @returns {Object} Parsed threshold configurations { [metricName]: { value: number, strategy: string } }
+ * @returns {Object} Parsed threshold configurations and concurrency modes
  */
 export function parseQueueConfig(linoConfig) {
   if (!linoConfig || typeof linoConfig !== 'string') return {};
@@ -105,6 +143,7 @@ export function parseQueueConfig(linoConfig) {
     if (!parsed || !Array.isArray(parsed) || parsed.length === 0) return {};
 
     const config = {};
+    const concurrency = {};
 
     // The parser returns: [{ id: null, values: [...] }]
     // We need to drill down to find the metric configurations
@@ -134,10 +173,11 @@ export function parseQueueConfig(linoConfig) {
         // Extract all IDs from this nested structure
         const ids = extractIds(item.values);
 
-        // Find metric name, percentage, and strategy
+        // Find metric name, percentage, strategy, and concurrency mode
         let metricName = null;
         let thresholdValue = null;
         let strategy = null;
+        let concurrencyMode = null;
 
         for (const id of ids) {
           // Check for percentage
@@ -153,10 +193,25 @@ export function parseQueueConfig(linoConfig) {
             continue;
           }
 
+          // Issue #1474: check for concurrency mode
+          if (CONCURRENCY_MODES.includes(id)) {
+            concurrencyMode = id;
+            continue;
+          }
+
           // Otherwise it's likely the metric name
           if (!metricName) {
             metricName = id;
           }
+        }
+
+        // Issue #1474: concurrency entry — `(agent-concurrency <mode>)`
+        if (metricName && concurrencyMode !== null && metricName.endsWith('-concurrency')) {
+          const tool = metricName.slice(0, -'-concurrency'.length);
+          if (tool) {
+            concurrency[tool] = validateConcurrencyMode(concurrencyMode);
+          }
+          continue;
         }
 
         if (metricName && thresholdValue !== null) {
@@ -167,6 +222,10 @@ export function parseQueueConfig(linoConfig) {
           };
         }
       }
+    }
+
+    if (Object.keys(concurrency).length > 0) {
+      config.concurrency = concurrency;
     }
 
     return config;
@@ -192,6 +251,45 @@ const parseIntWithDefault = (envVar, defaultValue) => {
 
 // Parse links notation config from environment variable (if provided)
 const linoConfig = parseQueueConfig(getenv('HIVE_MIND_QUEUE_CONFIG', ''));
+
+/**
+ * Per-tool concurrency mode defaults (Issue #1474).
+ *
+ * The agent queue defaults to 'global-one-at-a-time' because the project is
+ * primarily tested against free-tier providers (OpenCode Zen, Kilo Gateway)
+ * whose rate limits are quickly tripped if two agent commands run in parallel.
+ * Operators who run their own paid keys can flip individual tools off via
+ * env var or HIVE_MIND_QUEUE_CONFIG.
+ */
+const CONCURRENCY_DEFAULTS = Object.freeze({
+  claude: 'off',
+  agent: 'global-one-at-a-time',
+  codex: 'off',
+  qwen: 'off',
+  gemini: 'off',
+});
+
+/**
+ * Resolve concurrency mode for a tool with priority:
+ * 1. HIVE_MIND_QUEUE_CONFIG (links notation, `(<tool>-concurrency <mode>)`)
+ * 2. HIVE_MIND_<TOOL>_CONCURRENCY env var
+ * 3. Built-in default for the tool
+ *
+ * @param {string} tool - Tool name (claude, agent, codex, qwen, gemini)
+ * @param {string} defaultMode - Default mode if nothing else is configured
+ * @returns {string} A valid concurrency mode from CONCURRENCY_MODES
+ */
+function resolveConcurrencyMode(tool, defaultMode) {
+  const fromLino = linoConfig.concurrency && linoConfig.concurrency[tool];
+  if (fromLino && CONCURRENCY_MODES.includes(fromLino)) {
+    return fromLino;
+  }
+  const envValue = getenv(`HIVE_MIND_${tool.toUpperCase()}_CONCURRENCY`, '');
+  if (envValue && CONCURRENCY_MODES.includes(envValue)) {
+    return envValue;
+  }
+  return validateConcurrencyMode(defaultMode, 'off');
+}
 
 /**
  * Get threshold configuration with priority:
@@ -280,6 +378,16 @@ export const QUEUE_CONFIG = {
 
   // Process detection
   CLAUDE_PROCESS_NAMES: ['claude'], // Process names to detect
+
+  // Issue #1474: per-tool concurrency mode.
+  // Priority: HIVE_MIND_QUEUE_CONFIG > HIVE_MIND_<TOOL>_CONCURRENCY > default.
+  concurrency: {
+    claude: resolveConcurrencyMode('claude', CONCURRENCY_DEFAULTS.claude),
+    agent: resolveConcurrencyMode('agent', CONCURRENCY_DEFAULTS.agent),
+    codex: resolveConcurrencyMode('codex', CONCURRENCY_DEFAULTS.codex),
+    qwen: resolveConcurrencyMode('qwen', CONCURRENCY_DEFAULTS.qwen),
+    gemini: resolveConcurrencyMode('gemini', CONCURRENCY_DEFAULTS.gemini),
+  },
 };
 
 /**
@@ -345,14 +453,25 @@ export function isOneAtATimeStrategy(metric) {
   return getStrategy(metric) === 'dequeue-one-at-a-time';
 }
 
+/**
+ * Get configured concurrency mode for a tool (Issue #1474).
+ * @param {string} tool - Tool name (claude, agent, codex, qwen, gemini)
+ * @returns {string} Concurrency mode from CONCURRENCY_MODES
+ */
+export function getConcurrencyMode(tool) {
+  return QUEUE_CONFIG.concurrency[tool] || 'off';
+}
+
 export default {
   QUEUE_CONFIG,
   DISPLAY_THRESHOLDS,
   THRESHOLD_STRATEGIES,
+  CONCURRENCY_MODES,
   thresholdToPercent,
   parseQueueConfig,
   getStrategy,
   isRejectStrategy,
   isEnqueueStrategy,
   isOneAtATimeStrategy,
+  getConcurrencyMode,
 };

--- a/src/telegram-bot.mjs
+++ b/src/telegram-bot.mjs
@@ -770,11 +770,20 @@ async function handleSolveCommand(ctx) {
 
   // Determine tool from args (default: claude)
   let solveTool = 'claude';
+  // Issue #1474: also extract --model alias at the queue boundary so the
+  //   queue can gate per-free-model concurrency. Mirrors the parsing in
+  //   validateModelInArgs() but only needs the literal string value, not
+  //   resolution to a provider ID — equality is enough for gating.
+  let solveModel = null;
   for (let i = 0; i < args.length; i++) {
     if (args[i] === '--tool' && i + 1 < args.length) {
       solveTool = args[i + 1];
     } else if (args[i].startsWith('--tool=')) {
       solveTool = args[i].substring('--tool='.length);
+    } else if ((args[i] === '--model' || args[i] === '-m') && i + 1 < args.length) {
+      solveModel = args[i + 1];
+    } else if (args[i].startsWith('--model=')) {
+      solveModel = args[i].substring('--model='.length);
     }
   }
 
@@ -874,7 +883,7 @@ async function handleSolveCommand(ctx) {
     const startingMessage = await safeReply(ctx, formatStartingWorkSessionMessage({ infoBlock, locale: solveLocale }), { reply_to_message_id: ctx.message.message_id });
     await executeAndUpdateMessage(ctx, startingMessage, 'solve', argsWithLocale, infoBlock, effectiveSolveIsolation, solveTool, solveUrlContext, { showLimits: solveShowLimits, limitsAtStart: solveLimitsAtStart, locale: solveLocale });
   } else {
-    const queueItem = solveQueue.enqueue({ url: normalizedUrl, args: argsWithLocale, ctx, requester, infoBlock, tool: solveTool, perCommandIsolation: effectiveSolveIsolation, urlContext: solveUrlContext, showLimits: solveShowLimits, limitsAtStart: solveLimitsAtStart, locale: solveLocale });
+    const queueItem = solveQueue.enqueue({ url: normalizedUrl, args: argsWithLocale, ctx, requester, infoBlock, tool: solveTool, model: solveModel, perCommandIsolation: effectiveSolveIsolation, urlContext: solveUrlContext, showLimits: solveShowLimits, limitsAtStart: solveLimitsAtStart, locale: solveLocale });
     const queueMessage = buildSolveQueuedMessage({ locale: solveLocale, tool: solveTool, position: toolQueuedCount + 1, infoBlock, reason: check.reason ? escapeMarkdown(check.reason) : '' }); // tool-specific position (#1551)
     const queuedMessage = await safeReply(ctx, queueMessage, { reply_to_message_id: ctx.message.message_id });
     queueItem.messageInfo = { chatId: queuedMessage.chat.id, messageId: queuedMessage.message_id };

--- a/src/telegram-solve-queue.concurrency.lib.mjs
+++ b/src/telegram-solve-queue.concurrency.lib.mjs
@@ -1,0 +1,79 @@
+/**
+ * Per-tool concurrency gate for the solve queue (Issue #1474).
+ *
+ * The gate decides whether a head-of-tool-queue item is allowed to start
+ * given the current set of in-flight items and the configured mode for that
+ * tool. Modes are defined in queue-config.lib.mjs (CONCURRENCY_MODES).
+ *
+ * Kept in a separate file from telegram-solve-queue.lib.mjs to keep the main
+ * queue module under the project's 1500-line cap (see
+ * scripts/check-file-line-limits.sh and eslint max-lines rule).
+ *
+ * @see https://github.com/link-assistant/hive-mind/issues/1474
+ */
+
+import { QUEUE_CONFIG } from './queue-config.lib.mjs';
+import { isFreeAgentModel } from './models/index.mjs';
+
+/**
+ * Count processing items with the same (tool, model) pair.
+ * @param {Map<string, {tool: string, model?: string|null}>} processing
+ * @param {string} tool
+ * @param {string|null} model
+ * @returns {number}
+ */
+export function countProcessingByToolAndModel(processing, tool, model) {
+  let count = 0;
+  const target = model || null;
+  for (const item of processing.values()) {
+    if (item.tool !== tool) continue;
+    const itemModel = item.model || null;
+    if (itemModel === target) count++;
+  }
+  return count;
+}
+
+/**
+ * Count processing items for a tool, regardless of model.
+ * @param {Map<string, {tool: string}>} processing
+ * @param {string} tool
+ * @returns {number}
+ */
+export function countProcessingByTool(processing, tool) {
+  let count = 0;
+  for (const item of processing.values()) {
+    if (item.tool === tool) count++;
+  }
+  return count;
+}
+
+/**
+ * Decide whether `item` is permitted to start under the configured
+ * per-tool concurrency mode. Returns true for unknown modes so a misconfig
+ * cannot wedge the queue.
+ *
+ * @param {Map<string, {tool: string, model?: string|null}>} processing
+ * @param {string} tool
+ * @param {{tool: string, model?: string|null}} item
+ * @returns {boolean}
+ */
+export function canStartUnderConcurrencyMode(processing, tool, item) {
+  const mode = (QUEUE_CONFIG.concurrency && QUEUE_CONFIG.concurrency[tool]) || 'off';
+  if (mode === 'off') return true;
+
+  if (mode === 'global-one-at-a-time') {
+    return countProcessingByTool(processing, tool) === 0;
+  }
+
+  if (mode === 'per-model-one-at-a-time') {
+    return countProcessingByToolAndModel(processing, tool, item.model || null) === 0;
+  }
+
+  if (mode === 'per-free-model-one-at-a-time') {
+    const model = item.model || null;
+    if (!model || !isFreeAgentModel(model)) return true;
+    return countProcessingByToolAndModel(processing, tool, model) === 0;
+  }
+
+  return true;
+}

--- a/src/telegram-solve-queue.lib.mjs
+++ b/src/telegram-solve-queue.lib.mjs
@@ -16,10 +16,12 @@
  */
 
 import { getCachedClaudeLimits, getCachedCodexLimits, getCachedGitHubLimits, getCachedMemoryInfo, getCachedCpuInfo, getCachedDiskInfo, getLimitCache } from './limits.lib.mjs';
-export { formatDuration, getRunningAgentProcesses, getRunningClaudeProcesses, getRunningCodexProcesses, getRunningGeminiProcesses, getRunningProcesses, getRunningQwenProcesses } from './telegram-solve-queue.helpers.lib.mjs';
 import { formatDuration, formatWaitingReason, getRunningAgentProcesses, getRunningClaudeProcesses, getRunningCodexProcesses, getRunningGeminiProcesses, getRunningProcesses, getRunningQwenProcesses } from './telegram-solve-queue.helpers.lib.mjs';
-export { QUEUE_CONFIG, THRESHOLD_STRATEGIES } from './queue-config.lib.mjs';
-import { QUEUE_CONFIG } from './queue-config.lib.mjs';
+export { formatDuration, getRunningAgentProcesses, getRunningClaudeProcesses, getRunningCodexProcesses, getRunningGeminiProcesses, getRunningProcesses, getRunningQwenProcesses } from './telegram-solve-queue.helpers.lib.mjs';
+import { QUEUE_CONFIG, THRESHOLD_STRATEGIES } from './queue-config.lib.mjs';
+export { QUEUE_CONFIG, THRESHOLD_STRATEGIES };
+import { normalizeAgentModelKey } from './models/index.mjs';
+import { canStartUnderConcurrencyMode as _canStartUnderConcurrencyMode, countProcessingByTool, countProcessingByToolAndModel } from './telegram-solve-queue.concurrency.lib.mjs';
 import { formatExecutingWorkSessionMessage, formatStartingWorkSessionMessage } from './work-session-formatting.lib.mjs';
 import { t } from './i18n.lib.mjs';
 import { lt } from './limits-i18n.lib.mjs';
@@ -62,6 +64,7 @@ class SolveQueueItem {
     this.requester = options.requester;
     this.infoBlock = options.infoBlock;
     this.tool = options.tool || 'claude';
+    this.model = normalizeAgentModelKey(options.model) || options.model || null;
     // Issue #1688: keep parsed URL context (owner/repo/number/type) so completion
     //   notifications can look up linked PRs for issue URLs.
     this.urlContext = options.urlContext || null;
@@ -356,20 +359,15 @@ export class SolveQueue {
   }
 
   /**
-   * Count processing items by tool type
-   * Used for tool-specific limit checking - e.g., Claude limits only count Claude processing items
-   * @param {string} tool - Tool type to count ('claude', 'agent', 'codex', 'gemini', etc.)
-   * @returns {number} Count of processing items with the specified tool
+   * Count processing items by tool type.
    * @see https://github.com/link-assistant/hive-mind/issues/1159
    */
   getProcessingCountByTool(tool) {
-    let count = 0;
-    for (const item of this.processing.values()) {
-      if (item.tool === tool) {
-        count++;
-      }
-    }
-    return count;
+    return countProcessingByTool(this.processing, tool);
+  }
+
+  getProcessingCountByToolAndModel(tool, model) {
+    return countProcessingByToolAndModel(this.processing, tool, model);
   }
 
   /**
@@ -412,11 +410,17 @@ export class SolveQueue {
           // Skip but don't block other tools
           continue;
         }
+
+        if (!this.canStartUnderConcurrencyMode(tool, item)) continue;
         startableItems.push({ item, tool, index: 0, check });
       }
     }
 
     return startableItems;
+  }
+
+  canStartUnderConcurrencyMode(tool, item) {
+    return _canStartUnderConcurrencyMode(this.processing, tool, item);
   }
 
   /**

--- a/tests/solve-queue-concurrency.test.mjs
+++ b/tests/solve-queue-concurrency.test.mjs
@@ -1,0 +1,486 @@
+#!/usr/bin/env node
+/**
+ * Solve Queue Concurrency Tests (Issue #1474)
+ *
+ * Verifies per-tool concurrency modes:
+ * - 'global-one-at-a-time' (default for agent)
+ * - 'per-free-model-one-at-a-time'
+ * - 'per-model-one-at-a-time'
+ * - 'off' (default for claude/codex/qwen/gemini)
+ *
+ * Also covers HIVE_MIND_QUEUE_CONFIG lino notation parsing and
+ * isFreeAgentModel() classification.
+ *
+ * Run with: node tests/solve-queue-concurrency.test.mjs
+ *
+ * @see https://github.com/link-assistant/hive-mind/issues/1474
+ */
+
+import assert from 'node:assert/strict';
+import { SolveQueue, QUEUE_CONFIG, resetSolveQueue } from '../src/telegram-solve-queue.lib.mjs';
+import { parseQueueConfig, CONCURRENCY_MODES } from '../src/queue-config.lib.mjs';
+import { isFreeAgentModel, normalizeAgentModelKey } from '../src/models/index.mjs';
+import { resetLimitCache } from '../src/limits.lib.mjs';
+
+let testsPassed = 0;
+let testsFailed = 0;
+
+function test(name, fn) {
+  try {
+    fn();
+    console.log(`✅ ${name}`);
+    testsPassed++;
+  } catch (error) {
+    console.log(`❌ ${name}`);
+    console.log(`   Error: ${error.message}`);
+    testsFailed++;
+  }
+}
+
+async function asyncTest(name, fn) {
+  try {
+    await fn();
+    console.log(`✅ ${name}`);
+    testsPassed++;
+  } catch (error) {
+    console.log(`❌ ${name}`);
+    console.log(`   Error: ${error.message}`);
+    testsFailed++;
+  }
+}
+
+function beforeEach() {
+  resetSolveQueue();
+  resetLimitCache();
+}
+
+/**
+ * Build a queue with all external process probes stubbed to "nothing running"
+ * and system resource / API limit checks stubbed to "always OK", so concurrency
+ * gating is exercised in isolation regardless of the host's RAM/CPU/disk state.
+ * Uses autoStart=false so the consumer loop doesn't actually spawn anything.
+ */
+function buildQueue() {
+  const queue = new SolveQueue({
+    verbose: false,
+    autoStart: false,
+    getRunningProcesses: async () => ({ count: 0, processes: [] }),
+    getRunningIsolatedSessions: async () => ({ count: 0, sessions: [], byTool: {} }),
+  });
+  const okCheck = { ok: true, reasons: [], oneAtATime: false, rejected: false, rejectReason: null };
+  queue.checkSystemResources = async () => ({ ...okCheck });
+  queue.checkApiLimits = async () => ({ ...okCheck });
+  return queue;
+}
+
+/**
+ * Mutate QUEUE_CONFIG.concurrency for a single test and restore after.
+ *
+ * Works for both sync and async `fn`:
+ *  - If `fn()` returns a thenable, attach restore to its resolution/rejection
+ *    AND return a promise so callers can `await` it.
+ *  - If `fn()` returns a plain value, restore synchronously before returning.
+ *
+ * A naive `try { return fn() } finally { restore() }` is wrong for async fns
+ * because `finally` runs immediately after the pending promise is returned,
+ * restoring state before the async body has actually executed.
+ */
+function withConcurrency(overrides, fn) {
+  const saved = { ...QUEUE_CONFIG.concurrency };
+  const restore = () => {
+    for (const k of Object.keys(QUEUE_CONFIG.concurrency)) delete QUEUE_CONFIG.concurrency[k];
+    Object.assign(QUEUE_CONFIG.concurrency, saved);
+  };
+  Object.assign(QUEUE_CONFIG.concurrency, overrides);
+  let result;
+  try {
+    result = fn();
+  } catch (err) {
+    restore();
+    throw err;
+  }
+  if (result && typeof result.then === 'function') {
+    return result.then(
+      value => {
+        restore();
+        return value;
+      },
+      err => {
+        restore();
+        throw err;
+      }
+    );
+  }
+  restore();
+  return result;
+}
+
+// ============================================================================
+// isFreeAgentModel & normalizeAgentModelKey
+// ============================================================================
+
+console.log('\n📋 isFreeAgentModel / normalizeAgentModelKey (R4)\n');
+
+test('isFreeAgentModel detects -free suffix on bare alias', () => {
+  assert.equal(isFreeAgentModel('minimax-m2.5-free'), true);
+  assert.equal(isFreeAgentModel('gpt-5-nano-free'), true);
+});
+
+test('isFreeAgentModel detects entries in freeToBaseModelMap', () => {
+  assert.equal(isFreeAgentModel('nemotron-3-super-free'), true);
+  assert.equal(isFreeAgentModel('deepseek-r1-free'), true);
+});
+
+test('isFreeAgentModel detects -free suffix on fully-prefixed ids', () => {
+  assert.equal(isFreeAgentModel('opencode/minimax-m2.5-free'), true);
+  assert.equal(isFreeAgentModel('kilo/glm-5-free'), true);
+});
+
+test('isFreeAgentModel returns false for paid / unknown models', () => {
+  assert.equal(isFreeAgentModel('claude-sonnet-4-5'), false);
+  assert.equal(isFreeAgentModel('gpt-5'), false);
+  assert.equal(isFreeAgentModel(''), false);
+  assert.equal(isFreeAgentModel(null), false);
+  assert.equal(isFreeAgentModel(undefined), false);
+});
+
+test('normalizeAgentModelKey returns mapped id when known, raw otherwise', () => {
+  // Unmapped string survives untouched (used as the gating key).
+  assert.equal(normalizeAgentModelKey('some-unknown-model'), 'some-unknown-model');
+  assert.equal(normalizeAgentModelKey(''), '');
+  assert.equal(normalizeAgentModelKey(null), '');
+});
+
+// ============================================================================
+// QUEUE_CONFIG defaults (R1, R5)
+// ============================================================================
+
+console.log('\n📋 Concurrency defaults (R1, R5)\n');
+
+test('agent concurrency defaults to global-one-at-a-time', () => {
+  assert.equal(QUEUE_CONFIG.concurrency.agent, 'global-one-at-a-time');
+});
+
+test('claude/codex/qwen/gemini concurrency default to off', () => {
+  assert.equal(QUEUE_CONFIG.concurrency.claude, 'off');
+  assert.equal(QUEUE_CONFIG.concurrency.codex, 'off');
+  assert.equal(QUEUE_CONFIG.concurrency.qwen, 'off');
+  assert.equal(QUEUE_CONFIG.concurrency.gemini, 'off');
+});
+
+test('CONCURRENCY_MODES enumerates the supported modes', () => {
+  assert.deepEqual([...CONCURRENCY_MODES].sort(), ['global-one-at-a-time', 'off', 'per-free-model-one-at-a-time', 'per-model-one-at-a-time']);
+});
+
+// ============================================================================
+// parseQueueConfig — lino notation for *-concurrency entries (R3)
+// ============================================================================
+
+console.log('\n📋 parseQueueConfig — *-concurrency lino entries (R3)\n');
+
+test('parseQueueConfig parses (agent-concurrency per-free-model-one-at-a-time)', () => {
+  const cfg = parseQueueConfig('((agent-concurrency per-free-model-one-at-a-time))');
+  assert.deepEqual(cfg.concurrency, { agent: 'per-free-model-one-at-a-time' });
+});
+
+test('parseQueueConfig parses multiple *-concurrency entries', () => {
+  const cfg = parseQueueConfig('((agent-concurrency per-free-model-one-at-a-time)(claude-concurrency global-one-at-a-time))');
+  assert.deepEqual(cfg.concurrency, {
+    agent: 'per-free-model-one-at-a-time',
+    claude: 'global-one-at-a-time',
+  });
+});
+
+test('parseQueueConfig accepts *-concurrency alongside threshold entries', () => {
+  const cfg = parseQueueConfig('((ram (65% enqueue))(agent-concurrency global-one-at-a-time))');
+  assert.ok(cfg.ram, 'ram threshold should still be parsed');
+  assert.equal(cfg.ram.value, 0.65);
+  assert.equal(cfg.ram.strategy, 'enqueue');
+  assert.deepEqual(cfg.concurrency, { agent: 'global-one-at-a-time' });
+});
+
+test('parseQueueConfig drops *-concurrency entries with unknown modes', () => {
+  // An unrecognized mode is silently dropped so the queue falls back to the
+  // env var or the built-in default rather than booting in a confusing state.
+  const cfg = parseQueueConfig('((agent-concurrency totally-bogus))');
+  assert.equal(cfg.concurrency, undefined, 'No concurrency entry should be emitted');
+});
+
+// ============================================================================
+// SolveQueueItem.model plumbing
+// ============================================================================
+
+console.log('\n📋 SolveQueueItem.model plumbing\n');
+
+test('enqueue stores the requested model on the queue item (normalized for gating)', () => {
+  beforeEach();
+  const queue = buildQueue();
+  const item = queue.enqueue({
+    url: 'https://github.com/test/repo/issues/1',
+    args: '',
+    requester: 'u',
+    infoBlock: 'i',
+    tool: 'agent',
+    model: 'minimax-m2.5-free',
+  });
+  // The queue normalizes the alias to its full provider id (opencode/...)
+  // so that two requests for the same provider-side rate-limited model share
+  // a slot, while kilo/minimax-m2.5-free (different provider) gets its own.
+  assert.equal(item.model, 'opencode/minimax-m2.5-free');
+  queue.stop();
+});
+
+test('enqueue normalizes alias so opencode/ and kilo/ variants use separate slots', () => {
+  beforeEach();
+  const queue = buildQueue();
+  const a = queue.enqueue({ url: 'https://github.com/test/repo/issues/1', args: '', requester: 'u', infoBlock: 'i', tool: 'agent', model: 'minimax-m2.5-free' });
+  const b = queue.enqueue({ url: 'https://github.com/test/repo/issues/2', args: '', requester: 'u', infoBlock: 'i', tool: 'agent', model: 'kilo/minimax-m2.5-free' });
+  assert.equal(a.model, 'opencode/minimax-m2.5-free');
+  assert.equal(b.model, 'kilo/minimax-m2.5-free');
+  assert.notEqual(a.model, b.model, 'Different providers must produce different gating keys');
+  queue.stop();
+});
+
+test('enqueue preserves unknown model strings as-is', () => {
+  beforeEach();
+  const queue = buildQueue();
+  const item = queue.enqueue({ url: 'https://github.com/test/repo/issues/1', args: '', requester: 'u', infoBlock: 'i', tool: 'agent', model: 'totally-custom-model' });
+  assert.equal(item.model, 'totally-custom-model');
+  queue.stop();
+});
+
+test('enqueue without a model stores null (no gating possible)', () => {
+  beforeEach();
+  const queue = buildQueue();
+  const item = queue.enqueue({
+    url: 'https://github.com/test/repo/issues/1',
+    args: '',
+    requester: 'u',
+    infoBlock: 'i',
+    tool: 'agent',
+  });
+  assert.equal(item.model, null);
+  queue.stop();
+});
+
+test('getProcessingCountByToolAndModel counts only matching (tool, model) pairs', () => {
+  beforeEach();
+  const queue = buildQueue();
+  queue.processing.set('a', { id: 'a', tool: 'agent', model: 'minimax-m2.5-free' });
+  queue.processing.set('b', { id: 'b', tool: 'agent', model: 'minimax-m2.5-free' });
+  queue.processing.set('c', { id: 'c', tool: 'agent', model: 'gpt-5-nano' });
+  queue.processing.set('d', { id: 'd', tool: 'claude', model: 'claude-sonnet-4-5' });
+  assert.equal(queue.getProcessingCountByToolAndModel('agent', 'minimax-m2.5-free'), 2);
+  assert.equal(queue.getProcessingCountByToolAndModel('agent', 'gpt-5-nano'), 1);
+  assert.equal(queue.getProcessingCountByToolAndModel('agent', 'nonexistent'), 0);
+  assert.equal(queue.getProcessingCountByToolAndModel('claude', 'claude-sonnet-4-5'), 1);
+  queue.stop();
+});
+
+// ============================================================================
+// canStartUnderConcurrencyMode — direct unit tests
+// ============================================================================
+
+console.log('\n📋 canStartUnderConcurrencyMode (Issue #1474)\n');
+
+test("'off' mode never blocks", () => {
+  beforeEach();
+  const queue = buildQueue();
+  queue.processing.set('a', { id: 'a', tool: 'claude', model: 'x' });
+  withConcurrency({ claude: 'off' }, () => {
+    const item = { tool: 'claude', model: 'x' };
+    assert.equal(queue.canStartUnderConcurrencyMode('claude', item), true);
+  });
+  queue.stop();
+});
+
+test("'global-one-at-a-time' blocks when any item of this tool is processing", () => {
+  beforeEach();
+  const queue = buildQueue();
+  withConcurrency({ agent: 'global-one-at-a-time' }, () => {
+    const item = { tool: 'agent', model: 'minimax-m2.5-free' };
+    assert.equal(queue.canStartUnderConcurrencyMode('agent', item), true);
+    queue.processing.set('a', { id: 'a', tool: 'agent', model: 'gpt-5-nano' });
+    assert.equal(queue.canStartUnderConcurrencyMode('agent', item), false);
+  });
+  queue.stop();
+});
+
+test("'global-one-at-a-time' does not consider other tools' processing items", () => {
+  beforeEach();
+  const queue = buildQueue();
+  queue.processing.set('a', { id: 'a', tool: 'claude', model: 'x' });
+  withConcurrency({ agent: 'global-one-at-a-time' }, () => {
+    const item = { tool: 'agent', model: 'minimax-m2.5-free' };
+    assert.equal(queue.canStartUnderConcurrencyMode('agent', item), true);
+  });
+  queue.stop();
+});
+
+test("'per-free-model-one-at-a-time' gates only free models", () => {
+  beforeEach();
+  const queue = buildQueue();
+  withConcurrency({ agent: 'per-free-model-one-at-a-time' }, () => {
+    queue.processing.set('a', { id: 'a', tool: 'agent', model: 'minimax-m2.5-free' });
+    // Same free model is blocked
+    assert.equal(queue.canStartUnderConcurrencyMode('agent', { tool: 'agent', model: 'minimax-m2.5-free' }), false);
+    // Different free model is allowed (key R2 case)
+    assert.equal(queue.canStartUnderConcurrencyMode('agent', { tool: 'agent', model: 'gpt-5-nano-free' }), true);
+    // Non-free model is NOT gated even if a free one is in flight
+    assert.equal(queue.canStartUnderConcurrencyMode('agent', { tool: 'agent', model: 'claude-sonnet-4-5' }), true);
+    // Item with no declared model bypasses the gate
+    assert.equal(queue.canStartUnderConcurrencyMode('agent', { tool: 'agent', model: null }), true);
+  });
+  queue.stop();
+});
+
+test("'per-model-one-at-a-time' gates every model", () => {
+  beforeEach();
+  const queue = buildQueue();
+  withConcurrency({ agent: 'per-model-one-at-a-time' }, () => {
+    queue.processing.set('a', { id: 'a', tool: 'agent', model: 'claude-sonnet-4-5' });
+    assert.equal(queue.canStartUnderConcurrencyMode('agent', { tool: 'agent', model: 'claude-sonnet-4-5' }), false);
+    assert.equal(queue.canStartUnderConcurrencyMode('agent', { tool: 'agent', model: 'minimax-m2.5-free' }), true);
+  });
+  queue.stop();
+});
+
+test('unknown concurrency mode falls back to permissive', () => {
+  beforeEach();
+  const queue = buildQueue();
+  withConcurrency({ agent: 'totally-bogus-mode' }, () => {
+    queue.processing.set('a', { id: 'a', tool: 'agent', model: 'minimax-m2.5-free' });
+    assert.equal(queue.canStartUnderConcurrencyMode('agent', { tool: 'agent', model: 'minimax-m2.5-free' }), true);
+  });
+  queue.stop();
+});
+
+// ============================================================================
+// findStartableItems — integration with the concurrency gate
+// ============================================================================
+
+console.log('\n📋 findStartableItems gating (R1, R2, R5)\n');
+
+await asyncTest('R1: agent default (global-one-at-a-time) makes only 1 of 2 startable', async () => {
+  beforeEach();
+  const queue = buildQueue();
+  queue.enqueue({ url: 'https://github.com/test/repo/issues/1', args: '', requester: 'u', infoBlock: 'i', tool: 'agent', model: 'minimax-m2.5-free' });
+  queue.enqueue({ url: 'https://github.com/test/repo/issues/2', args: '', requester: 'u', infoBlock: 'i', tool: 'agent', model: 'gpt-5-nano' });
+
+  const first = await queue.findStartableItems();
+  const agentStarts = first.filter(s => s.tool === 'agent');
+  assert.equal(agentStarts.length, 1, 'Only one agent item is startable at a time');
+
+  // Simulate the first item moving to processing
+  queue.processing.set(agentStarts[0].item.id, agentStarts[0].item);
+  // Remove it from the queue so findStartableItems considers the next head
+  const aq = queue.getToolQueue('agent');
+  const idx = aq.findIndex(i => i.id === agentStarts[0].item.id);
+  if (idx !== -1) aq.splice(idx, 1);
+
+  const second = await queue.findStartableItems();
+  const agentStartsAgain = second.filter(s => s.tool === 'agent');
+  assert.equal(agentStartsAgain.length, 0, 'Second agent item still blocked while first is processing');
+  queue.stop();
+});
+
+await asyncTest('R2: per-free-model mode lets two different free models start in parallel', async () => {
+  beforeEach();
+  const queue = buildQueue();
+  await withConcurrency({ agent: 'per-free-model-one-at-a-time' }, async () => {
+    queue.enqueue({ url: 'https://github.com/test/repo/issues/1', args: '', requester: 'u', infoBlock: 'i', tool: 'agent', model: 'minimax-m2.5-free' });
+    queue.enqueue({ url: 'https://github.com/test/repo/issues/2', args: '', requester: 'u', infoBlock: 'i', tool: 'agent', model: 'gpt-5-nano-free' });
+
+    // First pass: head of queue is minimax-m2.5-free (normalized to opencode/...)
+    // per-free-model has 0 in-flight for that key, so startable.
+    const first = await queue.findStartableItems();
+    assert.equal(first.length, 1, 'Only the head of each tool queue is considered per cycle');
+    assert.equal(first[0].item.model, 'opencode/minimax-m2.5-free');
+
+    // Move first item into processing
+    queue.processing.set(first[0].item.id, first[0].item);
+    queue.getToolQueue('agent').shift();
+
+    // Second pass: head is gpt-5-nano-free — different free model (unknown alias
+    // so it stays as 'gpt-5-nano-free'), still startable in parallel.
+    const second = await queue.findStartableItems();
+    assert.equal(second.length, 1, 'Different free model is independently startable');
+    assert.equal(second[0].item.model, 'gpt-5-nano-free');
+  });
+  queue.stop();
+});
+
+await asyncTest('R2: per-free-model mode blocks two items with the SAME free model', async () => {
+  beforeEach();
+  const queue = buildQueue();
+  await withConcurrency({ agent: 'per-free-model-one-at-a-time' }, async () => {
+    queue.enqueue({ url: 'https://github.com/test/repo/issues/1', args: '', requester: 'u', infoBlock: 'i', tool: 'agent', model: 'minimax-m2.5-free' });
+    queue.enqueue({ url: 'https://github.com/test/repo/issues/2', args: '', requester: 'u', infoBlock: 'i', tool: 'agent', model: 'minimax-m2.5-free' });
+
+    const first = await queue.findStartableItems();
+    assert.equal(first.length, 1, 'First minimax item is startable');
+
+    // Move it into processing and pop it from the queue
+    queue.processing.set(first[0].item.id, first[0].item);
+    queue.getToolQueue('agent').shift();
+
+    const second = await queue.findStartableItems();
+    const blocked = second.filter(s => s.tool === 'agent');
+    assert.equal(blocked.length, 0, 'Second same-free-model item is blocked while first is in-flight');
+  });
+  queue.stop();
+});
+
+await asyncTest('R5: claude default (off) does not gate concurrent same-model items', async () => {
+  beforeEach();
+  const queue = buildQueue();
+  // Claude default is 'off'; two claude items should both be startable.
+  queue.enqueue({ url: 'https://github.com/test/repo/issues/1', args: '', requester: 'u', infoBlock: 'i', tool: 'claude', model: 'claude-sonnet-4-5' });
+  queue.enqueue({ url: 'https://github.com/test/repo/issues/2', args: '', requester: 'u', infoBlock: 'i', tool: 'claude', model: 'claude-sonnet-4-5' });
+
+  const first = await queue.findStartableItems();
+  // findStartableItems only ever returns the head of each tool queue per pass,
+  // so we expect 1 claude entry. But it should NOT be blocked by an in-flight
+  // claude item — verify by simulating one in processing and checking the head
+  // is still permitted.
+  assert.equal(first.length, 1, 'Head-of-queue claude item is startable');
+
+  queue.processing.set(first[0].item.id, first[0].item);
+  queue.getToolQueue('claude').shift();
+
+  const second = await queue.findStartableItems();
+  const claudeStarts = second.filter(s => s.tool === 'claude');
+  assert.equal(claudeStarts.length, 1, 'A second claude item starts even while first is in-flight (off mode)');
+  queue.stop();
+});
+
+await asyncTest('cross-tool isolation: agent gate does NOT block claude/codex', async () => {
+  beforeEach();
+  const queue = buildQueue();
+  // Pretend an agent item is in-flight; with default global-one-at-a-time on agent
+  // this would block additional agent starts but must NOT affect claude.
+  queue.processing.set('agent-in-flight', { id: 'agent-in-flight', tool: 'agent', model: 'minimax-m2.5-free' });
+  queue.enqueue({ url: 'https://github.com/test/repo/issues/1', args: '', requester: 'u', infoBlock: 'i', tool: 'claude' });
+  queue.enqueue({ url: 'https://github.com/test/repo/issues/2', args: '', requester: 'u', infoBlock: 'i', tool: 'agent', model: 'gpt-5-nano-free' });
+
+  const startables = await queue.findStartableItems();
+  const claudeStarts = startables.filter(s => s.tool === 'claude');
+  const agentStarts = startables.filter(s => s.tool === 'agent');
+  assert.equal(claudeStarts.length, 1, 'Claude is unaffected by agent gating');
+  assert.equal(agentStarts.length, 0, 'Agent is blocked by its global-one-at-a-time mode');
+  queue.stop();
+});
+
+// ============================================================================
+console.log('\n📊 Test Results\n');
+console.log(`Tests passed: ${testsPassed}`);
+console.log(`Tests failed: ${testsFailed}`);
+console.log(`Total tests: ${testsPassed + testsFailed}`);
+
+if (testsFailed > 0) {
+  console.log('\n❌ Some tests failed!');
+  process.exit(1);
+} else {
+  console.log('\n✅ All tests passed!');
+  process.exit(0);
+}


### PR DESCRIPTION
## Summary

Closes #1474.

Implements per-tool concurrency gating for the solve queue so the `--tool agent` queue can run one task at a time per **free** model (e.g. one `minimax-m2.5-free` task at a time, in parallel with one `gpt-5-nano-free` task). The agent queue defaults to **global one-at-a-time** today; operators flip individual queues (claude, agent, codex, qwen, gemini) to a different mode via env vars or the existing `HIVE_MIND_QUEUE_CONFIG` links notation.

- Closes the gap left by separate-tool queues (#1159) and the threshold-strategy framework (#1253), which were both about *when* to throttle but not *how many in parallel per model*.
- No external scheduler/library introduced — the helper is ~80 lines in a new pure module (`src/telegram-solve-queue.concurrency.lib.mjs`) plus a wire-up in `findStartableItems()`.

See [`docs/case-studies/issue-1474/README.md`](docs/case-studies/issue-1474/README.md) for the full design, R1–R7 requirements, and acceptance criteria.

## Concurrency modes

| Mode | Behavior |
|---|---|
| `off` | No extra cap from the queue layer (default for claude/codex/qwen/gemini). |
| `global-one-at-a-time` | At most 1 in-flight item across the tool's entire queue. **Default for agent.** |
| `per-free-model-one-at-a-time` | For free models, at most 1 in-flight item per `(tool, model)`. Non-free models bypass the gate. |
| `per-model-one-at-a-time` | At most 1 in-flight item per `(tool, model)` for every model. |

### Configuration surface

1. **Env var per tool** — `HIVE_MIND_AGENT_CONCURRENCY=per-free-model-one-at-a-time` (same for `CLAUDE`, `CODEX`, `QWEN`, `GEMINI`).
2. **Links notation** — extend `HIVE_MIND_QUEUE_CONFIG`:
   ```
   (
     (agent-concurrency per-free-model-one-at-a-time)
     (claude-concurrency global-one-at-a-time)
   )
   ```
3. **Built-in defaults** — `agent: global-one-at-a-time`, all others `off`.

Resolution priority: `HIVE_MIND_QUEUE_CONFIG` > `HIVE_MIND_<TOOL>_CONCURRENCY` > built-in default.

## Requirements traceability

- [x] **R1** — `--tool agent` defaults to globally and unconditionally 1-at-a-time. Verified by `R1: agent default (global-one-at-a-time) makes only 1 of 2 startable`.
- [x] **R2** — Each specific *free* agent model has its own 1-at-a-time slot. Verified by `R2: per-free-model mode lets two different free models start in parallel` + `R2: per-free-model mode blocks two items with the SAME free model`.
- [x] **R3** — Every queue's mode is configurable via env vars **and** `HIVE_MIND_QUEUE_CONFIG`. Verified by `parseQueueConfig — *-concurrency lino entries (R3)` (4 cases).
- [x] **R4** — Free-model detection covers both providers (OpenCode Zen `opencode/...-free` and Kilo Gateway `kilo/...-free`) and aliases. Verified by `isFreeAgentModel` unit cases.
- [x] **R5** — Other tools (claude/codex/qwen/gemini) are unaffected unless explicitly configured. Verified by `R5: claude default (off) does not gate concurrent same-model items` + `cross-tool isolation: agent gate does NOT block claude/codex`.
- [x] **R6** — Behavior covered by automated tests (28 new tests in `tests/solve-queue-concurrency.test.mjs`) and documented in `docs/case-studies/issue-1474/README.md`.
- [x] **R7** — No regressions: full `npm test` green (207/207 test files), lint clean, all line caps respected.

## Test plan

- [x] `node tests/solve-queue-concurrency.test.mjs` → 28/28 pass
- [x] `npm test` (default suite) → 207/207 test files pass
- [x] `npm run lint` → clean
- [x] `bash scripts/check-file-line-limits.sh` → all files ≤ 1500 lines

## Reproduction (manual)

```sh
# Default agent queue: global-one-at-a-time
HIVE_MIND_QUEUE_CONFIG="" node -e "
import('./src/queue-config.lib.mjs').then(m => console.log(m.QUEUE_CONFIG.concurrency))
"
# → { claude: 'off', agent: 'global-one-at-a-time', codex: 'off', qwen: 'off', gemini: 'off' }

# Switch agent to per-free-model mode
HIVE_MIND_AGENT_CONCURRENCY=per-free-model-one-at-a-time node -e "
import('./src/queue-config.lib.mjs').then(m => console.log(m.QUEUE_CONFIG.concurrency.agent))
"
# → 'per-free-model-one-at-a-time'
```

## Files changed

| Path | Purpose |
|---|---|
| `src/models/index.mjs` | Add `isFreeAgentModel`, `normalizeAgentModelKey` helpers. |
| `src/queue-config.lib.mjs` | Add `CONCURRENCY_MODES`, `(<tool>-concurrency <mode>)` lino parsing, `HIVE_MIND_<TOOL>_CONCURRENCY` env var, `QUEUE_CONFIG.concurrency`, `getConcurrencyMode`. |
| `src/telegram-solve-queue.lib.mjs` | `SolveQueueItem.model` + gate in `findStartableItems`. |
| `src/telegram-solve-queue.concurrency.lib.mjs` *(new)* | Pure helpers: `countProcessingByTool`, `countProcessingByToolAndModel`, `canStartUnderConcurrencyMode`. |
| `src/telegram-bot.mjs` | Parse `--model`/`-m`/`--model=` at the queue boundary; pass to `enqueue`. |
| `tests/solve-queue-concurrency.test.mjs` *(new)* | 28 tests covering R1–R5. |
| `docs/case-studies/issue-1474/README.md` *(new)* | Full design + R1–R7 requirements. |
| `.changeset/issue-1474-agent-concurrency.md` *(new)* | Patch-bump changeset. |
| `experiments/{debug-r1,debug-concurrency-second-pass,reproduce-r2-failing,verify-finally-bug}.mjs` *(new)* | Reproducible debug scripts for future investigation. |

## Atomic commits

1. `feat(models): add isFreeAgentModel and normalizeAgentModelKey helpers`
2. `feat(queue): add per-tool concurrency mode to QUEUE_CONFIG`
3. `feat(queue): gate findStartableItems on per-(tool, model) concurrency`
4. `feat(telegram-bot): forward --model alias into the solve queue`
5. `test(queue): cover per-(tool, model) concurrency gating`
6. `docs(case-studies): add issue-1474 case study + changeset`
7. `chore(experiments): add debug scripts for issue-1474 investigation`
