### PR TITLE
feat(telegram): clickable executed-items list in /solve_queue + /queue alias (#1837)

### DIFF
--- a/.changeset/issue-1837-queue-clickable-list.md
+++ b/.changeset/issue-1837-queue-clickable-list.md
@@ -1,0 +1,17 @@
+---
+'@link-assistant/hive-mind': patch
+---
+
+feat(telegram): list executed issues/PRs as clickable links in /solve_queue, add /queue alias (#1837)
+
+The `/solve_queue` detailed status previously showed only per-tool counts and a
+final `Completed: N, Failed: M` line, so a stuck or running task could not be
+opened from the message. It now lists each processing (`▶️`), pending (`•`),
+recently completed (`✅`), and failed (`❌`, with the error reason) item as a
+clickable `[owner/repo#number](url)` link, capped per section
+(`HIVE_MIND_MAX_DISPLAY_ITEMS_PER_QUEUE`, default 5) with a localized
+`... and N more` line to stay under Telegram's 4096-character limit.
+
+Also adds `/queue` as a shorter alias for `/solve_queue` (both the entity-based
+command regex and the text-based fallback handler), and documents the work in
+`docs/case-studies/issue-1837`.

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,0 +1,1 @@
+# .gitkeep file auto-generated at 2026-05-29T21:58:40.454Z for PR creation at branch issue-1837-3c7f512ce3b5 for issue https://github.com/link-assistant/hive-mind/issues/1837

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,1 +1,0 @@
-# .gitkeep file auto-generated at 2026-05-29T21:58:40.454Z for PR creation at branch issue-1837-3c7f512ce3b5 for issue https://github.com/link-assistant/hive-mind/issues/1837

--- a/docs/case-studies/issue-1837/README.md
+++ b/docs/case-studies/issue-1837/README.md
@@ -1,0 +1,307 @@
+# Case Study: Issue #1837 — `/queue` (alias of `/solve_queue`) improvements
+
+## Overview
+
+This case study documents the analysis and implementation for issue
+[#1837](https://github.com/link-assistant/hive-mind/issues/1837), an
+**enhancement** (not a bug) to the Telegram bot's solve-queue status command.
+
+The `/solve_queue` command reports the state of the per-tool work queues
+(`claude`, `agent`, `codex`, `qwen`, `gemini`). Before this change it printed
+**only counts** — per-tool `pending`/`processing` numbers plus a final
+`Completed: N, Failed: M` line. It never listed _which_ issues or pull requests
+were running, queued, completed, or failed. When something is stuck or
+executing, an operator could see _that_ one item was processing but had no way to
+jump to it.
+
+This PR makes three changes:
+
+1. **Clickable lists of the actual executed items.** The detailed status now
+   lists each processing item (`▶️`), each pending item (`•`), and the recent
+   `Completed` (`✅`) and `Failed` (`❌`, with the error reason) items, each as a
+   clickable Markdown link `[owner/repo#number](url)` to the issue/PR.
+2. **`/queue` alias.** `/queue` is now a synonym for `/solve_queue`, so checking
+   the queue is faster to type.
+3. **This deep case study** with the requirement breakdown, solution options,
+   and a review of existing components.
+
+## Issue Details
+
+- **Issue**: [#1837](https://github.com/link-assistant/hive-mind/issues/1837)
+- **Title**: `/queue` (alias of `/solve_queue`) improvements
+- **Labels**: `documentation`, `enhancement`
+- **Author**: @konard
+- **Reported**: 2026-05-29
+- **Pull Request**: [#1840](https://github.com/link-assistant/hive-mind/pull/1840) on branch `issue-1837-3c7f512ce3b5`
+- **Data files**:
+  - [`issue-1837.json`](./issue-1837.json) — the raw issue payload (title, body, labels, author).
+  - [`implementation.diff`](./implementation.diff) — the full diff implemented in this PR.
+
+### Reported behavior (verbatim from the issue)
+
+The issue shows the current `/solve_queue` output:
+
+```
+📋 Solve Queue Status
+
+claude (pending: 0, processing: 1)
+
+agent (pending: 0, processing: 0)
+
+codex (pending: 0, processing: 0)
+
+qwen (pending: 0, processing: 0)
+
+gemini (pending: 0, processing: 0)
+
+Completed: 0, Failed: 1
+```
+
+> Now I don't see actual list of executed issues/pull requests as clickable
+> list, that must be fixed, and we we should add /queue as alias for it.
+>
+> It will simplify search tasks that are stuck or yet executing.
+
+## Requirements (extracted verbatim from the issue)
+
+Each requirement from the issue body, and where it is addressed:
+
+1. **Show the actual list of executed issues/pull requests as a clickable list.**
+   "Now I don't see actual list of executed issues/pull requests as clickable
+   list, that must be fixed." → [Requirement 1: Clickable lists](#requirement-1--clickable-lists-of-executed-items).
+2. **Add `/queue` as an alias for `/solve_queue`.** → [Requirement 2: `/queue` alias](#requirement-2--queue-alias).
+3. **Collect data related to the issue into `./docs/case-studies/issue-1837`.**
+   → [`issue-1837.json`](./issue-1837.json), [`implementation.diff`](./implementation.diff), and this document.
+4. **Do a deep case study analysis (search online for additional facts/data).**
+   → This document; see [Online research](#online-research).
+5. **List each and all requirements from the issue.** → This section.
+6. **Propose possible solutions / solution plans for each requirement.** →
+   [Solution options](#solution-options-considered).
+7. **Check known existing components/libraries that solve a similar problem or
+   can help.** → [Existing components reviewed](#existing-components--libraries-reviewed).
+8. **Plan and execute everything in this single pull request.** → All changes
+   land in PR #1840 on branch `issue-1837-3c7f512ce3b5`.
+
+## Requirement 1 — Clickable lists of executed items
+
+### Why the list was missing
+
+The detailed status is built by `SolveQueue.formatDetailedStatus()` in
+[`src/telegram-solve-queue.lib.mjs`](../../../src/telegram-solve-queue.lib.mjs).
+Before this change it iterated the per-tool queues and printed only the
+`pending`/`processing` _counts_ (it derived the processing count from `pgrep` +
+tracked isolation sessions), then appended a single `Completed: N, Failed: M`
+summary line.
+
+The queue object already tracks everything needed for a list:
+
+- `this.queues[tool]` — array of pending `SolveQueueItem`s (each has `.url`,
+  `.status`, `.getWaitTime()`, `.waitingReason`).
+- `this.processing` — a `Map` of in-flight items keyed by id (each has `.tool`,
+  `.url`, `.status`).
+- `this.completed` / `this.failed` — arrays of finished items (capped at 100;
+  failed items carry `.error`).
+
+So no new data had to be collected — the information was discarded at the
+formatting step. The fix is purely a formatting change: render those items as a
+clickable list.
+
+### Why "clickable" needs care under Telegram Markdown
+
+The bot sends this message with `parse_mode: 'Markdown'` (legacy Markdown).
+Under legacy Markdown:
+
+- A **bare URL is auto-linked** and clickable — so even the old (URL-less) output
+  would have been clickable _if_ it had printed URLs.
+- The richer `[label](url)` **inline-link syntax** is supported, which lets us
+  show a compact, human-readable label (`owner/repo#number`) instead of a long
+  raw URL.
+- **`_` and `*` are Markdown-special**; an owner/repo name containing them inside
+  link _text_ can break the parser and make Telegram reject the whole message.
+
+The implemented `formatQueueItemLink(url)` helper
+([`src/telegram-solve-queue.helpers.lib.mjs`](../../../src/telegram-solve-queue.helpers.lib.mjs))
+parses a GitHub issue/PR URL into `owner/repo#number` and:
+
+- returns `[owner/repo#number](url)` when the label is Markdown-safe
+  (`^[A-Za-z0-9/#.-]+$`), giving a compact clickable link; otherwise
+- falls back to the **bare URL** (still auto-linked/clickable, just longer); and
+- returns the original string unchanged for non-GitHub / unparseable URLs.
+
+This keeps the message safe to parse in all cases while still being clickable.
+
+### Keeping the message under Telegram's 4096-character cap
+
+Telegram caps a message at **4096 UTF-8 characters after entity parsing** (see
+[Online research](#online-research)). A busy queue could list hundreds of
+items and blow past that cap. To stay safe, each section is capped at
+`QUEUE_CONFIG.MAX_DISPLAY_ITEMS_PER_QUEUE` (default **5**, override via
+`HIVE_MIND_MAX_DISPLAY_ITEMS_PER_QUEUE`) and collapses the remainder into a
+localized `... and N more` line (the existing `queue_and_more` i18n key). The
+`Completed`/`Failed` history is shown **most-recent-first** so the newest results
+are easiest to find.
+
+### New output format
+
+```
+📋 Solve Queue Status
+
+claude (pending: 1, processing: 1)
+  ▶️ owner/repo#12 (started, 3m 10s)
+  • owner/repo#34 (waiting, 1m 2s)
+    └ RAM usage is 70% (threshold: 65%)
+
+agent (pending: 0, processing: 0)
+
+codex (pending: 0, processing: 0)
+
+qwen (pending: 0, processing: 0)
+
+gemini (pending: 0, processing: 0)
+
+Completed (3):
+  ✅ owner/repo#7
+  ✅ owner/repo#5
+  ✅ owner/repo#2
+
+Failed (1):
+  ❌ owner/repo#8 — Error message text
+
+Completed: 3, Failed: 1
+```
+
+Each `owner/repo#number` is a clickable link to the issue/PR. The final
+`Completed: N, Failed: M` summary line is preserved for backward compatibility
+(and the existing test asserts on it).
+
+## Requirement 2 — `/queue` alias
+
+Telegram bot commands are dispatched two ways in this codebase:
+
+1. **Entity-based** via `bot.command(regex, handler)` in
+   [`src/telegram-solve-queue-command.lib.mjs`](../../../src/telegram-solve-queue-command.lib.mjs).
+   The regex was widened from `^solve[_-]?queue$` to
+   `^(?:solve[_-]?queue|queue)$` (case-insensitive). This matches `/queue` and
+   `/QUEUE` while still **not** matching unrelated commands like `/queued`.
+2. **Text-based fallback** in [`src/telegram-bot.mjs`](../../../src/telegram-bot.mjs)
+   (added for issue #1232, which handles hyphenated forms Telegram can't send as
+   entities). The `handlers` map gained `queue: handleSolveQueueCommand`
+   alongside the existing `solve_queue` / `solvequeue` entries.
+
+The help text in all four locales (`en`, `ru`, `zh`, `hi`) was updated to
+mention the alias, e.g. `` `/solve_queue` (alias: `/queue`) - Show solve queue
+status ``.
+
+There is no `setMyCommands` registration in the codebase, so the alias needed
+only the regex + fallback changes — no command-menu update.
+
+## Solution options considered
+
+### Requirement 1 — how to render the list
+
+| Option                                             | Description                                               | Trade-off                                                                                                                                   | Chosen                           |
+| -------------------------------------------------- | --------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------- |
+| **A. Bare URLs**                                   | Print `item.url` directly; rely on Telegram auto-linking. | Simplest; clickable; but long and noisy, and a list of raw URLs is hard to scan.                                                            | No                               |
+| **B. Inline Markdown links `[owner/repo#n](url)`** | Compact, scannable, clickable.                            | Needs Markdown-safety guard for `_`/`*` in repo names.                                                                                      | **Yes** (with bare-URL fallback) |
+| **C. MarkdownV2 / HTML parse mode**                | Richer/escaping-safe formatting.                          | Would require changing the parse mode for the whole message and re-escaping all existing content — large blast radius for no extra benefit. | No                               |
+| **D. Telegram message entities (manual offsets)**  | Programmatic links without Markdown.                      | Most robust but verbose; offsets must be recomputed as the message is assembled — overkill here.                                            | No                               |
+
+Option **B with a bare-URL fallback** (the implemented `formatQueueItemLink`)
+gives the compact, clickable, scannable list the issue asks for while staying
+safe under the existing legacy-Markdown pipeline.
+
+### Requirement 1 — how to bound message size
+
+| Option                                 | Description                                        | Chosen                                                                                        |
+| -------------------------------------- | -------------------------------------------------- | --------------------------------------------------------------------------------------------- |
+| **Cap per section + "and N more"**     | Show the first N (configurable) items per section. | **Yes** — reuses the existing `queue_and_more` key and `MAX_DISPLAY_ITEMS_PER_QUEUE` pattern. |
+| **Paginate across multiple messages**  | Send several messages / inline keyboard pages.     | Deferred — more complex; not requested.                                                       |
+| **Truncate the whole message blindly** | Cut at 4096 chars.                                 | No — could cut mid-link and break Markdown.                                                   |
+
+### Requirement 2 — how to add the alias
+
+| Option                                            | Description                              | Chosen                                                              |
+| ------------------------------------------------- | ---------------------------------------- | ------------------------------------------------------------------- |
+| **Widen the existing regex + fallback map**       | One handler, two dispatch paths updated. | **Yes** — minimal, consistent with how `/solvequeue` already works. |
+| **Register a separate `bot.command('queue', …)`** | Second registration.                     | No — duplicates wiring and risks drift between the two handlers.    |
+
+## Existing components / libraries reviewed
+
+- **`formatDuration` / `formatWaitingReason`** ([`telegram-solve-queue.helpers.lib.mjs`](../../../src/telegram-solve-queue.helpers.lib.mjs)) —
+  already used for human-readable wait times and reasons; reused as-is for each listed item.
+- **`lt()` limits-i18n** ([`src/limits-i18n.lib.mjs`](../../../src/limits-i18n.lib.mjs)) —
+  already defines `queue_completed`, `queue_failed`, `queue_pending`,
+  `queue_processing`, `queue_status_*`, and `queue_and_more`. The new lists reuse
+  these keys, so **no new translation keys were needed**.
+- **`QUEUE_CONFIG`** ([`src/queue-config.lib.mjs`](../../../src/queue-config.lib.mjs)) —
+  the existing env-overridable config object; the new
+  `MAX_DISPLAY_ITEMS_PER_QUEUE` follows the same `parseIntWithDefault(...)`
+  pattern as every other tunable.
+- **`parseGitHubUrl()`** ([`src/github.lib.mjs`](../../../src/github.lib.mjs)) —
+  considered for parsing the URL into `owner/repo/number`. **Not** imported,
+  because that module pulls in heavy GitHub-API dependencies that would bloat the
+  formatting path; a small local regex in `formatQueueItemLink` is sufficient and
+  dependency-free.
+- **Text-fallback handler map** ([`src/telegram-bot.mjs`](../../../src/telegram-bot.mjs), issue #1232) —
+  the established mechanism for command aliases that Telegram can't send as
+  entities; reused for `/queue`.
+- **Telegraf** — the bot framework; `bot.command(regex, handler)` already accepts
+  a regex, so the alias needed only a wider pattern, not a new dependency.
+
+## Online research
+
+- **Telegram message length** — the Bot API limits a message to **1–4096 UTF-8
+  characters after entity parsing**
+  ([Telegram Bot API](https://core.telegram.org/bots/api),
+  [node-telegram-bot-api #165](https://github.com/yagop/node-telegram-bot-api/issues/165)).
+  This is the reason the lists are capped per section with `... and N more`.
+- **Markdown inline links** — legacy Markdown supports `[inline URL](http://example.com/)`,
+  and Telegram auto-links bare URLs; clients show an "Open this link?" confirmation
+  ([Telegram Bot API](https://core.telegram.org/bots/api)). This is why both the
+  compact-link and bare-URL fallbacks render as clickable.
+
+## The implementation
+
+### Files changed
+
+| File                                       | Change                                                                                                   |
+| ------------------------------------------ | -------------------------------------------------------------------------------------------------------- |
+| `src/telegram-solve-queue-command.lib.mjs` | Regex widened to `^(?:solve[_-]?queue\|queue)$` to match `/queue`.                                       |
+| `src/telegram-bot.mjs`                     | Added `queue: handleSolveQueueCommand` to the text-fallback handler map.                                 |
+| `src/telegram-solve-queue.helpers.lib.mjs` | New `formatQueueItemLink(url)` and `formatQueueHistorySection(...)` helpers.                             |
+| `src/telegram-solve-queue.lib.mjs`         | `formatDetailedStatus()` now lists processing/pending/completed/failed items as clickable links.         |
+| `src/queue-config.lib.mjs`                 | New `MAX_DISPLAY_ITEMS_PER_QUEUE` (default 5, env `HIVE_MIND_MAX_DISPLAY_ITEMS_PER_QUEUE`).              |
+| `src/locales/{en,ru,zh,hi}.lino`           | Help text mentions the `/queue` alias.                                                                   |
+| `tests/solve-queue.test.mjs`               | New tests for clickable links in pending/completed/failed sections.                                      |
+| `tests/test-solve-queue-command.mjs`       | New tests asserting `/queue` and `/QUEUE` match (and `/queued` does not), plus the text-fallback wiring. |
+
+The full diff is preserved in [`implementation.diff`](./implementation.diff).
+
+### Design notes
+
+- `formatQueueItemLink` and `formatQueueHistorySection` live in the **helpers**
+  module (not the main lib) to keep `telegram-solve-queue.lib.mjs` under the
+  repo's 1500-line ESLint `max-lines` cap and to make the link/section formatting
+  independently unit-testable.
+- The final `Completed: N, Failed: M` summary line is intentionally **retained**
+  for backward compatibility and is still asserted by the existing
+  `formatDetailedStatus includes all sections` test.
+
+## Testing
+
+- `tests/solve-queue.test.mjs` (72 tests) — includes two new tests:
+  - `formatDetailedStatus renders clickable Markdown links for queued items (issue #1837)`
+  - `formatDetailedStatus lists completed and failed items as clickable links (issue #1837)`
+- `tests/test-solve-queue-command.mjs` (25 tests) — includes:
+  - `Command regex matches queue (alias added in issue #1837)`
+  - `Command regex matches QUEUE (case insensitive alias)`
+  - `Command regex does not match unrelated commands like queued`
+  - `telegram-bot.mjs includes /queue alias in text fallback handlers (issue #1837)`
+- `npm run lint` passes (the main lib stays under the 1500-line limit).
+
+## Outcome
+
+All issue requirements are addressed in PR #1840: the detailed `/solve_queue`
+(and new `/queue`) status now shows the executed issues/PRs as a clickable list,
+`/queue` works as an alias, and this case study captures the data, analysis,
+requirement breakdown, solution options, and existing-component review.

--- a/docs/case-studies/issue-1837/implementation.diff
+++ b/docs/case-studies/issue-1837/implementation.diff
@@ -1,0 +1,384 @@
+diff --git a/src/locales/en.lino b/src/locales/en.lino
+index 3038f59a..31fce6f7 100644
+--- a/src/locales/en.lino
++++ b/src/locales/en.lino
+@@ -515,7 +515,7 @@ en
+           detail "Tool aliases imply `--tool <tool>`: `/codex <github-url>` equals `/solve <github-url> --tool codex`"
+         reply "Or reply to a message with a GitHub link: `/solve`"
+         disabled "*/solve* (aliases: */do*, */continue*, */claude*, */codex*, */opencode*, */agent*, */gemini*, */qwen*) - ❌ Disabled"
+-        queue "`/solve_queue` - Show solve queue status"
++        queue "`/solve_queue` (alias: `/queue`) - Show solve queue status"
+       locked
+         options "🔒 Locked options: `{{options}}`"
+       task
+diff --git a/src/locales/hi.lino b/src/locales/hi.lino
+index 3f578c7c..728fce6f 100644
+--- a/src/locales/hi.lino
++++ b/src/locales/hi.lino
+@@ -515,7 +515,7 @@ hi
+           detail "Tool aliases `--tool <tool>` लगाते हैं: `/codex <github-url>` का अर्थ `/solve <github-url> --tool codex` है"
+         reply "या GitHub लिंक वाले संदेश का उत्तर दें: `/solve`"
+         disabled "*/solve* (aliases: */do*, */continue*, */claude*, */codex*, */opencode*, */agent*, */gemini*, */qwen*) - ❌ अक्षम"
+-        queue "`/solve_queue` - solve queue status दिखाएँ"
++        queue "`/solve_queue` (उपनाम: `/queue`) - solve queue status दिखाएँ"
+       locked
+         options "🔒 लॉक किए गए विकल्प: `{{options}}`"
+       task
+diff --git a/src/locales/ru.lino b/src/locales/ru.lino
+index f89e3f68..2a832268 100644
+--- a/src/locales/ru.lino
++++ b/src/locales/ru.lino
+@@ -515,7 +515,7 @@ ru
+           detail "Алиасы инструментов добавляют `--tool <tool>`: `/codex <github-url>` равно `/solve <github-url> --tool codex`"
+         reply "Или ответьте на сообщение со ссылкой GitHub: `/solve`"
+         disabled "*/solve* (алиасы: */do*, */continue*, */claude*, */codex*, */opencode*, */agent*, */gemini*, */qwen*) - ❌ Отключено"
+-        queue "`/solve_queue` - Показать состояние очереди solve"
++        queue "`/solve_queue` (псевдоним: `/queue`) - Показать состояние очереди solve"
+       locked
+         options "🔒 Заблокированные опции: `{{options}}`"
+       task
+diff --git a/src/locales/zh.lino b/src/locales/zh.lino
+index eccea63f..721f3981 100644
+--- a/src/locales/zh.lino
++++ b/src/locales/zh.lino
+@@ -515,7 +515,7 @@ zh
+           detail "工具别名会添加 `--tool <tool>`：`/codex <github-url>` 等同于 `/solve <github-url> --tool codex`"
+         reply "也可以回复包含 GitHub 链接的消息：`/solve`"
+         disabled "*/solve*（别名：*/do*、*/continue*、*/claude*、*/codex*、*/opencode*、*/agent*、*/gemini*、*/qwen*）- ❌ 已禁用"
+-        queue "`/solve_queue` - 显示 solve 队列状态"
++        queue "`/solve_queue`（别名：`/queue`）- 显示 solve 队列状态"
+       locked
+         options "🔒 锁定选项：`{{options}}`"
+       task
+diff --git a/src/queue-config.lib.mjs b/src/queue-config.lib.mjs
+index cfdc9755..9528c16a 100644
+--- a/src/queue-config.lib.mjs
++++ b/src/queue-config.lib.mjs
+@@ -280,6 +280,13 @@ export const QUEUE_CONFIG = {
+ 
+   // Process detection
+   CLAUDE_PROCESS_NAMES: ['claude'], // Process names to detect
++
++  // Display
++  // Maximum number of items shown per section (pending/processing/completed/failed)
++  // in the /solve_queue (/queue) detailed status before collapsing into a
++  // "... and N more" line. Keeps the Telegram message under the 4096-char cap.
++  // See: https://github.com/link-assistant/hive-mind/issues/1837
++  MAX_DISPLAY_ITEMS_PER_QUEUE: parseIntWithDefault('HIVE_MIND_MAX_DISPLAY_ITEMS_PER_QUEUE', 5),
+ };
+ 
+ /**
+diff --git a/src/telegram-bot.mjs b/src/telegram-bot.mjs
+index ea71473b..574c9c91 100755
+--- a/src/telegram-bot.mjs
++++ b/src/telegram-bot.mjs
+@@ -1169,7 +1169,8 @@ bot.on('message', async (ctx, next) => {
+   // /subscribe + /unsubscribe (#1688) are intentionally not in the text fallback — Telegraf's bot.command() is sufficient.
+   const solveHandlers = Object.fromEntries(SOLVE_COMMAND_NAMES.map(command => [command, handleSolveCommand]));
+   const taskHandlers = Object.fromEntries(TASK_COMMAND_NAMES.map(command => [command, handleTaskCommand]));
+-  const handlers = { ...solveHandlers, ...taskHandlers, hive: handleHiveCommand, solve_queue: handleSolveQueueCommand, solvequeue: handleSolveQueueCommand };
++  // /queue is the short alias for /solve_queue (issue #1837)
++  const handlers = { ...solveHandlers, ...taskHandlers, hive: handleHiveCommand, solve_queue: handleSolveQueueCommand, solvequeue: handleSolveQueueCommand, queue: handleSolveQueueCommand };
+ 
+   const handler = handlers[extracted.command];
+   if (!handler) return next();
+diff --git a/src/telegram-solve-queue-command.lib.mjs b/src/telegram-solve-queue-command.lib.mjs
+index 58c62a81..c7dd59b6 100644
+--- a/src/telegram-solve-queue-command.lib.mjs
++++ b/src/telegram-solve-queue-command.lib.mjs
+@@ -97,11 +97,12 @@ export function registerSolveQueueCommand(bot, options) {
+     });
+   }
+ 
+-  // Match /solve_queue, /solve-queue, or /solvequeue (case-insensitive)
++  // Match /solve_queue, /solve-queue, /solvequeue, or the short /queue alias (case-insensitive)
+   // Note: Telegram Bot API only supports underscores in command names, not hyphens.
+-  // The entity-based matching handles /solve_queue and /solvequeue.
++  // The entity-based matching handles /solve_queue, /solvequeue, and /queue.
+   // /solve-queue is handled by the text-based fallback in telegram-bot.mjs (issue #1232).
+-  bot.command(/^solve[_-]?queue$/i, handleSolveQueueCommand);
++  // The /queue alias was added in issue #1837 to make checking the queue faster to type.
++  bot.command(/^(?:solve[_-]?queue|queue)$/i, handleSolveQueueCommand);
+ 
+   return { handleSolveQueueCommand };
+ }
+diff --git a/src/telegram-solve-queue.helpers.lib.mjs b/src/telegram-solve-queue.helpers.lib.mjs
+index 0f39a8db..a144a925 100644
+--- a/src/telegram-solve-queue.helpers.lib.mjs
++++ b/src/telegram-solve-queue.helpers.lib.mjs
+@@ -6,6 +6,64 @@ import { lt } from './limits-i18n.lib.mjs';
+ 
+ const execAsync = promisify(exec);
+ 
++/**
++ * Build a clickable, human-readable link to a queued issue/PR for the
++ * /solve_queue (/queue) detailed status (issue #1837).
++ *
++ * For GitHub issue/PR URLs we render a compact `[owner/repo#number](url)`
++ * Markdown link so the list is scannable and clickable. When the label would
++ * contain Markdown-special characters (e.g. `_` or `*` in an owner/repo name)
++ * that could break Telegram's legacy Markdown parser, we fall back to the bare
++ * URL — which Telegram still auto-links and renders as clickable.
++ *
++ * Non-GitHub or unparseable URLs also fall back to the bare URL.
++ *
++ * @param {string} url - The issue/PR URL.
++ * @returns {string} A Markdown link or bare URL safe for `parse_mode: 'Markdown'`.
++ */
++export function formatQueueItemLink(url) {
++  if (!url || typeof url !== 'string') return String(url ?? '');
++  const match = url.match(/github\.com\/([^/\s]+)\/([^/\s]+)\/(?:issues|pull)\/(\d+)/i);
++  if (!match) return url;
++  const [, owner, repo, number] = match;
++  const label = `${owner}/${repo}#${number}`;
++  // Only build a Markdown link when the label has no Markdown-special chars
++  // that would break the legacy parser inside link text. Otherwise the bare
++  // URL is still clickable in Telegram.
++  if (/^[A-Za-z0-9/#.-]+$/.test(label)) {
++    return `[${label}](${url})`;
++  }
++  return url;
++}
++
++/**
++ * Render a history section (Completed / Failed) for the detailed queue status
++ * as a clickable list, most-recent-first, capped at `max` items with a
++ * "... and N more" line (issue #1837).
++ *
++ * @param {object} opts
++ * @param {Array} opts.items - History items (each with `url`, optional `error`).
++ * @param {string} opts.emoji - Leading emoji for each row (e.g. '✅' or '❌').
++ * @param {string} opts.label - Localized section heading.
++ * @param {number} opts.max - Maximum items to list before collapsing.
++ * @param {string|null} opts.locale - Locale for the "and N more" label.
++ * @param {boolean} [opts.withError] - Append `— error` when the item failed.
++ * @returns {string} The formatted section (empty string when no items).
++ */
++export function formatQueueHistorySection({ items, emoji, label, max, locale, withError = false }) {
++  if (!items || items.length === 0) return '';
++  let section = `*${label}* (${items.length}):\n`;
++  for (const item of [...items].reverse().slice(0, max)) {
++    section += `  ${emoji} ${formatQueueItemLink(item.url)}`;
++    if (withError && item.error) section += ` — ${item.error}`;
++    section += '\n';
++  }
++  if (items.length > max) {
++    section += `    ... ${lt('queue_and_more', { count: items.length - max }, { locale })}\n`;
++  }
++  return `${section}\n`;
++}
++
+ /**
+  * Count running processes by name.
+  * @param {string} processName - Process name to search for (e.g., 'claude', 'agent', 'codex', 'gemini')
+diff --git a/src/telegram-solve-queue.lib.mjs b/src/telegram-solve-queue.lib.mjs
+index ececea66..2a8b7846 100644
+--- a/src/telegram-solve-queue.lib.mjs
++++ b/src/telegram-solve-queue.lib.mjs
+@@ -17,7 +17,7 @@
+ 
+ import { getCachedClaudeLimits, getCachedCodexLimits, getCachedGitHubLimits, getCachedMemoryInfo, getCachedCpuInfo, getCachedDiskInfo, getLimitCache } from './limits.lib.mjs';
+ export { formatDuration, getRunningAgentProcesses, getRunningClaudeProcesses, getRunningCodexProcesses, getRunningGeminiProcesses, getRunningProcesses, getRunningQwenProcesses } from './telegram-solve-queue.helpers.lib.mjs';
+-import { formatDuration, formatWaitingReason, getRunningAgentProcesses, getRunningClaudeProcesses, getRunningCodexProcesses, getRunningGeminiProcesses, getRunningProcesses, getRunningQwenProcesses } from './telegram-solve-queue.helpers.lib.mjs';
++import { formatDuration, formatQueueHistorySection, formatQueueItemLink, formatWaitingReason, getRunningAgentProcesses, getRunningClaudeProcesses, getRunningCodexProcesses, getRunningGeminiProcesses, getRunningProcesses, getRunningQwenProcesses } from './telegram-solve-queue.helpers.lib.mjs';
+ export { QUEUE_CONFIG, THRESHOLD_STRATEGIES } from './queue-config.lib.mjs';
+ import { QUEUE_CONFIG } from './queue-config.lib.mjs';
+ import { formatExecutingWorkSessionMessage, formatStartingWorkSessionMessage } from './work-session-formatting.lib.mjs';
+@@ -1320,28 +1320,17 @@ export class SolveQueue {
+   }
+ 
+   /**
+-   * Format detailed queue status for Telegram message
+-   * Groups output by tool queue, shows first 5 items per queue, and uses human-readable time.
++   * Format detailed queue status for Telegram message.
++   * Groups output by tool queue (clickable links per item), then lists the
++   * Completed and Failed history as clickable links, capped per section.
+    *
+    * Processing count = max(actual AI CLI processes via pgrep, tracked
+    * `$ --status` executing screen-isolated sessions), not queue state.
+    *
+-   * Output format:
+-   * ```
+-   * 📋 Solve Queue Status
+-   *
+-   * claude (pending: 6, processing: 0)
+-   * • url1 (waiting, 5h 43m 23s)
+-   *   └ RAM usage is 70% (threshold: 65%)
+-   * • url2 (queued, 2m 15s)
+-   *
+-   * agent (pending: 2, processing: 0)
+-   * • url3 (waiting, 1h 2m 5s)
+-   * ```
+-   *
+    * @returns {Promise<string>}
+    * @see https://github.com/link-assistant/hive-mind/issues/1159
+    * @see https://github.com/link-assistant/hive-mind/issues/1267
++   * @see https://github.com/link-assistant/hive-mind/issues/1837
+    */
+   async formatDetailedStatus(options = {}) {
+     const locale = getLocale(options);
+@@ -1359,22 +1348,37 @@ export class SolveQueue {
+       const processing = externalProcessing.byTool[tool] || 0;
+       message += `*${tool}* (${lt('queue_pending', {}, { locale })}: ${pending}, ${lt('queue_processing', {}, { locale })}: ${processing})\n`;
+ 
+-      // Show first 5 queued items for this tool
+-      const displayItems = toolQueue.slice(0, 5);
++      // Show the items this queue is actively processing for this tool, with a
++      // clickable link to each issue/PR (issue #1837). These come from the
++      // queue's own tracking, so they may differ from the pgrep-based count above.
++      const processingItems = Array.from(this.processing.values()).filter(item => item.tool === tool);
++      for (const item of processingItems.slice(0, QUEUE_CONFIG.MAX_DISPLAY_ITEMS_PER_QUEUE)) {
++        const waitTime = formatDuration(item.getWaitTime(), { locale });
++        message += `  ▶️ ${formatQueueItemLink(item.url)} (${queueStatusLabel(item.status, locale)}, ${waitTime})\n`;
++      }
++
++      // Show first queued items for this tool with clickable links
++      const displayItems = toolQueue.slice(0, QUEUE_CONFIG.MAX_DISPLAY_ITEMS_PER_QUEUE);
+       for (const item of displayItems) {
+         const waitTime = formatDuration(item.getWaitTime(), { locale });
+-        message += `  • ${item.url} (${queueStatusLabel(item.status, locale)}, ${waitTime})\n`;
++        message += `  • ${formatQueueItemLink(item.url)} (${queueStatusLabel(item.status, locale)}, ${waitTime})\n`;
+         if (item.waitingReason) {
+           message += `    └ ${item.waitingReason}\n`;
+         }
+       }
+-      if (toolQueue.length > 5) {
+-        message += `    ... ${lt('queue_and_more', { count: toolQueue.length - 5 }, { locale })}\n`;
++      if (toolQueue.length > QUEUE_CONFIG.MAX_DISPLAY_ITEMS_PER_QUEUE) {
++        message += `    ... ${lt('queue_and_more', { count: toolQueue.length - QUEUE_CONFIG.MAX_DISPLAY_ITEMS_PER_QUEUE }, { locale })}\n`;
+       }
+ 
+       message += '\n';
+     }
+ 
++    // Completed / Failed lists - clickable links to the executed issues/PRs,
++    // most-recent-first so the newest results are easy to find (issue #1837).
++    const max = QUEUE_CONFIG.MAX_DISPLAY_ITEMS_PER_QUEUE;
++    message += formatQueueHistorySection({ items: this.completed, emoji: '✅', label: lt('queue_completed', {}, { locale }), max, locale });
++    message += formatQueueHistorySection({ items: this.failed, emoji: '❌', label: lt('queue_failed', {}, { locale }), max, locale, withError: true });
++
+     // Summary stats
+     message += `${lt('queue_completed', {}, { locale })}: ${stats.completed}, ${lt('queue_failed', {}, { locale })}: ${stats.failed}\n`;
+ 
+diff --git a/tests/solve-queue.test.mjs b/tests/solve-queue.test.mjs
+index 675370f3..9fb618d5 100644
+--- a/tests/solve-queue.test.mjs
++++ b/tests/solve-queue.test.mjs
+@@ -471,6 +471,72 @@ await asyncTest('formatDetailedStatus includes all sections', async () => {
+   queue.stop();
+ });
+ 
++// Issue #1837: the detailed status must show the actual executed issues/PRs as a
++// clickable list (not just counts), so stuck/running tasks are easy to find.
++await asyncTest('formatDetailedStatus renders clickable Markdown links for queued items (issue #1837)', async () => {
++  beforeEach();
++  const queue = new SolveQueue();
++
++  queue.enqueue({
++    url: 'https://github.com/test/repo/issues/42',
++    args: '',
++    requester: 'testuser',
++    infoBlock: 'Test info',
++  });
++
++  const status = await queue.formatDetailedStatus();
++
++  // Pending items should appear as a compact, clickable Markdown link
++  // [owner/repo#number](url) rather than a bare count.
++  assert.ok(
++    status.includes('[test/repo#42](https://github.com/test/repo/issues/42)'),
++    'Should render queued item as a clickable Markdown link'
++  );
++
++  queue.stop();
++});
++
++await asyncTest('formatDetailedStatus lists completed and failed items as clickable links (issue #1837)', async () => {
++  beforeEach();
++  const queue = new SolveQueue();
++
++  // Simulate one completed and one failed item directly in history.
++  const completedItem = queue.enqueue({
++    url: 'https://github.com/test/repo/pull/7',
++    args: '',
++    requester: 'testuser',
++    infoBlock: 'done',
++  });
++  const failedItem = queue.enqueue({
++    url: 'https://github.com/test/repo/issues/8',
++    args: '',
++    requester: 'testuser',
++    infoBlock: 'broke',
++  });
++  // Move them out of the pending queues into history.
++  for (const tool of Object.keys(queue.queues)) {
++    queue.queues[tool] = queue.queues[tool].filter((i) => i !== completedItem && i !== failedItem);
++  }
++  completedItem.status = QueueItemStatus.STARTED;
++  queue.completed.push(completedItem);
++  failedItem.setFailed(new Error('boom'));
++  queue.failed.push(failedItem);
++
++  const status = await queue.formatDetailedStatus();
++
++  assert.ok(
++    status.includes('[test/repo#7](https://github.com/test/repo/pull/7)'),
++    'Completed section should list the PR as a clickable link'
++  );
++  assert.ok(
++    status.includes('[test/repo#8](https://github.com/test/repo/issues/8)'),
++    'Failed section should list the issue as a clickable link'
++  );
++  assert.ok(status.includes('boom'), 'Failed item should include the error reason');
++
++  queue.stop();
++});
++
+ // ============================================================================
+ // Claude Process Detection Tests
+ // ============================================================================
+diff --git a/tests/test-solve-queue-command.mjs b/tests/test-solve-queue-command.mjs
+index 823fed00..4cc51040 100644
+--- a/tests/test-solve-queue-command.mjs
++++ b/tests/test-solve-queue-command.mjs
+@@ -148,11 +148,26 @@ test('Command regex does not match solve', () => {
+   assert.ok(!pattern.test('solve'), 'Should not match solve');
+ });
+ 
+-test('Command regex does not match queue', () => {
++test('Command regex matches queue (alias added in issue #1837)', () => {
+   const bot = createMockBot();
+   registerSolveQueueCommand(bot, createOptions());
+   const pattern = bot.registeredCommands[0].pattern;
+-  assert.ok(!pattern.test('queue'), 'Should not match queue');
++  assert.ok(pattern.test('queue'), 'Should match the /queue alias');
++});
++
++test('Command regex matches QUEUE (case insensitive alias)', () => {
++  const bot = createMockBot();
++  registerSolveQueueCommand(bot, createOptions());
++  const pattern = bot.registeredCommands[0].pattern;
++  assert.ok(pattern.test('QUEUE'), 'Should match the /QUEUE alias case-insensitively');
++});
++
++test('Command regex does not match unrelated commands like queued', () => {
++  const bot = createMockBot();
++  registerSolveQueueCommand(bot, createOptions());
++  const pattern = bot.registeredCommands[0].pattern;
++  assert.ok(!pattern.test('queued'), 'Should not match queued');
++  assert.ok(!pattern.test('myqueue'), 'Should not match myqueue');
+ });
+ 
+ // ============================================================================
+@@ -309,6 +324,11 @@ await asyncTest('telegram-bot.mjs includes solve_queue in text fallback handlers
+   assert.ok(content.includes('solve_queue: handleSolveQueueCommand'), 'Text fallback should include solve_queue handler');
+ });
+ 
++await asyncTest('telegram-bot.mjs includes /queue alias in text fallback handlers (issue #1837)', async () => {
++  const content = await readFile(join(__dirname, '..', 'src', 'telegram-bot.mjs'), 'utf-8');
++  assert.ok(content.includes('queue: handleSolveQueueCommand'), 'Text fallback should include the /queue alias handler');
++});
++
+ await asyncTest('telegram-solve-queue.lib.mjs uses /solve_queue in log messages (not /solve-queue)', async () => {
+   const content = await readFile(join(__dirname, '..', 'src', 'telegram-solve-queue.lib.mjs'), 'utf-8');
+   assert.ok(!content.includes('[VERBOSE] /solve-queue'), 'Should NOT use /solve-queue in VERBOSE log messages');

--- a/docs/case-studies/issue-1837/issue-1837.json
+++ b/docs/case-studies/issue-1837/issue-1837.json
@@ -1,0 +1,11 @@
+{
+  "author": { "id": "MDQ6VXNlcjE0MzE5MDQ=", "is_bot": false, "login": "konard", "name": "Konstantin Diachenko" },
+  "body": "```\n/solve_queue\n```\n\n```\n📋 Solve Queue Status\n\nclaude (pending: 0, processing: 1)\n\nagent (pending: 0, processing: 0)\n\ncodex (pending: 0, processing: 0)\n\nqwen (pending: 0, processing: 0)\n\ngemini (pending: 0, processing: 0)\n\nCompleted: 0, Failed: 1\n```\n\nNow I don't see actual list of executed issues/pull requests as clickable list, that must be fixed, and we we should add /queue as alias for it.\n\nIt will simplify search tasks that are stuck or yet executing.\n\nWe need to collect data related about the issue to this repository, make sure we compile that data to `./docs/case-studies/issue-{id}` folder, and use it to do deep case study analysis (also make sure to search online for additional facts and data), list of each and all requirements from the issue, and propose possible solutions and solution plans for each requirement (we should also check known existing components/libraries, that solve similar problem or can help in solutions).\n\nPlease plan and execute everything in this single pull request, you have unlimited time and context, as context auto-compacts and you can continue indefinitely, until it is each and every requirement fully addressed, and everything is totally done.\n",
+  "createdAt": "2026-05-29T20:08:56Z",
+  "labels": [
+    { "color": "0075ca", "description": "Improvements or additions to documentation", "id": "LA_kwDOPUU0qc8AAAACGYm6jw", "name": "documentation" },
+    { "color": "a2eeef", "description": "New feature or request", "id": "LA_kwDOPUU0qc8AAAACGYm6mA", "name": "enhancement" }
+  ],
+  "title": "/queue (alias of /solve_queue) improvements",
+  "url": "https://github.com/link-assistant/hive-mind/issues/1837"
+}

--- a/src/locales/en.lino
+++ b/src/locales/en.lino
@@ -515,7 +515,7 @@ en
           detail "Tool aliases imply `--tool <tool>`: `/codex <github-url>` equals `/solve <github-url> --tool codex`"
         reply "Or reply to a message with a GitHub link: `/solve`"
         disabled "*/solve* (aliases: */do*, */continue*, */claude*, */codex*, */opencode*, */agent*, */gemini*, */qwen*) - ❌ Disabled"
-        queue "`/solve_queue` - Show solve queue status"
+        queue "`/solve_queue` (alias: `/queue`) - Show solve queue status"
       locked
         options "🔒 Locked options: `{{options}}`"
       task

--- a/src/locales/hi.lino
+++ b/src/locales/hi.lino
@@ -515,7 +515,7 @@ hi
           detail "Tool aliases `--tool <tool>` लगाते हैं: `/codex <github-url>` का अर्थ `/solve <github-url> --tool codex` है"
         reply "या GitHub लिंक वाले संदेश का उत्तर दें: `/solve`"
         disabled "*/solve* (aliases: */do*, */continue*, */claude*, */codex*, */opencode*, */agent*, */gemini*, */qwen*) - ❌ अक्षम"
-        queue "`/solve_queue` - solve queue status दिखाएँ"
+        queue "`/solve_queue` (उपनाम: `/queue`) - solve queue status दिखाएँ"
       locked
         options "🔒 लॉक किए गए विकल्प: `{{options}}`"
       task

--- a/src/locales/ru.lino
+++ b/src/locales/ru.lino
@@ -515,7 +515,7 @@ ru
           detail "Алиасы инструментов добавляют `--tool <tool>`: `/codex <github-url>` равно `/solve <github-url> --tool codex`"
         reply "Или ответьте на сообщение со ссылкой GitHub: `/solve`"
         disabled "*/solve* (алиасы: */do*, */continue*, */claude*, */codex*, */opencode*, */agent*, */gemini*, */qwen*) - ❌ Отключено"
-        queue "`/solve_queue` - Показать состояние очереди solve"
+        queue "`/solve_queue` (псевдоним: `/queue`) - Показать состояние очереди solve"
       locked
         options "🔒 Заблокированные опции: `{{options}}`"
       task

--- a/src/locales/zh.lino
+++ b/src/locales/zh.lino
@@ -515,7 +515,7 @@ zh
           detail "工具别名会添加 `--tool <tool>`：`/codex <github-url>` 等同于 `/solve <github-url> --tool codex`"
         reply "也可以回复包含 GitHub 链接的消息：`/solve`"
         disabled "*/solve*（别名：*/do*、*/continue*、*/claude*、*/codex*、*/opencode*、*/agent*、*/gemini*、*/qwen*）- ❌ 已禁用"
-        queue "`/solve_queue` - 显示 solve 队列状态"
+        queue "`/solve_queue`（别名：`/queue`）- 显示 solve 队列状态"
       locked
         options "🔒 锁定选项：`{{options}}`"
       task

--- a/src/queue-config.lib.mjs
+++ b/src/queue-config.lib.mjs
@@ -280,6 +280,13 @@ export const QUEUE_CONFIG = {
 
   // Process detection
   CLAUDE_PROCESS_NAMES: ['claude'], // Process names to detect
+
+  // Display
+  // Maximum number of items shown per section (pending/processing/completed/failed)
+  // in the /solve_queue (/queue) detailed status before collapsing into a
+  // "... and N more" line. Keeps the Telegram message under the 4096-char cap.
+  // See: https://github.com/link-assistant/hive-mind/issues/1837
+  MAX_DISPLAY_ITEMS_PER_QUEUE: parseIntWithDefault('HIVE_MIND_MAX_DISPLAY_ITEMS_PER_QUEUE', 5),
 };
 
 /**

--- a/src/telegram-bot.mjs
+++ b/src/telegram-bot.mjs
@@ -1169,7 +1169,8 @@ bot.on('message', async (ctx, next) => {
   // /subscribe + /unsubscribe (#1688) are intentionally not in the text fallback — Telegraf's bot.command() is sufficient.
   const solveHandlers = Object.fromEntries(SOLVE_COMMAND_NAMES.map(command => [command, handleSolveCommand]));
   const taskHandlers = Object.fromEntries(TASK_COMMAND_NAMES.map(command => [command, handleTaskCommand]));
-  const handlers = { ...solveHandlers, ...taskHandlers, hive: handleHiveCommand, solve_queue: handleSolveQueueCommand, solvequeue: handleSolveQueueCommand };
+  // /queue is the short alias for /solve_queue (issue #1837)
+  const handlers = { ...solveHandlers, ...taskHandlers, hive: handleHiveCommand, solve_queue: handleSolveQueueCommand, solvequeue: handleSolveQueueCommand, queue: handleSolveQueueCommand };
 
   const handler = handlers[extracted.command];
   if (!handler) return next();

--- a/src/telegram-solve-queue-command.lib.mjs
+++ b/src/telegram-solve-queue-command.lib.mjs
@@ -97,11 +97,12 @@ export function registerSolveQueueCommand(bot, options) {
     });
   }
 
-  // Match /solve_queue, /solve-queue, or /solvequeue (case-insensitive)
+  // Match /solve_queue, /solve-queue, /solvequeue, or the short /queue alias (case-insensitive)
   // Note: Telegram Bot API only supports underscores in command names, not hyphens.
-  // The entity-based matching handles /solve_queue and /solvequeue.
+  // The entity-based matching handles /solve_queue, /solvequeue, and /queue.
   // /solve-queue is handled by the text-based fallback in telegram-bot.mjs (issue #1232).
-  bot.command(/^solve[_-]?queue$/i, handleSolveQueueCommand);
+  // The /queue alias was added in issue #1837 to make checking the queue faster to type.
+  bot.command(/^(?:solve[_-]?queue|queue)$/i, handleSolveQueueCommand);
 
   return { handleSolveQueueCommand };
 }

--- a/src/telegram-solve-queue.helpers.lib.mjs
+++ b/src/telegram-solve-queue.helpers.lib.mjs
@@ -7,6 +7,64 @@ import { lt } from './limits-i18n.lib.mjs';
 const execAsync = promisify(exec);
 
 /**
+ * Build a clickable, human-readable link to a queued issue/PR for the
+ * /solve_queue (/queue) detailed status (issue #1837).
+ *
+ * For GitHub issue/PR URLs we render a compact `[owner/repo#number](url)`
+ * Markdown link so the list is scannable and clickable. When the label would
+ * contain Markdown-special characters (e.g. `_` or `*` in an owner/repo name)
+ * that could break Telegram's legacy Markdown parser, we fall back to the bare
+ * URL — which Telegram still auto-links and renders as clickable.
+ *
+ * Non-GitHub or unparseable URLs also fall back to the bare URL.
+ *
+ * @param {string} url - The issue/PR URL.
+ * @returns {string} A Markdown link or bare URL safe for `parse_mode: 'Markdown'`.
+ */
+export function formatQueueItemLink(url) {
+  if (!url || typeof url !== 'string') return String(url ?? '');
+  const match = url.match(/github\.com\/([^/\s]+)\/([^/\s]+)\/(?:issues|pull)\/(\d+)/i);
+  if (!match) return url;
+  const [, owner, repo, number] = match;
+  const label = `${owner}/${repo}#${number}`;
+  // Only build a Markdown link when the label has no Markdown-special chars
+  // that would break the legacy parser inside link text. Otherwise the bare
+  // URL is still clickable in Telegram.
+  if (/^[A-Za-z0-9/#.-]+$/.test(label)) {
+    return `[${label}](${url})`;
+  }
+  return url;
+}
+
+/**
+ * Render a history section (Completed / Failed) for the detailed queue status
+ * as a clickable list, most-recent-first, capped at `max` items with a
+ * "... and N more" line (issue #1837).
+ *
+ * @param {object} opts
+ * @param {Array} opts.items - History items (each with `url`, optional `error`).
+ * @param {string} opts.emoji - Leading emoji for each row (e.g. '✅' or '❌').
+ * @param {string} opts.label - Localized section heading.
+ * @param {number} opts.max - Maximum items to list before collapsing.
+ * @param {string|null} opts.locale - Locale for the "and N more" label.
+ * @param {boolean} [opts.withError] - Append `— error` when the item failed.
+ * @returns {string} The formatted section (empty string when no items).
+ */
+export function formatQueueHistorySection({ items, emoji, label, max, locale, withError = false }) {
+  if (!items || items.length === 0) return '';
+  let section = `*${label}* (${items.length}):\n`;
+  for (const item of [...items].reverse().slice(0, max)) {
+    section += `  ${emoji} ${formatQueueItemLink(item.url)}`;
+    if (withError && item.error) section += ` — ${item.error}`;
+    section += '\n';
+  }
+  if (items.length > max) {
+    section += `    ... ${lt('queue_and_more', { count: items.length - max }, { locale })}\n`;
+  }
+  return `${section}\n`;
+}
+
+/**
  * Count running processes by name.
  * @param {string} processName - Process name to search for (e.g., 'claude', 'agent', 'codex', 'gemini')
  * @param {boolean} verbose - Whether to log verbose output

--- a/src/telegram-solve-queue.lib.mjs
+++ b/src/telegram-solve-queue.lib.mjs
@@ -17,7 +17,7 @@
 
 import { getCachedClaudeLimits, getCachedCodexLimits, getCachedGitHubLimits, getCachedMemoryInfo, getCachedCpuInfo, getCachedDiskInfo, getLimitCache } from './limits.lib.mjs';
 export { formatDuration, getRunningAgentProcesses, getRunningClaudeProcesses, getRunningCodexProcesses, getRunningGeminiProcesses, getRunningProcesses, getRunningQwenProcesses } from './telegram-solve-queue.helpers.lib.mjs';
-import { formatDuration, formatWaitingReason, getRunningAgentProcesses, getRunningClaudeProcesses, getRunningCodexProcesses, getRunningGeminiProcesses, getRunningProcesses, getRunningQwenProcesses } from './telegram-solve-queue.helpers.lib.mjs';
+import { formatDuration, formatQueueHistorySection, formatQueueItemLink, formatWaitingReason, getRunningAgentProcesses, getRunningClaudeProcesses, getRunningCodexProcesses, getRunningGeminiProcesses, getRunningProcesses, getRunningQwenProcesses } from './telegram-solve-queue.helpers.lib.mjs';
 export { QUEUE_CONFIG, THRESHOLD_STRATEGIES } from './queue-config.lib.mjs';
 import { QUEUE_CONFIG } from './queue-config.lib.mjs';
 import { formatExecutingWorkSessionMessage, formatStartingWorkSessionMessage } from './work-session-formatting.lib.mjs';
@@ -1320,28 +1320,17 @@ export class SolveQueue {
   }
 
   /**
-   * Format detailed queue status for Telegram message
-   * Groups output by tool queue, shows first 5 items per queue, and uses human-readable time.
+   * Format detailed queue status for Telegram message.
+   * Groups output by tool queue (clickable links per item), then lists the
+   * Completed and Failed history as clickable links, capped per section.
    *
    * Processing count = max(actual AI CLI processes via pgrep, tracked
    * `$ --status` executing screen-isolated sessions), not queue state.
    *
-   * Output format:
-   * ```
-   * 📋 Solve Queue Status
-   *
-   * claude (pending: 6, processing: 0)
-   * • url1 (waiting, 5h 43m 23s)
-   *   └ RAM usage is 70% (threshold: 65%)
-   * • url2 (queued, 2m 15s)
-   *
-   * agent (pending: 2, processing: 0)
-   * • url3 (waiting, 1h 2m 5s)
-   * ```
-   *
    * @returns {Promise<string>}
    * @see https://github.com/link-assistant/hive-mind/issues/1159
    * @see https://github.com/link-assistant/hive-mind/issues/1267
+   * @see https://github.com/link-assistant/hive-mind/issues/1837
    */
   async formatDetailedStatus(options = {}) {
     const locale = getLocale(options);
@@ -1359,21 +1348,36 @@ export class SolveQueue {
       const processing = externalProcessing.byTool[tool] || 0;
       message += `*${tool}* (${lt('queue_pending', {}, { locale })}: ${pending}, ${lt('queue_processing', {}, { locale })}: ${processing})\n`;
 
-      // Show first 5 queued items for this tool
-      const displayItems = toolQueue.slice(0, 5);
+      // Show the items this queue is actively processing for this tool, with a
+      // clickable link to each issue/PR (issue #1837). These come from the
+      // queue's own tracking, so they may differ from the pgrep-based count above.
+      const processingItems = Array.from(this.processing.values()).filter(item => item.tool === tool);
+      for (const item of processingItems.slice(0, QUEUE_CONFIG.MAX_DISPLAY_ITEMS_PER_QUEUE)) {
+        const waitTime = formatDuration(item.getWaitTime(), { locale });
+        message += `  ▶️ ${formatQueueItemLink(item.url)} (${queueStatusLabel(item.status, locale)}, ${waitTime})\n`;
+      }
+
+      // Show first queued items for this tool with clickable links
+      const displayItems = toolQueue.slice(0, QUEUE_CONFIG.MAX_DISPLAY_ITEMS_PER_QUEUE);
       for (const item of displayItems) {
         const waitTime = formatDuration(item.getWaitTime(), { locale });
-        message += `  • ${item.url} (${queueStatusLabel(item.status, locale)}, ${waitTime})\n`;
+        message += `  • ${formatQueueItemLink(item.url)} (${queueStatusLabel(item.status, locale)}, ${waitTime})\n`;
         if (item.waitingReason) {
           message += `    └ ${item.waitingReason}\n`;
         }
       }
-      if (toolQueue.length > 5) {
-        message += `    ... ${lt('queue_and_more', { count: toolQueue.length - 5 }, { locale })}\n`;
+      if (toolQueue.length > QUEUE_CONFIG.MAX_DISPLAY_ITEMS_PER_QUEUE) {
+        message += `    ... ${lt('queue_and_more', { count: toolQueue.length - QUEUE_CONFIG.MAX_DISPLAY_ITEMS_PER_QUEUE }, { locale })}\n`;
       }
 
       message += '\n';
     }
+
+    // Completed / Failed lists - clickable links to the executed issues/PRs,
+    // most-recent-first so the newest results are easy to find (issue #1837).
+    const max = QUEUE_CONFIG.MAX_DISPLAY_ITEMS_PER_QUEUE;
+    message += formatQueueHistorySection({ items: this.completed, emoji: '✅', label: lt('queue_completed', {}, { locale }), max, locale });
+    message += formatQueueHistorySection({ items: this.failed, emoji: '❌', label: lt('queue_failed', {}, { locale }), max, locale, withError: true });
 
     // Summary stats
     message += `${lt('queue_completed', {}, { locale })}: ${stats.completed}, ${lt('queue_failed', {}, { locale })}: ${stats.failed}\n`;

--- a/tests/solve-queue.test.mjs
+++ b/tests/solve-queue.test.mjs
@@ -473,57 +473,29 @@ await asyncTest('formatDetailedStatus includes all sections', async () => {
 
 // Issue #1837: the detailed status must show the actual executed issues/PRs as a
 // clickable list (not just counts), so stuck/running tasks are easy to find.
-await asyncTest('formatDetailedStatus renders clickable Markdown links for queued items (issue #1837)', async () => {
+await asyncTest('formatDetailedStatus renders clickable links for queued/completed/failed items (issue #1837)', async () => {
   beforeEach();
   const queue = new SolveQueue();
 
-  queue.enqueue({
-    url: 'https://github.com/test/repo/issues/42',
-    args: '',
-    requester: 'testuser',
-    infoBlock: 'Test info',
-  });
-
-  const status = await queue.formatDetailedStatus();
-
-  // Pending items should appear as a compact, clickable Markdown link
-  // [owner/repo#number](url) rather than a bare count.
-  assert.ok(status.includes('[test/repo#42](https://github.com/test/repo/issues/42)'), 'Should render queued item as a clickable Markdown link');
-
-  queue.stop();
-});
-
-await asyncTest('formatDetailedStatus lists completed and failed items as clickable links (issue #1837)', async () => {
-  beforeEach();
-  const queue = new SolveQueue();
-
-  // Simulate one completed and one failed item directly in history.
-  const completedItem = queue.enqueue({
-    url: 'https://github.com/test/repo/pull/7',
-    args: '',
-    requester: 'testuser',
-    infoBlock: 'done',
-  });
-  const failedItem = queue.enqueue({
-    url: 'https://github.com/test/repo/issues/8',
-    args: '',
-    requester: 'testuser',
-    infoBlock: 'broke',
-  });
-  // Move them out of the pending queues into history.
+  // One pending item, plus one completed + one failed item placed in history.
+  queue.enqueue({ url: 'https://github.com/test/repo/issues/42', args: '', requester: 'u', infoBlock: 'x' });
+  const done = queue.enqueue({ url: 'https://github.com/test/repo/pull/7', args: '', requester: 'u', infoBlock: 'd' });
+  const bad = queue.enqueue({ url: 'https://github.com/test/repo/issues/8', args: '', requester: 'u', infoBlock: 'b' });
   for (const tool of Object.keys(queue.queues)) {
-    queue.queues[tool] = queue.queues[tool].filter(i => i !== completedItem && i !== failedItem);
+    queue.queues[tool] = queue.queues[tool].filter(i => i !== done && i !== bad);
   }
-  completedItem.status = QueueItemStatus.STARTED;
-  queue.completed.push(completedItem);
-  failedItem.setFailed(new Error('boom'));
-  queue.failed.push(failedItem);
+  done.status = QueueItemStatus.STARTED;
+  queue.completed.push(done);
+  bad.setFailed(new Error('boom'));
+  queue.failed.push(bad);
 
   const status = await queue.formatDetailedStatus();
 
-  assert.ok(status.includes('[test/repo#7](https://github.com/test/repo/pull/7)'), 'Completed section should list the PR as a clickable link');
-  assert.ok(status.includes('[test/repo#8](https://github.com/test/repo/issues/8)'), 'Failed section should list the issue as a clickable link');
-  assert.ok(status.includes('boom'), 'Failed item should include the error reason');
+  // Items render as compact, clickable [owner/repo#number](url) links, not counts.
+  assert.ok(status.includes('[test/repo#42](https://github.com/test/repo/issues/42)'), 'queued item should be a clickable link');
+  assert.ok(status.includes('[test/repo#7](https://github.com/test/repo/pull/7)'), 'completed PR should be a clickable link');
+  assert.ok(status.includes('[test/repo#8](https://github.com/test/repo/issues/8)'), 'failed issue should be a clickable link');
+  assert.ok(status.includes('boom'), 'failed item should include the error reason');
 
   queue.stop();
 });

--- a/tests/solve-queue.test.mjs
+++ b/tests/solve-queue.test.mjs
@@ -471,6 +471,63 @@ await asyncTest('formatDetailedStatus includes all sections', async () => {
   queue.stop();
 });
 
+// Issue #1837: the detailed status must show the actual executed issues/PRs as a
+// clickable list (not just counts), so stuck/running tasks are easy to find.
+await asyncTest('formatDetailedStatus renders clickable Markdown links for queued items (issue #1837)', async () => {
+  beforeEach();
+  const queue = new SolveQueue();
+
+  queue.enqueue({
+    url: 'https://github.com/test/repo/issues/42',
+    args: '',
+    requester: 'testuser',
+    infoBlock: 'Test info',
+  });
+
+  const status = await queue.formatDetailedStatus();
+
+  // Pending items should appear as a compact, clickable Markdown link
+  // [owner/repo#number](url) rather than a bare count.
+  assert.ok(status.includes('[test/repo#42](https://github.com/test/repo/issues/42)'), 'Should render queued item as a clickable Markdown link');
+
+  queue.stop();
+});
+
+await asyncTest('formatDetailedStatus lists completed and failed items as clickable links (issue #1837)', async () => {
+  beforeEach();
+  const queue = new SolveQueue();
+
+  // Simulate one completed and one failed item directly in history.
+  const completedItem = queue.enqueue({
+    url: 'https://github.com/test/repo/pull/7',
+    args: '',
+    requester: 'testuser',
+    infoBlock: 'done',
+  });
+  const failedItem = queue.enqueue({
+    url: 'https://github.com/test/repo/issues/8',
+    args: '',
+    requester: 'testuser',
+    infoBlock: 'broke',
+  });
+  // Move them out of the pending queues into history.
+  for (const tool of Object.keys(queue.queues)) {
+    queue.queues[tool] = queue.queues[tool].filter(i => i !== completedItem && i !== failedItem);
+  }
+  completedItem.status = QueueItemStatus.STARTED;
+  queue.completed.push(completedItem);
+  failedItem.setFailed(new Error('boom'));
+  queue.failed.push(failedItem);
+
+  const status = await queue.formatDetailedStatus();
+
+  assert.ok(status.includes('[test/repo#7](https://github.com/test/repo/pull/7)'), 'Completed section should list the PR as a clickable link');
+  assert.ok(status.includes('[test/repo#8](https://github.com/test/repo/issues/8)'), 'Failed section should list the issue as a clickable link');
+  assert.ok(status.includes('boom'), 'Failed item should include the error reason');
+
+  queue.stop();
+});
+
 // ============================================================================
 // Claude Process Detection Tests
 // ============================================================================

--- a/tests/test-solve-queue-command.mjs
+++ b/tests/test-solve-queue-command.mjs
@@ -148,11 +148,26 @@ test('Command regex does not match solve', () => {
   assert.ok(!pattern.test('solve'), 'Should not match solve');
 });
 
-test('Command regex does not match queue', () => {
+test('Command regex matches queue (alias added in issue #1837)', () => {
   const bot = createMockBot();
   registerSolveQueueCommand(bot, createOptions());
   const pattern = bot.registeredCommands[0].pattern;
-  assert.ok(!pattern.test('queue'), 'Should not match queue');
+  assert.ok(pattern.test('queue'), 'Should match the /queue alias');
+});
+
+test('Command regex matches QUEUE (case insensitive alias)', () => {
+  const bot = createMockBot();
+  registerSolveQueueCommand(bot, createOptions());
+  const pattern = bot.registeredCommands[0].pattern;
+  assert.ok(pattern.test('QUEUE'), 'Should match the /QUEUE alias case-insensitively');
+});
+
+test('Command regex does not match unrelated commands like queued', () => {
+  const bot = createMockBot();
+  registerSolveQueueCommand(bot, createOptions());
+  const pattern = bot.registeredCommands[0].pattern;
+  assert.ok(!pattern.test('queued'), 'Should not match queued');
+  assert.ok(!pattern.test('myqueue'), 'Should not match myqueue');
 });
 
 // ============================================================================
@@ -307,6 +322,11 @@ await asyncTest('help message includes /solve_queue using backtick code block', 
 await asyncTest('telegram-bot.mjs includes solve_queue in text fallback handlers', async () => {
   const content = await readFile(join(__dirname, '..', 'src', 'telegram-bot.mjs'), 'utf-8');
   assert.ok(content.includes('solve_queue: handleSolveQueueCommand'), 'Text fallback should include solve_queue handler');
+});
+
+await asyncTest('telegram-bot.mjs includes /queue alias in text fallback handlers (issue #1837)', async () => {
+  const content = await readFile(join(__dirname, '..', 'src', 'telegram-bot.mjs'), 'utf-8');
+  assert.ok(content.includes('queue: handleSolveQueueCommand'), 'Text fallback should include the /queue alias handler');
 });
 
 await asyncTest('telegram-solve-queue.lib.mjs uses /solve_queue in log messages (not /solve-queue)', async () => {


### PR DESCRIPTION
## Summary

Implements issue #1837: the `/solve_queue` Telegram status command now shows the **actual executed issues/PRs as a clickable list** (not just counts), and adds **`/queue`** as a shorter alias.

Fixes #1837

## What changed

### 1. Clickable list of executed items
`SolveQueue.formatDetailedStatus()` previously printed only per-tool `pending`/`processing` counts plus a single `Completed: N, Failed: M` line. It now lists, per tool:
- `▶️` each **processing** item, `•` each **pending** item (with status + wait time + waiting reason)
- a **Completed** (`✅`) and **Failed** (`❌`, with the error reason) section, most-recent-first

Each item renders as a clickable Markdown link `[owner/repo#number](url)` via the new `formatQueueItemLink()` helper. When an owner/repo name contains Markdown-special characters it falls back to the bare URL (still auto-linked by Telegram). Each section is capped at `HIVE_MIND_MAX_DISPLAY_ITEMS_PER_QUEUE` (default **5**) with a localized `... and N more` line, to stay under Telegram's 4096-character message limit. The legacy `Completed: N, Failed: M` summary line is preserved.

### 2. `/queue` alias
- Command regex widened to `^(?:solve[_-]?queue|queue)$` (matches `/queue`, `/QUEUE`; still rejects `/queued`)
- Text-fallback handler map in `telegram-bot.mjs` gained `queue: handleSolveQueueCommand`
- Help text updated in `en`/`ru`/`zh`/`hi` locales

### 3. Deep case study
`docs/case-studies/issue-1837/` — requirement breakdown, root cause of the missing list, solution options, existing-component review, and online research (Telegram message limit + Markdown links). Includes the raw issue payload and full diff as data files.

## Before / After

**Before** (counts only — nothing clickable):
```
📋 Solve Queue Status

claude (pending: 0, processing: 1)
...
Completed: 0, Failed: 1
```

**After** (clickable links to each item):
```
📋 Solve Queue Status

claude (pending: 1, processing: 1)
  ▶️ owner/repo#12 (started, 3m 10s)
  • owner/repo#34 (waiting, 1m 2s)
...
Completed (3):
  ✅ owner/repo#7
Failed (1):
  ❌ owner/repo#8 — Error message text

Completed: 3, Failed: 1
```

## How to reproduce / verify
1. Run `/solve_queue` or the new `/queue` in an authorized Telegram chat with items in the queue/history — each issue/PR is now a tappable link.

## Tests
- `tests/solve-queue.test.mjs` (72 pass) — new tests for clickable links in pending/completed/failed sections
- `tests/test-solve-queue-command.mjs` (25 pass) — new tests for the `/queue` alias (regex + text fallback)
- Full default suite: **223 test files pass**; `npm run lint` clean
- Changeset added (`patch`)
