### PR TITLE
fix: handle gitignored auto-PR placeholder (Failed to add .gitkeep) (#1825)

### DIFF
--- a/.changeset/issue-1825-gitkeep-ignored.md
+++ b/.changeset/issue-1825-gitkeep-ignored.md
@@ -1,0 +1,5 @@
+---
+'@link-assistant/hive-mind': patch
+---
+
+Fix "Failed to add .gitkeep" abort during auto-PR creation when the target repository's `.gitignore` matches the seed placeholder (issue #1825). Placeholder staging now routes through `addPlaceholderFileToGit`, which detects the ignored path with `git check-ignore` and retries with `git add -f`. Because the placeholder is created by the solver to seed the initial commit and removed once the task completes, force-adding it is safe.

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,1 +1,0 @@
-# .gitkeep file auto-generated at 2026-05-26T20:52:09.575Z for PR creation at branch issue-1825-499e18ca09e5 for issue https://github.com/link-assistant/hive-mind/issues/1825

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,0 +1,1 @@
+# .gitkeep file auto-generated at 2026-05-26T20:52:09.575Z for PR creation at branch issue-1825-499e18ca09e5 for issue https://github.com/link-assistant/hive-mind/issues/1825

--- a/docs/case-studies/issue-1825/README.md
+++ b/docs/case-studies/issue-1825/README.md
@@ -1,0 +1,257 @@
+# Case study — Issue #1825: "Failed to add .gitkeep"
+
+- **Issue:** [link-assistant/hive-mind#1825](https://github.com/link-assistant/hive-mind/issues/1825) — _Failed to add .gitkeep_ (label: `bug`)
+- **Reported by:** @konard, 2026-05-26
+- **Pull request:** [#1826](https://github.com/link-assistant/hive-mind/pull/1826)
+- **First observed on:** [rumaster/tg-games#3](https://github.com/rumaster/tg-games/issues/3) (two solver runs: Claude Sonnet 4.6 and OpenAI GPT‑5.5)
+- **Affected version:** `solve` v1.72.6
+
+> Raw evidence (issue JSON, upstream issue JSON, and the two full failure logs) is archived under [`logs/`](./logs).
+
+---
+
+## 1. Executive summary
+
+When `solve` opens its initial draft PR, it seeds the branch with a throwaway
+placeholder file (default `.gitkeep`, or `CLAUDE.md`), commits it, pushes, and
+opens the PR. The placeholder is removed again when the task completes.
+
+If the **target repository's `.gitignore` matches the placeholder** (here
+`rumaster/tg-games` ignores `.gitkeep`), the staging step `git add .gitkeep`
+exits non‑zero with _"The following paths are ignored by one of your .gitignore
+files"_. The code treated any non‑zero `git add` as fatal and threw
+`Failed to add .gitkeep`, which bubbled up to `❌ FATAL ERROR: PR creation
+failed` and aborted the whole session before the agent could do any work.
+
+The placeholder belongs to `solve` and is temporary, so the fix is to **detect
+the gitignore case (`git check-ignore`) and force‑add it (`git add -f`)**. This
+is exactly what the solver's own error hint already told users to do manually
+(`git add -f .gitkeep`).
+
+---
+
+## 2. Timeline / sequence of events
+
+Reconstructed from [`logs/comment-4548365659-konard.md`](./logs/comment-4548365659-konard.md)
+(Claude Sonnet 4.6 run); the GPT‑5.5 run in
+[`logs/comment-4548385976-konard.md`](./logs/comment-4548385976-konard.md) is
+identical in the failing step.
+
+| Time (UTC) | Event                                                                                                                                                   |
+| ---------- | ------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| 20:10:55   | `solve v1.72.6` starts on `https://github.com/rumaster/tg-games/issues/3` (`--tool claude --verbose --language ru`).                                    |
+| 20:11:02   | Write access to public repo `rumaster/tg-games` confirmed → works directly on the repo (no fork).                                                       |
+| 20:11:05   | Clones repo, creates branch `issue-3-12527c46fb0f` from `main`.                                                                                         |
+| 20:11:06   | `🚀 Auto PR creation: ENABLED`. Mode resolved to **`.gitkeep`** (`--claude-file=false, --gitkeep-file=true, --auto-gitkeep-file=true`).                 |
+| 20:11:06   | `✅ File created: .gitkeep`, then `📦 Adding file: To git staging`.                                                                                     |
+| 20:11:06   | `git add .gitkeep` → **STDERR**: _"The following paths are ignored by one of your .gitignore files: .gitkeep … Use -f if you really want to add them."_ |
+| 20:11:06   | `❌ Failed to add .gitkeep` → `❌ FATAL ERROR: PR creation failed`.                                                                                     |
+| 20:11:06   | Stack trace: `handleAutoPrCreation (…/src/solve.auto-pr.lib.mjs:175:13)` → `solve.mjs:559`. Session ends with no work done.                             |
+
+The exact stack frame (`solve.auto-pr.lib.mjs:175`) is the `throw new Error('Failed to add ${fileName}')` line.
+
+---
+
+## 3. Requirements extracted from the issue
+
+The issue is a meta-task. Each explicit requirement and how it is addressed:
+
+| #   | Requirement                                                                                                                              | Status                                                                                                                                                                            |
+| --- | ---------------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| R1  | Download all logs/data about the issue into `./docs/case-studies/issue-1825/`.                                                           | ✅ [`logs/`](./logs)                                                                                                                                                              |
+| R2  | Deep case-study analysis (incl. online research for additional facts).                                                                   | ✅ this document (§7 cites git docs/behavior).                                                                                                                                    |
+| R3  | Reconstruct the timeline / sequence of events.                                                                                           | ✅ §2                                                                                                                                                                             |
+| R4  | List each and all requirements from the issue.                                                                                           | ✅ this table                                                                                                                                                                     |
+| R5  | Find the root cause of each problem.                                                                                                     | ✅ §4                                                                                                                                                                             |
+| R6  | Propose solutions / solution plans, checking existing components/libraries.                                                              | ✅ §5, §7                                                                                                                                                                         |
+| R7  | If data is insufficient for root cause, add debug output / verbose mode.                                                                 | ✅ §6 — data was already sufficient (`--verbose` log pinpointed the line); the fix adds verbose diagnostics for the force‑add path.                                               |
+| R8  | If the issue is related to another repo where issues can be reported, report it (reproducible example, workaround, code fix suggestion). | ✅ §8 — the defect is in hive-mind, not in `rumaster/tg-games`; the third‑party repo only has a harmless config quirk (workaround documented), so no spurious bug is filed there. |
+| R9  | Fully apply the fix across the entire codebase (fix every place the issue can occur).                                                    | ✅ §5 — both `git add` placeholder sites in `solve.auto-pr.lib.mjs` are fixed; the cleanup path operates on already-tracked files and is unaffected.                              |
+| R10 | Plan and execute everything in the single PR #1826.                                                                                      | ✅                                                                                                                                                                                |
+
+---
+
+## 4. Root-cause analysis
+
+### 4.1 The defect
+
+`src/solve.auto-pr.lib.mjs` staged the placeholder with a plain add and treated
+any non‑zero exit as fatal:
+
+```js
+const addResult = await $({ cwd: tempDir })`git add ${fileName}`;
+if (addResult.code !== 0) {
+  await log(`❌ Failed to add ${fileName}`, { level: 'error' });
+  // …
+  throw new Error(`Failed to add ${fileName}`); // ← solve.auto-pr.lib.mjs:175
+}
+```
+
+`git add <path>` exits **1** when `<path>` is matched by `.gitignore` (and not
+already tracked), printing the _"paths are ignored … Use -f"_ hint. So a target
+repo that gitignores `.gitkeep` makes this throw.
+
+### 4.2 Why the existing fallbacks did not catch it
+
+`solve.auto-pr.lib.mjs` already had ignore-handling, but only for `CLAUDE.md`:
+
+1. **Pre-check (CLAUDE.md → .gitkeep):** `if (useClaudeFile && useAutoGitkeepFile)` runs `git check-ignore CLAUDE.md` and switches to `.gitkeep`. It never checks whether **`.gitkeep` itself** is ignored.
+2. **"Nothing staged" fallback:** only reached when `git add` exits **0** but stages nothing (identical content). When `.gitkeep` is ignored, `git add` exits **1**, so the hard throw at line 175 fires _before_ this fallback.
+
+Since v1.72.x the **default placeholder is `.gitkeep`** (see
+`docs/case-studies/issue-804-gitkeep-vs-claude-file/`), so the unprotected path
+became the common path — any target repo that ignores `.gitkeep` now fails.
+
+### 4.3 Trigger condition (confirmed)
+
+`rumaster/tg-games`'s root `.gitignore` (fetched via the GitHub API) ends with:
+
+```
+node_modules/
+dist/
+*.log
+.env
+.env.local
+coverage/
+.DS_Store
+.gitkeep        ← matches the placeholder
+```
+
+### 4.4 Reproduction
+
+[`experiments/issue-1825-reproduce-gitkeep-ignored.mjs`](../../../experiments/issue-1825-reproduce-gitkeep-ignored.mjs)
+creates a repo whose `.gitignore` contains `.gitkeep` and shows:
+
+```
+=== Step 1: plain `git add .gitkeep` (current code) ===
+exit code: 1  → reproduces bug: YES (add failed)
+=== Step 2: `git check-ignore .gitkeep` ===
+exit code: 0 (0 means ignored)
+=== Step 3: `git add -f .gitkeep` (the fix) ===
+exit code: 0  → git status --short: A  .gitkeep  → fix works: YES (staged)
+```
+
+---
+
+## 5. The fix (and full-codebase coverage)
+
+A small, testable helper is added in
+[`src/solve.auto-pr-placeholder.lib.mjs`](../../../src/solve.auto-pr-placeholder.lib.mjs):
+
+```js
+export async function addPlaceholderFileToGit({ $, tempDir, fileName, log, formatAligned, verbose }) {
+  const addResult = await $({ cwd: tempDir, silent: true })`git add ${fileName}`;
+  if (addResult.code === 0) return { code: 0, forced: false, ignored: false, stderr: '' };
+
+  const checkIgnore = await $({ cwd: tempDir, silent: true })`git check-ignore ${fileName}`;
+  if (checkIgnore.code !== 0) {
+    // Not a gitignore failure — surface the original error unchanged.
+    return { code: addResult.code, forced: false, ignored: false, stderr: addResult.stderr?.toString() ?? '' };
+  }
+  // It is ignored, and the placeholder is ours + temporary → force-add it.
+  const forced = await $({ cwd: tempDir, silent: true })`git add -f ${fileName}`;
+  return { code: forced.code, forced: true, ignored: true, stderr: forced.stderr?.toString() ?? '' };
+}
+```
+
+Key safety properties:
+
+- **Force-add only for the ignored case.** A non‑ignore failure (permissions,
+  corrupt index, …) is returned unchanged so genuine errors are not masked.
+- **The placeholder is ours and temporary.** It is created solely to seed the
+  initial commit and is removed at task completion by `cleanupClaudeFile`
+  (`git rm -f`, which works regardless of `.gitignore`). Force-adding it cannot
+  leak unwanted files into the final PR.
+- It is the same remedy the tool already printed as a manual hint.
+
+**Every placeholder `git add` site is routed through the helper** (R9):
+
+| Location                                                                     | Placeholder                                      | Fixed                                                                                      |
+| ---------------------------------------------------------------------------- | ------------------------------------------------ | ------------------------------------------------------------------------------------------ |
+| `solve.auto-pr.lib.mjs` primary add (was line 170/throw 175)                 | `.gitkeep` **or** `CLAUDE.md`                    | ✅                                                                                         |
+| `solve.auto-pr.lib.mjs` inner `CLAUDE.md → .gitkeep` fallback (was line 216) | `.gitkeep`                                       | ✅                                                                                         |
+| `solve.results.lib.mjs:482` (cleanup conflict resolution)                    | restores a **tracked** file from a parent commit | N/A — `.gitignore` does not affect `git add` on already‑tracked paths, so no force needed. |
+
+The helper lives in its own module to keep `solve.auto-pr.lib.mjs` under the
+1500-line `max-lines` lint budget.
+
+### Tests
+
+[`tests/test-issue-1825-gitkeep-ignored.mjs`](../../../tests/test-issue-1825-gitkeep-ignored.mjs)
+(node:test, `default` suite) covers:
+
+1. Plain `git add .gitkeep` fails when ignored (guards the reproduction).
+2. Helper force-adds `.gitkeep` when ignored (`forced=true, ignored=true`, staged).
+3. Helper force-adds `CLAUDE.md` when ignored.
+4. Helper handles a glob ignore (`.git*`) that matches `.gitkeep` indirectly.
+5. Helper adds normally (`forced=false`) when the placeholder is **not** ignored.
+
+---
+
+## 6. Debug / verbose output (R7)
+
+The existing `--verbose` log already contained enough to pinpoint the failure
+(the staging step, the git stderr, and a stack trace to the exact line). To make
+the new behaviour observable, the helper emits, when the placeholder is ignored:
+
+```
+ℹ️  .gitkeep is ignored:  Force-adding placeholder (git add -f)
+```
+
+and, under `--verbose`:
+
+```
+   .gitkeep matched a .gitignore rule; retrying with: git add -f .gitkeep
+```
+
+The probing `git add` runs silently (its stderr is captured and only
+re-surfaced on a genuine failure), so the noisy git hint no longer leaks into
+normal output.
+
+---
+
+## 7. Existing components / libraries considered (R6)
+
+- **`git add -f` / `git check-ignore` (git itself).** The canonical mechanism.
+  `git check-ignore` exits 0 when a path is ignored; `git add -f` overrides the
+  ignore for a deliberate add. No third-party dependency is needed — git already
+  solves this, and the tool was already recommending it in its own hint text.
+- **`command-stream` `$`** (already used throughout `solve`). Returns
+  `{ code, stdout, stderr }` and does **not** throw on non-zero exit, so the
+  helper can branch on `.code` cleanly.
+- **In-repo precedent.** `cleanupClaudeFile` (`solve.results.lib.mjs`) already
+  uses `git rm -f` for the symmetric teardown of the same placeholder, so
+  force-handling the placeholder is consistent with existing design.
+- **Alternative rejected — appending a `.gitignore` negation (`!.gitkeep`).**
+  This would modify the target repo's `.gitignore`, changing user-owned content
+  and polluting the PR diff. Force-adding our own temporary file is strictly
+  less invasive.
+
+---
+
+## 8. Relationship to the upstream repository (R8)
+
+The failure surfaced while solving `rumaster/tg-games#3`, but the **defect is in
+hive-mind**, not in that repository. Ignoring `.gitkeep` is unusual (it defeats
+the conventional "keep an empty directory" purpose of the file) but is a valid,
+harmless choice for a repo owner, and after this fix hive-mind handles it
+gracefully. Therefore:
+
+- **No bug is filed against `rumaster/tg-games`** — there is no genuine defect in
+  their code, and filing a non-issue on a third party's tracker would be noise.
+- **Workaround for any affected target repo (documented, not required):** remove
+  `.gitkeep` from `.gitignore` (or add `!.gitkeep`). After PR #1826 this is no
+  longer necessary — the solver force-adds its own placeholder.
+- **The code fix** lives in this repository (§5) and is the authoritative remedy.
+
+---
+
+## 9. Files in this case study
+
+| Path                                                                           | Contents                                           |
+| ------------------------------------------------------------------------------ | -------------------------------------------------- |
+| [`logs/hive-mind-issue-1825.json`](./logs/hive-mind-issue-1825.json)           | The hive-mind issue (title, body, labels, author). |
+| [`logs/tg-games-issue-3.json`](./logs/tg-games-issue-3.json)                   | Upstream issue where the failure was observed.     |
+| [`logs/tg-games-issue-3-comments.json`](./logs/tg-games-issue-3-comments.json) | Raw comments API payload.                          |
+| [`logs/comment-4548365659-konard.md`](./logs/comment-4548365659-konard.md)     | Full failure log — Claude Sonnet 4.6 run.          |
+| [`logs/comment-4548385976-konard.md`](./logs/comment-4548385976-konard.md)     | Full failure log — OpenAI GPT‑5.5 run.             |

--- a/experiments/issue-1825-reproduce-gitkeep-ignored.mjs
+++ b/experiments/issue-1825-reproduce-gitkeep-ignored.mjs
@@ -1,0 +1,56 @@
+#!/usr/bin/env node
+/**
+ * Reproduction for issue #1825: "Failed to add .gitkeep".
+ *
+ * When the target repository's .gitignore matches `.gitkeep`, the auto-PR
+ * creation step runs `git add .gitkeep`, which exits non-zero with
+ * "The following paths are ignored by one of your .gitignore files", and the
+ * solver aborts with FATAL ERROR: PR creation failed.
+ *
+ * This script demonstrates:
+ *   1. Plain `git add .gitkeep` fails (exit code 1) when .gitkeep is ignored.
+ *   2. `git check-ignore .gitkeep` confirms the file is ignored (exit code 0).
+ *   3. `git add -f .gitkeep` succeeds and stages the file (the fix).
+ */
+
+if (typeof globalThis.use === 'undefined') {
+  globalThis.use = (await eval(await (await fetch('https://unpkg.com/use-m/use.js')).text())).use;
+}
+const use = globalThis.use;
+
+const { $ } = await use('command-stream');
+const fs = (await use('fs')).promises;
+const path = (await use('path')).default;
+const os = (await use('os')).default;
+
+const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), 'issue-1825-'));
+await $({ cwd: tempDir })`git init -q`;
+await $({ cwd: tempDir })`git config user.email "test@example.com"`;
+await $({ cwd: tempDir })`git config user.name "Test User"`;
+
+// Simulate rumaster/tg-games: .gitignore matches .gitkeep
+await fs.writeFile(path.join(tempDir, '.gitignore'), '.gitkeep\n');
+await $({ cwd: tempDir })`git add .gitignore`;
+await $({ cwd: tempDir })`git commit -q -m "Add gitignore that ignores .gitkeep"`;
+
+// Solver writes the placeholder .gitkeep
+await fs.writeFile(path.join(tempDir, '.gitkeep'), '# placeholder for PR creation\n');
+
+console.log('=== Step 1: plain `git add .gitkeep` (current code) ===');
+const plain = await $({ cwd: tempDir })`git add .gitkeep`;
+console.log(`exit code: ${plain.code}`);
+console.log(`stderr: ${(plain.stderr ? plain.stderr.toString() : '').trim()}`);
+console.log(`-> reproduces bug: ${plain.code !== 0 ? 'YES (add failed)' : 'NO'}`);
+
+console.log('\n=== Step 2: `git check-ignore .gitkeep` ===');
+const checkIgnore = await $({ cwd: tempDir, silent: true })`git check-ignore .gitkeep`;
+console.log(`exit code: ${checkIgnore.code} (0 means ignored)`);
+
+console.log('\n=== Step 3: `git add -f .gitkeep` (the fix) ===');
+const forced = await $({ cwd: tempDir })`git add -f .gitkeep`;
+console.log(`exit code: ${forced.code}`);
+const status = await $({ cwd: tempDir })`git status --short`;
+console.log(`git status --short: ${status.stdout.toString().trim() || '(empty)'}`);
+console.log(`-> fix works: ${forced.code === 0 && status.stdout.toString().includes('.gitkeep') ? 'YES (staged)' : 'NO'}`);
+
+await fs.rm(tempDir, { recursive: true, force: true });

--- a/src/solve.auto-pr-placeholder.lib.mjs
+++ b/src/solve.auto-pr-placeholder.lib.mjs
@@ -1,0 +1,70 @@
+/**
+ * Placeholder-staging helper for auto PR creation.
+ *
+ * Extracted from solve.auto-pr.lib.mjs (issue #1825) to keep that module under
+ * the max-lines lint budget.
+ */
+
+/**
+ * Stage the temporary placeholder file (CLAUDE.md or .gitkeep) used to seed the
+ * initial auto-PR commit.
+ *
+ * The solver writes this placeholder deliberately to create the first commit so
+ * a draft PR can be opened, and removes it again once the task completes (see
+ * cleanupClaudeFile in solve.results.lib.mjs). When the target repository's
+ * .gitignore matches the placeholder — issue #1825: e.g. rumaster/tg-games
+ * ignores `.gitkeep` — a plain `git add <file>` exits non-zero with
+ * "The following paths are ignored by one of your .gitignore files", which
+ * previously aborted PR creation with a fatal "Failed to add .gitkeep".
+ *
+ * Because the placeholder belongs to us and is short-lived, we confirm the path
+ * is actually ignored with `git check-ignore` and then retry with
+ * `git add -f`. Force-adding only happens for the ignored-placeholder case;
+ * any other add failure is surfaced unchanged so genuine errors are not masked.
+ *
+ * @param {object} params
+ * @param {Function} params.$ - command-stream tagged-template runner.
+ * @param {string} params.tempDir - repository working directory.
+ * @param {string} params.fileName - placeholder file name (CLAUDE.md or .gitkeep).
+ * @param {Function} [params.log] - async logger.
+ * @param {Function} [params.formatAligned] - log line formatter.
+ * @param {boolean} [params.verbose] - emit verbose diagnostics.
+ * @returns {Promise<{code: number, forced: boolean, ignored: boolean, stderr: string}>}
+ */
+export async function addPlaceholderFileToGit({ $, tempDir, fileName, log, formatAligned, verbose = false }) {
+  // Run silently: `git add` is quiet on success and only emits the noisy
+  // "paths are ignored ... Use -f" hint on failure, which we capture in
+  // `stderr` and re-surface from the caller only when the failure is genuine.
+  const addResult = await $({ cwd: tempDir, silent: true })`git add ${fileName}`;
+  if (addResult.code === 0) {
+    return { code: 0, forced: false, ignored: false, stderr: '' };
+  }
+
+  const stderr = addResult.stderr ? addResult.stderr.toString() : '';
+
+  // Determine whether the add failed because the placeholder is git-ignored.
+  // `git check-ignore` exits 0 when the path matches a .gitignore rule.
+  const checkIgnore = await $({ cwd: tempDir, silent: true })`git check-ignore ${fileName}`;
+  const ignored = checkIgnore.code === 0;
+
+  if (!ignored) {
+    // The failure was not caused by .gitignore — surface the original error so
+    // genuine problems (permissions, corrupt index, ...) are not masked.
+    return { code: addResult.code, forced: false, ignored: false, stderr };
+  }
+
+  if (log && formatAligned) {
+    await log(formatAligned('ℹ️', `${fileName} is ignored:`, 'Force-adding placeholder (git add -f)'));
+  }
+  if (verbose && log) {
+    await log(`   ${fileName} matched a .gitignore rule; retrying with: git add -f ${fileName}`, { verbose: true });
+  }
+
+  const forcedResult = await $({ cwd: tempDir, silent: true })`git add -f ${fileName}`;
+  return {
+    code: forcedResult.code,
+    forced: true,
+    ignored: true,
+    stderr: forcedResult.stderr ? forcedResult.stderr.toString() : '',
+  };
+}

--- a/src/solve.auto-pr.lib.mjs
+++ b/src/solve.auto-pr.lib.mjs
@@ -8,6 +8,7 @@ import { handleRejectedPushForAutoPr, synchronizeExistingIssueBranchBeforeAutoPr
 import { emitForkAwareDiagnostic } from './solve.auto-pr-fork-diagnostic.lib.mjs';
 
 import { wrapDollarWithGhRetry as _wrapDollarWithGhRetry, execGhWithRetry } from './github-rate-limit.lib.mjs'; // rate-limit marker (#1726): gh API calls flow through $ wrapped by caller. Issue #1756: execGhWithRetry retries on transient 5xx (504) too.
+import { addPlaceholderFileToGit } from './solve.auto-pr-placeholder.lib.mjs'; // Issue #1825: force-adds the seed placeholder when the target repo gitignores it.
 
 export async function handleAutoPrCreation({ argv, tempDir, branchName, issueNumber, owner, repo, defaultBranch, forkedRepo, isContinueMode, prNumber, log, formatAligned, $, reportError, path, fs }) {
   // Skip auto-PR creation if:
@@ -166,12 +167,13 @@ Proceed.
     // Add and commit the file
     await log(formatAligned('📦', 'Adding file:', 'To git staging'));
 
-    // Use explicit cwd option for better reliability
-    const addResult = await $({ cwd: tempDir })`git add ${fileName}`;
+    // Issue #1825: force-adds the placeholder when the target repo gitignores
+    // it (e.g. ignores `.gitkeep`), so PR creation is no longer aborted.
+    const addResult = await addPlaceholderFileToGit({ $, tempDir, fileName, log, formatAligned, verbose: argv.verbose });
 
     if (addResult.code !== 0) {
       await log(`❌ Failed to add ${fileName}`, { level: 'error' });
-      await log(`   Error: ${addResult.stderr ? addResult.stderr.toString() : 'Unknown error'}`, { level: 'error' });
+      await log(`   Error: ${addResult.stderr || 'Unknown error'}`, { level: 'error' });
       throw new Error(`Failed to add ${fileName}`);
     }
 
@@ -212,12 +214,12 @@ Proceed.
           await fs.writeFile(gitkeepPath, gitkeepContent);
           await log(formatAligned('✅', 'Created:', '.gitkeep file'));
 
-          // Try to add .gitkeep
-          const gitkeepAddResult = await $({ cwd: tempDir })`git add .gitkeep`;
+          // Try to add .gitkeep (force-added if it too is gitignored — issue #1825)
+          const gitkeepAddResult = await addPlaceholderFileToGit({ $, tempDir, fileName: '.gitkeep', log, formatAligned, verbose: argv.verbose });
 
           if (gitkeepAddResult.code !== 0) {
             await log('❌ Failed to add .gitkeep', { level: 'error' });
-            await log(`   Error: ${gitkeepAddResult.stderr ? gitkeepAddResult.stderr.toString() : 'Unknown error'}`, {
+            await log(`   Error: ${gitkeepAddResult.stderr || 'Unknown error'}`, {
               level: 'error',
             });
             throw new Error('Failed to add .gitkeep');

--- a/tests/test-issue-1825-gitkeep-ignored.mjs
+++ b/tests/test-issue-1825-gitkeep-ignored.mjs
@@ -1,0 +1,124 @@
+#!/usr/bin/env node
+
+/**
+ * Regression tests for issue #1825: "Failed to add .gitkeep".
+ *
+ * When the target repository's .gitignore matches the auto-PR placeholder
+ * (e.g. rumaster/tg-games ignores `.gitkeep`), the auto-PR creation step ran
+ * `git add .gitkeep`, which exits non-zero with "The following paths are
+ * ignored by one of your .gitignore files", and the solver aborted with
+ * "FATAL ERROR: PR creation failed".
+ *
+ * The fix routes placeholder staging through addPlaceholderFileToGit, which
+ * confirms the path is git-ignored via `git check-ignore` and retries with
+ * `git add -f`. The placeholder is created by the solver to seed the initial
+ * commit and is removed when the task completes, so force-adding is safe.
+ *
+ * @hive-mind-test-suite default
+ */
+
+// Use use-m to dynamically import command-stream (matches the rest of the suite).
+if (typeof globalThis.use === 'undefined') {
+  globalThis.use = (await eval(await (await fetch('https://unpkg.com/use-m/use.js')).text())).use;
+}
+const use = globalThis.use;
+
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+const { $ } = await use('command-stream');
+const fs = (await use('fs')).promises;
+const path = (await use('path')).default;
+const os = (await use('os')).default;
+
+const { addPlaceholderFileToGit } = await import('../src/solve.auto-pr-placeholder.lib.mjs');
+
+async function createTestRepo({ gitignore } = {}) {
+  const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), 'test-issue-1825-'));
+  await $({ cwd: tempDir })`git init -q`;
+  await $({ cwd: tempDir })`git config user.email "test@example.com"`;
+  await $({ cwd: tempDir })`git config user.name "Test User"`;
+  if (gitignore) {
+    await fs.writeFile(path.join(tempDir, '.gitignore'), gitignore);
+    await $({ cwd: tempDir })`git add .gitignore`;
+    await $({ cwd: tempDir })`git commit -q -m "Add .gitignore"`;
+  }
+  return tempDir;
+}
+
+async function statusShort(tempDir) {
+  const result = await $({ cwd: tempDir })`git status --short`;
+  return result.stdout ? result.stdout.toString().trim() : '';
+}
+
+test('plain git add .gitkeep fails when the repo gitignores it (reproduces the bug)', async () => {
+  const tempDir = await createTestRepo({ gitignore: '.gitkeep\n' });
+  try {
+    await fs.writeFile(path.join(tempDir, '.gitkeep'), '# placeholder\n');
+    const plain = await $({ cwd: tempDir })`git add .gitkeep`;
+    assert.notEqual(plain.code, 0, 'plain `git add .gitkeep` should fail for an ignored path');
+    assert.equal(await statusShort(tempDir), '', 'nothing should be staged by the failed add');
+  } finally {
+    await fs.rm(tempDir, { recursive: true, force: true });
+  }
+});
+
+test('addPlaceholderFileToGit force-adds .gitkeep when it is gitignored', async () => {
+  const tempDir = await createTestRepo({ gitignore: '.gitkeep\n' });
+  try {
+    await fs.writeFile(path.join(tempDir, '.gitkeep'), '# placeholder\n');
+    const result = await addPlaceholderFileToGit({ $, tempDir, fileName: '.gitkeep' });
+
+    assert.equal(result.code, 0, 'force-add should succeed');
+    assert.equal(result.forced, true, 'placeholder should be reported as force-added');
+    assert.equal(result.ignored, true, 'placeholder should be detected as gitignored');
+    assert.match(await statusShort(tempDir), /\.gitkeep/, '.gitkeep should be staged');
+  } finally {
+    await fs.rm(tempDir, { recursive: true, force: true });
+  }
+});
+
+test('addPlaceholderFileToGit force-adds CLAUDE.md when it is gitignored', async () => {
+  const tempDir = await createTestRepo({ gitignore: 'CLAUDE.md\n' });
+  try {
+    await fs.writeFile(path.join(tempDir, 'CLAUDE.md'), '# task details\n');
+    const result = await addPlaceholderFileToGit({ $, tempDir, fileName: 'CLAUDE.md' });
+
+    assert.equal(result.code, 0, 'force-add should succeed');
+    assert.equal(result.forced, true, 'placeholder should be reported as force-added');
+    assert.equal(result.ignored, true, 'placeholder should be detected as gitignored');
+    assert.match(await statusShort(tempDir), /CLAUDE\.md/, 'CLAUDE.md should be staged');
+  } finally {
+    await fs.rm(tempDir, { recursive: true, force: true });
+  }
+});
+
+test('addPlaceholderFileToGit handles gitignore patterns that match .gitkeep indirectly', async () => {
+  // A repo that ignores all dotfiles via a glob would also catch .gitkeep.
+  const tempDir = await createTestRepo({ gitignore: '.git*\n!.gitignore\n' });
+  try {
+    await fs.writeFile(path.join(tempDir, '.gitkeep'), '# placeholder\n');
+    const result = await addPlaceholderFileToGit({ $, tempDir, fileName: '.gitkeep' });
+
+    assert.equal(result.code, 0, 'force-add should succeed for glob-matched ignore');
+    assert.equal(result.forced, true, 'placeholder should be reported as force-added');
+    assert.match(await statusShort(tempDir), /\.gitkeep/, '.gitkeep should be staged');
+  } finally {
+    await fs.rm(tempDir, { recursive: true, force: true });
+  }
+});
+
+test('addPlaceholderFileToGit adds normally (no force) when the placeholder is not ignored', async () => {
+  const tempDir = await createTestRepo();
+  try {
+    await fs.writeFile(path.join(tempDir, '.gitkeep'), '# placeholder\n');
+    const result = await addPlaceholderFileToGit({ $, tempDir, fileName: '.gitkeep' });
+
+    assert.equal(result.code, 0, 'add should succeed');
+    assert.equal(result.forced, false, 'no force-add should be needed for a non-ignored file');
+    assert.equal(result.ignored, false, 'placeholder should not be detected as gitignored');
+    assert.match(await statusShort(tempDir), /\.gitkeep/, '.gitkeep should be staged');
+  } finally {
+    await fs.rm(tempDir, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
## Summary

Fixes #1825 — the `solve` auto-PR step aborted with **"Failed to add .gitkeep"** whenever the target repository's `.gitignore` matched the seed placeholder.

To open the initial draft PR, the solver writes a short-lived placeholder (`.gitkeep` by default, or `CLAUDE.md`), commits it, and pushes the branch (the placeholder is removed again when the task completes). Staging used a plain `git add <file>`. When the placeholder is git-ignored (e.g. [`rumaster/tg-games`](https://github.com/rumaster/tg-games) ends its `.gitignore` with `.gitkeep`), `git add` exits non-zero with *"The following paths are ignored by one of your .gitignore files"*, and the hard throw aborted the whole run.

## Root cause

`src/solve.auto-pr.lib.mjs` ran `git add ${fileName}` and threw on a non-zero exit. `git add` returns 1 for an ignored, untracked path, so PR creation failed before any work could begin. The existing `CLAUDE.md → .gitkeep` fallback never checked whether `.gitkeep` itself was ignored, and the "nothing staged" branch was unreachable because `git add` *errored* rather than staging nothing.

Reproduced on `solve` v1.72.6 against `rumaster/tg-games#3` with both Claude Sonnet 4.6 and GPT-5.5 (failure logs archived in the case study).

## The fix

Placeholder staging now routes through a new helper `addPlaceholderFileToGit` (extracted to `src/solve.auto-pr-placeholder.lib.mjs` to keep the module under the `max-lines` budget). It:

1. tries a normal `git add` (silently);
2. on failure, confirms the path is git-ignored via `git check-ignore`;
3. if ignored, retries with `git add -f` (logging an informational note, with extra detail under `--verbose`);
4. surfaces any **non-ignore** failure unchanged so genuine errors aren't masked.

Force-adding is safe because the placeholder is created by the solver itself and removed at task completion.

Both placeholder call-sites (primary `.gitkeep`/`CLAUDE.md` add and the inner `CLAUDE.md → .gitkeep` fallback) now use the helper — the only two spots in the codebase that stage the seed placeholder. The cleanup path (`solve.results.lib.mjs`) operates on an already-tracked file, which `.gitignore` does not affect, so it needs no change.

## How to reproduce

```sh
# target repo whose .gitignore contains ".gitkeep"
node experiments/issue-1825-reproduce-gitkeep-ignored.mjs
```

Before the fix: `git add .gitkeep` exits 1 → solver throws `Failed to add .gitkeep`.
After the fix: `addPlaceholderFileToGit` detects the ignore and force-adds, so the placeholder is staged and PR creation proceeds.

## Tests

`tests/test-issue-1825-gitkeep-ignored.mjs` (default suite, 5 tests, all passing):

- plain `git add .gitkeep` fails on an ignored path (reproduces the bug);
- helper force-adds `.gitkeep` when ignored;
- helper force-adds `CLAUDE.md` when ignored;
- helper handles a glob ignore (`.git*`) that catches `.gitkeep` indirectly;
- helper adds normally (no force) when the placeholder is not ignored.

## Case study

The full investigation — timeline, complete requirements list, root-cause analysis, full-codebase coverage, existing-components survey, and archived issue/upstream/failure logs — is in [`docs/case-studies/issue-1825/`](docs/case-studies/issue-1825/README.md).

## Notes on the upstream repo

No bug was filed against `rumaster/tg-games`: the defect is in hive-mind, not their repo. Ignoring `.gitkeep` is unusual but a valid config, and after this fix it is handled gracefully. The case study also documents a manual workaround (remove `.gitkeep` from the target `.gitignore`).
