### PR TITLE
fix(solve): surface core tool error instead of bare `CLAUDE execution failed` (#1845)

### DIFF
--- a/.changeset/issue-1845-core-error-message.md
+++ b/.changeset/issue-1845-core-error-message.md
@@ -13,15 +13,24 @@ the failure-return boundary, so no downstream consumer could display it.
 
 Every AI tool runner now surfaces a structured `errorInfo` (with a `.message`)
 on its failure returns (`claude`, `gemini`, `opencode`, `qwen`; `codex` and
-`agent` already did). A new shared `formatToolExecutionFailure` helper in
-`lib.mjs` builds a self-explanatory message
-(`CLAUDE execution failed with API Error: Output blocked by content filtering
-policy`), and all failure-display sites — `solve.mjs` (terminal exit, GitHub
-failure comment, and the critical-error auto-commit reason),
-`solve.auto-merge.lib.mjs`, and `solve.watch.lib.mjs` — now use it. The helper
-collapses whitespace, caps the core error length, and never falls back to the
-agent's success summary.
+`agent` already did). Two shared helpers in `lib.mjs` — `extractToolErrorCore`
+(the core error string) and `formatToolExecutionFailure` (the full
+`CLAUDE execution failed with API Error: Output blocked by content filtering
+policy` message) — share one precedence so every surface stays consistent.
+All failure sites now use them: `solve.mjs` (terminal exit, GitHub failure
+comment, critical-error auto-commit reason), `solve.auto-merge.lib.mjs` and
+`solve.watch.lib.mjs` (GitHub message + new terminal `Error details:` lines),
+and `review.mjs`. The helpers collapse whitespace, cap the core error length,
+and never fall back to the agent's success summary.
 
-The existing auto-commit-on-critical-error path (#1834) is confirmed to run on
-the failure exit and is now labeled with the real failure cause. Adds unit and
-cross-tool tests and a deep case study in `docs/case-studies/issue-1845`.
+`isApiError` in `solve.restart-shared.lib.mjs` now classifies through the same
+extractor, so a Claude `API Error:` reported via `errorInfo` (never `result`)
+is detected and watch mode's `MAX_API_ERROR_RETRIES` backoff guard keeps
+working instead of retrying forever.
+
+The auto-commit-on-critical-error path (#1834) is confirmed to run on the
+failure exit and is now labeled with the real failure cause; the same guarded
+auto-commit is also added to `handleFailure()` so the `uncaughtException`,
+`unhandledRejection`, and top-level-catch exits preserve uncommitted work too.
+Adds unit, cross-tool, auto-commit, and `isApiError` tests plus a deep case
+study in `docs/case-studies/issue-1845`.

--- a/.changeset/issue-1845-core-error-message.md
+++ b/.changeset/issue-1845-core-error-message.md
@@ -1,0 +1,27 @@
+---
+'@link-assistant/hive-mind': patch
+---
+
+fix(solve): surface the core tool error instead of bare `CLAUDE execution failed` (#1845)
+
+When an AI tool run failed, both the terminal and the posted GitHub
+`🚨 Solution Draft Failed` comment showed only the generic
+`CLAUDE execution failed`, even though the underlying tool had reported a
+specific cause (for example `API Error: Output blocked by content filtering
+policy`). The real message was captured inside the tool runner but dropped at
+the failure-return boundary, so no downstream consumer could display it.
+
+Every AI tool runner now surfaces a structured `errorInfo` (with a `.message`)
+on its failure returns (`claude`, `gemini`, `opencode`, `qwen`; `codex` and
+`agent` already did). A new shared `formatToolExecutionFailure` helper in
+`lib.mjs` builds a self-explanatory message
+(`CLAUDE execution failed with API Error: Output blocked by content filtering
+policy`), and all failure-display sites — `solve.mjs` (terminal exit, GitHub
+failure comment, and the critical-error auto-commit reason),
+`solve.auto-merge.lib.mjs`, and `solve.watch.lib.mjs` — now use it. The helper
+collapses whitespace, caps the core error length, and never falls back to the
+agent's success summary.
+
+The existing auto-commit-on-critical-error path (#1834) is confirmed to run on
+the failure exit and is now labeled with the real failure cause. Adds unit and
+cross-tool tests and a deep case study in `docs/case-studies/issue-1845`.

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,1 +1,0 @@
-# .gitkeep file auto-generated at 2026-05-30T17:30:24.835Z for PR creation at branch issue-1845-cd4f58dbfe8f for issue https://github.com/link-assistant/hive-mind/issues/1845

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,0 +1,1 @@
+# .gitkeep file auto-generated at 2026-05-30T17:30:24.835Z for PR creation at branch issue-1845-cd4f58dbfe8f for issue https://github.com/link-assistant/hive-mind/issues/1845

--- a/docs/case-studies/issue-1845/README.md
+++ b/docs/case-studies/issue-1845/README.md
@@ -15,7 +15,7 @@ Each requirement is tracked with its status in this PR.
 | #   | Requirement                                                                                                                                                                                                                     | Status                                                                                                |
 | --- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------- |
 | R1  | Show the **core error message** to the user: instead of `CLAUDE execution failed`, show `CLAUDE execution failed with API Error: Output blocked by content filtering policy`, so the user has a rough idea what went wrong.     | ✅ Implemented                                                                                        |
-| R2  | On **all failures**, automatically commit (and push) uncommitted changes.                                                                                                                                                       | ✅ Verified / wired to the improved message                                                           |
+| R2  | On **all failures**, automatically commit (and push) uncommitted changes.                                                                                                                                                       | ✅ Tool-failure path verified + **exception/rejection/main-error paths gap closed** (see §4.4)        |
 | R3  | Download all logs/data about the issue into `./docs/case-studies/issue-1845/` and do a **deep case study** (timeline, requirement list, root causes, solution plans, known libraries). Also search online for additional facts. | ✅ This document                                                                                      |
 | R4  | If there is **not enough data** to find the root cause, add debug output / verbose mode for the next iteration.                                                                                                                 | ✅ Root cause found; verbose tracing already present and confirmed sufficient                         |
 | R5  | If the issue relates to **another repository/project**, report it there with reproducible examples, workarounds, and fix suggestions.                                                                                           | ✅ Analyzed — see §7 (upstream is Anthropic Claude CLI behavior; no hive-mind bug to report upstream) |
@@ -97,11 +97,12 @@ The same pattern existed across **every** AI tool runner except `codex` and `age
 - `opencode.lib.mjs` — 3 failure returns
 - `qwen.lib.mjs` — 2 non-limit failure returns
 
-And the consumption side had three independent display/exit/log sites:
+And the consumption side had four independent display/exit/log sites:
 
 - `solve.mjs` (terminal exit + GitHub failure comment + auto-commit reason)
 - `solve.auto-merge.lib.mjs` (auto-merge resume + general failure)
 - `solve.watch.lib.mjs` (watch-mode failure)
+- `review.mjs` (review-command failure)
 
 A fix in only one place would have left the bug in the others — matching R6's "fix it in all of them."
 
@@ -120,17 +121,25 @@ Each tool runner's failure return now includes a structured
 - `qwen.lib.mjs` — `errorInfo: { message: combinedErrorText || errorMessage || ... }` + exception case.
 - `codex.lib.mjs` / `agent.lib.mjs` — already returned structured error info; left as-is (their `errorInfo.message` is compatible).
 
-### 4.2 Shared formatter — single source of truth
+### 4.2 Shared extractor + formatter — single source of truth
 
-A new exported helper in `src/lib.mjs`:
+Two exported helpers in `src/lib.mjs` share **one** precedence so every failure
+surface shows the same root cause and they can never diverge:
 
 ```js
-export const formatToolExecutionFailure = ({ tool, toolResult, maxLength = 300 } = {}) => {
-  const base = `${(tool || 'claude').toUpperCase()} execution failed`;
+// Returns just the core error string (no prefix), or null when none is available.
+export const extractToolErrorCore = ({ toolResult } = {}) => {
   const errorInfo = toolResult?.errorInfo;
   const rawCore = errorInfo?.message || errorInfo?.errorMatch || (typeof errorInfo === 'string' ? errorInfo : null) || toolResult?.result || null;
-  if (!rawCore || typeof rawCore !== 'string') return base;
-  let core = rawCore.replace(/\s+/g, ' ').trim();
+  if (!rawCore || typeof rawCore !== 'string') return null;
+  const core = rawCore.replace(/\s+/g, ' ').trim();
+  return core || null;
+};
+
+// Builds the full "<TOOL> execution failed with <core>" message for comments/exit.
+export const formatToolExecutionFailure = ({ tool, toolResult, maxLength = 300 } = {}) => {
+  const base = `${(tool || 'claude').toUpperCase()} execution failed`;
+  let core = extractToolErrorCore({ toolResult });
   if (!core) return base;
   if (core.toLowerCase().includes('execution failed')) return base; // avoid duplication
   if (core.length > maxLength) core = `${core.slice(0, maxLength - 1)}…`;
@@ -142,14 +151,18 @@ Design decisions:
 
 - **Does not** fall back to `resultSummary` — that field holds the agent's _normal_ work summary on success, and would be misleading as an "error."
 - Collapses whitespace/newlines to a single clean line.
-- Caps at 300 chars to keep terminal/comment output readable.
+- Caps at 300 chars (in the formatter) to keep terminal/comment output readable.
 - Avoids duplicating the base phrase when the core already contains "execution failed."
+- `extractToolErrorCore` is the shared root-cause extractor reused by the terminal
+  "Error details:" lines (watch / auto-merge / review) so they show the **same**
+  core error as the GitHub comment, without the "<TOOL> execution failed with" prefix.
 
-### 4.3 Consumer side — all three display sites use the helper
+### 4.3 Consumer side — every display / exit / log site shows the core error
 
 - `solve.mjs`: terminal exit message, GitHub failure-comment `errorMessage`, and the auto-commit `reason` all use `formatToolExecutionFailure(...)`.
-- `solve.auto-merge.lib.mjs`: resume-failure and general-failure `errorMessage`.
-- `solve.watch.lib.mjs`: watch-mode failure `errorMessage`.
+- `solve.auto-merge.lib.mjs`: resume-failure and general-failure GitHub `errorMessage` use `formatToolExecutionFailure`; the **terminal** `RESUME FAILED` / `EXECUTION FAILED` blocks now also print an `Error details:` line via `extractToolErrorCore(...)`.
+- `solve.watch.lib.mjs`: watch-mode failure GitHub `errorMessage` uses `formatToolExecutionFailure`; the **terminal** `MAXIMUM API ERROR RETRIES REACHED` block's `Error details:` line now uses `extractToolErrorCore(...)` instead of `toolResult.result` (which is frequently unset on Claude failures, so it previously printed "Unknown API error").
+- `review.mjs`: the generic `❌ Command execution failed. Check the log file for details.` now appends the core error via `extractToolErrorCore(...)` when one is available.
 
 **Result:** for the exact scenario in this issue, the user now sees
 
@@ -157,7 +170,8 @@ Design decisions:
 CLAUDE execution failed with API Error: Output blocked by content filtering policy
 ```
 
-both in the terminal and in the posted GitHub failure comment.
+both in the terminal and in the posted GitHub failure comment — and the same core
+string appears in the watch / auto-merge "Error details:" terminal lines.
 
 ### 4.4 Auto-commit on all failures (R2)
 
@@ -167,13 +181,36 @@ Issue #1834 already added `commitUncommittedChangesOnCriticalError` (gated by
 failure-exit block of `solve.mjs` (before `safeExit(1, ...)`) and again at the
 general post-session chokepoint for limit/error cases. This PR routes the
 improved failure message into the commit `reason`, so the auto-commit is both
-**guaranteed on the failure path** and **labeled with the real cause**.
+**guaranteed on the tool-failure path** and **labeled with the real cause**.
+
+**Gap closed in this PR.** The tool-failure chokepoint in `solve.mjs` only covers
+the _graceful_ failure path. Three other exits bypassed it entirely and could
+leave the agent's work uncommitted on disk:
+
+- `uncaughtException` (`createUncaughtExceptionHandler`)
+- `unhandledRejection` (`createUnhandledRejectionHandler`)
+- the top-level `catch` in `solve.mjs` (`handleMainExecutionError`)
+
+All three funnel through `handleFailure()` in `src/solve.error-handlers.lib.mjs`,
+so this PR adds the **same guarded auto-commit at the very start of
+`handleFailure()`** — before issue creation / log attachment / PR close. It is
+gated by the identical config flag and only acts when `cleanupContext.tempDir`
+is set (a working tree exists). To make the working-tree state reachable from the
+exception handlers, `solve.mjs` now threads the in-place-mutated `cleanupContext`
+object into `errorHandlerOptions` and the `handleMainExecutionError` call. The
+step is best-effort: a commit/push failure is swallowed (logged at verbose level)
+so it can never mask the original error that triggered the exit.
+
+This is verified by `tests/test-issue-1845-failure-auto-commit.mjs` (6 tests):
+commit+push on a dirty tree, no-commit on a clean tree, skip when
+`cleanupContext` is absent or has no `tempDir`, never-throws when git fails, and
+the config default being `true`.
 
 ---
 
 ## 5. Tests
 
-`tests/format-tool-execution-failure-1845.test.mjs` (21 assertions) reproduces
+`tests/format-tool-execution-failure-1845.test.mjs` (27 assertions) reproduces
 the bug and locks in the fix:
 
 - The exact issue example (`API Error: Output blocked by content filtering policy`).
@@ -183,6 +220,14 @@ the bug and locks in the fix:
 - **Cross-tool result-shape tests** confirming the helper extracts the message
   from the real shapes returned by claude / codex (`getCodexErrorEventSummary`)
   / gemini / opencode / qwen / agent.
+- **`extractToolErrorCore` tests** (the shared extractor used by the terminal
+  "Error details:" lines): core extraction, the `message → errorMatch → string →
+result` precedence, whitespace collapsing, null cases, and that it does **not**
+  use `resultSummary`.
+
+`tests/test-issue-1845-failure-auto-commit.mjs` (6 assertions) locks in R2 for
+the exception/rejection/main-error paths by driving `handleFailure()` with a
+scriptable `$` command-stream double — see §4.4.
 
 ---
 
@@ -218,15 +263,18 @@ the bug and locks in the fix:
 
 ## 8. Files changed
 
-| File                                                | Change                                                                                 |
-| --------------------------------------------------- | -------------------------------------------------------------------------------------- |
-| `src/lib.mjs`                                       | Added exported `formatToolExecutionFailure` helper                                     |
-| `src/claude.lib.mjs`                                | Added `errorInfo` to all 4 failure returns                                             |
-| `src/gemini.lib.mjs`                                | Added `errorInfo` to command-failed + exception returns                                |
-| `src/opencode.lib.mjs`                              | Added `errorInfo` to 3 failure returns                                                 |
-| `src/qwen.lib.mjs`                                  | Added `errorInfo` to command-failed + exception returns                                |
-| `src/solve.mjs`                                     | Use `formatToolExecutionFailure` for terminal exit, GitHub comment, auto-commit reason |
-| `src/solve.auto-merge.lib.mjs`                      | Use the helper for resume + general failure messages                                   |
-| `src/solve.watch.lib.mjs`                           | Use the helper for watch-mode failure message                                          |
-| `tests/format-tool-execution-failure-1845.test.mjs` | New unit + cross-tool tests                                                            |
-| `docs/case-studies/issue-1845/`                     | This case study + raw failure log                                                      |
+| File                                                | Change                                                                                                                                         |
+| --------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------- |
+| `src/lib.mjs`                                       | Added exported `extractToolErrorCore` extractor + `formatToolExecutionFailure` helper (formatter reuses extractor)                             |
+| `src/claude.lib.mjs`                                | Added `errorInfo` to all 4 failure returns                                                                                                     |
+| `src/gemini.lib.mjs`                                | Added `errorInfo` to command-failed + exception returns                                                                                        |
+| `src/opencode.lib.mjs`                              | Added `errorInfo` to 3 failure returns                                                                                                         |
+| `src/qwen.lib.mjs`                                  | Added `errorInfo` to command-failed + exception returns                                                                                        |
+| `src/solve.mjs`                                     | Use `formatToolExecutionFailure` for terminal exit / GitHub comment / auto-commit reason; thread `cleanupContext` into the error handlers (R2) |
+| `src/solve.auto-merge.lib.mjs`                      | Helper for resume + general failure GitHub messages; new `Error details:` terminal line via `extractToolErrorCore`                             |
+| `src/solve.watch.lib.mjs`                           | Helper for watch-mode GitHub message; `Error details:` terminal line now uses `extractToolErrorCore`                                           |
+| `src/review.mjs`                                    | Append the core error to the generic `Command execution failed` message via `extractToolErrorCore`                                             |
+| `src/solve.error-handlers.lib.mjs`                  | `handleFailure()` auto-commits uncommitted work (R2) on exception / rejection / main-error exits before exiting                                |
+| `tests/format-tool-execution-failure-1845.test.mjs` | Unit + cross-tool tests + `extractToolErrorCore` tests (27)                                                                                    |
+| `tests/test-issue-1845-failure-auto-commit.mjs`     | New tests for the R2 exception-path auto-commit in `handleFailure()` (6)                                                                       |
+| `docs/case-studies/issue-1845/`                     | This case study + raw failure log                                                                                                              |

--- a/docs/case-studies/issue-1845/README.md
+++ b/docs/case-studies/issue-1845/README.md
@@ -1,0 +1,232 @@
+# Case Study — Issue #1845: Surface the core error message instead of bare `CLAUDE execution failed`
+
+- **Issue:** [#1845 — We need to show users core error message, not just `CLAUDE execution failed`](https://github.com/link-assistant/hive-mind/issues/1845)
+- **Pull Request:** [#1846](https://github.com/link-assistant/hive-mind/pull/1846)
+- **Label:** `bug`
+- **Reported from:** [xlabtg/teleton-agent#519 (comment 4583539585)](https://github.com/xlabtg/teleton-agent/pull/519#issuecomment-4583539585)
+- **Date analyzed:** 2026-05-30
+
+---
+
+## 1. Requirements extracted from the issue
+
+Each requirement is tracked with its status in this PR.
+
+| #   | Requirement                                                                                                                                                                                                                     | Status                                                                                                |
+| --- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------- |
+| R1  | Show the **core error message** to the user: instead of `CLAUDE execution failed`, show `CLAUDE execution failed with API Error: Output blocked by content filtering policy`, so the user has a rough idea what went wrong.     | ✅ Implemented                                                                                        |
+| R2  | On **all failures**, automatically commit (and push) uncommitted changes.                                                                                                                                                       | ✅ Verified / wired to the improved message                                                           |
+| R3  | Download all logs/data about the issue into `./docs/case-studies/issue-1845/` and do a **deep case study** (timeline, requirement list, root causes, solution plans, known libraries). Also search online for additional facts. | ✅ This document                                                                                      |
+| R4  | If there is **not enough data** to find the root cause, add debug output / verbose mode for the next iteration.                                                                                                                 | ✅ Root cause found; verbose tracing already present and confirmed sufficient                         |
+| R5  | If the issue relates to **another repository/project**, report it there with reproducible examples, workarounds, and fix suggestions.                                                                                           | ✅ Analyzed — see §7 (upstream is Anthropic Claude CLI behavior; no hive-mind bug to report upstream) |
+| R6  | **Apply the fix across the entire codebase** — if the problem exists in multiple places, fix all of them.                                                                                                                       | ✅ All tool runners + all failure-display sites                                                       |
+| R7  | Plan and execute everything in the **single PR #1846**.                                                                                                                                                                         | ✅                                                                                                    |
+
+---
+
+## 2. Timeline / sequence of events
+
+Reconstructed from the failure log in [`raw-data/solution-draft-log.txt`](./raw-data/solution-draft-log.txt) (downloaded from the Gist linked in the upstream failure comment). All timestamps UTC.
+
+| Time                    | Event                                                                                                                                                                                                            | Log evidence                      |
+| ----------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | --------------------------------- |
+| 17:18:21                | AI work session started on `xlabtg/teleton-agent#519`.                                                                                                                                                           | "AI Work Session Started" comment |
+| 17:18:32                | Claude CLI session begins; session id `45441128-80e2-48c1-a2ea-f81ede05030b`.                                                                                                                                    | line 564, 651                     |
+| 17:18:34 – 17:20:40     | 18 turns of normal streamed `assistant`/`tool` messages, all `"is_error": false`.                                                                                                                                | lines 957–4900                    |
+| 17:20:40.898            | Claude CLI emits an **assistant message** whose text is `API Error: Output blocked by content filtering policy`, with top-level `"error": "unknown"`.                                                            | line 5097, 5105                   |
+| 17:20:40.901            | Claude CLI emits the **result event**: `"subtype": "success"`, **`"is_error": true`**, `"num_turns": 18`, `"result": "API Error: Output blocked by content filtering policy"`, `"stop_reason": "stop_sequence"`. | lines 5108–5117                   |
+| 17:20:40.902            | hive-mind captures result summary; logs `📝 Captured result summary from Claude output`.                                                                                                                         | line 5169                         |
+| 17:20:40.903            | hive-mind detects the error: `⚠️ Detected error from Claude CLI (subtype: success)`.                                                                                                                             | line 5171                         |
+| 17:20:41.280            | Exit code updated to `1` from command result.                                                                                                                                                                    | line 5173                         |
+| 17:20:41.281            | Terminal shows `❌ Claude command failed with exit code 1`.                                                                                                                                                      | line 5176                         |
+| 17:20:41.306            | hive-mind begins `📄 Attaching failure logs to Pull Request...`.                                                                                                                                                 | line 5202                         |
+| (earlier run, 17:00:06) | The posted GitHub failure comment shows only ` ```CLAUDE execution failed``` ` — **the captured core error never reached the user**.                                                                             | embedded comment at line 163      |
+
+**Key observation:** the real error string (`API Error: Output blocked by content filtering policy`) _was_ captured inside `claude.lib.mjs` (`lastMessage`/`result`), but it was **dropped** before the user-facing layer. The terminal and the GitHub comment showed only the generic `CLAUDE execution failed`.
+
+---
+
+## 3. Root cause analysis
+
+### 3.1 Where the real error lives
+
+In `src/claude.lib.mjs`, the streamed `result` event sets:
+
+```js
+if (data.is_error === true) {
+  lastMessage = data.result || JSON.stringify(data);   // "API Error: Output blocked by content filtering policy"
+  ...
+  await log(`⚠️ Detected error from Claude CLI (subtype: ${subtype})`, { verbose: true });
+}
+```
+
+So `lastMessage` correctly held the meaningful error.
+
+### 3.2 Where it was lost (the bug)
+
+The failure `return` objects from the tool runner only reported `success: false` and **did not carry the captured error message**. For example, the main command-failed return contained no `errorInfo`. The caller in `src/solve.mjs` then built the user-facing message from a hardcoded template:
+
+```js
+// BEFORE — solve.mjs
+const toolForFailure = argv.tool || 'claude';
+// ... only ever produced:
+`${toolForFailure.toUpperCase()} execution failed`;
+```
+
+This same generic string was passed as `errorMessage` to `attachLogToGitHub`, which renders it verbatim inside the `🚨 Solution Draft Failed` comment (`src/github.lib.mjs`):
+
+```
+## 🚨 Solution Draft Failed
+The automated solution draft encountered an error:
+```
+
+CLAUDE execution failed
+
+```
+
+```
+
+**Root cause:** a _data-propagation gap_ — the tool runners discarded the captured core error (`lastMessage`) at their failure-return boundary, so every downstream consumer (terminal exit message, GitHub failure comment, auto-commit reason) could only fall back to the generic phrase.
+
+### 3.3 Why it affected multiple places (R6)
+
+The same pattern existed across **every** AI tool runner except `codex` and `agent` (which already returned a structured `errorInfo`):
+
+- `claude.lib.mjs` — 4 failure returns, none carried the error
+- `gemini.lib.mjs` — 2 failure returns
+- `opencode.lib.mjs` — 3 failure returns
+- `qwen.lib.mjs` — 2 non-limit failure returns
+
+And the consumption side had three independent display/exit/log sites:
+
+- `solve.mjs` (terminal exit + GitHub failure comment + auto-commit reason)
+- `solve.auto-merge.lib.mjs` (auto-merge resume + general failure)
+- `solve.watch.lib.mjs` (watch-mode failure)
+
+A fix in only one place would have left the bug in the others — matching R6's "fix it in all of them."
+
+---
+
+## 4. Solution implemented
+
+### 4.1 Producer side — every runner now surfaces `errorInfo`
+
+Each tool runner's failure return now includes a structured
+`errorInfo: { message, exitCode? }` carrying the captured core error:
+
+- `claude.lib.mjs` — `errorInfo: { message: lastMessage || \`Claude command failed with exit code ${exitCode}\`, exitCode }` on all 4 failure returns (stuck-retry, transient-persisted, command-failed, exception).
+- `gemini.lib.mjs` — `errorInfo: { message: errorText || ... }` + exception case.
+- `opencode.lib.mjs` — `errorInfo` on permission-prompt, command-failed, and exception returns.
+- `qwen.lib.mjs` — `errorInfo: { message: combinedErrorText || errorMessage || ... }` + exception case.
+- `codex.lib.mjs` / `agent.lib.mjs` — already returned structured error info; left as-is (their `errorInfo.message` is compatible).
+
+### 4.2 Shared formatter — single source of truth
+
+A new exported helper in `src/lib.mjs`:
+
+```js
+export const formatToolExecutionFailure = ({ tool, toolResult, maxLength = 300 } = {}) => {
+  const base = `${(tool || 'claude').toUpperCase()} execution failed`;
+  const errorInfo = toolResult?.errorInfo;
+  const rawCore = errorInfo?.message || errorInfo?.errorMatch || (typeof errorInfo === 'string' ? errorInfo : null) || toolResult?.result || null;
+  if (!rawCore || typeof rawCore !== 'string') return base;
+  let core = rawCore.replace(/\s+/g, ' ').trim();
+  if (!core) return base;
+  if (core.toLowerCase().includes('execution failed')) return base; // avoid duplication
+  if (core.length > maxLength) core = `${core.slice(0, maxLength - 1)}…`;
+  return `${base} with ${core}`;
+};
+```
+
+Design decisions:
+
+- **Does not** fall back to `resultSummary` — that field holds the agent's _normal_ work summary on success, and would be misleading as an "error."
+- Collapses whitespace/newlines to a single clean line.
+- Caps at 300 chars to keep terminal/comment output readable.
+- Avoids duplicating the base phrase when the core already contains "execution failed."
+
+### 4.3 Consumer side — all three display sites use the helper
+
+- `solve.mjs`: terminal exit message, GitHub failure-comment `errorMessage`, and the auto-commit `reason` all use `formatToolExecutionFailure(...)`.
+- `solve.auto-merge.lib.mjs`: resume-failure and general-failure `errorMessage`.
+- `solve.watch.lib.mjs`: watch-mode failure `errorMessage`.
+
+**Result:** for the exact scenario in this issue, the user now sees
+
+```
+CLAUDE execution failed with API Error: Output blocked by content filtering policy
+```
+
+both in the terminal and in the posted GitHub failure comment.
+
+### 4.4 Auto-commit on all failures (R2)
+
+Issue #1834 already added `commitUncommittedChangesOnCriticalError` (gated by
+`config.lib.mjs` → `criticalErrorRecovery.autoCommitUncommittedChanges`, env
+`HIVE_MIND_AUTO_COMMIT_ON_CRITICAL_ERROR`, default `true`). It runs in the
+failure-exit block of `solve.mjs` (before `safeExit(1, ...)`) and again at the
+general post-session chokepoint for limit/error cases. This PR routes the
+improved failure message into the commit `reason`, so the auto-commit is both
+**guaranteed on the failure path** and **labeled with the real cause**.
+
+---
+
+## 5. Tests
+
+`tests/format-tool-execution-failure-1845.test.mjs` (21 assertions) reproduces
+the bug and locks in the fix:
+
+- The exact issue example (`API Error: Output blocked by content filtering policy`).
+- Generic fallback when no `errorInfo` is present.
+- `resultSummary` is **not** used as an error.
+- Whitespace collapsing, truncation, duplicate-phrase avoidance.
+- **Cross-tool result-shape tests** confirming the helper extracts the message
+  from the real shapes returned by claude / codex (`getCodexErrorEventSummary`)
+  / gemini / opencode / qwen / agent.
+
+---
+
+## 6. Known components / libraries considered (R3)
+
+- **`cleanErrorMessage` (existing in `src/lib.mjs`)** — strips shell noise from
+  `Error` objects. Reused conceptually; the new helper does its own light
+  normalization tuned for tool-result strings rather than exceptions.
+- **`getCodexErrorEventSummary` (existing in `src/codex.lib.mjs`)** — already the
+  "structured error" pattern; the fix generalizes the same idea (`errorInfo`
+  object with a `.message`) to all runners, so no new dependency is needed.
+- **`commitUncommittedChangesOnCriticalError` (existing, Issue #1834)** — reused
+  for R2 instead of writing new auto-commit logic.
+- No external npm library was warranted: this is an internal data-propagation
+  fix, and adding a dependency for string formatting would be over-engineering.
+
+---
+
+## 7. Upstream / cross-repo analysis (R5)
+
+- The originating run was on **`xlabtg/teleton-agent#519`**, but that repo only
+  _consumed_ hive-mind; the bug (dropping the error message) is entirely in
+  **this** repo, so it is fixed here.
+- The underlying `API Error: Output blocked by content filtering policy` is a
+  **server-side content-filtering response from Anthropic's Claude API/CLI**,
+  surfaced as `result` with `is_error: true`, `subtype: success`,
+  `stop_reason: stop_sequence`. This is _expected upstream behavior_, not a
+  hive-mind defect — there is no reproducible hive-mind bug to file against the
+  Claude CLI. The correct hive-mind behavior is exactly what this PR does:
+  faithfully surface that message to the user. No external issue is required.
+
+---
+
+## 8. Files changed
+
+| File                                                | Change                                                                                 |
+| --------------------------------------------------- | -------------------------------------------------------------------------------------- |
+| `src/lib.mjs`                                       | Added exported `formatToolExecutionFailure` helper                                     |
+| `src/claude.lib.mjs`                                | Added `errorInfo` to all 4 failure returns                                             |
+| `src/gemini.lib.mjs`                                | Added `errorInfo` to command-failed + exception returns                                |
+| `src/opencode.lib.mjs`                              | Added `errorInfo` to 3 failure returns                                                 |
+| `src/qwen.lib.mjs`                                  | Added `errorInfo` to command-failed + exception returns                                |
+| `src/solve.mjs`                                     | Use `formatToolExecutionFailure` for terminal exit, GitHub comment, auto-commit reason |
+| `src/solve.auto-merge.lib.mjs`                      | Use the helper for resume + general failure messages                                   |
+| `src/solve.watch.lib.mjs`                           | Use the helper for watch-mode failure message                                          |
+| `tests/format-tool-execution-failure-1845.test.mjs` | New unit + cross-tool tests                                                            |
+| `docs/case-studies/issue-1845/`                     | This case study + raw failure log                                                      |

--- a/docs/case-studies/issue-1845/README.md
+++ b/docs/case-studies/issue-1845/README.md
@@ -106,6 +106,15 @@ And the consumption side had four independent display/exit/log sites:
 
 A fix in only one place would have left the bug in the others — matching R6's "fix it in all of them."
 
+A deeper audit for R6 found a **fifth** consumer that read the same dropped field for a
+different purpose: `isApiError()` in `src/solve.restart-shared.lib.mjs` classified a failure
+as an API error by scanning `toolResult.result` only. Because Claude (and now gemini /
+opencode / qwen) report failures via `errorInfo` and never set `result`, a real
+`API Error:` from Claude was misclassified as **non-API**. The watch-mode loop
+(`solve.watch.lib.mjs`) then reset its consecutive-API-error counter and could retry a hard
+API error indefinitely, defeating the `MAX_API_ERROR_RETRIES` infinite-loop guard. The same
+"reads `result`, ignores `errorInfo`" root cause, so it is fixed the same way (see §4.3).
+
 ---
 
 ## 4. Solution implemented
@@ -163,6 +172,7 @@ Design decisions:
 - `solve.auto-merge.lib.mjs`: resume-failure and general-failure GitHub `errorMessage` use `formatToolExecutionFailure`; the **terminal** `RESUME FAILED` / `EXECUTION FAILED` blocks now also print an `Error details:` line via `extractToolErrorCore(...)`.
 - `solve.watch.lib.mjs`: watch-mode failure GitHub `errorMessage` uses `formatToolExecutionFailure`; the **terminal** `MAXIMUM API ERROR RETRIES REACHED` block's `Error details:` line now uses `extractToolErrorCore(...)` instead of `toolResult.result` (which is frequently unset on Claude failures, so it previously printed "Unknown API error").
 - `review.mjs`: the generic `❌ Command execution failed. Check the log file for details.` now appends the core error via `extractToolErrorCore(...)` when one is available.
+- `solve.restart-shared.lib.mjs`: `isApiError()` now classifies via `extractToolErrorCore(...)` instead of reading `toolResult.result` directly, so an `API Error:` reported through `errorInfo` (the Claude failure shape) is correctly detected. It still falls back to `result`, preserving back-compat for any runner that sets it. This keeps the watch-mode `MAX_API_ERROR_RETRIES` backoff/escalation guard working for Claude API errors instead of looping forever.
 
 **Result:** for the exact scenario in this issue, the user now sees
 
@@ -229,6 +239,13 @@ result` precedence, whitespace collapsing, null cases, and that it does **not**
 the exception/rejection/main-error paths by driving `handleFailure()` with a
 scriptable `$` command-stream double — see §4.4.
 
+`tests/test-auto-restart-usage-limit-1356.mjs` was extended with 7 assertions
+(now 26 total) covering the `isApiError()` fix from §4.3: an `API Error:` reported
+through `errorInfo.message` (the Claude failure shape with no `result` field),
+through `errorInfo` as a plain string, and through `errorInfo.errorMatch` are all
+detected; legacy `result`-based detection still works; a generic `errorInfo`
+failure is not an API error; and `resultSummary` never drives classification.
+
 ---
 
 ## 6. Known components / libraries considered (R3)
@@ -274,7 +291,9 @@ scriptable `$` command-stream double — see §4.4.
 | `src/solve.auto-merge.lib.mjs`                      | Helper for resume + general failure GitHub messages; new `Error details:` terminal line via `extractToolErrorCore`                             |
 | `src/solve.watch.lib.mjs`                           | Helper for watch-mode GitHub message; `Error details:` terminal line now uses `extractToolErrorCore`                                           |
 | `src/review.mjs`                                    | Append the core error to the generic `Command execution failed` message via `extractToolErrorCore`                                             |
+| `src/solve.restart-shared.lib.mjs`                  | `isApiError()` classifies via `extractToolErrorCore` so `errorInfo`-only Claude API errors are detected (keeps watch-mode retry guard working) |
 | `src/solve.error-handlers.lib.mjs`                  | `handleFailure()` auto-commits uncommitted work (R2) on exception / rejection / main-error exits before exiting                                |
 | `tests/format-tool-execution-failure-1845.test.mjs` | Unit + cross-tool tests + `extractToolErrorCore` tests (27)                                                                                    |
 | `tests/test-issue-1845-failure-auto-commit.mjs`     | New tests for the R2 exception-path auto-commit in `handleFailure()` (6)                                                                       |
+| `tests/test-auto-restart-usage-limit-1356.mjs`      | Extended with `isApiError()` `errorInfo`-shape tests (Issue #1845, +7)                                                                         |
 | `docs/case-studies/issue-1845/`                     | This case study + raw failure log                                                                                                              |

--- a/docs/case-studies/issue-1845/raw-data/solution-draft-log.txt
+++ b/docs/case-studies/issue-1845/raw-data/solution-draft-log.txt
@@ -1,0 +1,5202 @@
+# Solve.mjs Log - 2026-05-30T17:18:00.345Z
+
+[2026-05-30T17:18:00.346Z] [INFO] 📁 Log file: /home/box/solve-2026-05-30T17-18-00-345Z.log
+[2026-05-30T17:18:00.347Z] [INFO]    (All output will be logged here)
+[2026-05-30T17:18:01.172Z] [INFO] 
+[2026-05-30T17:18:01.174Z] [INFO] 🚀 solve v1.73.7
+[2026-05-30T17:18:01.175Z] [INFO] 🔧 Raw command executed:
+[2026-05-30T17:18:01.177Z] [INFO]    /home/box/.nvm/versions/node/v20.20.2/bin/node /home/box/.bun/bin/solve https://github.com/xlabtg/teleton-agent/pull/519 --model opus --tool claude --attach-logs --verbose --no-tool-check --disable-report-issue --language ru
+[2026-05-30T17:18:01.179Z] [INFO] 
+[2026-05-30T17:18:01.220Z] [INFO] 
+[2026-05-30T17:18:01.221Z] [WARNING] ⚠️  SECURITY WARNING: --attach-logs is ENABLED
+[2026-05-30T17:18:01.221Z] [INFO] 
+[2026-05-30T17:18:01.222Z] [INFO]    This option will upload the complete solution draft log file to the Pull Request.
+[2026-05-30T17:18:01.222Z] [INFO]    The log may contain sensitive information such as:
+[2026-05-30T17:18:01.223Z] [INFO]    • API keys, tokens, or secrets
+[2026-05-30T17:18:01.223Z] [INFO]    • File paths and directory structures
+[2026-05-30T17:18:01.223Z] [INFO]    • Command outputs and error messages
+[2026-05-30T17:18:01.224Z] [INFO]    • Internal system information
+[2026-05-30T17:18:01.224Z] [INFO] 
+[2026-05-30T17:18:01.224Z] [INFO]    ⚠️  DO NOT use this option with public repositories or if the log
+[2026-05-30T17:18:01.226Z] [INFO]        might contain sensitive data that should not be shared publicly.
+[2026-05-30T17:18:01.227Z] [INFO] 
+[2026-05-30T17:18:01.230Z] [INFO]    Continuing in 5 seconds... (Press Ctrl+C to abort)
+[2026-05-30T17:18:01.230Z] [INFO] 
+[2026-05-30T17:18:01.231Z] [STDOUT]    Countdown: 5 seconds remaining...
+[2026-05-30T17:18:02.233Z] [STDOUT]    Countdown: 4 seconds remaining...
+[2026-05-30T17:18:03.233Z] [STDOUT]    Countdown: 3 seconds remaining...
+[2026-05-30T17:18:04.234Z] [STDOUT]    Countdown: 2 seconds remaining...
+[2026-05-30T17:18:05.235Z] [STDOUT]    Countdown: 1 seconds remaining...
+[2026-05-30T17:18:06.237Z] [INFO] 
+[2026-05-30T17:18:06.236Z] [STDOUT]    Proceeding with log attachment enabled.                    
+[2026-05-30T17:18:06.318Z] [INFO] 💾 Disk space check: 61382MB available (2048MB required) ✅
+[2026-05-30T17:18:06.323Z] [INFO] 🧠 Memory check: 9556MB available, swap: none, total: 9556MB (256MB required) ✅
+[2026-05-30T17:18:06.346Z] [INFO] ⏩ Skipping tool connection validation (dry-run mode or skip-tool-connection-check enabled)
+[2026-05-30T17:18:06.347Z] [INFO] ⏩ Skipping GitHub authentication check (dry-run mode or skip-tool-connection-check enabled)
+[2026-05-30T17:18:06.348Z] [INFO] 📋 URL validation:
+[2026-05-30T17:18:06.349Z] [INFO]    Input URL: https://github.com/xlabtg/teleton-agent/pull/519
+[2026-05-30T17:18:06.349Z] [INFO]    Is Issue URL: false
+[2026-05-30T17:18:06.349Z] [INFO]    Is PR URL: true
+[2026-05-30T17:18:06.350Z] [INFO] 🔍 --auto-accept-invite: Checking for pending invitation to xlabtg/teleton-agent...
+[2026-05-30T17:18:06.665Z] [INFO]    Found 2 total pending repo invitation(s)
+[2026-05-30T17:18:06.666Z] [INFO]    No pending repository invitation found for xlabtg/teleton-agent
+[2026-05-30T17:18:07.045Z] [INFO]    Found 0 total pending org invitation(s)
+[2026-05-30T17:18:07.047Z] [INFO]    No pending organization invitation found for xlabtg
+[2026-05-30T17:18:07.047Z] [INFO] ℹ️  --auto-accept-invite: No pending invitation found for xlabtg/teleton-agent or organization xlabtg
+[2026-05-30T17:18:07.048Z] [INFO] 🔍 Checking repository access for auto-fork...
+[2026-05-30T17:18:07.403Z] [STDOUT] {"admin":false,"maintain":false,"pull":true,"push":false,"triage":false}
+[2026-05-30T17:18:07.799Z] [STDOUT] public
+[2026-05-30T17:18:07.808Z] [INFO]    Repository visibility: public
+[2026-05-30T17:18:07.809Z] [INFO] ✅ Auto-fork: No write access detected, enabling fork mode
+[2026-05-30T17:18:07.810Z] [INFO] ✅ Repository access check: Skipped (fork mode enabled)
+[2026-05-30T17:18:08.095Z] [STDOUT] xlabtg
+[2026-05-30T17:18:08.457Z] [STDOUT] xlabtg/teleton-agent
+[2026-05-30T17:18:08.778Z] [STDOUT] {"number":519,"state":"OPEN"}
+[2026-05-30T17:18:09.124Z] [STDOUT] public
+[2026-05-30T17:18:09.129Z] [INFO]    Repository visibility: public
+[2026-05-30T17:18:09.130Z] [INFO]    Auto-cleanup default: false (repository is public)
+[2026-05-30T17:18:09.131Z] [INFO] 🔄 Continue mode: Working with PR #519
+[2026-05-30T17:18:09.131Z] [INFO]    Continue mode activated: PR URL provided directly
+[2026-05-30T17:18:09.132Z] [INFO]    PR Number set to: 519
+[2026-05-30T17:18:09.133Z] [INFO]    Will fetch PR details and linked issue
+[2026-05-30T17:18:09.544Z] [STDOUT] {"body":"## 🤖 AI-Powered Solution Draft\n\nThis pull request is being automatically generated to solve issue xlabtg/teleton-agent#502.\n\n### 📋 Issue Reference\nFixes xlabtg/teleton-agent#502\n\n### 🚧 Status\n**Work in Progress** - The AI assistant is currently analyzing and implementing the solution draft.\n\n### 📝 Implementation Details\n_Details will be added as the solution draft is developed..._\n\n---\n*This PR was created automatically by the AI issue solver*","headRefName":"issue-502-b91556a7ecb2","headRepository":{"id":"R_kgDOSJ6uaQ","name":"xlabtg-teleton-agent","nameWithOwner":"konard/xlabtg-teleton-agent"},"headRepositoryOwner":{"id":"MDQ6VXNlcjE0MzE5MDQ=","name":"Konstantin Diachenko","login":"konard"},"mergeStateStatus":"UNSTABLE","number":519,"state":"OPEN"}
+[2026-05-30T17:18:09.549Z] [INFO] 🍴 Detected fork PR from konard/xlabtg-teleton-agent
+[2026-05-30T17:18:09.550Z] [INFO]    Fork owner: konard
+[2026-05-30T17:18:09.551Z] [INFO]    Will clone fork repository for continue mode
+[2026-05-30T17:18:09.552Z] [INFO] 📝 PR branch: issue-502-b91556a7ecb2
+[2026-05-30T17:18:09.553Z] [INFO] 🔗 Found linked issue #502
+[2026-05-30T17:18:09.555Z] [INFO] 
+[2026-05-30T17:18:09.555Z] [INFO] Creating temporary directory: /tmp/gh-issue-solver-1780161489554
+[2026-05-30T17:18:09.557Z] [INFO] 
+[2026-05-30T17:18:09.557Z] [INFO] 🍴 Fork mode:                ENABLED
+[2026-05-30T17:18:09.558Z] [INFO]  Checking fork status...   
+[2026-05-30T17:18:09.558Z] [INFO] 
+[2026-05-30T17:18:09.922Z] [STDOUT] konard
+[2026-05-30T17:18:09.930Z] [INFO] 🔍 Detecting fork conflicts... 
+[2026-05-30T17:18:15.305Z] [STDOUT] {"fork":true,"source":"TONresistor/teleton-agent"}
+[2026-05-30T17:18:15.737Z] [STDOUT] konard
+[2026-05-30T17:18:16.157Z] [INFO] ✅ No fork conflict:         Safe to proceed
+[2026-05-30T17:18:16.499Z] [STDOUT] {"name":"xlabtg-teleton-agent"}
+[2026-05-30T17:18:16.504Z] [INFO] ✅ Fork exists:              konard/xlabtg-teleton-agent
+[2026-05-30T17:18:16.504Z] [INFO] 🔍 Validating fork parent... 
+[2026-05-30T17:18:16.870Z] [STDOUT] {"fork":true,"parent":"xlabtg/teleton-agent","source":"TONresistor/teleton-agent"}
+[2026-05-30T17:18:16.875Z] [INFO] ✅ Fork parent validated:    xlabtg/teleton-agent
+[2026-05-30T17:18:16.876Z] [INFO] 
+[2026-05-30T17:18:16.876Z] [INFO] 📥 Cloning repository:       konard/xlabtg-teleton-agent
+[2026-05-30T17:18:17.414Z] [STDOUT] Cloning into '/tmp/gh-issue-solver-1780161489554'...
+[2026-05-30T17:18:18.995Z] [STDOUT] From https://github.com/xlabtg/teleton-agent
+ * [new branch]      main       -> upstream/main
+ * [new tag]         v0.8.20    -> v0.8.20
+[2026-05-30T17:18:18.995Z] [STDOUT]  * [new tag]         v0.8.21    -> v0.8.21
+ * [new tag]         v0.8.22    -> v0.8.22
+[2026-05-30T17:18:19.021Z] [INFO] ✅ Cloned to:                /tmp/gh-issue-solver-1780161489554
+[2026-05-30T17:18:19.035Z] [STDOUT] origin	https://github.com/konard/xlabtg-teleton-agent.git (fetch)
+origin	https://github.com/konard/xlabtg-teleton-agent.git (push)
+upstream	https://github.com/xlabtg/teleton-agent.git (fetch)
+upstream	https://github.com/xlabtg/teleton-agent.git (push)
+[2026-05-30T17:18:19.037Z] [INFO] 🔗 Setting upstream:         xlabtg/teleton-agent
+[2026-05-30T17:18:19.048Z] [STDOUT] https://github.com/xlabtg/teleton-agent.git
+[2026-05-30T17:18:19.049Z] [INFO] ℹ️ Upstream exists:          Using existing upstream remote
+[2026-05-30T17:18:19.049Z] [INFO] 🔄 Fetching upstream...      
+[2026-05-30T17:18:19.338Z] [STDERR] From https://github.com/xlabtg/teleton-agent
+ * [new branch]      release-please--branches--main--components--teleton -> upstream/release-please--branches--main--components--teleton
+[2026-05-30T17:18:19.349Z] [INFO] ✅ Upstream fetched:         Successfully
+[2026-05-30T17:18:19.350Z] [INFO] 🔄 Syncing default branch... 
+[2026-05-30T17:18:19.359Z] [STDOUT] main
+[2026-05-30T17:18:19.745Z] [STDOUT] main
+[2026-05-30T17:18:19.750Z] [INFO] ℹ️ Default branch:           main
+[2026-05-30T17:18:19.920Z] [STDOUT] HEAD is now at a4a6077 Merge pull request #518 from xlabtg/release-please--branches--main--components--teleton
+[2026-05-30T17:18:19.920Z] [INFO] ✅ Default branch synced:    with upstream/main
+[2026-05-30T17:18:19.922Z] [INFO] 🔄 Pushing to fork:          main branch
+[2026-05-30T17:18:20.474Z] [STDOUT] Everything up-to-date
+[2026-05-30T17:18:20.483Z] [INFO] ✅ Fork updated:             Default branch pushed to fork
+[2026-05-30T17:18:20.484Z] [INFO] 
+[2026-05-30T17:18:20.484Z] [INFO] 🔍 Checking PR fork:         Determining if branch is in another fork...
+[2026-05-30T17:18:20.985Z] [STDOUT] konard
+[2026-05-30T17:18:20.988Z] [INFO] ℹ️ PR fork owner:            Same as current user, using origin remote
+[2026-05-30T17:18:21.069Z] [STDOUT] main
+[2026-05-30T17:18:21.082Z] [STDOUT] a4a**********************************75c
+[2026-05-30T17:18:21.084Z] [INFO] 
+[2026-05-30T17:18:21.084Z] [INFO] 📌 Default branch:           main
+[2026-05-30T17:18:21.108Z] [INFO] 
+[2026-05-30T17:18:21.108Z] [INFO] 🔄 Checking out PR branch:   issue-502-b91556a7ecb2
+[2026-05-30T17:18:21.109Z] [INFO] 📥 Fetching branches:        From remote...
+[2026-05-30T17:18:21.490Z] [STDERR] Switched to a new branch 'issue-502-b91556a7ecb2'
+[2026-05-30T17:18:21.491Z] [STDOUT] branch 'issue-502-b91556a7ecb2' set up to track 'origin/issue-502-b91556a7ecb2'.
+[2026-05-30T17:18:21.491Z] [INFO] 🔍 Verifying:                Branch checkout...
+[2026-05-30T17:18:21.504Z] [STDOUT] issue-502-b91556a7ecb2
+[2026-05-30T17:18:21.504Z] [INFO] ✅ Branch checked out:       issue-502-b91556a7ecb2
+[2026-05-30T17:18:21.505Z] [INFO] ✅ Current branch:           issue-502-b91556a7ecb2
+[2026-05-30T17:18:21.505Z] [INFO]    Branch operation: Checkout existing PR branch
+[2026-05-30T17:18:21.505Z] [INFO]    Branch verification: Matches expected
+[2026-05-30T17:18:21.508Z] [INFO] 
+[2026-05-30T17:18:21.508Z] [INFO] 🔄 Continue mode:            ACTIVE
+[2026-05-30T17:18:21.509Z] [INFO]    Using existing PR:      #519
+[2026-05-30T17:18:21.510Z] [INFO]    PR URL:                 https://github.com/xlabtg/teleton-agent/pull/519
+[2026-05-30T17:18:21.510Z] [INFO] 
+[2026-05-30T17:18:21.510Z] [INFO] 🚀 Starting work session:    2026-05-30T17:18:21.510Z
+[2026-05-30T17:18:21.844Z] [STDOUT] true
+[2026-05-30T17:18:21.849Z] [INFO]   ✅ PR status:              Already in draft mode
+[2026-05-30T17:18:22.630Z] [STDOUT] github.com
+  ✓ Logged in to github.com account konard (/home/box/.config/gh/hosts.yml)
+  - Active account: true
+  - Git operations protocol: https
+  - Token: gho_************************************
+  - Token scopes: 'gist', 'read:org', 'repo', 'user', 'workflow'
+[2026-05-30T17:18:23.287Z] [STDOUT] {"url":"https://api.github.com/repos/xlabtg/teleton-agent/issues/comments/4583534149","html_url":"https://github.com/xlabtg/teleton-agent/pull/519#issuecomment-4583534149","issue_url":"https://api.github.com/repos/xlabtg/teleton-agent/issues/519","id":4583534149,"node_id":"IC_kwDORfHVp88AAAABETMuRQ","user":{"login":"konard","id":1431904,"node_id":"MDQ6VXNlcjE0MzE5MDQ=","avatar_url":"https://avatars.githubusercontent.com/u/1431904?u=eef2c91c80a671714d3fd8c08ef91b297840056b&v=4","gravatar_id":"","url":"https://api.github.com/users/konard","html_url":"https://github.com/konard","followers_url":"https://api.github.com/users/konard/followers","following_url":"https://api.github.com/users/konard/following{/other_user}","gists_url":"https://api.github.com/users/konard/gists{/gist_id}","starred_url":"https://api.github.com/users/konard/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/konard/subscriptions","organizations_url":"https://api.github.com/users/konard/orgs","repos_url":"https://api.github.com/users/konard/repos","events_url":"https://api.github.com/users/konard/events{/privacy}","received_events_url":"https://api.github.com/users/konard/received_events","type":"User","user_view_type":"public","site_admin":false},"created_at":"2026-05-30T17:18:23Z","updated_at":"2026-05-30T17:18:23Z","author_association":"NONE","body":"🤖 **AI Work Session Started**\n\nStarting automated work session at 2026-05-30T17:18:21.510Z\n\nThe PR has been converted to draft mode while work is in progress.\n\n_This comment marks the beginning of an AI work session. Please wait for the session to finish, and provide your feedback._","reactions":{"url":"https://api.github.com/repos/xlabtg/teleton-agent/issues/comments/4583534149/reactions","total_count":0,"+1":0,"-1":0,"laugh":0,"hooray":0,"confused":0,"heart":0,"rocket":0,"eyes":0},"performed_via_github_app":null,"pin":null}
+[2026-05-30T17:18:23.297Z] [INFO]   💬 Posted:                 AI Work Session Started comment (id=4583534149)
+[2026-05-30T17:18:23.656Z] [STDOUT] konard
+[2026-05-30T17:18:23.662Z] [INFO]   👤 Current user:           konard
+[2026-05-30T17:18:23.662Z] [INFO] 
+[2026-05-30T17:18:23.662Z] [INFO] 📊 Comment counting conditions:
+[2026-05-30T17:18:23.663Z] [INFO]    prNumber: 519
+[2026-05-30T17:18:23.664Z] [INFO]    branchName: issue-502-b91556a7ecb2
+[2026-05-30T17:18:23.665Z] [INFO]    isContinueMode: true
+[2026-05-30T17:18:23.665Z] [INFO]    Will count comments: true
+[2026-05-30T17:18:23.666Z] [INFO] 💬 Counting comments:        Checking for new comments since last commit...
+[2026-05-30T17:18:23.666Z] [INFO]    PR #519 on branch: issue-502-b91556a7ecb2
+[2026-05-30T17:18:23.666Z] [INFO]    Owner/Repo: xlabtg/teleton-agent
+[2026-05-30T17:18:23.667Z] [INFO]    Repository path: /tmp/gh-issue-solver-1780161489554
+[2026-05-30T17:18:23.679Z] [STDOUT] 2026-05-30T16:58:19+00:00
+[2026-05-30T17:18:23.682Z] [INFO]   📅 Last commit time:       2026-05-30T16:58:19.000Z
+[2026-05-30T17:18:23.975Z] [STDOUT] []
+[2026-05-30T17:18:24.294Z] [STDOUT] [{"url":"https://api.github.com/repos/xlabtg/teleton-agent/issues/comments/4583494179","html_url":"https://github.com/xlabtg/teleton-agent/pull/519#issuecomment-4583494179","issue_url":"https://api.github.com/repos/xlabtg/teleton-agent/issues/519","id":4583494179,"node_id":"IC_kwDORfHVp88AAAABETKSIw","user":{"login":"konard","id":1431904,"node_id":"MDQ6VXNlcjE0MzE5MDQ=","avatar_url":"https://avatars.githubusercontent.com/u/1431904?v=4","gravatar_id":"","url":"https://api.github.com/users/konard","html_url":"https://github.com/konard","followers_url":"https://api.github.com/users/konard/followers","following_url":"https://api.github.com/users/konard/following{/other_user}","gists_url":"https://api.github.com/users/konard/gists{/gist_id}","starred_url":"https://api.github.com/users/konard/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/konard/subscriptions","organizations_url":"https://api.github.com/users/konard/orgs","repos_url":"https://api.github.com/users/konard/repos","events_url":"https://api.github.com/users/konard/events{/privacy}","received_events_url":"https://api.github.com/users/konard/received_events","type":"User","user_view_type":"public","site_admin":false},"created_at":"2026-05-30T17:00:06Z","updated_at":"2026-05-30T17:00:06Z","body":"## 🚨 Solution Draft Failed\nThe automated solution draft encountered an error:\n```\nCLAUDE execution failed\n```\n\n### 🤖 **Models used:**\n- Tool: Anthropic Claude Code\n- Requested: `opus`\n- **Model: Claude Opus 4.8** (`claude-opus-4-8`)\n\n### 📎 **Failure log uploaded as Gist** (481KB)\n- [View complete failure log](https://gist.githubusercontent.com/konard/6f9fb05e1abd6359866cd3e116c595a9/raw/f8bdf792da7e6130c5ec174bb2dc7f7679e44af0/solution-draft-log-pr-1780160400086.txt)\n\n---\n*Now working session is ended, feel free to review and add any feedback on the solution draft.*","author_association":"NONE","reactions":{"url":"https://api.github.com/repos/xlabtg/teleton-agent/issues/comments/4583494179/reactions","total_count":0,"+1":0,"-1":0,"laugh":0,"hooray":0,"confused":0,"heart":0,"rocket":0,"eyes":0},"performed_via_github_app":null},{"url":"https://api.github.com/repos/xlabtg/teleton-agent/issues/comments/4583534149","html_url":"https://github.com/xlabtg/teleton-agent/pull/519#issuecomment-4583534149","issue_url":"https://api.github.com/repos/xlabtg/teleton-agent/issues/519","id":4583534149,"node_id":"IC_kwDORfHVp88AAAABETMuRQ","user":{"login":"konard","id":1431904,"node_id":"MDQ6VXNlcjE0MzE5MDQ=","avatar_url":"https://avatars.githubusercontent.com/u/1431904?v=4","gravatar_id":"","url":"https://api.github.com/users/konard","html_url":"https://github.com/konard","followers_url":"https://api.github.com/users/konard/followers","following_url":"https://api.github.com/users/konard/following{/other_user}","gists_url":"https://api.github.com/users/konard/gists{/gist_id}","starred_url":"https://api.github.com/users/konard/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/konard/subscriptions","organizations_url":"https://api.github.com/users/konard/orgs","repos_url":"https://api.github.com/users/konard/repos","events_url":"https://api.github.com/users/konard/events{/privacy}","received_events_url":"https://api.github.com/users/konard/received_events","type":"User","user_view_type":"public","site_admin":false},"created_at":"2026-05-30T17:18:23Z","updated_at":"2026-05-30T17:18:23Z","body":"🤖 **AI Work Session Started**\n\nStarting automated work session at 2026-05-30T17:18:21.510Z\n\nThe PR has been converted to draft mode while work is in progress.\n\n_This comment marks the beginning of an AI work session. Please wait for the session to finish, and provide your feedback._","author_association":"NONE","reactions":{"url":"https://api.github.com/repos/xlabtg/teleton-agent/issues/comments/4583534149/reactions","total_count":0,"+1":0,"-1":0,"laugh":0,"hooray":0,"confused":0,"heart":0,"rocket":0,"eyes":0},"performed_via_github_app":null}]
+[2026-05-30T17:18:24.563Z] [STDOUT] []
+[2026-05-30T17:18:24.569Z] [INFO]   💬 New PR comments:        0
+[2026-05-30T17:18:24.570Z] [INFO]   💬 New PR review comments: 0
+[2026-05-30T17:18:24.570Z] [INFO]   💬 New issue comments:     0
+[2026-05-30T17:18:24.570Z] [INFO]    Total new comments: 0
+[2026-05-30T17:18:24.571Z] [INFO]    Comment lines to add: No (saving tokens)
+[2026-05-30T17:18:24.571Z] [INFO]    PR review comments fetched: 0
+[2026-05-30T17:18:24.572Z] [INFO]    PR conversation comments fetched: 2
+[2026-05-30T17:18:24.572Z] [INFO]    Total PR comments checked: 2
+[2026-05-30T17:18:25.031Z] [STDOUT] {"url":"https://api.github.com/repos/xlabtg/teleton-agent/pulls/519","id":3774433233,"node_id":"PR_kwDORfHVp87g-UfR","html_url":"https://github.com/xlabtg/teleton-agent/pull/519","diff_url":"https://github.com/xlabtg/teleton-agent/pull/519.diff","patch_url":"https://github.com/xlabtg/teleton-agent/pull/519.patch","issue_url":"https://api.github.com/repos/xlabtg/teleton-agent/issues/519","number":519,"state":"open","locked":false,"title":"[WIP] [R13][P2] Community health files: Code of Conduct, PR template, issue chooser, governance","user":{"login":"konard","id":1431904,"node_id":"MDQ6VXNlcjE0MzE5MDQ=","avatar_url":"https://avatars.githubusercontent.com/u/1431904?v=4","gravatar_id":"","url":"https://api.github.com/users/konard","html_url":"https://github.com/konard","followers_url":"https://api.github.com/users/konard/followers","following_url":"https://api.github.com/users/konard/following{/other_user}","gists_url":"https://api.github.com/users/konard/gists{/gist_id}","starred_url":"https://api.github.com/users/konard/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/konard/subscriptions","organizations_url":"https://api.github.com/users/konard/orgs","repos_url":"https://api.github.com/users/konard/repos","events_url":"https://api.github.com/users/konard/events{/privacy}","received_events_url":"https://api.github.com/users/konard/received_events","type":"User","user_view_type":"public","site_admin":false},"body":"## 🤖 AI-Powered Solution Draft\n\nThis pull request is being automatically generated to solve issue xlabtg/teleton-agent#502.\n\n### 📋 Issue Reference\nFixes xlabtg/teleton-agent#502\n\n### 🚧 Status\n**Work in Progress** - The AI assistant is currently analyzing and implementing the solution draft.\n\n### 📝 Implementation Details\n_Details will be added as the solution draft is developed..._\n\n---\n*This PR was created automatically by the AI issue solver*","created_at":"2026-05-30T16:58:26Z","updated_at":"2026-05-30T17:18:23Z","closed_at":null,"merged_at":null,"merge_commit_sha":"c530911f5572787ba8320e2dc3c77d4081b7af83","assignees":[],"requested_reviewers":[],"requested_teams":[],"labels":[],"milestone":null,"draft":true,"commits_url":"https://api.github.com/repos/xlabtg/teleton-agent/pulls/519/commits","review_comments_url":"https://api.github.com/repos/xlabtg/teleton-agent/pulls/519/comments","review_comment_url":"https://api.github.com/repos/xlabtg/teleton-agent/pulls/comments{/number}","comments_url":"https://api.github.com/repos/xlabtg/teleton-agent/issues/519/comments","statuses_url":"https://api.github.com/repos/xlabtg/teleton-agent/statuses/826**********************************60a","head":{"label":"konard:issue-502-b91556a7ecb2","ref":"issue-502-b91556a7ecb2","sha":"826**********************************60a","user":{"login":"konard","id":1431904,"node_id":"MDQ6VXNlcjE0MzE5MDQ=","avatar_url":"https://avatars.githubusercontent.com/u/1431904?v=4","gravatar_id":"","url":"https://api.github.com/users/konard","html_url":"https://github.com/konard","followers_url":"https://api.github.com/users/konard/followers","following_url":"https://api.github.com/users/konard/following{/other_user}","gists_url":"https://api.github.com/users/konard/gists{/gist_id}","starred_url":"https://api.github.com/users/konard/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/konard/subscriptions","organizations_url":"https://api.github.com/users/konard/orgs","repos_url":"https://api.github.com/users/konard/repos","events_url":"https://api.github.com/users/konard/events{/privacy}","received_events_url":"https://api.github.com/users/konard/received_events","type":"User","user_view_type":"public","site_admin":false},"repo":{"id":1218358889,"node_id":"R_kgDOSJ6uaQ","name":"xlabtg-teleton-agent","full_name":"konard/xlabtg-teleton-agent","private":false,"owner":{"login":"konard","id":1431904,"node_id":"MDQ6VXNlcjE0MzE5MDQ=","avatar_url":"https://avatars.githubusercontent.com/u/1431904?v=4","gravatar_id":"","url":"https://api.github.com/users/konard","html_url":"https://github.com/konard","followers_url":"https://api.github.com/users/konard/followers","following_url":"https://api.github.com/users/konard/following{/other_user}","gists_url":"https://api.github.com/users/konard/gists{/gist_id}","starred_url":"https://api.github.com/users/konard/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/konard/subscriptions","organizations_url":"https://api.github.com/users/konard/orgs","repos_url":"https://api.github.com/users/konard/repos","events_url":"https://api.github.com/users/konard/events{/privacy}","received_events_url":"https://api.github.com/users/konard/received_events","type":"User","user_view_type":"public","site_admin":false},"html_url":"https://github.com/konard/xlabtg-teleton-agent","description":"Teleton: Autonomous AI Agent for Telegram & TON Blockchain","fork":true,"url":"https://api.github.com/repos/konard/xlabtg-teleton-agent","forks_url":"https://api.github.com/repos/konard/xlabtg-teleton-agent/forks","keys_url":"https://api.github.com/repos/konard/xlabtg-teleton-agent/keys{/key_id}","collaborators_url":"https://api.github.com/repos/konard/xlabtg-teleton-agent/collaborators{/collaborator}","teams_url":"https://api.github.com/repos/konard/xlabtg-teleton-agent/teams","hooks_url":"https://api.github.com/repos/konard/xlabtg-teleton-agent/hooks","issue_events_url":"https://api.github.com/repos/konard/xlabtg-teleton-agent/issues/events{/number}","events_url":"https://api.github.com/repos/konard/xlabtg-teleton-agent/events","assignees_url":"https://api.github.com/repos/konard/xlabtg-teleton-agent/assignees{/user}","branches_url":"https://api.github.com/repos/konard/xlabtg-teleton-agent/branches{/branch}","tags_url":"https://api.github.com/repos/konard/xlabtg-teleton-agent/tags","blobs_url":"https://api.github.com/repos/konard/xlabtg-teleton-agent/git/blobs{/sha}","git_tags_url":"https://api.github.com/repos/konard/xlabtg-teleton-agent/git/tags{/sha}","git_refs_url":"https://api.github.com/repos/konard/xlabtg-teleton-agent/git/refs{/sha}","trees_url":"https://api.github.com/repos/konard/xlabtg-teleton-agent/git/trees{/sha}","statuses_url":"https://api.github.com/repos/konard/xlabtg-teleton-agent/statuses/{sha}","languages_url":"https://api.github.com/repos/konard/xlabtg-teleton-agent/languages","stargazers_url":"https://api.github.com/repos/konard/xlabtg-teleton-agent/stargazers","contributors_url":"https://api.github.com/repos/konard/xlabtg-teleton-agent/contributors","subscribers_url":"https://api.github.com/repos/konard/xlabtg-teleton-agent/subscribers","subscription_url":"https://api.github.com/repos/konard/xlabtg-teleton-agent/subscription","commits_url":"https://api.github.com/repos/konard/xlabtg-teleton-agent/commits{/sha}","git_commits_url":"https://api.github.com/repos/konard/xlabtg-teleton-agent/git/commits{/sha}","comments_url":"https://api.github.com/repos/konard/xlabtg-teleton-agent/comments{/number}","issue_comment_url":"https://api.github.com/repos/konard/xlabtg-teleton-agent/issues/comments{/number}","contents_url":"https://api.github.com/repos/konard/xlabtg-teleton-agent/contents/{+path}","compare_url":"https://api.github.com/repos/konard/xlabtg-teleton-agent/compare/{base}...{head}","merges_url":"https://api.github.com/repos/konard/xlabtg-teleton-agent/merges","archive_url":"https://api.github.com/repos/konard/xlabtg-teleton-agent/{archive_format}{/ref}","downloads_url":"https://api.github.com/repos/konard/xlabtg-teleton-agent/downloads","issues_url":"https://api.github.com/repos/konard/xlabtg-teleton-agent/issues{/number}","pulls_url":"https://api.github.com/repos/konard/xlabtg-teleton-agent/pulls{/number}","milestones_url":"https://api.github.com/repos/konard/xlabtg-teleton-agent/milestones{/number}","notifications_url":"https://api.github.com/repos/konard/xlabtg-teleton-agent/notifications{?since,all,participating}","labels_url":"https://api.github.com/repos/konard/xlabtg-teleton-agent/labels{/name}","releases_url":"https://api.github.com/repos/konard/xlabtg-teleton-agent/releases{/id}","deployments_url":"https://api.github.com/repos/konard/xlabtg-teleton-agent/deployments","created_at":"2026-04-22T19:49:28Z","updated_at":"2026-05-30T16:58:24Z","pushed_at":"2026-05-30T17:01:11Z","git_url":"git://github.com/konard/xlabtg-teleton-agent.git","ssh_url":"git@github.com:konard/xlabtg-teleton-agent.git","clone_url":"https://github.com/konard/xlabtg-teleton-agent.git","svn_url":"https://github.com/konard/xlabtg-teleton-agent","homepage":null,"size":10187,"stargazers_count":0,"watchers_count":0,"language":"TypeScript","has_issues":true,"has_projects":true,"has_downloads":true,"has_wiki":true,"has_pages":false,"has_discussions":false,"forks_count":0,"mirror_url":null,"archived":false,"disabled":false,"open_issues_count":14,"license":{"key":"mit","name":"MIT License","spdx_id":"MIT","url":"https://api.github.com/licenses/mit","node_id":"MDc6TGljZW5zZTEz"},"allow_forking":true,"is_template":false,"web_commit_signoff_required":false,"has_pull_requests":true,"pull_request_creation_policy":"all","topics":[],"visibility":"public","forks":0,"open_issues":14,"watchers":0,"default_branch":"main"}},"base":{"label":"xlabtg:main","ref":"main","sha":"a4a**********************************75c","user":{"login":"xlabtg","id":241960702,"node_id":"U_kgDODmwG_g","avatar_url":"https://avatars.githubusercontent.com/u/241960702?v=4","gravatar_id":"","url":"https://api.github.com/users/xlabtg","html_url":"https://github.com/xlabtg","followers_url":"https://api.github.com/users/xlabtg/followers","following_url":"https://api.github.com/users/xlabtg/following{/other_user}","gists_url":"https://api.github.com/users/xlabtg/gists{/gist_id}","starred_url":"https://api.github.com/users/xlabtg/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/xlabtg/subscriptions","organizations_url":"https://api.github.com/users/xlabtg/orgs","repos_url":"https://api.github.com/users/xlabtg/repos","events_url":"https://api.github.com/users/xlabtg/events{/privacy}","received_events_url":"https://api.github.com/users/xlabtg/received_events","type":"User","user_view_type":"public","site_admin":false},"repo":{"id":1173476775,"node_id":"R_kgDORfHVpw","name":"teleton-agent","full_name":"xlabtg/teleton-agent","private":false,"owner":{"login":"xlabtg","id":241960702,"node_id":"U_kgDODmwG_g","avatar_url":"https://avatars.githubusercontent.com/u/241960702?v=4","gravatar_id":"","url":"https://api.github.com/users/xlabtg","html_url":"https://github.com/xlabtg","followers_url":"https://api.github.com/users/xlabtg/followers","following_url":"https://api.github.com/users/xlabtg/following{/other_user}","gists_url":"https://api.github.com/users/xlabtg/gists{/gist_id}","starred_url":"https://api.github.com/users/xlabtg/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/xlabtg/subscriptions","organizations_url":"https://api.github.com/users/xlabtg/orgs","repos_url":"https://api.github.com/users/xlabtg/repos","events_url":"https://api.github.com/users/xlabtg/events{/privacy}","received_events_url":"https://api.github.com/users/xlabtg/received_events","type":"User","user_view_type":"public","site_admin":false},"html_url":"https://github.com/xlabtg/teleton-agent","description":"Teleton: Autonomous AI Agent for Telegram & TON Blockchain","fork":true,"url":"https://api.github.com/repos/xlabtg/teleton-agent","forks_url":"https://api.github.com/repos/xlabtg/teleton-agent/forks","keys_url":"https://api.github.com/repos/xlabtg/teleton-agent/keys{/key_id}","collaborators_url":"https://api.github.com/repos/xlabtg/teleton-agent/collaborators{/collaborator}","teams_url":"https://api.github.com/repos/xlabtg/teleton-agent/teams","hooks_url":"https://api.github.com/repos/xlabtg/teleton-agent/hooks","issue_events_url":"https://api.github.com/repos/xlabtg/teleton-agent/issues/events{/number}","events_url":"https://api.github.com/repos/xlabtg/teleton-agent/events","assignees_url":"https://api.github.com/repos/xlabtg/teleton-agent/assignees{/user}","branches_url":"https://api.github.com/repos/xlabtg/teleton-agent/branches{/branch}","tags_url":"https://api.github.com/repos/xlabtg/teleton-agent/tags","blobs_url":"https://api.github.com/repos/xlabtg/teleton-agent/git/blobs{/sha}","git_tags_url":"https://api.github.com/repos/xlabtg/teleton-agent/git/tags{/sha}","git_refs_url":"https://api.github.com/repos/xlabtg/teleton-agent/git/refs{/sha}","trees_url":"https://api.github.com/repos/xlabtg/teleton-agent/git/trees{/sha}","statuses_url":"https://api.github.com/repos/xlabtg/teleton-agent/statuses/{sha}","languages_url":"https://api.github.com/repos/xlabtg/teleton-agent/languages","stargazers_url":"https://api.github.com/repos/xlabtg/teleton-agent/stargazers","contributors_url":"https://api.github.com/repos/xlabtg/teleton-agent/contributors","subscribers_url":"https://api.github.com/repos/xlabtg/teleton-agent/subscribers","subscription_url":"https://api.github.com/repos/xlabtg/teleton-agent/subscription","commits_url":"https://api.github.com/repos/xlabtg/teleton-agent/commits{/sha}","git_commits_url":"https://api.github.com/repos/xlabtg/teleton-agent/git/commits{/sha}","comments_url":"https://api.github.com/repos/xlabtg/teleton-agent/comments{/number}","issue_comment_url":"https://api.github.com/repos/xlabtg/teleton-agent/issues/comments{/number}","contents_url":"https://api.github.com/repos/xlabtg/teleton-agent/contents/{+path}","compare_url":"https://api.github.com/repos/xlabtg/teleton-agent/compare/{base}...{head}","merges_url":"https://api.github.com/repos/xlabtg/teleton-agent/merges","archive_url":"https://api.github.com/repos/xlabtg/teleton-agent/{archive_format}{/ref}","downloads_url":"https://api.github.com/repos/xlabtg/teleton-agent/downloads","issues_url":"https://api.github.com/repos/xlabtg/teleton-agent/issues{/number}","pulls_url":"https://api.github.com/repos/xlabtg/teleton-agent/pulls{/number}","milestones_url":"https://api.github.com/repos/xlabtg/teleton-agent/milestones{/number}","notifications_url":"https://api.github.com/repos/xlabtg/teleton-agent/notifications{?since,all,participating}","labels_url":"https://api.github.com/repos/xlabtg/teleton-agent/labels{/name}","releases_url":"https://api.github.com/repos/xlabtg/teleton-agent/releases{/id}","deployments_url":"https://api.github.com/repos/xlabtg/teleton-agent/deployments","created_at":"2026-03-05T12:08:57Z","updated_at":"2026-05-30T12:36:52Z","pushed_at":"2026-05-30T12:37:01Z","git_url":"git://github.com/xlabtg/teleton-agent.git","ssh_url":"git@github.com:xlabtg/teleton-agent.git","clone_url":"https://github.com/xlabtg/teleton-agent.git","svn_url":"https://github.com/xlabtg/teleton-agent","homepage":null,"size":10171,"stargazers_count":4,"watchers_count":4,"language":"TypeScript","has_issues":true,"has_projects":true,"has_downloads":true,"has_wiki":true,"has_pages":false,"has_discussions":false,"forks_count":3,"mirror_url":null,"archived":false,"disabled":false,"open_issues_count":3,"license":{"key":"mit","name":"MIT License","spdx_id":"MIT","url":"https://api.github.com/licenses/mit","node_id":"MDc6TGljZW5zZTEz"},"allow_forking":true,"is_template":false,"web_commit_signoff_required":false,"has_pull_requests":true,"pull_request_creation_policy":"all","topics":[],"visibility":"public","forks":3,"open_issues":3,"watchers":4,"default_branch":"main"}},"_links":{"self":{"href":"https://api.github.com/repos/xlabtg/teleton-agent/pulls/519"},"html":{"href":"https://github.com/xlabtg/teleton-agent/pull/519"},"issue":{"href":"https://api.github.com/repos/xlabtg/teleton-agent/issues/519"},"comments":{"href":"https://api.github.com/repos/xlabtg/teleton-agent/issues/519/comments"},"review_comments":{"href":"https://api.github.com/repos/xlabtg/teleton-agent/pulls/519/comments"},"review_comment":{"href":"https://api.github.com/repos/xlabtg/teleton-agent/pulls/comments{/number}"},"commits":{"href":"https://api.github.com/repos/xlabtg/teleton-agent/pulls/519/commits"},"statuses":{"href":"https://api.github.com/repos/xlabtg/teleton-agent/statuses/826**********************************60a"}},"author_association":"NONE","auto_merge":null,"assignee":null,"active_lock_reason":null,"merged":false,"mergeable":true,"rebaseable":true,"mergeable_state":"unstable","merged_by":null,"comments":2,"review_comments":0,"maintainer_can_modify":true,"commits":1,"additions":2,"deletions":1,"changed_files":1}
+[2026-05-30T17:18:25.335Z] [STDOUT] {"url":"https://api.github.com/repos/xlabtg/teleton-agent/issues/502","repository_url":"https://api.github.com/repos/xlabtg/teleton-agent","labels_url":"https://api.github.com/repos/xlabtg/teleton-agent/issues/502/labels{/name}","comments_url":"https://api.github.com/repos/xlabtg/teleton-agent/issues/502/comments","events_url":"https://api.github.com/repos/xlabtg/teleton-agent/issues/502/events","html_url":"https://github.com/xlabtg/teleton-agent/issues/502","id":4551683706,"node_id":"I_kwDORfHVp88AAAABD00ueg","number":502,"title":"[R13][P2] Community health files: Code of Conduct, PR template, issue chooser, governance","user":{"login":"konard","id":1431904,"node_id":"MDQ6VXNlcjE0MzE5MDQ=","avatar_url":"https://avatars.githubusercontent.com/u/1431904?v=4","gravatar_id":"","url":"https://api.github.com/users/konard","html_url":"https://github.com/konard","followers_url":"https://api.github.com/users/konard/followers","following_url":"https://api.github.com/users/konard/following{/other_user}","gists_url":"https://api.github.com/users/konard/gists{/gist_id}","starred_url":"https://api.github.com/users/konard/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/konard/subscriptions","organizations_url":"https://api.github.com/users/konard/orgs","repos_url":"https://api.github.com/users/konard/repos","events_url":"https://api.github.com/users/konard/events{/privacy}","received_events_url":"https://api.github.com/users/konard/received_events","type":"User","user_view_type":"public","site_admin":false},"labels":[],"state":"open","locked":false,"assignees":[],"milestone":null,"comments":0,"created_at":"2026-05-29T21:18:15Z","updated_at":"2026-05-29T21:18:15Z","closed_at":null,"assignee":null,"author_association":"NONE","active_lock_reason":null,"sub_issues_summary":{"total":0,"completed":0,"percent_completed":0},"issue_dependencies_summary":{"blocked_by":0,"total_blocked_by":0,"blocking":0,"total_blocking":0},"body":"## Summary\n\n**Priority:** P2 — Polish / sustaining  \n**Tags:** `readiness`, `documentation`  \n**Relates to:** #487 (readiness analysis)\n\n---\n\n## Problem\n\nThe project already has `CONTRIBUTING.md` and `SECURITY.md`, which is a good start. However, several GitHub community health files are still missing:\n- **Code of Conduct** — required for GitHub's community health checklist; signals a welcoming project\n- **Pull Request template** — without it, PRs arrive with no description, no checklist, no context\n- **Issue chooser / issue templates** — generic issue form leads to low-quality bug reports; feature requests mixed with bugs\n- **GitHub Discussions** — no async community space for questions, ideas, and show-and-tell\n- **Governance** — no documented decision-making process (who merges, who releases, how RFCs work)\n\n---\n\n## Tasks\n\n### Code of Conduct\n- [ ] Add `.github/CODE_OF_CONDUCT.md` (Contributor Covenant 2.1)\n- [ ] Link from README and CONTRIBUTING.md\n\n### Pull Request template\n- [ ] Add `.github/PULL_REQUEST_TEMPLATE.md` with:\n  - Description of change\n  - Type (bug fix / feature / refactor / docs)\n  - Testing done\n  - Checklist (tests pass, docs updated, CHANGELOG entry)\n\n### Issue templates\n- [ ] Add `.github/ISSUE_TEMPLATE/bug_report.yml` (structured bug report)\n- [ ] Add `.github/ISSUE_TEMPLATE/feature_request.yml` (feature proposal)\n- [ ] Add `.github/ISSUE_TEMPLATE/config.yml` (issue chooser with links to Discussions for questions)\n\n### GitHub Discussions\n- [ ] Enable Discussions on the repository\n- [ ] Create initial categories: Q&A, Ideas, Show & Tell, Announcements\n\n### Governance (optional lightweight)\n- [ ] Add `GOVERNANCE.md` documenting: maintainer list, merge policy, release cadence, RFC process\n\n---\n\n## Acceptance criteria\n\n- GitHub community health checklist shows 100% (Code of Conduct, Contributing, Security, Support)\n- New issues default to structured templates\n- PRs include the template checklist\n- Discussions are enabled and have at least the Q&A category\n","closed_by":null,"reactions":{"url":"https://api.github.com/repos/xlabtg/teleton-agent/issues/502/reactions","total_count":0,"+1":0,"-1":0,"laugh":0,"hooray":0,"confused":0,"heart":0,"rocket":0,"eyes":0},"timeline_url":"https://api.github.com/repos/xlabtg/teleton-agent/issues/502/timeline","performed_via_github_app":null,"state_reason":null,"pinned_comment":null}
+[2026-05-30T17:18:25.706Z] [STDOUT] {"id":1173476775,"node_id":"R_kgDORfHVpw","name":"teleton-agent","full_name":"xlabtg/teleton-agent","private":false,"owner":{"login":"xlabtg","id":241960702,"node_id":"U_kgDODmwG_g","avatar_url":"https://avatars.githubusercontent.com/u/241960702?v=4","gravatar_id":"","url":"https://api.github.com/users/xlabtg","html_url":"https://github.com/xlabtg","followers_url":"https://api.github.com/users/xlabtg/followers","following_url":"https://api.github.com/users/xlabtg/following{/other_user}","gists_url":"https://api.github.com/users/xlabtg/gists{/gist_id}","starred_url":"https://api.github.com/users/xlabtg/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/xlabtg/subscriptions","organizations_url":"https://api.github.com/users/xlabtg/orgs","repos_url":"https://api.github.com/users/xlabtg/repos","events_url":"https://api.github.com/users/xlabtg/events{/privacy}","received_events_url":"https://api.github.com/users/xlabtg/received_events","type":"User","user_view_type":"public","site_admin":false},"html_url":"https://github.com/xlabtg/teleton-agent","description":"Teleton: Autonomous AI Agent for Telegram & TON Blockchain","fork":true,"url":"https://api.github.com/repos/xlabtg/teleton-agent","forks_url":"https://api.github.com/repos/xlabtg/teleton-agent/forks","keys_url":"https://api.github.com/repos/xlabtg/teleton-agent/keys{/key_id}","collaborators_url":"https://api.github.com/repos/xlabtg/teleton-agent/collaborators{/collaborator}","teams_url":"https://api.github.com/repos/xlabtg/teleton-agent/teams","hooks_url":"https://api.github.com/repos/xlabtg/teleton-agent/hooks","issue_events_url":"https://api.github.com/repos/xlabtg/teleton-agent/issues/events{/number}","events_url":"https://api.github.com/repos/xlabtg/teleton-agent/events","assignees_url":"https://api.github.com/repos/xlabtg/teleton-agent/assignees{/user}","branches_url":"https://api.github.com/repos/xlabtg/teleton-agent/branches{/branch}","tags_url":"https://api.github.com/repos/xlabtg/teleton-agent/tags","blobs_url":"https://api.github.com/repos/xlabtg/teleton-agent/git/blobs{/sha}","git_tags_url":"https://api.github.com/repos/xlabtg/teleton-agent/git/tags{/sha}","git_refs_url":"https://api.github.com/repos/xlabtg/teleton-agent/git/refs{/sha}","trees_url":"https://api.github.com/repos/xlabtg/teleton-agent/git/trees{/sha}","statuses_url":"https://api.github.com/repos/xlabtg/teleton-agent/statuses/{sha}","languages_url":"https://api.github.com/repos/xlabtg/teleton-agent/languages","stargazers_url":"https://api.github.com/repos/xlabtg/teleton-agent/stargazers","contributors_url":"https://api.github.com/repos/xlabtg/teleton-agent/contributors","subscribers_url":"https://api.github.com/repos/xlabtg/teleton-agent/subscribers","subscription_url":"https://api.github.com/repos/xlabtg/teleton-agent/subscription","commits_url":"https://api.github.com/repos/xlabtg/teleton-agent/commits{/sha}","git_commits_url":"https://api.github.com/repos/xlabtg/teleton-agent/git/commits{/sha}","comments_url":"https://api.github.com/repos/xlabtg/teleton-agent/comments{/number}","issue_comment_url":"https://api.github.com/repos/xlabtg/teleton-agent/issues/comments{/number}","contents_url":"https://api.github.com/repos/xlabtg/teleton-agent/contents/{+path}","compare_url":"https://api.github.com/repos/xlabtg/teleton-agent/compare/{base}...{head}","merges_url":"https://api.github.com/repos/xlabtg/teleton-agent/merges","archive_url":"https://api.github.com/repos/xlabtg/teleton-agent/{archive_format}{/ref}","downloads_url":"https://api.github.com/repos/xlabtg/teleton-agent/downloads","issues_url":"https://api.github.com/repos/xlabtg/teleton-agent/issues{/number}","pulls_url":"https://api.github.com/repos/xlabtg/teleton-agent/pulls{/number}","milestones_url":"https://api.github.com/repos/xlabtg/teleton-agent/milestones{/number}","notifications_url":"https://api.github.com/repos/xlabtg/teleton-agent/notifications{?since,all,participating}","labels_url":"https://api.github.com/repos/xlabtg/teleton-agent/labels{/name}","releases_url":"https://api.github.com/repos/xlabtg/teleton-agent/releases{/id}","deployments_url":"https://api.github.com/repos/xlabtg/teleton-agent/deployments","created_at":"2026-03-05T12:08:57Z","updated_at":"2026-05-30T12:36:52Z","pushed_at":"2026-05-30T12:37:01Z","git_url":"git://github.com/xlabtg/teleton-agent.git","ssh_url":"git@github.com:xlabtg/teleton-agent.git","clone_url":"https://github.com/xlabtg/teleton-agent.git","svn_url":"https://github.com/xlabtg/teleton-agent","homepage":null,"size":10171,"stargazers_count":4,"watchers_count":4,"language":"TypeScript","has_issues":true,"has_projects":true,"has_downloads":true,"has_wiki":true,"has_pages":false,"has_discussions":false,"forks_count":3,"mirror_url":null,"archived":false,"disabled":false,"open_issues_count":3,"license":{"key":"mit","name":"MIT License","spdx_id":"MIT","url":"https://api.github.com/licenses/mit","node_id":"MDc6TGljZW5zZTEz"},"allow_forking":true,"is_template":false,"web_commit_signoff_required":false,"has_pull_requests":true,"pull_request_creation_policy":"all","topics":[],"visibility":"public","forks":3,"open_issues":3,"watchers":4,"default_branch":"main","permissions":{"admin":false,"maintain":false,"push":false,"triage":false,"pull":true},"temp_clone_token":"","parent":{"id":1151877538,"node_id":"R_kgDORKhBog","name":"teleton-agent","full_name":"TONresistor/teleton-agent","private":false,"owner":{"login":"TONresistor","id":240980241,"node_id":"U_kgDODl0REQ","avatar_url":"https://avatars.githubusercontent.com/u/240980241?v=4","gravatar_id":"","url":"https://api.github.com/users/TONresistor","html_url":"https://github.com/TONresistor","followers_url":"https://api.github.com/users/TONresistor/followers","following_url":"https://api.github.com/users/TONresistor/following{/other_user}","gists_url":"https://api.github.com/users/TONresistor/gists{/gist_id}","starred_url":"https://api.github.com/users/TONresistor/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/TONresistor/subscriptions","organizations_url":"https://api.github.com/users/TONresistor/orgs","repos_url":"https://api.github.com/users/TONresistor/repos","events_url":"https://api.github.com/users/TONresistor/events{/privacy}","received_events_url":"https://api.github.com/users/TONresistor/received_events","type":"User","user_view_type":"public","site_admin":false},"html_url":"https://github.com/TONresistor/teleton-agent","description":"Teleton: Autonomous AI Agent for Telegram & TON Blockchain","fork":false,"url":"https://api.github.com/repos/TONresistor/teleton-agent","forks_url":"https://api.github.com/repos/TONresistor/teleton-agent/forks","keys_url":"https://api.github.com/repos/TONresistor/teleton-agent/keys{/key_id}","collaborators_url":"https://api.github.com/repos/TONresistor/teleton-agent/collaborators{/collaborator}","teams_url":"https://api.github.com/repos/TONresistor/teleton-agent/teams","hooks_url":"https://api.github.com/repos/TONresistor/teleton-agent/hooks","issue_events_url":"https://api.github.com/repos/TONresistor/teleton-agent/issues/events{/number}","events_url":"https://api.github.com/repos/TONresistor/teleton-agent/events","assignees_url":"https://api.github.com/repos/TONresistor/teleton-agent/assignees{/user}","branches_url":"https://api.github.com/repos/TONresistor/teleton-agent/branches{/branch}","tags_url":"https://api.github.com/repos/TONresistor/teleton-agent/tags","blobs_url":"https://api.github.com/repos/TONresistor/teleton-agent/git/blobs{/sha}","git_tags_url":"https://api.github.com/repos/TONresistor/teleton-agent/git/tags{/sha}","git_refs_url":"https://api.github.com/repos/TONresistor/teleton-agent/git/refs{/sha}","trees_url":"https://api.github.com/repos/TONresistor/teleton-agent/git/trees{/sha}","statuses_url":"https://api.github.com/repos/TONresistor/teleton-agent/statuses/{sha}","languages_url":"https://api.github.com/repos/TONresistor/teleton-agent/languages","stargazers_url":"https://api.github.com/repos/TONresistor/teleton-agent/stargazers","contributors_url":"https://api.github.com/repos/TONresistor/teleton-agent/contributors","subscribers_url":"https://api.github.com
+[2026-05-30T17:18:25.706Z] [STDOUT] /repos/TONresistor/teleton-agent/subscribers","subscription_url":"https://api.github.com/repos/TONresistor/teleton-agent/subscription","commits_url":"https://api.github.com/repos/TONresistor/teleton-agent/commits{/sha}","git_commits_url":"https://api.github.com/repos/TONresistor/teleton-agent/git/commits{/sha}","comments_url":"https://api.github.com/repos/TONresistor/teleton-agent/comments{/number}","issue_comment_url":"https://api.github.com/repos/TONresistor/teleton-agent/issues/comments{/number}","contents_url":"https://api.github.com/repos/TONresistor/teleton-agent/contents/{+path}","compare_url":"https://api.github.com/repos/TONresistor/teleton-agent/compare/{base}...{head}","merges_url":"https://api.github.com/repos/TONresistor/teleton-agent/merges","archive_url":"https://api.github.com/repos/TONresistor/teleton-agent/{archive_format}{/ref}","downloads_url":"https://api.github.com/repos/TONresistor/teleton-agent/downloads","issues_url":"https://api.github.com/repos/TONresistor/teleton-agent/issues{/number}","pulls_url":"https://api.github.com/repos/TONresistor/teleton-agent/pulls{/number}","milestones_url":"https://api.github.com/repos/TONresistor/teleton-agent/milestones{/number}","notifications_url":"https://api.github.com/repos/TONresistor/teleton-agent/notifications{?since,all,participating}","labels_url":"https://api.github.com/repos/TONresistor/teleton-agent/labels{/name}","releases_url":"https://api.github.com/repos/TONresistor/teleton-agent/releases{/id}","deployments_url":"https://api.github.com/repos/TONresistor/teleton-agent/deployments","created_at":"2026-02-07T02:47:21Z","updated_at":"2026-05-29T08:07:09Z","pushed_at":"2026-05-21T23:31:42Z","git_url":"git://github.com/TONresistor/teleton-agent.git","ssh_url":"git@github.com:TONresistor/teleton-agent.git","clone_url":"https://github.com/TONresistor/teleton-agent.git","svn_url":"https://github.com/TONresistor/teleton-agent","homepage":null,"size":3150,"stargazers_count":75,"watchers_count":75,"language":"TypeScript","has_issues":true,"has_projects":true,"has_downloads":true,"has_wiki":true,"has_pages":false,"has_discussions":true,"forks_count":28,"mirror_url":null,"archived":false,"disabled":false,"open_issues_count":5,"license":{"key":"mit","name":"MIT License","spdx_id":"MIT","url":"https://api.github.com/licenses/mit","node_id":"MDc6TGljZW5zZTEz"},"allow_forking":true,"is_template":false,"web_commit_signoff_required":false,"has_pull_requests":true,"pull_request_creation_policy":"all","topics":["ai-agent","autonomous-agent","gramjs","llm","nodejs","open-source","plugin-sdk","rag","self-hosted","telegram","ton-blockchain","typescript"],"visibility":"public","forks":28,"open_issues":5,"watchers":75,"default_branch":"main"},"source":{"id":1151877538,"node_id":"R_kgDORKhBog","name":"teleton-agent","full_name":"TONresistor/teleton-agent","private":false,"owner":{"login":"TONresistor","id":240980241,"node_id":"U_kgDODl0REQ","avatar_url":"https://avatars.githubusercontent.com/u/240980241?v=4","gravatar_id":"","url":"https://api.github.com/users/TONresistor","html_url":"https://github.com/TONresistor","followers_url":"https://api.github.com/users/TONresistor/followers","following_url":"https://api.github.com/users/TONresistor/following{/other_user}","gists_url":"https://api.github.com/users/TONresistor/gists{/gist_id}","starred_url":"https://api.github.com/users/TONresistor/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/TONresistor/subscriptions","organizations_url":"https://api.github.com/users/TONresistor/orgs","repos_url":"https://api.github.com/users/TONresistor/repos","events_url":"https://api.github.com/users/TONresistor/events{/privacy}","received_events_url":"https://api.github.com/users/TONresistor/received_events","type":"User","user_view_type":"public","site_admin":false},"html_url":"https://github.com/TONresistor/teleton-agent","description":"Teleton: Autonomous AI Agent for Telegram & TON Blockchain","fork":false,"url":"https://api.github.com/repos/TONresistor/teleton-agent","forks_url":"https://api.github.com/repos/TONresistor/teleton-agent/forks","keys_url":"https://api.github.com/repos/TONresistor/teleton-agent/keys{/key_id}","collaborators_url":"https://api.github.com/repos/TONresistor/teleton-agent/collaborators{/collaborator}","teams_url":"https://api.github.com/repos/TONresistor/teleton-agent/teams","hooks_url":"https://api.github.com/repos/TONresistor/teleton-agent/hooks","issue_events_url":"https://api.github.com/repos/TONresistor/teleton-agent/issues/events{/number}","events_url":"https://api.github.com/repos/TONresistor/teleton-agent/events","assignees_url":"https://api.github.com/repos/TONresistor/teleton-agent/assignees{/user}","branches_url":"https://api.github.com/repos/TONresistor/teleton-agent/branches{/branch}","tags_url":"https://api.github.com/repos/TONresistor/teleton-agent/tags","blobs_url":"https://api.github.com/repos/TONresistor/teleton-agent/git/blobs{/sha}","git_tags_url":"https://api.github.com/repos/TONresistor/teleton-agent/git/tags{/sha}","git_refs_url":"https://api.github.com/repos/TONresistor/teleton-agent/git/refs{/sha}","trees_url":"https://api.github.com/repos/TONresistor/teleton-agent/git/trees{/sha}","statuses_url":"https://api.github.com/repos/TONresistor/teleton-agent/statuses/{sha}","languages_url":"https://api.github.com/repos/TONresistor/teleton-agent/languages","stargazers_url":"https://api.github.com/repos/TONresistor/teleton-agent/stargazers","contributors_url":"https://api.github.com/repos/TONresistor/teleton-agent/contributors","subscribers_url":"https://api.github.com/repos/TONresistor/teleton-agent/subscribers","subscription_url":"https://api.github.com/repos/TONresistor/teleton-agent/subscription","commits_url":"https://api.github.com/repos/TONresistor/teleton-agent/commits{/sha}","git_commits_url":"https://api.github.com/repos/TONresistor/teleton-agent/git/commits{/sha}","comments_url":"https://api.github.com/repos/TONresistor/teleton-agent/comments{/number}","issue_comment_url":"https://api.github.com/repos/TONresistor/teleton-agent/issues/comments{/number}","contents_url":"https://api.github.com/repos/TONresistor/teleton-agent/contents/{+path}","compare_url":"https://api.github.com/repos/TONresistor/teleton-agent/compare/{base}...{head}","merges_url":"https://api.github.com/repos/TONresistor/teleton-agent/merges","archive_url":"https://api.github.com/repos/TONresistor/teleton-agent/{archive_format}{/ref}","downloads_url":"https://api.github.com/repos/TONresistor/teleton-agent/downloads","issues_url":"https://api.github.com/repos/TONresistor/teleton-agent/issues{/number}","pulls_url":"https://api.github.com/repos/TONresistor/teleton-agent/pulls{/number}","milestones_url":"https://api.github.com/repos/TONresistor/teleton-agent/milestones{/number}","notifications_url":"https://api.github.com/repos/TONresistor/teleton-agent/notifications{?since,all,participating}","labels_url":"https://api.github.com/repos/TONresistor/teleton-agent/labels{/name}","releases_url":"https://api.github.com/repos/TONresistor/teleton-agent/releases{/id}","deployments_url":"https://api.github.com/repos/TONresistor/teleton-agent/deployments","created_at":"2026-02-07T02:47:21Z","updated_at":"2026-05-29T08:07:09Z","pushed_at":"2026-05-21T23:31:42Z","git_url":"git://github.com/TONresistor/teleton-agent.git","ssh_url":"git@github.com:TONresistor/teleton-agent.git","clone_url":"https://github.com/TONresistor/teleton-agent.git","svn_url":"https://github.com/TONresistor/teleton-agent","homepage":null,"size":3150,"stargazers_count":75,"watchers_count":75,"language":"TypeScript","has_issues":true,"has_projects":true,"has_downloads":true,"has_wiki":true,"has_pages":false,"has_discussions":true,"forks_count":28,"mirror_url":null,"archived":false,"disabled":false,"open_issues_count":5,"license":{"key":"mit","name":"MIT License","spdx_id":"MIT","url":"https://api.github.com/licenses/mit","node_id":"MDc6TGljZW5zZTEz"},"allow_forking":true,"is_template":false,"web_commit_signoff_required":false,"has_pull_requests":true,"pull_request_creation_policy":"all","topics":["ai-agent","autonomous-agent","gramjs","llm","nodejs","open-source","plugin-sdk","rag","self-hosted","telegram","ton-blockchain","typescript"],"visibility":"public","forks":28,"open_issues":5,"watchers":75,"default_branch":"main"},"network_count":28,"subscribers_count":0}
+[2026-05-30T17:18:25.892Z] [STDOUT] {
+  "message": "Not Found",
+  "documentation_url": "https://docs.github.com/rest",
+  "status": "404"
+}
+[2026-05-30T17:18:25.892Z] [STDERR] gh: Not Found (HTTP 404)
+[2026-05-30T17:18:26.295Z] [STDOUT] 826**********************************60a
+[2026-05-30T17:18:26.849Z] [STDOUT] [
+[2026-05-30T17:18:26.850Z] [STDOUT] {"total_count":24,"check_runs":[{"id":78663732687,"name":"Deploy to Vercel","node_id":"CR_kwDORfHVp88AAAASULlNzw","head_sha":"826**********************************60a","external_id":"cdf231f2-b949-5d02-997b-14f44c818189","url":"https://api.github.com/repos/xlabtg/teleton-agent/check-runs/78663732687","html_url":"https://github.com/xlabtg/teleton-agent/actions/runs/26689643837/job/78663732687","details_url":"https://github.com/xlabtg/teleton-agent/actions/runs/26689643837/job/78663732687","status":"completed","conclusion":"success","started_at":"2026-05-30T16:59:26Z","completed_at":"2026-05-30T16:59:53Z","output":{"title":null,"summary":null,"text":null,"annotations_count":1,"annotations_url":"https://api.github.com/repos/xlabtg/teleton-agent/check-runs/78663732687/annotations"},"check_suite":{"id":71541102617},"app":{"id":15368,"client_id":"Iv1.05c79e9ad1f6bdfa","slug":"github-actions","node_id":"MDM6QXBwMTUzNjg=","owner":{"login":"github","id":9919,"node_id":"MDEyOk9yZ2FuaXphdGlvbjk5MTk=","avatar_url":"https://avatars.githubusercontent.com/u/9919?v=4","gravatar_id":"","url":"https://api.github.com/users/github","html_url":"https://github.com/github","followers_url":"https://api.github.com/users/github/followers","following_url":"https://api.github.com/users/github/following{/other_user}","gists_url":"https://api.github.com/users/github/gists{/gist_id}","starred_url":"https://api.github.com/users/github/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/github/subscriptions","organizations_url":"https://api.github.com/users/github/orgs","repos_url":"https://api.github.com/users/github/repos","events_url":"https://api.github.com/users/github/events{/privacy}","received_events_url":"https://api.github.com/users/github/received_events","type":"Organization","user_view_type":"public","site_admin":false},"name":"GitHub Actions","description":"Automate your workflow from idea to production","external_url":"https://help.github.com/en/actions","html_url":"https://github.com/apps/github-actions","created_at":"2018-07-30T09:30:17Z","updated_at":"2026-05-05T14:51:38Z","permissions":{"actions":"write","administration":"read","artifact_metadata":"write","attestations":"write","checks":"write","code_quality":"write","contents":"write","copilot_requests":"write","deployments":"write","discussions":"write","issues":"write","merge_queues":"write","metadata":"read","models":"read","packages":"write","pages":"write","pull_requests":"write","repository_hooks":"write","repository_projects":"write","security_events":"write","statuses":"write","vulnerability_alerts":"read"},"events":["branch_protection_rule","check_run","check_suite","create","delete","deployment","deployment_status","discussion","discussion_comment","fork","gollum","issues","issue_comment","label","merge_group","milestone","page_build","public","pull_request","pull_request_review","pull_request_review_comment","push","registry_package","release","repository","repository_dispatch","status","watch","workflow_dispatch","workflow_run"]},"pull_requests":[],"deployment":{"url":"https://api.github.com/repos/xlabtg/teleton-agent/deployments/4874085565","id":4874085565,"node_id":"DE_kwDORfHVp88AAAABIoSkvQ","task":"deploy","original_environment":"pr-preview","environment":"pr-preview","description":null,"created_at":"2026-05-30T16:59:23Z","updated_at":"2026-05-30T16:59:54Z","statuses_url":"https://api.github.com/repos/xlabtg/teleton-agent/deployments/4874085565/statuses","repository_url":"https://api.github.com/repos/xlabtg/teleton-agent"}},{"id":78663731362,"name":"Deploy to Vercel","node_id":"CR_kwDORfHVp88AAAASULlIog","head_sha":"826**********************************60a","external_id":"e94a8be8-831d-52df-9500-03940a5c098f","url":"https://api.github.com/repos/xlabtg/teleton-agent/check-runs/78663731362","html_url":"https://github.com/xlabtg/teleton-agent/actions/runs/26689643842/job/78663731362","details_url":"https://github.com/xlabtg/teleton-agent/actions/runs/26689643842/job/78663731362","status":"completed","conclusion":"skipped","started_at":"2026-05-30T16:59:22Z","completed_at":"2026-05-30T16:59:21Z","output":{"title":null,"summary":null,"text":null,"annotations_count":0,"annotations_url":"https://api.github.com/repos/xlabtg/teleton-agent/check-runs/78663731362/annotations"},"check_suite":{"id":71541102640},"app":{"id":15368,"client_id":"Iv1.05c79e9ad1f6bdfa","slug":"github-actions","node_id":"MDM6QXBwMTUzNjg=","owner":{"login":"github","id":9919,"node_id":"MDEyOk9yZ2FuaXphdGlvbjk5MTk=","avatar_url":"https://avatars.githubusercontent.com/u/9919?v=4","gravatar_id":"","url":"https://api.github.com/users/github","html_url":"https://github.com/github","followers_url":"https://api.github.com/users/github/followers","following_url":"https://api.github.com/users/github/following{/other_user}","gists_url":"https://api.github.com/users/github/gists{/gist_id}","starred_url":"https://api.github.com/users/github/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/github/subscriptions","organizations_url":"https://api.github.com/users/github/orgs","repos_url":"https://api.github.com/users/github/repos","events_url":"https://api.github.com/users/github/events{/privacy}","received_events_url":"https://api.github.com/users/github/received_events","type":"Organization","user_view_type":"public","site_admin":false},"name":"GitHub Actions","description":"Automate your workflow from idea to production","external_url":"https://help.github.com/en/actions","html_url":"https://github.com/apps/github-actions","created_at":"2018-07-30T09:30:17Z","updated_at":"2026-05-05T14:51:38Z","permissions":{"actions":"write","administration":"read","artifact_metadata":"write","attestations":"write","checks":"write","code_quality":"write","contents":"write","copilot_requests":"write","deployments":"write","discussions":"write","issues":"write","merge_queues":"write","metadata":"read","models":"read","packages":"write","pages":"write","pull_requests":"write","repository_hooks":"write","repository_projects":"write","security_events":"write","statuses":"write","vulnerability_alerts":"read"},"events":["branch_protection_rule","check_run","check_suite","create","delete","deployment","deployment_status","discussion","discussion_comment","fork","gollum","issues","issue_comment","label","merge_group","milestone","page_build","public","pull_request","pull_request_review","pull_request_review_comment","push","registry_package","release","repository","repository_dispatch","status","watch","workflow_dispatch","workflow_run"]},"pull_requests":[]},{"id":78663682574,"name":"E2E / WebUI (Playwright)","node_id":"CR_kwDORfHVp88AAAASULiKDg","head_sha":"826**********************************60a","external_id":"eab89700-b0b3-5790-85c8-3ba78d541410","url":"https://api.github.com/repos/xlabtg/teleton-agent/check-runs/78663682574","html_url":"https://github.com/xlabtg/teleton-agent/actions/runs/26689643862/job/78663682574","details_url":"https://github.com/xlabtg/teleton-agent/actions/runs/26689643862/job/78663682574","status":"completed","conclusion":"skipped","started_at":"2026-05-30T16:58:30Z","completed_at":"2026-05-30T16:58:30Z","output":{"title":null,"summary":null,"text":null,"annotations_count":0,"annotations_url":"https://api.github.com/repos/xlabtg/teleton-agent/check-runs/78663682574/annotations"},"check_suite":{"id":71541102705},"app":{"id":15368,"client_id":"Iv1.05c79e9ad1f6bdfa","slug":"github-actions","node_id":"MDM6QXBwMTUzNjg=","owner":{"login":"github","id":9919,"node_id":"MDEyOk9yZ2FuaXphdGlvbjk5MTk=","avatar_url":"https://avatars.githubusercontent.com/u/9919?v=4","gravatar_id":"","url":"https://api.github.com/users/github","html_url":"https://github.com/github","followers_url":"https://api.github.com/users/github/followers","following_url":"https://api.github.com/users/github/following{/other_user}","gists_url":"https://api.github.com/users/github/gists{/gist_id}","starred_url":"https://api.github.com/users/github/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/github/subscriptions","organizations_url":"https://api.github.com/users/github/orgs","repos_url":"https://api.github.com/users/github/repos","events_url":"https://api.github.com/users/github/events{/privacy}","received_events_url":"https://api.github.com/users/github/received_events","type":"Organization","user_view_type":"public","site_admin":false},"name":"GitHub Actions","description":"Automate your workflow from idea to production","external_url":"https://help.github.com/en/actions","html_url":"https://github.com/apps/github-actions","created_at":"2018-07-30T09:30:17Z","updated_at":"2026-05-05T14:51:38Z","permissions":{"actions":"write","administration":"read","artifact_metadata":"write","attestations":"write","checks":"write","code_quality":"write","contents":"write","copilot_requests":"write","deployments":"write","discussions":"write","issues":"write","merge_queues":"write","metadata":"read","models":"read","packages":"write","pages":"write","pull_requests":"write","repository_hooks":"write","repository_projects":"write","security_events":"write","statuses":"write","vulnerability_alerts":"read"},"events":["branch_protection_rule","check_run","check_suite","create","delete","deployment","deployment_status","discussion","discussion_comment","fork","gollum","issues","issue_comment","label","merge_group","milestone","page_build","public","pull_request","pull_request_review","pull_request_review_comment","push","registry_package","release","repository","repository_dispatch","status","watch","workflow_dispatch","workflow_run"]},"pull_requests":[]},{"id":78663682521,"name":"E2E / WebUI (Playwright)","node_id":"CR_kwDORfHVp88AAAASULiJ2Q","head_sha":"826**********************************60a","external_id":"b7754595-7e01-5988-9003-80bc8d87b0b7","url":"https://api.github.com/repos/xlabtg/teleton-agent/check-runs/78663682521","html_url":"https://github.com/xlabtg/teleton-agent/actions/runs/26689643829/job/78663682521","details_url":"https://github.com/xlabtg/teleton-agent/actions/runs/26689643829/job/78663682521","status":"completed","conclusion":"skipped","started_at":"2026-05-30T16:58:30Z","completed_at":"2026-05-30T16:58:30Z","output":{"title":null,"summary":null,"text":null,"annotations_count":0,"annotations_url":"https://api.github.com/repos/xlabtg/teleton-agent/check-runs/78663682521/annotations"},"check_suite":{"id":71541102586},"app":{"id":15368,"client_id":"Iv1.05c79e9ad1f6bdfa","slug":"github-actions","node_id":"MDM6QXBwMTUzNjg=","owner":{"login":"github","id":9919,"node_id":"MDEyOk9yZ2FuaXphdGlvbjk5MTk=","avatar_url":"https://avatars.githubusercontent.com/u/9919?v=4","gravatar_id":"","url":"https://api.github.com/users/github","html_url":"https://github.com/github","followers_url":"https://api.github.com/users/github/followers","following_url":"https://api.github.com/users/github/following{/other_user}","gists_url":"https://api.github.com/users/github/gists{/gist_id}","starred_url":"https://api.github.com/users/github/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/github/subscriptions","organizations_url":"https://api.github.com/users/github/orgs","repos_url":"https://api.github.com/users/github/repos","events_url":"https://api.github.com/users/github/events{/privacy}","received_events_url":"https://api.github.com/users/github/received_events","type":"Organization","user_view_type":"public","site_admin":false},"name":"GitHub Actions","description":"Automate your workflow from idea to production","external_url":"https://help.github.com/en/actions","html_url":"https://github.com/apps/github-actions","created_at":"2018-07-30T09:30:17Z","updated_at":"2026-05-05T14:51:38Z","permissions":{"actions":"write","administration":"read","artifact_metadata":"write","attestations":"write","checks":"write","code_quality":"write","contents":"write","copilot_requests":"write","deployments":"write","discussions":"write","issues":"write","merge_queues":"write","metadata":"read","models":"read","packages":"write","pages":"write","pull_requests":"write","repository_hooks":"write","repository_projects":"write","security_events":"write","statuses":"write","vulnerability_alerts":"read"},"events":["branch_protection_rule","check_run","check_suite","create","delete","deployment","deployment_status","discussion","discussion_comment","fork","gollum","issues","issue_comment","label","merge_group","milestone","page_build","public","pull_request","pull_request_review","pull_request_review_comment","push","registry_package","release","repository","repository_dispatch","status","watch","workflow_dispatch","workflow_run"]},"pull_requests":[]},{"id":78663682520,"name":"CI / Quality (push)","node_id":"CR_kwDORfHVp88AAAASULiJ2A","head_sha":"826**********************************60a","external_id":"4085be03-9bdc-500d-9f60-d8d306800bb3","url":"https://api.github.com/repos/xlabtg/teleton-agent/check-runs/78663682520","html_url":"https://github.com/xlabtg/teleton-agent/actions/runs/26689643837/job/78663682520","details_url":"https://github.com/xlabtg/teleton-agent/actions/runs/26689643837/job/78663682520","status":"completed","conclusion":"skipped","started_at":"2026-05-30T16:58:30Z","completed_at":"2026-05-30T16:58:30Z","output":{"title":null,"summary":null,"text":null,"annotations_count":0,"annotations_url":"https://api.github.com/repos/xlabtg/teleton-agent/check-runs/78663682520/annotations"},"check_suite":{"id":71541102617},"app":{"id":15368,"client_id":"Iv1.05c79e9ad1f6bdfa","slug":"github-actions","node_id":"MDM6QXBwMTUzNjg=","owner":{"login":"github","id":9919,"node_id":"MDEyOk9yZ2FuaXphdGlvbjk5MTk=","avatar_url":"https://avatars.githubusercontent.com/u/9919?v=4","gravatar_id":"","url":"https://api.github.com/users/github","html_url":"https://github.com/github","followers_url":"https://api.github.com/users/github/followers","following_url":"https://api.github.com/users/github/following{/other_user}","gists_url":"https://api.github.com/users/github/gists{/gist_id}","starred_url":"https://api.github.com/users/github/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/github/subscriptions","organizations_url":"https://api.github.com/users/github/orgs","repos_url":"https://api.github.com/users/github/repos","events_url":"https://api.github.com/users/github/events{/privacy}","received_events_url":"https://api.github.com/users/github/received_events","type":"Organization","user_view_type":"public","site_admin":false},"name":"GitHub Actions","description":"Automate your workflow from idea to production","external_url":"https://help.github.com/en/actions","html_url":"https://github.com/apps/github-actions","created_at":"2018-07-30T09:30:17Z","updated_at":"2026-05-05T14:51:38Z","permissions":{"actions":"write","administration":"read","artifact_metadata":"write","attestations":"write","checks":"write","code_quality":"write","contents":"write","copilot_requests":"write","deployments":"write","discussions":"write","issues":"write","merge_queues":"write","metadata":"read","models":"read","packages":"write","pages":"write","pull_requests":"write","repository_hooks":"write","repository_projects":"write","security_events":"write","statuses":"write","vulnerability_alerts":"read"},"events":["branch_protection_rule","check_run","check_suite","create","delete","deployment","deployment_status","discussion","discussion_comment","fork","gollum","issues","issue_comment","label","merge_group","milestone","page_build","public","pull_request","pull_request_review","pull_request_review_comment","push","registry_package","release","repository","repository_dispatch","status","watch","workflow_dispatch","workflow_run"]},"pull_requests":[]},{"id":78663682502,"name":"CI / Quality (push)","node_id":"CR_kwDORfHVp88AAAASULiJxg","head_sha":"826**********************************60a","external_id":"665cd596-b920-5e2d-909a-097d4efe1d89","url":"https://api.github.com/repos/xlabtg/teleton-agent/check-runs/78663682502","html_url":"https://github.com/xlabtg/teleton-agent/actions/runs/26689643842/job/78663682502","details_url":"https://github.com/xlabtg/teleton-agent/actions/runs/26689643842/job/78663682502","status":"completed","conclusion":"skipped","started_at":"2026-05-30T16:58:30Z","completed_at":"2026-05-30T16:58:30Z","output":{"title":null,"summary":null,"text":null,"annotations_count":0,"annotations_url":"https://api.github.com/repos/xlabtg/teleton-agent/check-runs/78663682502/annotations"},"check_suite":{"id":71541102640},"app":{"id":15368,"client_id":"Iv1.05c79e9ad1f6bdfa","slug":"github-actions","node_id":"MDM6QXBwMTUzNjg=","owner":{"login":"github","id":9919,"node_id":"MDEyOk9yZ2FuaXphdGlvbjk5MTk=","avatar_url":"https://avatars.githubusercontent.com/u/9919?v=4","gravatar_id":"","url":"https://api.github.com/users/github","html_url":"https://github.com/github","followers_url":"https://api.github.com/users/github/followers","following_url":"https://api.github.com/users/github/following{/other_user}","gists_url":"https://api.github.com/users/github/gists{/gist_id}","starred_url":"https://api.github.com/users/github/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/github/subscriptions","organizations_url":"https://api.github.com/users/github/orgs","repos_url":"https://api.github.com/users/github/repos","events_url":"https://api.github.com/users/github/events{/privacy}","received_events_url":"https://api.github.com/users/github/received_events","type":"Organization","user_view_type":"public","site_admin":false},"name":"GitHub Actions","description":"Automate your workflow from idea to production","external_url":"https://help.github.com/en/actions","html_url":"https://github.com/apps/github-actions","created_at":"2018-07-30T09:30:17Z","updated_at":"2026-05-05T14:51:38Z","permissions":{"actions":"write","administration":"read","artifact_metadata":"write","attestations":"write","checks":"write","code_quality":"write","contents":"write","copilot_requests":"write","deployments":"write","discussions":"write","issues":"write","merge_queues":"write","metadata":"read","models":"read","packages":"write","pages":"write","pull_requests":"write","repository_hooks":"write","repository_projects":"write","security_events":"write","statuses":"write","vulnerability_alerts":"read"},"events":["branch_protection_rule","check_run","check_suite","create","delete","deployment","deployment_status","discussion","discussion_comment","fork","gollum","issues","issue_comment","label","merge_group","milestone","page_build","public","pull_request","pull_request_review","pull_request_review_comment","push","registry_package","release","repository","repository_dispatch","status","watch","workflow_dispatch","workflow_run"]},"pull_requests":[]},{"id":78663682409,"name":"CI / Build (Runtime) (22)","node_id":"CR_kwDORfHVp88AAAASULiJaQ","head_sha":"826**********************************60a","external_id":"ad60d19f-f92f-5247-b3c2-43afd728a323","url":"https://api.github.com/repos/xlabtg/teleton-agent/check-runs/78663682409","html_url":"https://github.com/xlabtg/teleton-agent/actions/runs/26689643842/job/78663682409","details_url":"https://github.com/xlabtg/teleton-agent/actions/runs/26689643842/job/78663682409","status":"completed","conclusion":"success","started_at":"2026-05-30T16:58:32Z","completed_at":"2026-05-30T16:59:11Z","output":{"title":null,"summary":null,"text":null,"annotations_count":1,"annotations_url":"https://api.github.com/repos/xlabtg/teleton-agent/check-runs/78663682409/annotations"},"check_suite":{"id":71541102640},"app":{"id":15368,"client_id":"Iv1.05c79e9ad1f6bdfa","slug":"github-actions","node_id":"MDM6QXBwMTUzNjg=","owner":{"login":"github","id":9919,"node_id":"MDEyOk9yZ2FuaXphdGlvbjk5MTk=","avatar_url":"https://avatars.githubusercontent.com/u/9919?v=4","gravatar_id":"","url":"https://api.github.com/users/github","html_url":"https://github.com/github","followers_url":"https://api.github.com/users/github/followers","following_url":"https://api.github.com/users/github/following{/other_user}","gists_url":"https://api.github.com/users/github/gists{/gist_id}","starred_url":"https://api.github.com/users/github/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/github/subscriptions","organizations_url":"https://api.github.com/users/github/orgs","repos_url":"https://api.github.com/users/github/repos","events_url":"https://api.github.com/users/github/events{/privacy}","received_events_url":"https://api.github.com/users/github/received_events","type":"Organization","user_view_type":"public","site_admin":false},"name":"GitHub Actions","description":"Automate your workflow from idea to production","external_url":"https://help.github.com/en/actions","html_url":"https://github.com/apps/github-actions","created_at":"2018-07-30T09:30:17Z","updated_at":"2026-05-05T14:51:38Z","permissions":{"actions":"write","administration":"read","artifact_metadata":"write","attestations":"write","checks":"write","code_quality":"write","contents":"write","copilot_requests":"write","deployments":"write","discussions":"write","issues":"write","merge_queues":"write","metadata":"read","models":"read","packages":"write","pages":"write","pull_requests":"write","repository_hooks":"write","repository_projects":"write","security_events":"write","statuses":"write","vulnerability_alerts":"read"},"events":["branch_protection_rule","check_run","check_suite","create","delete","deployment","deployment_status","discussion","discussion_comment","fork","gollum","issues","issue_comment","label","merge_group","milestone","page_build","public","pull_request","pull_request_review","pull_request_review_comment","push","registry_package","release","repository","repository_dispatch","status","watch","workflow_dispatch","workflow_run"]},"pull_requests":[]},{"id":78663682408,"name":"Security audit","node_id":"CR_kwDORfHVp88AAAASULiJaA","head_sha":"826**********************************60a","external_id":"1b834a6d-c5d1-5f81-8873-6295e16185ab","url":"https://api.github.com/repos/xlabtg/teleton-agent/check-runs/78663682408","html_url":"https://github.com/xlabtg/teleton-agent/actions/runs/26689643842/job/78663682408","details_url":"https://github.com/xlabtg/teleton-agent/actions/runs/26689643842/job/78663682408","status":"completed","conclusion":"success","started_at":"2026-05-30T16:58:33Z","completed_at":"2026-05-30T16:59:06Z","output":{"title":null,"summary":null,"text":null,"annotations_count":1,"annotations_url":"https://api.github.com/repos/xlabtg/teleton-agent/check-runs/78663682408/annotations"},"check_suite":{"id":71541102640},"app":{"id":15368,"client_id":"Iv1.05c79e9ad1f6bdfa","slug":"github-actions","node_id":"MDM6QXBwMTUzNjg=","owner":{"login":"github","id":9919,"node_id":"MDEyOk9yZ2FuaXphdGlvbjk5MTk=","avatar_url":"https://avatars.githubusercontent.com/u/9919?v=4","gravatar_id":"","url":"https://api.github.com/users/github","html_url":"https://github.com/github","followers_url":"https://api.github.com/users/github/followers","following_url":"https://api.github.com/users/github/following{/other_user}","gists_url":"https://api.github.com/users/github/gists{/gist_id}","starred_url":"https://api.github.com/users/github/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/github/subscriptions","organizations_url":"https://api.github.com/users/github/orgs","repos_url":"https://api.github.com/users/github/repos","events_url":"https://api.github.com/users/github/events{/privacy}","received_events_url":"https://api.github.com/users/github/received_events","type":"Organization","user_view_type":"public","site_admin":false},"name":"GitHub Actions","description":"Automate your workflow from idea to production","external_url":"https://help.github.com/en/actions","html_url":"https://github.com/apps/github-actions","created_at":"2018-07-30T09:30:17Z","updated_at":"2026-05-05T14:51:38Z","permissions":{"actions":"write","administration":"read","artifact_metadata":"write","attestations":"write","checks":"write","code_quality":"write","contents":"write","copilot_requests":"write","deployments":"write","discussions":"write","issues":"write","merge_queues":"write","metadata":"read","models":"read","packages":"write","pages":"write","pull_requests":"write","repository_hooks":"write","repository_projects":"write","security_events":"write","statuses":"write","vulnerability_alerts":"read"},"events":["branch_protection_rule","check_run","check_suite","create","delete","deployment","deployment_status","discussion","discussion_comment","fork","gollum","issues","issue_comment","label","merge_group","milestone","page_build","public","pull_request","pull_request_review","pull_request_review_comment","push","registry_package","release","repository","repository_dispatch","status","watch","workflow_dispatch","workflow_run"]},"pull_requests":[]},{"id":78663682406,"name":"CI / Build (Runtime) (20)","node_id":"CR_kwDORfHVp88AAAASULiJZg","head_sha":"826**********************************60a","external_id":"08a46d1f-62a5-5b22-b74b-09d5de30db51","url":"https://api.github.com/repos/xlabtg/teleton-agent/check-runs/78663682406","html_url":"https://github.com/xlabtg/teleton-agent/actions/runs/26689643842/job/78663682406","details_url":"https://github.com/xlabtg/teleton-agent/actions/runs/26689643842/job/78663682406","status":"completed","conclusion":"success","started_at":"2026-05-30T16:58:32Z","completed_at":"2026-05-30T16:59:21Z","output":{"title":null,"summary":null,"text":null,"annotations_count":1,"annotations_url":"https://api.github.com/repos/xlabtg/teleton-agent/check-runs/78663682406/annotations"},"check_suite":{"id":71541102640},"app":{"id":15368,"client_id":"Iv1.05c79e9ad1f6bdfa","slug":"github-actions","node_id":"MDM6QXBwMTUzNjg=","owner":{"login":"github","id":9919,"node_id":"MDEyOk9yZ2FuaXphdGlvbjk5MTk=","avatar_url":"https://avatars.githubusercontent.com/u/9919?v=4","gravatar_id":"","url":"https://api.github.com/users/github","html_url":"https://github.com/github","followers_url":"https://api.github.com/users/github/followers","following_url":"https://api.github.com/users/github/following{/other_user}","gists_url":"https://api.github.com/users/github/gists{/gist_id}","starred_url":"https://api.github.com/users/github/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/github/subscriptions","organizations_url":"https://api.github.com/users/github/orgs","repos_url":"https://api.github.com/users/github/repos","events_url":"https://api.github.com/users/github/events{/privacy}","received_events_url":"https://api.github.com/users/github/received_events","type":"Organization","user_view_type":"public","site_admin":false},"name":"GitHub Actions","description":"Automate your workflow from idea to production","external_url":"https://help.github.com/en/actions","html_url":"https://github.com/apps/github-actions","created_at":"2018-07-30T09:30:17Z","updated_at":"2026-05-05T14:51:38Z","permissions":{"actions":"write","administration":"read","artifact_metadata":"write","attestations":"write","checks":"write","code_quality":"write","contents":"write","copilot_requests":"write","deployments":"write","discussions":"write","issues":"write","merge_queues":"write","metadata":"read","models":"read","packages":"write","pages":"write","pull_requests":"write","repository_hooks":"write","repository_projects":"write","security_events":"write","statuses":"write","vulnerability_alerts":"read"},"events":["branch_protection_rule","check_run","check_suite","create","delete","deployment","deployment_status","discussion","discussion_comment","fork","gollum","issues","issue_comment","label","merge_group","milestone","page_build","public","pull_request","pull_request_review","pull_request_review_comment","push","registry_package","release","repository","repository_dispatch","status","watch","workflow_dispatch","workflow_run"]},"pull_requests":[]},{"id":78663682397,"name":"CI / Deploy artifacts","node_id":"CR_kwDORfHVp88AAAASULiJXQ","head_sha":"826**********************************60a","external_id":"0b73be67-f9ab-5868-8137-975d2a798b96","url":"https://api.github.com/repos/xlabtg/teleton-agent/check-runs/78663682397","html_url":"https://github.com/xlabtg/teleton-agent/actions/runs/26689643842/job/78663682397","details_url":"https://github.com/xlabtg/teleton-agent/actions/runs/26689643842/job/78663682397","status":"completed","conclusion":"success","started_at":"2026-05-30T16:58:32Z","completed_at":"2026-05-30T16:58:38Z","output":{"title":null,"summary":null,"text":null,"annotations_count":1,"annotations_url":"https://api.github.com/repos/xlabtg/teleton-agent/check-runs/78663682397/annotations"},"check_suite":{"id":71541102640},"app":{"id":15368,"client_id":"Iv1.05c79e9ad1f6bdfa","slug":"github-actions","node_id":"MDM6QXBwMTUzNjg=","owner":{"login":"github","id":9919,"node_id":"MDEyOk9yZ2FuaXphdGlvbjk5MTk=","avatar_url":"https://avatars.githubusercontent.com/u/9919?v=4","gravatar_id":"","url":"https://api.github.com/users/github","html_url":"https://github.com/github","followers_url":"https://api.github.com/users/github/followers","following_url":"https://api.github.com/users/github/following{/other_user}","gists_url":"https://api.github.com/users/github/gists{/gist_id}","starred_url":"https://api.github.com/users/github/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/github/subscriptions","organizations_url":"https://api.github.com/users/github/orgs","repos_url":"https://api.github.com/users/github/repos","events_url":"https://api.github.com/users/github/events{/privacy}","received_events_url":"https://api.github.com/users/github/received_events","type":"Organization","user_view_type":"public","site_admin":false},"name":"GitHub Actions","description":"Automate your workflow from idea to production","external_url":"https://help.github.com/en/actions","html_url":"https://github.com/apps/github-actions","created_at":"2018-07-30T09:30:17Z","updated_at":"2026-05-05T14:51:38Z","permissions":{"actions":"write","administration":"read","artifact_metadata":"write","attestations":"write","checks":"write","code_quality":"write","contents":"write","copilot_requests":"write","deployments":"write","discussions":"write","issues":"write","merge_queues":"write","metadata":"read","models":"read","packages":"write","pages":"write","pull_requests":"write","repository_hooks":"write","repository_projects":"write","security_events":"write","statuses":"write","vulnerability_alerts":"read"},"events":["branch_protection_rule","check_run","check_suite","create","delete","deployment","deployment_status","discussion","discussion_comment","fork","gollum","issues","issue_comment","label","merge_group","milestone","page_build","public","pull_request","pull_request_review","pull_request_review_comment","push","registry_package","release","repository","repository_dispatch","status","watch","workflow_dispatch","workflow_run"]},"pull_requests":[]},{"id":78663682388,"name":"CI / Lint","node_id":"CR_kwDORfHVp88AAAASULiJVA","head_sha":"826**********************************60a","external_id":"ae483010-4d7e-5326-b967-056a12175c41","url":"https://api.github.com/repos/xlabtg/teleton-agent/check-runs/78663682388","html_url":"https://github.com/xlabtg/teleton-agent/actions/runs/26689643842/job/78663682388","details_url":"https://github.com/xlabtg/teleton-agent/actions/runs/26689643842/job/78663682388","status":"completed","conclusion":"success","started_at":"2026-05-30T16:58:33Z","completed_at":"2026-05-30T16:59:44Z","output":{"title":null,"summary":null,"text":null,"annotations_count":1,"annotations_url":"https://api.github.com/repos/xlabtg/teleton-agent/check-runs/78663682388/annotations"},"check_suite":{"id":71541102640},"app":{"id":15368,"client_id":"Iv1.05c79e9ad1f6bdfa","slug":"github-actions","node_id":"MDM6QXBwMTUzNjg=","owner":{"login":"github","id":9919,"node_id":"MDEyOk9yZ2FuaXphdGlvbjk5MTk=","avatar_url":"https://avatars.githubusercontent.com/u/9919?v=4","gravatar_id":"","url":"https://api.github.com/users/github","html_url":"https://github.com/github","followers_url":"https://api.github.com/users/github/followers","following_url":"https://api.github.com/users/github/following{/other_user}","gists_url":"https://api.github.com/users/github/gists{/gist_id}","starred_url":"https://api.github.com/users/github/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/github/subscriptions","organizations_url":"https://api.github.com/users/github/orgs","repos_url":"https://api.github.com/users/github/repos","events_url":"https://api.github.com/users/github/events{/privacy}","received_events_url":"https://api.github.com/users/github/received_events","type":"Organization","user_view_type":"public","site_admin":false},"name":"GitHub Actions","description":"Automate your workflow from idea to production","external_url":"https://help.github.com/en/actions","html_url":"https://github.com/apps/github-actions","created_at":"2018-07-30T09:30:17Z","updated_at":"2026-05-05T14:51:38Z","permissions":{"actions":"write","administration":"read","artifact_metadata":"write","attestations":"write","checks":"write","code_quality":"write","contents":"write","copilot_requests":"write","deployments":"write","discussions":"write","issues":"write","merge_queues":"write","metadata":"read","models":"read","packages":"write","pages":"write","pull_requests":"write","repository_hooks":"write","repository_projects":"write","security_events":"write","statuses":"write","vulnerability_alerts":"read"},"events":["branch_protection_rule","check_run","check_suite","create","delete","deployment","deployment_status","discussion","discussion_comment","fork","gollum","issues","issue_comment","label","merge_group","milestone","page_build","public","pull_request","pull_request_review","pull_request_review_comment","push","registry_package","release","repository","repository_dispatch","status","watch","workflow_dispatch","workflow_run"]},"pull_requests":[]},{"id":78663682380,"name":"CI / OpenAPI","node_id":"CR_kwDORfHVp88AAAASULiJTA","head_sha":"826**********************************60a","external_id":"364e6733-6105-54a0-985b-364e82f21a45","url":"https://api.github.com/repos/xlabtg/teleton-agent/check-runs/78663682380","html_url":"https://github.com/xlabtg/teleton-agent/actions/runs/26689643842/job/78663682380","details_url":"https://github.com/xlabtg/teleton-agent/actions/runs/26689643842/job/78663682380","status":"completed","conclusion":"success","started_at":"2026-05-30T16:58:32Z","completed_at":"2026-05-30T16:59:08Z","output":{"title":null,"summary":null,"text":null,"annotations_count":1,"annotations_url":"https://api.github.com/repos/xlabtg/teleton-agent/check-runs/78663682380/annotations"},"check_suite":{"id":71541102640},"app":{"id":15368,"client_id":"Iv1.05c79e9ad1f6bdfa","slug":"github-actions","node_id":"MDM6QXBwMTUzNjg=","owner":{"login":"github","id":9919,"node_id":"MDEyOk9yZ2FuaXphdGlvbjk5MTk=","avatar_url":"https://avatars.githubusercontent.com/u/9919?v=4","gravatar_id":"","url":"https://api.github.com/users/github","html_url":"https://github.com/github","followers_url":"https://api.github.com/users/github/followers","following_url":"https://api.github.com/users/github/following{/other_user}","gists_url":"https://api.github.com/users/github/gists{/gist_id}","starred_url":"https://api.github.com/users/github/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/github/subscriptions","organizations_url":"https://api.github.com/users/github/orgs","repos_url":"https://api.github.com/users/github/repos","events_url":"https://api.github.com/users/github/events{/privacy}","received_events_url":"https://api.github.com/users/github/received_events","type":"Organization","user_view_type":"public","site_admin":false},"name":"GitHub Actions","description":"Automate your workflow from idea to production","external_url":"https://help.github.com/en/actions","html_url":"https://github.com/apps/github-actions","created_at":"2018-07-30T09:30:17Z","updated_at":"2026-05-05T14:51:38Z","permissions":{"actions":"write","administration":"read","artifact_metadata":"write","attestations":"write","checks":"write","code_quality":"write","contents":"write","copilot_requests":"write","deployments":"write","discussions":"write","issues":"write","merge_queues":"write","metadata":"read","models":"read","packages":"write","pages":"write","pull_requests":"write","repository_hooks":"write","repository_projects":"write","security_events":"write","statuses":"write","vulnerability_alerts":"read"},"events":["branch_protection_rule","check_run","check_suite","create","delete","deployment","deployment_status","discussion","discussion_comment","fork","gollum","issues","issue_comment","label","merge_group","milestone","page_build","public","pull_request","pull_request_review","pull_request_review_comment","push","registry_package","release","repository","repository_dispatch","status","watch","workflow_dispatch","workflow_run"]},"pull_requests":[]},{"id":78663682377,"name":"CI / Build (SDK with DTS)","node_id":"CR_kwDORfHVp88AAAASULiJSQ","head_sha":"826**********************************60a","external_id":"ec23abae-bf31-5404-832f-6a934389aa52","url":"https://api.github.com/repos/xlabtg/teleton-agent/check-runs/78663682377","html_url":"https://github.com/xlabtg/teleton-agent/actions/runs/26689643842/job/78663682377","details_url":"https://github.com/xlabtg/teleton-agent/actions/runs/26689643842/job/78663682377","status":"completed","conclusion":"success","started_at":"2026-05-30T16:58:32Z","completed_at":"2026-05-30T16:59:08Z","output":{"title":null,"summary":null,"text":null,"annotations_count":1,"annotations_url":"https://api.github.com/repos/xlabtg/teleton-agent/check-runs/78663682377/annotations"},"check_suite":{"id":71541102640},"app":{"id":15368,"client_id":"Iv1.05c79e9ad1f6bdfa","slug":"github-actions","node_id":"MDM6QXBwMTUzNjg=","owner":{"login":"github","id":9919,"node_id":"MDEyOk9yZ2FuaXphdGlvbjk5MTk=","avatar_url":"https://avatars.githubusercontent.com/u/9919?v=4","gravatar_id":"","url":"https://api.github.com/users/github","html_url":"https://github.com/github","followers_url":"https://api.github.com/users/github/followers","following_url":"https://api.github.com/users/github/following{/other_user}","gists_url":"https://api.github.com/users/github/gists{/gist_id}","starred_url":"https://api.github.com/users/github/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/github/subscriptions","organizations_url":"https://api.github.com/users/github/orgs","repos_url":"https://api.github.com/users/github/repos","events_url":"https://api.github.com/users/github/events{/privacy}","received_events_url":"https://api.github.com/users/github/received_events","type":"Organization","user_view_type":"public","site_admin":false},"name":"GitHub Actions","description":"Automate your workflow from idea to production","external_url":"https://help.github.com/en/actions","html_url":"https://github.com/apps/github-actions","created_at":"2018-07-30T09:30:17Z","updated_at":"2026-05-05T14:51:38Z","permissions":{"actions":"write","administration":"read","artifact_metadata":"write","attestations":"write","checks":"write","code_quality":"write","contents":"write","copilot_requests":"write","deployments":"write","discussions":"write","issues":"write","merge_queues":"write","metadata":"read","models":"read","packages":"write","pages":"write","pull_requests":"write","repository_hooks":"write","repository_projects":"write","security_events":"write","statuses":"write","vulnerability_alerts":"read"},"events":["branch_protection_rule","check_run","check_suite","create","delete","deployment","deployment_status","discussion","discussion_comment","fork","gollum","issues","issue_comment","label","merge_group","milestone","page_build","public","pull_request","pull_request_review","pull_request_review_comment","push","registry_package","release","repository","repository_dispatch","status","watch","workflow_dispatch","workflow_run"]},"pull_requests":[]},{"id":78663682376,"name":"CI / Test","node_id":"CR_kwDORfHVp88AAAASULiJSA","head_sha":"826**********************************60a","external_id":"e2fe0a47-a27c-5cc8-85cf-20e348ba3afc","url":"https://api.github.com/repos/xlabtg/teleton-agent/check-runs/78663682376","html_url":"https://github.com/xlabtg/teleton-agent/actions/runs/26689643842/job/78663682376","details_url":"https://github.com/xlabtg/teleton-agent/actions/runs/26689643842/job/78663682376","status":"completed","conclusion":"failure","started_at":"2026-05-30T16:58:33Z","completed_at":"2026-05-30T17:00:00Z","output":{"title":null,"summary":null,"text":null,"annotations_count":3,"annotations_url":"https://api.github.com/repos/xlabtg/teleton-agent/check-runs/78663682376/annotations"},"check_suite":{"id":71541102640},"app":{"id":15368,"client_id":"Iv1.05c79e9ad1f6bdfa","slug":"github-actions","node_id":"MDM6QXBwMTUzNjg=","owner":{"login":"github","id":9919,"node_id":"MDEyOk9yZ2FuaXphdGlvbjk5MTk=","avatar_url":"https://avatars.githubusercontent.com/u/9919?v=4","gravatar_id":"","url":"https://api.github.com/users/github","html_url":"https://github.com/github","followers_url":"https://api.github.com/users/github/followers","following_url":"https://api.github.com/users/github/following{/other_user}","gists_url":"https://api.github.com/users/github/gists{/gist_id}","starred_url":"https://api.github.com/users/github/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/github/subscriptions","organizations_url":"https://api.github.com/users/github/orgs","repos_url":"https://api.github.com/users/github/repos","events_url":"https://api.github.com/users/github/events{/privacy}","received_events_url":"https://api.github.com/users/github/received_events","type":"Organization","user_view_type":"public","site_admin":false},"name":"GitHub Actions","description":"Automate your workflow from idea to production","external_url":"https://help.github.com/en/actions","html_url":"https://github.com/apps/github-actions","created_at":"2018-07-30T09:30:17Z","updated_at":"2026-05-05T14:51:38Z","permissions":{"actions":"write","administration":"read","artifact_metadata":"write","attestations":"write","checks":"write","code_quality":"write","contents":"write","copilot_requests":"write","deployments":"write","discussions":"write","issues":"write","merge_queues":"write","metadata":"read","models":"read","packages":"write","pages":"write","pull_requests":"write","repository_hooks":"write","repository_projects":"write","security_events":"write","statuses":"write","vulnerability_alerts":"read"},"events":["branch_protection_rule","check_run","check_suite","create","delete","deployment","deployment_status","discussion","discussion_comment","fork","gollum","issues","issue_comment","label","merge_group","milestone","page_build","public","pull_request","pull_request_review","pull_request_review_comment","push","registry_package","release","repository","repository_dispatch","status","watch","workflow_dispatch","workflow_run"]},"pull_requests":[]},{"id":78663682372,"name":"CI / TypeScript","node_id":"CR_kwDORfHVp88AAAASULiJRA","head_sha":"826**********************************60a","external_id":"154af21f-d29b-5bda-9946-ae5edef40f9d","url":"https://api.github.com/repos/xlabtg/teleton-agent/check-runs/78663682372","html_url":"https://github.com/xlabtg/teleton-agent/actions/runs/26689643842/job/78663682372","details_url":"https://github.com/xlabtg/teleton-agent/actions/runs/26689643842/job/78663682372","status":"completed","conclusion":"success","started_at":"2026-05-30T16:58:33Z","completed_at":"2026-05-30T16:59:19Z","output":{"title":null,"summary":null,"text":null,"annotations_count":1,"annotations_url":"https://api.github.com/repos/xlabtg/teleton-agent/check-runs/78663682372/annotations"},"check_suite":{"id":71541102640},"app":{"id":15368,"client_id":"Iv1.05c79e9ad1f6bdfa","slug":"github-actions","node_id":"MDM6QXBwMTUzNjg=","owner":{"login":"github","id":9919,"node_id":"MDEyOk9yZ2FuaXphdGlvbjk5MTk=","avatar_url":"https://avatars.githubusercontent.com/u/9919?v=4","gravatar_id":"","url":"https://api.github.com/users/github","html_url":"https://github.com/github","followers_url":"https://api.github.com/users/github/followers","following_url":"https://api.github.com/users/github/following{/other_user}","gists_url":"https://api.github.com/users/github/gists{/gist_id}","starred_url":"https://api.github.com/users/github/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/github/subscriptions","organizations_url":"https://api.github.com/users/github/orgs","repos_url":"https://api.github.com/users/github/repos","events_url":"https://api.github.com/users/github/events{/privacy}","received_events_url":"https://api.github.com/users/github/received_events","type":"Organization","user_view_type":"public","site_admin":false},"name":"GitHub Actions","description":"Automate your workflow from idea to production","external_url":"https://help.github.com/en/actions","html_url":"https://github.com/apps/github-actions","created_at":"2018-07-30T09:30:17Z","updated_at":"2026-05-05T14:51:38Z","permissions":{"actions":"write","administration":"read","artifact_metadata":"write","attestations":"write","checks":"write","code_quality":"write","contents":"write","copilot_requests":"write","deployments":"write","discussions":"write","issues":"write","merge_queues":"write","metadata":"read","models":"read","packages":"write","pages":"write","pull_requests":"write","repository_hooks":"write","repository_projects":"write","security_events":"write","statuses":"write","vulnerability_alerts":"read"},"events":["branch_protection_rule","check_run","check_suite","create","delete","deployment","deployment_status","discussion","discussion_comment","fork","gollum","issues","issue_comment","label","merge_group","milestone","page_build","public","pull_request","pull_request_review","pull_request_review_comment","push","registry_package","release","repository","repository_dispatch","status","watch","workflow_dispatch","workflow_run"]},"pull_requests":[]},{"id":78663682370,"name":"CI / TypeScript","node_id":"CR_kwDORfHVp88AAAASULiJQg","head_sha":"826**********************************60a","external_id":"9ee01ba9-fcff-525a-8ef1-fddb8c15d3fb","url":"https://api.github.com/repos/xlabtg/teleton-agent/check-runs/78663682370","html_url":"https://github.com/xlabtg/teleton-agent/actions/runs/26689643837/job/78663682370","details_url":"https://github.com/xlabtg/teleton-agent/actions/runs/26689643837/job/78663682370","status":"completed","conclusion":"success","started_at":"2026-05-30T16:58:33Z","completed_at":"2026-05-30T16:59:19Z","output":{"title":null,"summary":null,"text":null,"annotations_count":1,"annotations_url":"https://api.github.com/repos/xlabtg/teleton-agent/check-runs/78663682370/annotations"},"check_suite":{"id":71541102617},"app":{"id":15368,"client_id":"Iv1.05c79e9ad1f6bdfa","slug":"github-actions","node_id":"MDM6QXBwMTUzNjg=","owner":{"login":"github","id":9919,"node_id":"MDEyOk9yZ2FuaXphdGlvbjk5MTk=","avatar_url":"https://avatars.githubusercontent.com/u/9919?v=4","gravatar_id":"","url":"https://api.github.com/users/github","html_url":"https://github.com/github","followers_url":"https://api.github.com/users/github/followers","following_url":"https://api.github.com/users/github/following{/other_user}","gists_url":"https://api.github.com/users/github/gists{/gist_id}","starred_url":"https://api.github.com/users/github/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/github/subscriptions","organizations_url":"https://api.github.com/users/github/orgs","repos_url":"https://api.github.com/users/github/repos","events_url":"https://api.github.com/users/github/events{/privacy}","received_events_url":"https://api.github.com/users/github/received_events","type":"Organization","user_view_type":"public","site_admin":false},"name":"GitHub Actions","description":"Automate your workflow from idea to production","external_url":"https://help.github.com/en/actions","html_url":"https://github.com/apps/github-actions","created_at":"2018-07-30T09:30:17Z","updated_at":"2026-05-05T14:51:38Z","permissions":{"actions":"write","administration":"read","artifact_metadata":"write","attestations":"write","checks":"write","code_quality":"write","contents":"write","copilot_requests":"write","deployments":"write","discussions":"write","issues":"write","merge_queues":"write","metadata":"read","models":"read","packages":"write","pages":"write","pull_requests":"write","repository_hooks":"write","repository_projects":"write","security_events":"write","statuses":"write","vulnerability_alerts":"read"},"events":["branch_protection_rule","check_run","check_suite","create","delete","deployment","deployment_status","discussion","discussion_comment","fork","gollum","issues","issue_comment","label","merge_group","milestone","page_build","public","pull_request","pull_request_review","pull_request_review_comment","push","registry_package","release","repository","repository_dispatch","status","watch","workflow_dispatch","workflow_run"]},"pull_requests":[]},{"id":78663682361,"name":"CI / Build (SDK with DTS)","node_id":"CR_kwDORfHVp88AAAASULiJOQ","head_sha":"826**********************************60a","external_id":"7423f725-8cc0-5b51-a70b-9442e592da93","url":"https://api.github.com/repos/xlabtg/teleton-agent/check-runs/78663682361","html_url":"https://github.com/xlabtg/teleton-agent/actions/runs/26689643837/job/78663682361","details_url":"https://github.com/xlabtg/teleton-agent/actions/runs/26689643837/job/78663682361","status":"completed","conclusion":"success","started_at":"2026-05-30T16:58:33Z","completed_at":"2026-05-30T16:59:08Z","output":{"title":null,"summary":null,"text":null,"annotations_count":1,"annotations_url":"https://api.github.com/repos/xlabtg/teleton-agent/check-runs/78663682361/annotations"},"check_suite":{"id":71541102617},"app":{"id":15368,"client_id":"Iv1.05c79e9ad1f6bdfa","slug":"github-actions","node_id":"MDM6QXBwMTUzNjg=","owner":{"login":"github","id":9919,"node_id":"MDEyOk9yZ2FuaXphdGlvbjk5MTk=","avatar_url":"https://avatars.githubusercontent.com/u/9919?v=4","gravatar_id":"","url":"https://api.github.com/users/github","html_url":"https://github.com/github","followers_url":"https://api.github.com/users/github/followers","following_url":"https://api.github.com/users/github/following{/other_user}","gists_url":"https://api.github.com/users/github/gists{/gist_id}","starred_url":"https://api.github.com/users/github/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/github/subscriptions","organizations_url":"https://api.github.com/users/github/orgs","repos_url":"https://api.github.com/users/github/repos","events_url":"https://api.github.com/users/github/events{/privacy}","received_events_url":"https://api.github.com/users/github/received_events","type":"Organization","user_view_type":"public","site_admin":false},"name":"GitHub Actions","description":"Automate your workflow from idea to production","external_url":"https://help.github.com/en/actions","html_url":"https://github.com/apps/github-actions","created_at":"2018-07-30T09:30:17Z","updated_at":"2026-05-05T14:51:38Z","permissions":{"actions":"write","administration":"read","artifact_metadata":"write","attestations":"write","checks":"write","code_quality":"write","contents":"write","copilot_requests":"write","deployments":"write","discussions":"write","issues":"write","merge_queues":"write","metadata":"read","models":"read","packages":"write","pages":"write","pull_requests":"write","repository_hooks":"write","repository_projects":"write","security_events":"write","statuses":"write","vulnerability_alerts":"read"},"events":["branch_protection_rule","check_run","check_suite","create","delete","deployment","deployment_status","discussion","discussion_comment","fork","gollum","issues","issue_comment","label","merge_group","milestone","page_build","public","pull_request","pull_request_review","pull_request_review_comment","push","registry_package","release","repository","repository_dispatch","status","watch","workflow_dispatch","workflow_run"]},"pull_requests":[]},{"id":78663682359,"name":"CI / Build (Runtime) (22)","node_id":"CR_kwDORfHVp88AAAASULiJNw","head_sha":"826**********************************60a","external_id":"881952e2-c207-56c1-9921-68f29d99f83f","url":"https://api.github.com/repos/xlabtg/teleton-agent/check-runs/78663682359","html_url":"https://github.com/xlabtg/teleton-agent/actions/runs/26689643837/job/78663682359","details_url":"https://github.com/xlabtg/teleton-agent/actions/runs/26689643837/job/78663682359","status":"completed","conclusion":"success","started_at":"2026-05-30T16:58:33Z","completed_at":"2026-05-30T16:59:23Z","output":{"title":null,"summary":null,"text":null,"annotations_count":1,"annotations_url":"https://api.github.com/repos/xlabtg/teleton-agent/check-runs/78663682359/annotations"},"check_suite":{"id":71541102617},"app":{"id":15368,"client_id":"Iv1.05c79e9ad1f6bdfa","slug":"github-actions","node_id":"MDM6QXBwMTUzNjg=","own
+[2026-05-30T17:18:26.852Z] [STDOUT] er":{"login":"github","id":9919,"node_id":"MDEyOk9yZ2FuaXphdGlvbjk5MTk=","avatar_url":"https://avatars.githubusercontent.com/u/9919?v=4","gravatar_id":"","url":"https://api.github.com/users/github","html_url":"https://github.com/github","followers_url":"https://api.github.com/users/github/followers","following_url":"https://api.github.com/users/github/following{/other_user}","gists_url":"https://api.github.com/users/github/gists{/gist_id}","starred_url":"https://api.github.com/users/github/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/github/subscriptions","organizations_url":"https://api.github.com/users/github/orgs","repos_url":"https://api.github.com/users/github/repos","events_url":"https://api.github.com/users/github/events{/privacy}","received_events_url":"https://api.github.com/users/github/received_events","type":"Organization","user_view_type":"public","site_admin":false},"name":"GitHub Actions","description":"Automate your workflow from idea to production","external_url":"https://help.github.com/en/actions","html_url":"https://github.com/apps/github-actions","created_at":"2018-07-30T09:30:17Z","updated_at":"2026-05-05T14:51:38Z","permissions":{"actions":"write","administration":"read","artifact_metadata":"write","attestations":"write","checks":"write","code_quality":"write","contents":"write","copilot_requests":"write","deployments":"write","discussions":"write","issues":"write","merge_queues":"write","metadata":"read","models":"read","packages":"write","pages":"write","pull_requests":"write","repository_hooks":"write","repository_projects":"write","security_events":"write","statuses":"write","vulnerability_alerts":"read"},"events":["branch_protection_rule","check_run","check_suite","create","delete","deployment","deployment_status","discussion","discussion_comment","fork","gollum","issues","issue_comment","label","merge_group","milestone","page_build","public","pull_request","pull_request_review","pull_request_review_comment","push","registry_package","release","repository","repository_dispatch","status","watch","workflow_dispatch","workflow_run"]},"pull_requests":[]},{"id":78663682356,"name":"CI / Build (Runtime) (20)","node_id":"CR_kwDORfHVp88AAAASULiJNA","head_sha":"826**********************************60a","external_id":"cc619388-36b0-5ae7-928b-5ce280e698ec","url":"https://api.github.com/repos/xlabtg/teleton-agent/check-runs/78663682356","html_url":"https://github.com/xlabtg/teleton-agent/actions/runs/26689643837/job/78663682356","details_url":"https://github.com/xlabtg/teleton-agent/actions/runs/26689643837/job/78663682356","status":"completed","conclusion":"success","started_at":"2026-05-30T16:58:32Z","completed_at":"2026-05-30T16:59:20Z","output":{"title":null,"summary":null,"text":null,"annotations_count":1,"annotations_url":"https://api.github.com/repos/xlabtg/teleton-agent/check-runs/78663682356/annotations"},"check_suite":{"id":71541102617},"app":{"id":15368,"client_id":"Iv1.05c79e9ad1f6bdfa","slug":"github-actions","node_id":"MDM6QXBwMTUzNjg=","owner":{"login":"github","id":9919,"node_id":"MDEyOk9yZ2FuaXphdGlvbjk5MTk=","avatar_url":"https://avatars.githubusercontent.com/u/9919?v=4","gravatar_id":"","url":"https://api.github.com/users/github","html_url":"https://github.com/github","followers_url":"https://api.github.com/users/github/followers","following_url":"https://api.github.com/users/github/following{/other_user}","gists_url":"https://api.github.com/users/github/gists{/gist_id}","starred_url":"https://api.github.com/users/github/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/github/subscriptions","organizations_url":"https://api.github.com/users/github/orgs","repos_url":"https://api.github.com/users/github/repos","events_url":"https://api.github.com/users/github/events{/privacy}","received_events_url":"https://api.github.com/users/github/received_events","type":"Organization","user_view_type":"public","site_admin":false},"name":"GitHub Actions","description":"Automate your workflow from idea to production","external_url":"https://help.github.com/en/actions","html_url":"https://github.com/apps/github-actions","created_at":"2018-07-30T09:30:17Z","updated_at":"2026-05-05T14:51:38Z","permissions":{"actions":"write","administration":"read","artifact_metadata":"write","attestations":"write","checks":"write","code_quality":"write","contents":"write","copilot_requests":"write","deployments":"write","discussions":"write","issues":"write","merge_queues":"write","metadata":"read","models":"read","packages":"write","pages":"write","pull_requests":"write","repository_hooks":"write","repository_projects":"write","security_events":"write","statuses":"write","vulnerability_alerts":"read"},"events":["branch_protection_rule","check_run","check_suite","create","delete","deployment","deployment_status","discussion","discussion_comment","fork","gollum","issues","issue_comment","label","merge_group","milestone","page_build","public","pull_request","pull_request_review","pull_request_review_comment","push","registry_package","release","repository","repository_dispatch","status","watch","workflow_dispatch","workflow_run"]},"pull_requests":[]},{"id":78663682355,"name":"CI / Deploy artifacts","node_id":"CR_kwDORfHVp88AAAASULiJMw","head_sha":"826**********************************60a","external_id":"1c295c50-8619-5e5e-b628-234ce8bf9721","url":"https://api.github.com/repos/xlabtg/teleton-agent/check-runs/78663682355","html_url":"https://github.com/xlabtg/teleton-agent/actions/runs/26689643837/job/78663682355","details_url":"https://github.com/xlabtg/teleton-agent/actions/runs/26689643837/job/78663682355","status":"completed","conclusion":"success","started_at":"2026-05-30T16:58:33Z","completed_at":"2026-05-30T16:58:40Z","output":{"title":null,"summary":null,"text":null,"annotations_count":1,"annotations_url":"https://api.github.com/repos/xlabtg/teleton-agent/check-runs/78663682355/annotations"},"check_suite":{"id":71541102617},"app":{"id":15368,"client_id":"Iv1.05c79e9ad1f6bdfa","slug":"github-actions","node_id":"MDM6QXBwMTUzNjg=","owner":{"login":"github","id":9919,"node_id":"MDEyOk9yZ2FuaXphdGlvbjk5MTk=","avatar_url":"https://avatars.githubusercontent.com/u/9919?v=4","gravatar_id":"","url":"https://api.github.com/users/github","html_url":"https://github.com/github","followers_url":"https://api.github.com/users/github/followers","following_url":"https://api.github.com/users/github/following{/other_user}","gists_url":"https://api.github.com/users/github/gists{/gist_id}","starred_url":"https://api.github.com/users/github/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/github/subscriptions","organizations_url":"https://api.github.com/users/github/orgs","repos_url":"https://api.github.com/users/github/repos","events_url":"https://api.github.com/users/github/events{/privacy}","received_events_url":"https://api.github.com/users/github/received_events","type":"Organization","user_view_type":"public","site_admin":false},"name":"GitHub Actions","description":"Automate your workflow from idea to production","external_url":"https://help.github.com/en/actions","html_url":"https://github.com/apps/github-actions","created_at":"2018-07-30T09:30:17Z","updated_at":"2026-05-05T14:51:38Z","permissions":{"actions":"write","administration":"read","artifact_metadata":"write","attestations":"write","checks":"write","code_quality":"write","contents":"write","copilot_requests":"write","deployments":"write","discussions":"write","issues":"write","merge_queues":"write","metadata":"read","models":"read","packages":"write","pages":"write","pull_requests":"write","repository_hooks":"write","repository_projects":"write","security_events":"write","statuses":"write","vulnerability_alerts":"read"},"events":["branch_protection_rule","check_run","check_suite","create","delete","deployment","deployment_status","discussion","discussion_comment","fork","gollum","issues","issue_comment","label","merge_group","milestone","page_build","public","pull_request","pull_request_review","pull_request_review_comment","push","registry_package","release","repository","repository_dispatch","status","watch","workflow_dispatch","workflow_run"]},"pull_requests":[]},{"id":78663682354,"name":"CI / OpenAPI","node_id":"CR_kwDORfHVp88AAAASULiJMg","head_sha":"826**********************************60a","external_id":"991f6259-ca2e-5a01-91e2-b1992a92d207","url":"https://api.github.com/repos/xlabtg/teleton-agent/check-runs/78663682354","html_url":"https://github.com/xlabtg/teleton-agent/actions/runs/26689643837/job/78663682354","details_url":"https://github.com/xlabtg/teleton-agent/actions/runs/26689643837/job/78663682354","status":"completed","conclusion":"success","started_at":"2026-05-30T16:58:32Z","completed_at":"2026-05-30T16:59:07Z","output":{"title":null,"summary":null,"text":null,"annotations_count":1,"annotations_url":"https://api.github.com/repos/xlabtg/teleton-agent/check-runs/78663682354/annotations"},"check_suite":{"id":71541102617},"app":{"id":15368,"client_id":"Iv1.05c79e9ad1f6bdfa","slug":"github-actions","node_id":"MDM6QXBwMTUzNjg=","owner":{"login":"github","id":9919,"node_id":"MDEyOk9yZ2FuaXphdGlvbjk5MTk=","avatar_url":"https://avatars.githubusercontent.com/u/9919?v=4","gravatar_id":"","url":"https://api.github.com/users/github","html_url":"https://github.com/github","followers_url":"https://api.github.com/users/github/followers","following_url":"https://api.github.com/users/github/following{/other_user}","gists_url":"https://api.github.com/users/github/gists{/gist_id}","starred_url":"https://api.github.com/users/github/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/github/subscriptions","organizations_url":"https://api.github.com/users/github/orgs","repos_url":"https://api.github.com/users/github/repos","events_url":"https://api.github.com/users/github/events{/privacy}","received_events_url":"https://api.github.com/users/github/received_events","type":"Organization","user_view_type":"public","site_admin":false},"name":"GitHub Actions","description":"Automate your workflow from idea to production","external_url":"https://help.github.com/en/actions","html_url":"https://github.com/apps/github-actions","created_at":"2018-07-30T09:30:17Z","updated_at":"2026-05-05T14:51:38Z","permissions":{"actions":"write","administration":"read","artifact_metadata":"write","attestations":"write","checks":"write","code_quality":"write","contents":"write","copilot_requests":"write","deployments":"write","discussions":"write","issues":"write","merge_queues":"write","metadata":"read","models":"read","packages":"write","pages":"write","pull_requests":"write","repository_hooks":"write","repository_projects":"write","security_events":"write","statuses":"write","vulnerability_alerts":"read"},"events":["branch_protection_rule","check_run","check_suite","create","delete","deployment","deployment_status","discussion","discussion_comment","fork","gollum","issues","issue_comment","label","merge_group","milestone","page_build","public","pull_request","pull_request_review","pull_request_review_comment","push","registry_package","release","repository","repository_dispatch","status","watch","workflow_dispatch","workflow_run"]},"pull_requests":[]},{"id":78663682353,"name":"CI / Lint","node_id":"CR_kwDORfHVp88AAAASULiJMQ","head_sha":"826**********************************60a","external_id":"3583a4f1-d817-5d69-b5aa-c06700de8afb","url":"https://api.github.com/repos/xlabtg/teleton-agent/check-runs/78663682353","html_url":"https://github.com/xlabtg/teleton-agent/actions/runs/26689643837/job/78663682353","details_url":"https://github.com/xlabtg/teleton-agent/actions/runs/26689643837/job/78663682353","status":"completed","conclusion":"success","started_at":"2026-05-30T16:58:33Z","completed_at":"2026-05-30T16:59:48Z","output":{"title":null,"summary":null,"text":null,"annotations_count":1,"annotations_url":"https://api.github.com/repos/xlabtg/teleton-agent/check-runs/78663682353/annotations"},"check_suite":{"id":71541102617},"app":{"id":15368,"client_id":"Iv1.05c79e9ad1f6bdfa","slug":"github-actions","node_id":"MDM6QXBwMTUzNjg=","owner":{"login":"github","id":9919,"node_id":"MDEyOk9yZ2FuaXphdGlvbjk5MTk=","avatar_url":"https://avatars.githubusercontent.com/u/9919?v=4","gravatar_id":"","url":"https://api.github.com/users/github","html_url":"https://github.com/github","followers_url":"https://api.github.com/users/github/followers","following_url":"https://api.github.com/users/github/following{/other_user}","gists_url":"https://api.github.com/users/github/gists{/gist_id}","starred_url":"https://api.github.com/users/github/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/github/subscriptions","organizations_url":"https://api.github.com/users/github/orgs","repos_url":"https://api.github.com/users/github/repos","events_url":"https://api.github.com/users/github/events{/privacy}","received_events_url":"https://api.github.com/users/github/received_events","type":"Organization","user_view_type":"public","site_admin":false},"name":"GitHub Actions","description":"Automate your workflow from idea to production","external_url":"https://help.github.com/en/actions","html_url":"https://github.com/apps/github-actions","created_at":"2018-07-30T09:30:17Z","updated_at":"2026-05-05T14:51:38Z","permissions":{"actions":"write","administration":"read","artifact_metadata":"write","attestations":"write","checks":"write","code_quality":"write","contents":"write","copilot_requests":"write","deployments":"write","discussions":"write","issues":"write","merge_queues":"write","metadata":"read","models":"read","packages":"write","pages":"write","pull_requests":"write","repository_hooks":"write","repository_projects":"write","security_events":"write","statuses":"write","vulnerability_alerts":"read"},"events":["branch_protection_rule","check_run","check_suite","create","delete","deployment","deployment_status","discussion","discussion_comment","fork","gollum","issues","issue_comment","label","merge_group","milestone","page_build","public","pull_request","pull_request_review","pull_request_review_comment","push","registry_package","release","repository","repository_dispatch","status","watch","workflow_dispatch","workflow_run"]},"pull_requests":[]},{"id":78663682351,"name":"CI / Test","node_id":"CR_kwDORfHVp88AAAASULiJLw","head_sha":"826**********************************60a","external_id":"49edd089-1340-5666-8e50-c1baacd3db30","url":"https://api.github.com/repos/xlabtg/teleton-agent/check-runs/78663682351","html_url":"https://github.com/xlabtg/teleton-agent/actions/runs/26689643837/job/78663682351","details_url":"https://github.com/xlabtg/teleton-agent/actions/runs/26689643837/job/78663682351","status":"completed","conclusion":"failure","started_at":"2026-05-30T16:58:32Z","completed_at":"2026-05-30T16:59:54Z","output":{"title":null,"summary":null,"text":null,"annotations_count":3,"annotations_url":"https://api.github.com/repos/xlabtg/teleton-agent/check-runs/78663682351/annotations"},"check_suite":{"id":71541102617},"app":{"id":15368,"client_id":"Iv1.05c79e9ad1f6bdfa","slug":"github-actions","node_id":"MDM6QXBwMTUzNjg=","owner":{"login":"github","id":9919,"node_id":"MDEyOk9yZ2FuaXphdGlvbjk5MTk=","avatar_url":"https://avatars.githubusercontent.com/u/9919?v=4","gravatar_id":"","url":"https://api.github.com/users/github","html_url":"https://github.com/github","followers_url":"https://api.github.com/users/github/followers","following_url":"https://api.github.com/users/github/following{/other_user}","gists_url":"https://api.github.com/users/github/gists{/gist_id}","starred_url":"https://api.github.com/users/github/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/github/subscriptions","organizations_url":"https://api.github.com/users/github/orgs","repos_url":"https://api.github.com/users/github/repos","events_url":"https://api.github.com/users/github/events{/privacy}","received_events_url":"https://api.github.com/users/github/received_events","type":"Organization","user_view_type":"public","site_admin":false},"name":"GitHub Actions","description":"Automate your workflow from idea to production","external_url":"https://help.github.com/en/actions","html_url":"https://github.com/apps/github-actions","created_at":"2018-07-30T09:30:17Z","updated_at":"2026-05-05T14:51:38Z","permissions":{"actions":"write","administration":"read","artifact_metadata":"write","attestations":"write","checks":"write","code_quality":"write","contents":"write","copilot_requests":"write","deployments":"write","discussions":"write","issues":"write","merge_queues":"write","metadata":"read","models":"read","packages":"write","pages":"write","pull_requests":"write","repository_hooks":"write","repository_projects":"write","security_events":"write","statuses":"write","vulnerability_alerts":"read"},"events":["branch_protection_rule","check_run","check_suite","create","delete","deployment","deployment_status","discussion","discussion_comment","fork","gollum","issues","issue_comment","label","merge_group","milestone","page_build","public","pull_request","pull_request_review","pull_request_review_comment","push","registry_package","release","repository","repository_dispatch","status","watch","workflow_dispatch","workflow_run"]},"pull_requests":[]},{"id":78663682350,"name":"Security audit","node_id":"CR_kwDORfHVp88AAAASULiJLg","head_sha":"826**********************************60a","external_id":"ed51cf15-0395-55b4-88b2-e977feda569f","url":"https://api.github.com/repos/xlabtg/teleton-agent/check-runs/78663682350","html_url":"https://github.com/xlabtg/teleton-agent/actions/runs/26689643837/job/78663682350","details_url":"https://github.com/xlabtg/teleton-agent/actions/runs/26689643837/job/78663682350","status":"completed","conclusion":"success","started_at":"2026-05-30T16:58:32Z","completed_at":"2026-05-30T16:59:01Z","output":{"title":null,"summary":null,"text":null,"annotations_count":1,"annotations_url":"https://api.github.com/repos/xlabtg/teleton-agent/check-runs/78663682350/annotations"},"check_suite":{"id":71541102617},"app":{"id":15368,"client_id":"Iv1.05c79e9ad1f6bdfa","slug":"github-actions","node_id":"MDM6QXBwMTUzNjg=","owner":{"login":"github","id":9919,"node_id":"MDEyOk9yZ2FuaXphdGlvbjk5MTk=","avatar_url":"https://avatars.githubusercontent.com/u/9919?v=4","gravatar_id":"","url":"https://api.github.com/users/github","html_url":"https://github.com/github","followers_url":"https://api.github.com/users/github/followers","following_url":"https://api.github.com/users/github/following{/other_user}","gists_url":"https://api.github.com/users/github/gists{/gist_id}","starred_url":"https://api.github.com/users/github/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/github/subscriptions","organizations_url":"https://api.github.com/users/github/orgs","repos_url":"https://api.github.com/users/github/repos","events_url":"https://api.github.com/users/github/events{/privacy}","received_events_url":"https://api.github.com/users/github/received_events","type":"Organization","user_view_type":"public","site_admin":false},"name":"GitHub Actions","description":"Automate your workflow from idea to production","external_url":"https://help.github.com/en/actions","html_url":"https://github.com/apps/github-actions","created_at":"2018-07-30T09:30:17Z","updated_at":"2026-05-05T14:51:38Z","permissions":{"actions":"write","administration":"read","artifact_metadata":"write","attestations":"write","checks":"write","code_quality":"write","contents":"write","copilot_requests":"write","deployments":"write","discussions":"write","issues":"write","merge_queues":"write","metadata":"read","models":"read","packages":"write","pages":"write","pull_requests":"write","repository_hooks":"write","repository_projects":"write","security_events":"write","statuses":"write","vulnerability_alerts":"read"},"events":["branch_protection_rule","check_run","check_suite","create","delete","deployment","deployment_status","discussion","discussion_comment","fork","gollum","issues","issue_comment","label","merge_group","milestone","page_build","public","pull_request","pull_request_review","pull_request_review_comment","push","registry_package","release","repository","repository_dispatch","status","watch","workflow_dispatch","workflow_run"]},"pull_requests":[]}]}]
+[2026-05-30T17:18:27.190Z] [STDOUT] []
+[2026-05-30T17:18:27.194Z] [INFO]    Feedback info will be added to prompt:
+[2026-05-30T17:18:27.196Z] [INFO]      - Pull request description was edited after last commit
+[2026-05-30T17:18:27.196Z] [INFO]      - Merge status is UNSTABLE (non-passing commit status)
+[2026-05-30T17:18:27.196Z] [INFO]      - Failed pull request checks: 2
+[2026-05-30T17:18:27.196Z] [INFO] 📅 Getting timestamps:       From GitHub servers...
+[2026-05-30T17:18:27.524Z] [STDOUT] 2026-05-29T21:18:15Z
+[2026-05-30T17:18:27.528Z] [INFO]   📝 Issue updated:          2026-05-29T21:18:15.000Z
+[2026-05-30T17:18:27.813Z] [STDOUT] []
+[2026-05-30T17:18:27.819Z] [INFO]   💬 Comments:               None found
+[2026-05-30T17:18:28.198Z] [STDOUT] [{"createdAt":"2026-05-30T16:58:26Z"}]
+[2026-05-30T17:18:28.203Z] [INFO]   🔀 Recent PR:              2026-05-30T16:58:26.000Z
+[2026-05-30T17:18:28.204Z] [INFO] 
+[2026-05-30T17:18:28.204Z] [INFO] ✅ Reference time:           2026-05-30T16:58:26.000Z
+[2026-05-30T17:18:28.205Z] [INFO] 
+[2026-05-30T17:18:28.205Z] [INFO] 🔍 Checking for uncommitted changes to include as feedback...
+[2026-05-30T17:18:28.230Z] [INFO] ✅ No uncommitted changes found
+[2026-05-30T17:18:28.560Z] [STDOUT] accessibility.yml
+audit-weekly.yml
+benchmarks.yml
+ci.yml
+e2e.yml
+pages.yml
+release-please.yml
+release.yml
+seo-validate.yml
+telegram-notify.yml
+[2026-05-30T17:18:28.567Z] [INFO] 📦 Fork workflows detected:  https://github.com/konard/xlabtg-teleton-agent/actions?query=branch%3Aissue-502-b91556a7ecb2
+[2026-05-30T17:18:29.509Z] [STDOUT] Checking MCP server health…
+
+[2026-05-30T17:18:30.723Z] [STDOUT] playwright: npx -y @playwright/mcp@latest --isolated --headless --no-sandbox --timeout-action=600000 --viewport-size 1920x1080 - ✓ Connected
+[2026-05-30T17:18:31.221Z] [INFO] 🎭 Playwright MCP detected - enabling browser automation hints
+[2026-05-30T17:18:31.422Z] [INFO] 👁️  Model vision capability: supported
+[2026-05-30T17:18:31.428Z] [INFO] 
+[2026-05-30T17:18:31.428Z] [INFO] 📝 Final prompt structure:
+[2026-05-30T17:18:31.429Z] [INFO]    Characters: 633
+[2026-05-30T17:18:31.429Z] [INFO]    System prompt characters: 15151
+[2026-05-30T17:18:31.430Z] [INFO]    Feedback info: Included
+[2026-05-30T17:18:31.436Z] [INFO] 
+[2026-05-30T17:18:31.436Z] [INFO] 🤖 Executing Claude:         OPUS
+[2026-05-30T17:18:31.437Z] [INFO]    Model: opus
+[2026-05-30T17:18:31.438Z] [INFO]    Working directory: /tmp/gh-issue-solver-1780161489554
+[2026-05-30T17:18:31.439Z] [INFO]    Branch: issue-502-b91556a7ecb2
+[2026-05-30T17:18:31.441Z] [INFO]    Prompt length: 633 chars
+[2026-05-30T17:18:31.442Z] [INFO]    System prompt length: 15151 chars
+[2026-05-30T17:18:31.442Z] [INFO]    Feedback info included: Yes (3 lines)
+[2026-05-30T17:18:31.473Z] [INFO] 📈 System resources before execution:
+[2026-05-30T17:18:31.475Z] [INFO]    Memory: MemFree:         7293888 kB
+[2026-05-30T17:18:31.478Z] [INFO]    Load: 3.72 2.65 1.96 6/514 1229015
+[2026-05-30T17:18:31.484Z] [INFO] 🧭 Claude Code quiet config updated at /home/box/.claude/settings.json: settings[autoMemoryEnabled=false, spinnerTipsEnabled=false, awaySummaryEnabled=false, feedbackSurveyRate=0, includeCoAuthoredBy=false, includeGitInstructions=true, prefersReducedMotion=true, showThinkingSummaries=false, skipDangerousModePermissionPrompt=true, viewMode="verbose", attribution={"commit":"","pr":""}, permissions={"defaultMode":"bypassPermissions"}], env[CLAUDE_CODE_DISABLE_AUTO_MEMORY=1, CLAUDE_CODE_DISABLE_CRON=1, CLAUDE_CODE_DISABLE_TERMINAL_TITLE=1, CLAUDE_CODE_DISABLE_CLAUDE_MDS=1, CLAUDE_CODE_DISABLE_FAST_MODE=1, CLAUDE_CODE_DISABLE_FEEDBACK_SURVEY=1, CLAUDE_CODE_DISABLE_MOUSE=1, CLAUDE_CODE_ENABLE_AWAY_SUMMARY=0, CLAUDE_CODE_ENABLE_TASKS=1, CLAUDE_CODE_MAX_TOOL_USE_CONCURRENCY=4, CLAUDE_CODE_RESUME_INTERRUPTED_TURN=1, DISABLE_FEEDBACK_COMMAND=1]
+[2026-05-30T17:18:31.490Z] [INFO] 🧰 Created filtered MCP config (excluding 'claude.ai gmail*', 'claude.ai google drive*', 'claude.ai google calendar*'): /tmp/claude-mcp-no-useless-1780161511489-1196660.json
+[2026-05-30T17:18:31.491Z] [INFO] 🧰 Useless MCP servers (claude.ai Gmail/Drive/Calendar) disabled for this session via --strict-mcp-config (issue #1627)
+[2026-05-30T17:18:31.493Z] [INFO] 🧰 Disallowed 16 useless Claude Code tool(s) for this session (issue #1627)
+[2026-05-30T17:18:31.494Z] [INFO] 
+[2026-05-30T17:18:31.494Z] [INFO] 📝 Raw command:              
+[2026-05-30T17:18:31.497Z] [INFO] (cd "/tmp/gh-issue-solver-1780161489554" && claude --output-format stream-json --verbose --dangerously-skip-permissions --model claude-opus-4-8 --strict-mcp-config --mcp-config "/tmp/claude-mcp-no-useless-1780161511489-1196660.json" --disallowedTools AskUserQuestion CronCreate CronDelete CronList EnterPlanMode EnterWorktree ExitPlanMode ExitWorktree Monitor NotebookEdit PushNotification RemoteTrigger ScheduleWakeup mcp__claude_ai_Gmail__* mcp__claude_ai_Google_Drive__* mcp__claude_ai_Google_Calendar__* -p "Issue to solve: https://github.com/xlabtg/teleton-agent/issues/502
+[2026-05-30T17:18:31.497Z] [INFO] Your prepared branch: issue-502-b91556a7ecb2
+[2026-05-30T17:18:31.497Z] [INFO] Your prepared working directory: /tmp/gh-issue-solver-1780161489554
+[2026-05-30T17:18:31.497Z] [INFO] Your prepared Pull Request: https://github.com/xlabtg/teleton-agent/pull/519
+[2026-05-30T17:18:31.497Z] [INFO] Your forked repository: konard/xlabtg-teleton-agent
+[2026-05-30T17:18:31.497Z] [INFO] Original repository (upstream): xlabtg/teleton-agent
+[2026-05-30T17:18:31.497Z] [INFO] GitHub Actions on your fork: https://github.com/konard/xlabtg-teleton-agent/actions?query=branch%3Aissue-502-b91556a7ecb2
+[2026-05-30T17:18:31.497Z] [INFO] 
+[2026-05-30T17:18:31.497Z] [INFO] Pull request description was edited after last commit
+[2026-05-30T17:18:31.497Z] [INFO] Merge status is UNSTABLE (non-passing commit status)
+[2026-05-30T17:18:31.497Z] [INFO] Failed pull request checks: 2
+[2026-05-30T17:18:31.497Z] [INFO] 
+[2026-05-30T17:18:31.497Z] [INFO] Continue.
+[2026-05-30T17:18:31.497Z] [INFO] " --append-system-prompt "You are an AI issue solver. When you investigate issues, prefer root-cause analysis. When you communicate, prefer facts you have checked yourself or cite sources that provide evidence, such as quoted code or references to documents or web pages. When you are unsure or working from assumptions, test them yourself or ask clarifying questions.
+[2026-05-30T17:18:31.497Z] [INFO] General guidelines.
+[2026-05-30T17:18:31.497Z] [INFO]    - When you execute commands and the output becomes large, save the logs to files for easier review.
+[2026-05-30T17:18:31.497Z] [INFO]    - When running commands, avoid setting a timeout yourself. Let them run as long as needed. The default timeout of 2 minutes is usually enough, and once commands finish, review the logs in the file.
+[2026-05-30T17:18:31.497Z] [INFO]    - When running sudo commands, especially package installations like apt-get, yum, or npm install, run them in the background to avoid timeout issues and permission errors when the process needs to be killed. Use the run_in_background parameter or append & to the command.
+[2026-05-30T17:18:31.497Z] [INFO]    - When CI is failing or user reports failures, consider adding a detailed investigation protocol to your todo list with these steps:
+[2026-05-30T17:18:31.497Z] [INFO]       Step 1: List recent runs with timestamps using: gh run list --repo xlabtg/teleton-agent --branch issue-502-b91556a7ecb2 --limit 5 --json databaseId,conclusion,createdAt,headSha
+[2026-05-30T17:18:31.497Z] [INFO]       Step 2: Verify runs are after the latest commit by checking timestamps and SHA
+[2026-05-30T17:18:31.497Z] [INFO]       Step 3: For each non-passing run, download logs to preserve them: gh run view {run-id} --repo xlabtg/teleton-agent --log > ci-logs/{workflow}-{run-id}.log
+[2026-05-30T17:18:31.497Z] [INFO]       Step 4: Read each downloaded log file with the Read tool to understand the actual failures
+[2026-05-30T17:18:31.497Z] [INFO]       Step 5: Report findings with specific errors and line numbers from logs
+[2026-05-30T17:18:31.497Z] [INFO]       This detailed investigation is especially helpful when user mentions CI failures, asks to investigate logs, you see non-passing status, or when finalizing a PR.
+[2026-05-30T17:18:31.497Z] [INFO]       Note: If user says \"failing\" but tools show \"passing\", this might indicate stale data - consider downloading fresh logs and checking timestamps to resolve the discrepancy.
+[2026-05-30T17:18:31.497Z] [INFO]    - When a code or log file has more than 1500 lines, read it in chunks of 1500 lines.
+[2026-05-30T17:18:31.497Z] [INFO]    - When facing a complex problem, do as much tracing as possible and turn on all verbose modes.
+[2026-05-30T17:18:31.497Z] [INFO]    - When you create debug, test, or example scripts while fixing an issue, keep them in ./examples and/or ./experiments so you can reuse them later.
+[2026-05-30T17:18:31.497Z] [INFO]    - When you test assumptions, keep experiment scripts in ./experiments.
+[2026-05-30T17:18:31.497Z] [INFO]    - When an experiment demonstrates a real-world use case of the software, add it to ./examples.
+[2026-05-30T17:18:31.497Z] [INFO]    - When you face something extremely hard, use divide and conquer.
+[2026-05-30T17:18:31.497Z] [INFO] 
+[2026-05-30T17:18:31.497Z] [INFO] Initial research.
+[2026-05-30T17:18:31.497Z] [INFO]    - When you start, create a detailed plan for yourself and follow your todo list step by step. Add as many relevant points from these guidelines to the todo list as practical so you can track the work clearly.
+[2026-05-30T17:18:31.497Z] [INFO]    - When the user mentions CI failures or asks to investigate logs, consider adding these todos to track the investigation: (1) list recent CI runs with timestamps, (2) download logs from failed runs to the ci-logs/ directory, (3) analyze error messages and identify the root cause, (4) implement a fix, (5) verify that the fix resolves the specific errors found in the logs.
+[2026-05-30T17:18:31.497Z] [INFO]    - When you read the issue, read all details and comments thoroughly.
+[2026-05-30T17:18:31.497Z] [INFO]    - When you see screenshots or images in issue descriptions, pull request descriptions, comments, or discussions, download the image to a local file first, then use the Read tool to view and analyze it. Before reading downloaded images with the Read tool, verify that the file is a valid image rather than HTML by using a CLI tool such as the 'file' command. When corrupted or non-image files, such as GitHub \"Not Found\" pages saved as `.png`, are read, they can cause \"Could not process image\" errors and crash the AI solver process. When the file command shows \"HTML\", \"text\", or \"ASCII text\", the download failed, so do not call Read on that file. Instead: (1) when images are from GitHub issues or PRs, such as URLs containing \"github.com/user-attachments\", retry with: curl -L -H \"Authorization: token \$(gh auth token)\" -o <filename> \"<url>\" (2) when the retry still fails, skip the image and note that it was unavailable.
+[2026-05-30T17:18:31.497Z] [INFO]    - When you need issue details, use gh issue view https://github.com/xlabtg/teleton-agent/issues/502.
+[2026-05-30T17:18:31.497Z] [INFO]    - When you need related code, use gh search code --owner xlabtg [keywords].
+[2026-05-30T17:18:31.497Z] [INFO]    - When you need repo context, read files in your working directory.
+[2026-05-30T17:18:31.497Z] [INFO]    - When you study related work, study the most recent related pull requests.
+[2026-05-30T17:18:31.497Z] [INFO]    - When the issue is not defined clearly enough, write a comment with clarifying questions.
+[2026-05-30T17:18:31.497Z] [INFO]    - When accessing GitHub Gists (especially private ones), use gh gist view command instead of direct URL fetching to ensure proper authentication.
+[2026-05-30T17:18:31.497Z] [INFO]    - When you are fixing a bug, find the actual root cause first and run as many experiments as needed.
+[2026-05-30T17:18:31.497Z] [INFO]    - When you are fixing a bug and the code does not have enough tracing or logs, add them and keep them in the code with the default state switched off.
+[2026-05-30T17:18:31.497Z] [INFO]    - When you need comments on a pull request, note that GitHub has three different comment types with different API endpoints:
+[2026-05-30T17:18:31.497Z] [INFO]       1. PR review comments (inline code comments): gh api repos/xlabtg/teleton-agent/pulls/519/comments --paginate
+[2026-05-30T17:18:31.497Z] [INFO]       2. PR conversation comments (general discussion): gh api repos/xlabtg/teleton-agent/issues/519/comments --paginate
+[2026-05-30T17:18:31.497Z] [INFO]       3. PR reviews (approve/request changes): gh api repos/xlabtg/teleton-agent/pulls/519/reviews --paginate
+[2026-05-30T17:18:31.497Z] [INFO]       Note: The command \"gh pr view --json comments\" only returns conversation comments and misses review comments.
+[2026-05-30T17:18:31.497Z] [INFO]    - When you need the latest comments on the issue, use gh api repos/xlabtg/teleton-agent/issues/502/comments --paginate.
+[2026-05-30T17:18:31.497Z] [INFO] 
+[2026-05-30T17:18:31.497Z] [INFO] Solution development and testing.
+[2026-05-30T17:18:31.497Z] [INFO]    - When issue is solvable, first create a test that reproduces the problem, then implement the fix.
+[2026-05-30T17:18:31.497Z] [INFO]    - When implementing features, search for similar existing implementations in the codebase and use them as examples instead of implementing everything from scratch.
+[2026-05-30T17:18:31.497Z] [INFO]    - When coding, commit each atomic step that is useful on its own to the pull request branch so interrupted work remains preserved in the pull request.
+[2026-05-30T17:18:31.497Z] [INFO]    - When you test:
+[2026-05-30T17:18:31.497Z] [INFO]       start from testing of small functions using separate scripts;
+[2026-05-30T17:18:31.497Z] [INFO]       write unit tests with mocks for easy and quick start.
+[2026-05-30T17:18:31.497Z] [INFO]    - When you test integrations, use existing framework.
+[2026-05-30T17:18:31.497Z] [INFO]    - When you test solution draft, include automated checks in pr.
+[2026-05-30T17:18:31.497Z] [INFO]    - When you write or modify tests, consider setting reasonable timeouts at test, suite, and CI job levels so failures surface quickly instead of hanging.
+[2026-05-30T17:18:31.497Z] [INFO]    - When you see repeated test timeout patterns in CI, investigate the root cause rather than increasing timeouts.
+[2026-05-30T17:18:31.497Z] [INFO]    - When the issue is unclear, write a comment on the issue with questions.
+[2026-05-30T17:18:31.497Z] [INFO]    - When you encounter problems that you cannot solve yourself and need human help, write a comment on the pull request asking for help.
+[2026-05-30T17:18:31.497Z] [INFO]    - When you need human help, use gh pr comment 519 --body \"your message\" to comment on existing PR.
+[2026-05-30T17:18:31.497Z] [INFO] 
+[2026-05-30T17:18:31.497Z] [INFO] Reproducible testing.
+[2026-05-30T17:18:31.497Z] [INFO]    - When fixing a bug, create a test that reproduces the problem before implementing the fix. When you cannot reproduce the problem, you cannot verify the fix.
+[2026-05-30T17:18:31.497Z] [INFO]    - When encountering logic bugs, write an automated test that fails due to the bug, then implement the fix to make it pass.
+[2026-05-30T17:18:31.497Z] [INFO]    - When encountering UI bugs, capture a screenshot showing the problem state, then create a visual regression test or manual verification screenshot after the fix.
+[2026-05-30T17:18:31.497Z] [INFO]    - When creating tests, prefer minimum reproducible examples, meaning the simplest test case that demonstrates the issue.
+[2026-05-30T17:18:31.497Z] [INFO]    - When submitting a fix, include in the PR description: (1) how to reproduce the issue, (2) the automated test that verifies the fix, (3) before/after screenshots for UI issues.
+[2026-05-30T17:18:31.497Z] [INFO]    - When a bug fix does not have a reproducing test, treat the fix as incomplete because regressions can occur later without notice.
+[2026-05-30T17:18:31.497Z] [INFO] 
+[2026-05-30T17:18:31.497Z] [INFO] Preparing pull request.
+[2026-05-30T17:18:31.497Z] [INFO]    - When you code, follow contributing guidelines.
+[2026-05-30T17:18:31.497Z] [INFO]    - When you commit, write clear message.
+[2026-05-30T17:18:31.497Z] [INFO]    - When you need examples of style, use gh pr list --repo xlabtg/teleton-agent --state merged --search [keywords].
+[2026-05-30T17:18:31.497Z] [INFO]    - When you open pr, describe solution draft and include tests.
+[2026-05-30T17:18:31.497Z] [INFO]    - When there is a package with version and GitHub Actions workflows for automatic release, update the version (or other necessary release trigger) in your pull request to prepare for next release.
+[2026-05-30T17:18:31.497Z] [INFO]    - When you update existing pr 519, use gh pr edit to modify title and description.
+[2026-05-30T17:18:31.497Z] [INFO]    - When you are about to commit or push code, run local CI checks first if they are available in contributing guidelines (like ruff check, mypy, eslint, etc.) to catch errors before pushing.
+[2026-05-30T17:18:31.497Z] [INFO]    - When you finalize the pull request:
+[2026-05-30T17:18:31.497Z] [INFO]       follow style from merged prs for code, title, and description,
+[2026-05-30T17:18:31.497Z] [INFO]       check that no uncommitted changes corresponding to the original requirements are left behind,
+[2026-05-30T17:18:31.497Z] [INFO]       check that the default branch is merged into the pull request branch,
+[2026-05-30T17:18:31.497Z] [INFO]       check that all CI checks are passing if they exist before you finish,
+[2026-05-30T17:18:31.497Z] [INFO]       check for latest comments on the issue and pull request to ensure no recent feedback was missed,
+[2026-05-30T17:18:31.497Z] [INFO]       double-check that all changes in the pull request address the original requirements of the issue,
+[2026-05-30T17:18:31.497Z] [INFO]       check for newly introduced bugs in the pull request by carefully reading gh pr diff,
+[2026-05-30T17:18:31.497Z] [INFO]       check that no previously existing features were removed without an explicit request in the issue description, issue comments, or pull request comments.
+[2026-05-30T17:18:31.497Z] [INFO]    - When you finish implementation, use gh pr ready 519.
+[2026-05-30T17:18:31.497Z] [INFO] 
+[2026-05-30T17:18:31.497Z] [INFO] Workflow and collaboration.
+[2026-05-30T17:18:31.497Z] [INFO]    - When you check branch, verify with git branch --show-current.
+[2026-05-30T17:18:31.497Z] [INFO]    - When you push, push only to branch issue-502-b91556a7ecb2.
+[2026-05-30T17:18:31.497Z] [INFO]    - When you finish, create a pull request from branch issue-502-b91556a7ecb2. (Note: PR 519 already exists, update it instead)
+[2026-05-30T17:18:31.497Z] [INFO]    - When you organize workflow, use pull requests instead of direct merges to default branch (main or master).
+[2026-05-30T17:18:31.497Z] [INFO]    - When you manage commits, preserve commit history for later analysis.
+[2026-05-30T17:18:31.497Z] [INFO]    - When you contribute, keep repository history forward-moving with regular commits, pushes, and reverts if needed.
+[2026-05-30T17:18:31.497Z] [INFO]    - When you face conflict that you cannot resolve yourself, ask for help.
+[2026-05-30T17:18:31.497Z] [INFO]    - When you collaborate, respect branch protections by working only on issue-502-b91556a7ecb2.
+[2026-05-30T17:18:31.497Z] [INFO]    - When you mention a result, include the pull request URL or comment URL.
+[2026-05-30T17:18:31.497Z] [INFO]    - When you need to create pr, remember pr 519 already exists for this branch.
+[2026-05-30T17:18:31.497Z] [INFO] 
+[2026-05-30T17:18:31.497Z] [INFO] Self review.
+[2026-05-30T17:18:31.497Z] [INFO]    - When you check your solution draft, run all tests locally.
+[2026-05-30T17:18:31.497Z] [INFO]    - When you check your solution draft, verify git status shows a clean working tree with no uncommitted changes.
+[2026-05-30T17:18:31.497Z] [INFO]    - When you compare with repo style, use gh pr diff [number].
+[2026-05-30T17:18:31.497Z] [INFO]    - When you finalize, confirm code, tests, and description are consistent.
+[2026-05-30T17:18:31.497Z] [INFO] 
+[2026-05-30T17:18:31.497Z] [INFO] GitHub CLI command patterns.
+[2026-05-30T17:18:31.497Z] [INFO]    - When fetching lists from GitHub API, use the --paginate flag to ensure all results are returned (GitHub returns max 30 per page by default).
+[2026-05-30T17:18:31.497Z] [INFO]    - When listing PR review comments (inline code comments), use gh api repos/OWNER/REPO/pulls/NUMBER/comments --paginate.
+[2026-05-30T17:18:31.497Z] [INFO]    - When listing PR conversation comments, use gh api repos/OWNER/REPO/issues/NUMBER/comments --paginate.
+[2026-05-30T17:18:31.497Z] [INFO]    - When listing PR reviews, use gh api repos/OWNER/REPO/pulls/NUMBER/reviews --paginate.
+[2026-05-30T17:18:31.497Z] [INFO]    - When listing issue comments, use gh api repos/OWNER/REPO/issues/NUMBER/comments --paginate.
+[2026-05-30T17:18:31.497Z] [INFO]    - When adding PR comment, use gh pr comment NUMBER --body \"text\" --repo OWNER/REPO.
+[2026-05-30T17:18:31.497Z] [INFO]    - When adding issue comment, use gh issue comment NUMBER --body \"text\" --repo OWNER/REPO.
+[2026-05-30T17:18:31.497Z] [INFO]    - When viewing PR details, use gh pr view NUMBER --repo OWNER/REPO.
+[2026-05-30T17:18:31.497Z] [INFO]    - When filtering with jq, use gh api repos/\${owner}/\${repo}/pulls/\${prNumber}/comments --paginate --jq 'reverse | .[0:5]'.
+[2026-05-30T17:18:31.497Z] [INFO] 
+[2026-05-30T17:18:31.497Z] [INFO] Playwright MCP usage (browser automation via mcp__playwright__* tools).
+[2026-05-30T17:18:31.497Z] [INFO]    - When you develop frontend web applications (HTML, CSS, JavaScript, React, Vue, Angular, etc.), use Playwright MCP tools to test the UI in a real browser.
+[2026-05-30T17:18:31.497Z] [INFO]    - When WebFetch tool fails to retrieve expected content (e.g., returns empty content, JavaScript-rendered pages, or login-protected pages), use Playwright MCP tools (browser_navigate, browser_snapshot) as a fallback for web browsing.
+[2026-05-30T17:18:31.497Z] [INFO]    - When WebSearch tool fails or returns insufficient results, use Playwright MCP tools (browser_navigate, browser_snapshot) as a fallback for internet search.
+[2026-05-30T17:18:31.497Z] [INFO]    - When you need to interact with dynamic web pages that require JavaScript execution, use Playwright MCP tools.
+[2026-05-30T17:18:31.497Z] [INFO]    - When you need to visually verify how a web page looks or take screenshots, use browser_take_screenshot from Playwright MCP.
+[2026-05-30T17:18:31.497Z] [INFO]    - When you need to fill forms, click buttons, or perform user interactions on web pages, use Playwright MCP tools (browser_click, browser_type, browser_fill_form).
+[2026-05-30T17:18:31.497Z] [INFO]    - When you need to test responsive design or different viewport sizes, use browser_resize from Playwright MCP.
+[2026-05-30T17:18:31.497Z] [INFO]    - When you finish using the browser, close it with browser_close to free resources.
+[2026-05-30T17:18:31.497Z] [INFO]    - When reproducing UI bugs, use browser_take_screenshot to capture the problem state before implementing any fix.
+[2026-05-30T17:18:31.497Z] [INFO]    - When fixing UI bugs, take before/after screenshots to provide visual evidence of the fix for human verification.
+[2026-05-30T17:18:31.497Z] [INFO]    - When creating UI tests, save baseline screenshots to the repository for visual regression testing.
+[2026-05-30T17:18:31.497Z] [INFO]    - When verifying UI fixes, compare screenshots to ensure the fix does not introduce unintended visual changes.
+[2026-05-30T17:18:31.497Z] [INFO] 
+[2026-05-30T17:18:31.497Z] [INFO] Visual UI work and screenshots.
+[2026-05-30T17:18:31.497Z] [INFO]    - When you work on visual UI changes (frontend, CSS, HTML, design), include a render or screenshot of the final result in the pull request description.
+[2026-05-30T17:18:31.497Z] [INFO]    - When you need to show visual results, take a screenshot and save it to the repository (e.g., in a docs/screenshots/ or assets/ folder).
+[2026-05-30T17:18:31.497Z] [INFO]    - When you save screenshots to the repository, use permanent links in the pull request description markdown (e.g., https://github.com/konard/xlabtg-teleton-agent/blob/issue-502-b91556a7ecb2/docs/screenshots/result.png?raw=true).
+[2026-05-30T17:18:31.497Z] [INFO]    - When uploading images, commit them to the branch first, then reference them using the GitHub blob URL format with ?raw=true suffix (works for both public and private repositories).
+[2026-05-30T17:18:31.497Z] [INFO]    - When the visual result is important for review, mention it explicitly in the pull request description with the embedded image.
+[2026-05-30T17:18:31.497Z] [INFO]    - When fixing UI bugs, capture both the \"before\" (problem) and \"after\" (fixed) screenshots as evidence for human verification.
+[2026-05-30T17:18:31.497Z] [INFO]    - When reporting UI bugs, include a screenshot of the problem state to enable visual verification of the fix.
+[2026-05-30T17:18:31.497Z] [INFO]    - When the fix is visual, include side-by-side or sequential comparison of before/after states in the PR description.
+[2026-05-30T17:18:31.497Z] [INFO]    - When possible, create automated visual regression tests to prevent the UI bug from recurring.
+[2026-05-30T17:18:31.497Z] [INFO] 
+[2026-05-30T17:18:31.497Z] [INFO] Working language: Russian. When you communicate with the user via comments, commit messages, pull request titles/descriptions, and chat replies, use Russian. Code, identifiers, and command-line strings stay in their original form." | jq -c .)
+[2026-05-30T17:18:31.499Z] [INFO] 
+[2026-05-30T17:18:31.500Z] [INFO] 📋 User prompt:
+[2026-05-30T17:18:31.500Z] [INFO] ---BEGIN USER PROMPT---
+[2026-05-30T17:18:31.500Z] [INFO] Issue to solve: https://github.com/xlabtg/teleton-agent/issues/502
+[2026-05-30T17:18:31.500Z] [INFO] Your prepared branch: issue-502-b91556a7ecb2
+[2026-05-30T17:18:31.500Z] [INFO] Your prepared working directory: /tmp/gh-issue-solver-1780161489554
+[2026-05-30T17:18:31.500Z] [INFO] Your prepared Pull Request: https://github.com/xlabtg/teleton-agent/pull/519
+[2026-05-30T17:18:31.500Z] [INFO] Your forked repository: konard/xlabtg-teleton-agent
+[2026-05-30T17:18:31.500Z] [INFO] Original repository (upstream): xlabtg/teleton-agent
+[2026-05-30T17:18:31.500Z] [INFO] GitHub Actions on your fork: https://github.com/konard/xlabtg-teleton-agent/actions?query=branch%3Aissue-502-b91556a7ecb2
+[2026-05-30T17:18:31.500Z] [INFO] 
+[2026-05-30T17:18:31.500Z] [INFO] Pull request description was edited after last commit
+[2026-05-30T17:18:31.500Z] [INFO] Merge status is UNSTABLE (non-passing commit status)
+[2026-05-30T17:18:31.500Z] [INFO] Failed pull request checks: 2
+[2026-05-30T17:18:31.500Z] [INFO] 
+[2026-05-30T17:18:31.500Z] [INFO] Continue.
+[2026-05-30T17:18:31.500Z] [INFO] 
+[2026-05-30T17:18:31.500Z] [INFO] ---END USER PROMPT---
+[2026-05-30T17:18:31.501Z] [INFO] 📋 System prompt:
+[2026-05-30T17:18:31.501Z] [INFO] ---BEGIN SYSTEM PROMPT---
+[2026-05-30T17:18:31.501Z] [INFO] You are an AI issue solver. When you investigate issues, prefer root-cause analysis. When you communicate, prefer facts you have checked yourself or cite sources that provide evidence, such as quoted code or references to documents or web pages. When you are unsure or working from assumptions, test them yourself or ask clarifying questions.
+[2026-05-30T17:18:31.501Z] [INFO] General guidelines.
+[2026-05-30T17:18:31.501Z] [INFO]    - When you execute commands and the output becomes large, save the logs to files for easier review.
+[2026-05-30T17:18:31.501Z] [INFO]    - When running commands, avoid setting a timeout yourself. Let them run as long as needed. The default timeout of 2 minutes is usually enough, and once commands finish, review the logs in the file.
+[2026-05-30T17:18:31.501Z] [INFO]    - When running sudo commands, especially package installations like apt-get, yum, or npm install, run them in the background to avoid timeout issues and permission errors when the process needs to be killed. Use the run_in_background parameter or append & to the command.
+[2026-05-30T17:18:31.501Z] [INFO]    - When CI is failing or user reports failures, consider adding a detailed investigation protocol to your todo list with these steps:
+[2026-05-30T17:18:31.501Z] [INFO]       Step 1: List recent runs with timestamps using: gh run list --repo xlabtg/teleton-agent --branch issue-502-b91556a7ecb2 --limit 5 --json databaseId,conclusion,createdAt,headSha
+[2026-05-30T17:18:31.501Z] [INFO]       Step 2: Verify runs are after the latest commit by checking timestamps and SHA
+[2026-05-30T17:18:31.501Z] [INFO]       Step 3: For each non-passing run, download logs to preserve them: gh run view {run-id} --repo xlabtg/teleton-agent --log > ci-logs/{workflow}-{run-id}.log
+[2026-05-30T17:18:31.501Z] [INFO]       Step 4: Read each downloaded log file with the Read tool to understand the actual failures
+[2026-05-30T17:18:31.501Z] [INFO]       Step 5: Report findings with specific errors and line numbers from logs
+[2026-05-30T17:18:31.501Z] [INFO]       This detailed investigation is especially helpful when user mentions CI failures, asks to investigate logs, you see non-passing status, or when finalizing a PR.
+[2026-05-30T17:18:31.501Z] [INFO]       Note: If user says "failing" but tools show "passing", this might indicate stale data - consider downloading fresh logs and checking timestamps to resolve the discrepancy.
+[2026-05-30T17:18:31.501Z] [INFO]    - When a code or log file has more than 1500 lines, read it in chunks of 1500 lines.
+[2026-05-30T17:18:31.501Z] [INFO]    - When facing a complex problem, do as much tracing as possible and turn on all verbose modes.
+[2026-05-30T17:18:31.501Z] [INFO]    - When you create debug, test, or example scripts while fixing an issue, keep them in ./examples and/or ./experiments so you can reuse them later.
+[2026-05-30T17:18:31.501Z] [INFO]    - When you test assumptions, keep experiment scripts in ./experiments.
+[2026-05-30T17:18:31.501Z] [INFO]    - When an experiment demonstrates a real-world use case of the software, add it to ./examples.
+[2026-05-30T17:18:31.501Z] [INFO]    - When you face something extremely hard, use divide and conquer.
+[2026-05-30T17:18:31.501Z] [INFO] 
+[2026-05-30T17:18:31.501Z] [INFO] Initial research.
+[2026-05-30T17:18:31.501Z] [INFO]    - When you start, create a detailed plan for yourself and follow your todo list step by step. Add as many relevant points from these guidelines to the todo list as practical so you can track the work clearly.
+[2026-05-30T17:18:31.501Z] [INFO]    - When the user mentions CI failures or asks to investigate logs, consider adding these todos to track the investigation: (1) list recent CI runs with timestamps, (2) download logs from failed runs to the ci-logs/ directory, (3) analyze error messages and identify the root cause, (4) implement a fix, (5) verify that the fix resolves the specific errors found in the logs.
+[2026-05-30T17:18:31.501Z] [INFO]    - When you read the issue, read all details and comments thoroughly.
+[2026-05-30T17:18:31.501Z] [INFO]    - When you see screenshots or images in issue descriptions, pull request descriptions, comments, or discussions, download the image to a local file first, then use the Read tool to view and analyze it. Before reading downloaded images with the Read tool, verify that the file is a valid image rather than HTML by using a CLI tool such as the 'file' command. When corrupted or non-image files, such as GitHub "Not Found" pages saved as `.png`, are read, they can cause "Could not process image" errors and crash the AI solver process. When the file command shows "HTML", "text", or "ASCII text", the download failed, so do not call Read on that file. Instead: (1) when images are from GitHub issues or PRs, such as URLs containing "github.com/user-attachments", retry with: curl -L -H "Authorization: token $(gh auth token)" -o <filename> "<url>" (2) when the retry still fails, skip the image and note that it was unavailable.
+[2026-05-30T17:18:31.501Z] [INFO]    - When you need issue details, use gh issue view https://github.com/xlabtg/teleton-agent/issues/502.
+[2026-05-30T17:18:31.501Z] [INFO]    - When you need related code, use gh search code --owner xlabtg [keywords].
+[2026-05-30T17:18:31.501Z] [INFO]    - When you need repo context, read files in your working directory.
+[2026-05-30T17:18:31.501Z] [INFO]    - When you study related work, study the most recent related pull requests.
+[2026-05-30T17:18:31.501Z] [INFO]    - When the issue is not defined clearly enough, write a comment with clarifying questions.
+[2026-05-30T17:18:31.501Z] [INFO]    - When accessing GitHub Gists (especially private ones), use gh gist view command instead of direct URL fetching to ensure proper authentication.
+[2026-05-30T17:18:31.501Z] [INFO]    - When you are fixing a bug, find the actual root cause first and run as many experiments as needed.
+[2026-05-30T17:18:31.501Z] [INFO]    - When you are fixing a bug and the code does not have enough tracing or logs, add them and keep them in the code with the default state switched off.
+[2026-05-30T17:18:31.501Z] [INFO]    - When you need comments on a pull request, note that GitHub has three different comment types with different API endpoints:
+[2026-05-30T17:18:31.501Z] [INFO]       1. PR review comments (inline code comments): gh api repos/xlabtg/teleton-agent/pulls/519/comments --paginate
+[2026-05-30T17:18:31.501Z] [INFO]       2. PR conversation comments (general discussion): gh api repos/xlabtg/teleton-agent/issues/519/comments --paginate
+[2026-05-30T17:18:31.501Z] [INFO]       3. PR reviews (approve/request changes): gh api repos/xlabtg/teleton-agent/pulls/519/reviews --paginate
+[2026-05-30T17:18:31.501Z] [INFO]       Note: The command "gh pr view --json comments" only returns conversation comments and misses review comments.
+[2026-05-30T17:18:31.501Z] [INFO]    - When you need the latest comments on the issue, use gh api repos/xlabtg/teleton-agent/issues/502/comments --paginate.
+[2026-05-30T17:18:31.501Z] [INFO] 
+[2026-05-30T17:18:31.501Z] [INFO] Solution development and testing.
+[2026-05-30T17:18:31.501Z] [INFO]    - When issue is solvable, first create a test that reproduces the problem, then implement the fix.
+[2026-05-30T17:18:31.501Z] [INFO]    - When implementing features, search for similar existing implementations in the codebase and use them as examples instead of implementing everything from scratch.
+[2026-05-30T17:18:31.501Z] [INFO]    - When coding, commit each atomic step that is useful on its own to the pull request branch so interrupted work remains preserved in the pull request.
+[2026-05-30T17:18:31.501Z] [INFO]    - When you test:
+[2026-05-30T17:18:31.501Z] [INFO]       start from testing of small functions using separate scripts;
+[2026-05-30T17:18:31.501Z] [INFO]       write unit tests with mocks for easy and quick start.
+[2026-05-30T17:18:31.501Z] [INFO]    - When you test integrations, use existing framework.
+[2026-05-30T17:18:31.501Z] [INFO]    - When you test solution draft, include automated checks in pr.
+[2026-05-30T17:18:31.501Z] [INFO]    - When you write or modify tests, consider setting reasonable timeouts at test, suite, and CI job levels so failures surface quickly instead of hanging.
+[2026-05-30T17:18:31.501Z] [INFO]    - When you see repeated test timeout patterns in CI, investigate the root cause rather than increasing timeouts.
+[2026-05-30T17:18:31.501Z] [INFO]    - When the issue is unclear, write a comment on the issue with questions.
+[2026-05-30T17:18:31.501Z] [INFO]    - When you encounter problems that you cannot solve yourself and need human help, write a comment on the pull request asking for help.
+[2026-05-30T17:18:31.501Z] [INFO]    - When you need human help, use gh pr comment 519 --body "your message" to comment on existing PR.
+[2026-05-30T17:18:31.501Z] [INFO] 
+[2026-05-30T17:18:31.501Z] [INFO] Reproducible testing.
+[2026-05-30T17:18:31.501Z] [INFO]    - When fixing a bug, create a test that reproduces the problem before implementing the fix. When you cannot reproduce the problem, you cannot verify the fix.
+[2026-05-30T17:18:31.501Z] [INFO]    - When encountering logic bugs, write an automated test that fails due to the bug, then implement the fix to make it pass.
+[2026-05-30T17:18:31.501Z] [INFO]    - When encountering UI bugs, capture a screenshot showing the problem state, then create a visual regression test or manual verification screenshot after the fix.
+[2026-05-30T17:18:31.501Z] [INFO]    - When creating tests, prefer minimum reproducible examples, meaning the simplest test case that demonstrates the issue.
+[2026-05-30T17:18:31.501Z] [INFO]    - When submitting a fix, include in the PR description: (1) how to reproduce the issue, (2) the automated test that verifies the fix, (3) before/after screenshots for UI issues.
+[2026-05-30T17:18:31.501Z] [INFO]    - When a bug fix does not have a reproducing test, treat the fix as incomplete because regressions can occur later without notice.
+[2026-05-30T17:18:31.501Z] [INFO] 
+[2026-05-30T17:18:31.501Z] [INFO] Preparing pull request.
+[2026-05-30T17:18:31.501Z] [INFO]    - When you code, follow contributing guidelines.
+[2026-05-30T17:18:31.501Z] [INFO]    - When you commit, write clear message.
+[2026-05-30T17:18:31.501Z] [INFO]    - When you need examples of style, use gh pr list --repo xlabtg/teleton-agent --state merged --search [keywords].
+[2026-05-30T17:18:31.501Z] [INFO]    - When you open pr, describe solution draft and include tests.
+[2026-05-30T17:18:31.501Z] [INFO]    - When there is a package with version and GitHub Actions workflows for automatic release, update the version (or other necessary release trigger) in your pull request to prepare for next release.
+[2026-05-30T17:18:31.501Z] [INFO]    - When you update existing pr 519, use gh pr edit to modify title and description.
+[2026-05-30T17:18:31.501Z] [INFO]    - When you are about to commit or push code, run local CI checks first if they are available in contributing guidelines (like ruff check, mypy, eslint, etc.) to catch errors before pushing.
+[2026-05-30T17:18:31.501Z] [INFO]    - When you finalize the pull request:
+[2026-05-30T17:18:31.501Z] [INFO]       follow style from merged prs for code, title, and description,
+[2026-05-30T17:18:31.501Z] [INFO]       check that no uncommitted changes corresponding to the original requirements are left behind,
+[2026-05-30T17:18:31.501Z] [INFO]       check that the default branch is merged into the pull request branch,
+[2026-05-30T17:18:31.501Z] [INFO]       check that all CI checks are passing if they exist before you finish,
+[2026-05-30T17:18:31.501Z] [INFO]       check for latest comments on the issue and pull request to ensure no recent feedback was missed,
+[2026-05-30T17:18:31.501Z] [INFO]       double-check that all changes in the pull request address the original requirements of the issue,
+[2026-05-30T17:18:31.501Z] [INFO]       check for newly introduced bugs in the pull request by carefully reading gh pr diff,
+[2026-05-30T17:18:31.501Z] [INFO]       check that no previously existing features were removed without an explicit request in the issue description, issue comments, or pull request comments.
+[2026-05-30T17:18:31.501Z] [INFO]    - When you finish implementation, use gh pr ready 519.
+[2026-05-30T17:18:31.501Z] [INFO] 
+[2026-05-30T17:18:31.501Z] [INFO] Workflow and collaboration.
+[2026-05-30T17:18:31.501Z] [INFO]    - When you check branch, verify with git branch --show-current.
+[2026-05-30T17:18:31.501Z] [INFO]    - When you push, push only to branch issue-502-b91556a7ecb2.
+[2026-05-30T17:18:31.501Z] [INFO]    - When you finish, create a pull request from branch issue-502-b91556a7ecb2. (Note: PR 519 already exists, update it instead)
+[2026-05-30T17:18:31.501Z] [INFO]    - When you organize workflow, use pull requests instead of direct merges to default branch (main or master).
+[2026-05-30T17:18:31.501Z] [INFO]    - When you manage commits, preserve commit history for later analysis.
+[2026-05-30T17:18:31.501Z] [INFO]    - When you contribute, keep repository history forward-moving with regular commits, pushes, and reverts if needed.
+[2026-05-30T17:18:31.501Z] [INFO]    - When you face conflict that you cannot resolve yourself, ask for help.
+[2026-05-30T17:18:31.501Z] [INFO]    - When you collaborate, respect branch protections by working only on issue-502-b91556a7ecb2.
+[2026-05-30T17:18:31.501Z] [INFO]    - When you mention a result, include the pull request URL or comment URL.
+[2026-05-30T17:18:31.501Z] [INFO]    - When you need to create pr, remember pr 519 already exists for this branch.
+[2026-05-30T17:18:31.501Z] [INFO] 
+[2026-05-30T17:18:31.501Z] [INFO] Self review.
+[2026-05-30T17:18:31.501Z] [INFO]    - When you check your solution draft, run all tests locally.
+[2026-05-30T17:18:31.501Z] [INFO]    - When you check your solution draft, verify git status shows a clean working tree with no uncommitted changes.
+[2026-05-30T17:18:31.501Z] [INFO]    - When you compare with repo style, use gh pr diff [number].
+[2026-05-30T17:18:31.501Z] [INFO]    - When you finalize, confirm code, tests, and description are consistent.
+[2026-05-30T17:18:31.501Z] [INFO] 
+[2026-05-30T17:18:31.501Z] [INFO] GitHub CLI command patterns.
+[2026-05-30T17:18:31.501Z] [INFO]    - When fetching lists from GitHub API, use the --paginate flag to ensure all results are returned (GitHub returns max 30 per page by default).
+[2026-05-30T17:18:31.501Z] [INFO]    - When listing PR review comments (inline code comments), use gh api repos/OWNER/REPO/pulls/NUMBER/comments --paginate.
+[2026-05-30T17:18:31.501Z] [INFO]    - When listing PR conversation comments, use gh api repos/OWNER/REPO/issues/NUMBER/comments --paginate.
+[2026-05-30T17:18:31.501Z] [INFO]    - When listing PR reviews, use gh api repos/OWNER/REPO/pulls/NUMBER/reviews --paginate.
+[2026-05-30T17:18:31.501Z] [INFO]    - When listing issue comments, use gh api repos/OWNER/REPO/issues/NUMBER/comments --paginate.
+[2026-05-30T17:18:31.501Z] [INFO]    - When adding PR comment, use gh pr comment NUMBER --body "text" --repo OWNER/REPO.
+[2026-05-30T17:18:31.501Z] [INFO]    - When adding issue comment, use gh issue comment NUMBER --body "text" --repo OWNER/REPO.
+[2026-05-30T17:18:31.501Z] [INFO]    - When viewing PR details, use gh pr view NUMBER --repo OWNER/REPO.
+[2026-05-30T17:18:31.501Z] [INFO]    - When filtering with jq, use gh api repos/${owner}/${repo}/pulls/${prNumber}/comments --paginate --jq 'reverse | .[0:5]'.
+[2026-05-30T17:18:31.501Z] [INFO] 
+[2026-05-30T17:18:31.501Z] [INFO] Playwright MCP usage (browser automation via mcp__playwright__* tools).
+[2026-05-30T17:18:31.501Z] [INFO]    - When you develop frontend web applications (HTML, CSS, JavaScript, React, Vue, Angular, etc.), use Playwright MCP tools to test the UI in a real browser.
+[2026-05-30T17:18:31.501Z] [INFO]    - When WebFetch tool fails to retrieve expected content (e.g., returns empty content, JavaScript-rendered pages, or login-protected pages), use Playwright MCP tools (browser_navigate, browser_snapshot) as a fallback for web browsing.
+[2026-05-30T17:18:31.501Z] [INFO]    - When WebSearch tool fails or returns insufficient results, use Playwright MCP tools (browser_navigate, browser_snapshot) as a fallback for internet search.
+[2026-05-30T17:18:31.501Z] [INFO]    - When you need to interact with dynamic web pages that require JavaScript execution, use Playwright MCP tools.
+[2026-05-30T17:18:31.501Z] [INFO]    - When you need to visually verify how a web page looks or take screenshots, use browser_take_screenshot from Playwright MCP.
+[2026-05-30T17:18:31.501Z] [INFO]    - When you need to fill forms, click buttons, or perform user interactions on web pages, use Playwright MCP tools (browser_click, browser_type, browser_fill_form).
+[2026-05-30T17:18:31.501Z] [INFO]    - When you need to test responsive design or different viewport sizes, use browser_resize from Playwright MCP.
+[2026-05-30T17:18:31.501Z] [INFO]    - When you finish using the browser, close it with browser_close to free resources.
+[2026-05-30T17:18:31.501Z] [INFO]    - When reproducing UI bugs, use browser_take_screenshot to capture the problem state before implementing any fix.
+[2026-05-30T17:18:31.501Z] [INFO]    - When fixing UI bugs, take before/after screenshots to provide visual evidence of the fix for human verification.
+[2026-05-30T17:18:31.501Z] [INFO]    - When creating UI tests, save baseline screenshots to the repository for visual regression testing.
+[2026-05-30T17:18:31.501Z] [INFO]    - When verifying UI fixes, compare screenshots to ensure the fix does not introduce unintended visual changes.
+[2026-05-30T17:18:31.501Z] [INFO] 
+[2026-05-30T17:18:31.501Z] [INFO] Visual UI work and screenshots.
+[2026-05-30T17:18:31.501Z] [INFO]    - When you work on visual UI changes (frontend, CSS, HTML, design), include a render or screenshot of the final result in the pull request description.
+[2026-05-30T17:18:31.501Z] [INFO]    - When you need to show visual results, take a screenshot and save it to the repository (e.g., in a docs/screenshots/ or assets/ folder).
+[2026-05-30T17:18:31.501Z] [INFO]    - When you save screenshots to the repository, use permanent links in the pull request description markdown (e.g., https://github.com/konard/xlabtg-teleton-agent/blob/issue-502-b91556a7ecb2/docs/screenshots/result.png?raw=true).
+[2026-05-30T17:18:31.501Z] [INFO]    - When uploading images, commit them to the branch first, then reference them using the GitHub blob URL format with ?raw=true suffix (works for both public and private repositories).
+[2026-05-30T17:18:31.501Z] [INFO]    - When the visual result is important for review, mention it explicitly in the pull request description with the embedded image.
+[2026-05-30T17:18:31.501Z] [INFO]    - When fixing UI bugs, capture both the "before" (problem) and "after" (fixed) screenshots as evidence for human verification.
+[2026-05-30T17:18:31.501Z] [INFO]    - When reporting UI bugs, include a screenshot of the problem state to enable visual verification of the fix.
+[2026-05-30T17:18:31.501Z] [INFO]    - When the fix is visual, include side-by-side or sequential comparison of before/after states in the PR description.
+[2026-05-30T17:18:31.501Z] [INFO]    - When possible, create automated visual regression tests to prevent the UI bug from recurring.
+[2026-05-30T17:18:31.501Z] [INFO] 
+[2026-05-30T17:18:31.501Z] [INFO] Working language: Russian. When you communicate with the user via comments, commit messages, pull request titles/descriptions, and chat replies, use Russian. Code, identifiers, and command-line strings stay in their original form.
+[2026-05-30T17:18:31.501Z] [INFO] ---END SYSTEM PROMPT---
+[2026-05-30T17:18:31.504Z] [INFO] 📊 CLAUDE_CODE_MAX_OUTPUT_TOKENS: 128000, MCP_TIMEOUT: 900000ms, MCP_TOOL_TIMEOUT: 900000ms, ANTHROPIC_LOG: debug
+[2026-05-30T17:18:31.505Z] [INFO] 📊 CLAUDE_CODE_DISABLE_1M_CONTEXT=1, CLAUDE_CODE_AUTO_COMPACT_WINDOW=150000, CLAUDE_AUTOCOMPACT_PCT_OVERRIDE=95
+[2026-05-30T17:18:31.507Z] [INFO] 📋 Command details:          
+[2026-05-30T17:18:31.507Z] [INFO]   📂 Working directory:      /tmp/gh-issue-solver-1780161489554
+[2026-05-30T17:18:31.508Z] [INFO]   🌿 Branch:                 issue-502-b91556a7ecb2
+[2026-05-30T17:18:31.509Z] [INFO]   🤖 Model:                  Claude OPUS
+[2026-05-30T17:18:31.510Z] [INFO]   🍴 Fork:                   konard/xlabtg-teleton-agent
+[2026-05-30T17:18:31.511Z] [INFO] 
+[2026-05-30T17:18:31.511Z] [INFO] ▶️ Streaming output:         
+[2026-05-30T17:18:31.511Z] [INFO] 
+[2026-05-30T17:18:32.421Z] [INFO] {
+[2026-05-30T17:18:32.421Z] [INFO]   "type": "system",
+[2026-05-30T17:18:32.421Z] [INFO]   "subtype": "init",
+[2026-05-30T17:18:32.421Z] [INFO]   "cwd": "/tmp/gh-issue-solver-1780161489554",
+[2026-05-30T17:18:32.421Z] [INFO]   "session_id": "45441128-80e2-48c1-a2ea-f81ede05030b",
+[2026-05-30T17:18:32.421Z] [INFO]   "tools": [
+[2026-05-30T17:18:32.421Z] [INFO]     "Task",
+[2026-05-30T17:18:32.421Z] [INFO]     "Bash",
+[2026-05-30T17:18:32.421Z] [INFO]     "Edit",
+[2026-05-30T17:18:32.421Z] [INFO]     "Glob",
+[2026-05-30T17:18:32.421Z] [INFO]     "Grep",
+[2026-05-30T17:18:32.421Z] [INFO]     "Read",
+[2026-05-30T17:18:32.421Z] [INFO]     "Skill",
+[2026-05-30T17:18:32.421Z] [INFO]     "TaskCreate",
+[2026-05-30T17:18:32.421Z] [INFO]     "TaskGet",
+[2026-05-30T17:18:32.421Z] [INFO]     "TaskList",
+[2026-05-30T17:18:32.421Z] [INFO]     "TaskOutput",
+[2026-05-30T17:18:32.421Z] [INFO]     "TaskStop",
+[2026-05-30T17:18:32.421Z] [INFO]     "TaskUpdate",
+[2026-05-30T17:18:32.421Z] [INFO]     "ToolSearch",
+[2026-05-30T17:18:32.421Z] [INFO]     "WebFetch",
+[2026-05-30T17:18:32.421Z] [INFO]     "WebSearch",
+[2026-05-30T17:18:32.421Z] [INFO]     "Workflow",
+[2026-05-30T17:18:32.421Z] [INFO]     "Write"
+[2026-05-30T17:18:32.421Z] [INFO]   ],
+[2026-05-30T17:18:32.421Z] [INFO]   "mcp_servers": [
+[2026-05-30T17:18:32.421Z] [INFO]     {
+[2026-05-30T17:18:32.421Z] [INFO]       "name": "playwright",
+[2026-05-30T17:18:32.421Z] [INFO]       "status": "pending"
+[2026-05-30T17:18:32.421Z] [INFO]     }
+[2026-05-30T17:18:32.421Z] [INFO]   ],
+[2026-05-30T17:18:32.421Z] [INFO]   "model": "claude-opus-4-8",
+[2026-05-30T17:18:32.421Z] [INFO]   "permissionMode": "bypassPermissions",
+[2026-05-30T17:18:32.421Z] [INFO]   "slash_commands": [
+[2026-05-30T17:18:32.421Z] [INFO]     "deep-research",
+[2026-05-30T17:18:32.421Z] [INFO]     "update-config",
+[2026-05-30T17:18:32.421Z] [INFO]     "verify",
+[2026-05-30T17:18:32.421Z] [INFO]     "debug",
+[2026-05-30T17:18:32.421Z] [INFO]     "code-review",
+[2026-05-30T17:18:32.421Z] [INFO]     "simplify",
+[2026-05-30T17:18:32.421Z] [INFO]     "batch",
+[2026-05-30T17:18:32.421Z] [INFO]     "fewer-permission-prompts",
+[2026-05-30T17:18:32.421Z] [INFO]     "schedule",
+[2026-05-30T17:18:32.421Z] [INFO]     "claude-api",
+[2026-05-30T17:18:32.421Z] [INFO]     "run",
+[2026-05-30T17:18:32.421Z] [INFO]     "run-skill-generator",
+[2026-05-30T17:18:32.421Z] [INFO]     "clear",
+[2026-05-30T17:18:32.421Z] [INFO]     "compact",
+[2026-05-30T17:18:32.421Z] [INFO]     "context",
+[2026-05-30T17:18:32.421Z] [INFO]     "heapdump",
+[2026-05-30T17:18:32.421Z] [INFO]     "init",
+[2026-05-30T17:18:32.421Z] [INFO]     "reload-skills",
+[2026-05-30T17:18:32.421Z] [INFO]     "review",
+[2026-05-30T17:18:32.421Z] [INFO]     "security-review",
+[2026-05-30T17:18:32.421Z] [INFO]     "usage-credits",
+[2026-05-30T17:18:32.421Z] [INFO]     "extra-usage",
+[2026-05-30T17:18:32.421Z] [INFO]     "usage",
+[2026-05-30T17:18:32.421Z] [INFO]     "insights",
+[2026-05-30T17:18:32.421Z] [INFO]     "goal",
+[2026-05-30T17:18:32.421Z] [INFO]     "team-onboarding"
+[2026-05-30T17:18:32.421Z] [INFO]   ],
+[2026-05-30T17:18:32.421Z] [INFO]   "apiKeySource": "none",
+[2026-05-30T17:18:32.421Z] [INFO]   "claude_code_version": "2.1.158",
+[2026-05-30T17:18:32.421Z] [INFO]   "output_style": "default",
+[2026-05-30T17:18:32.421Z] [INFO]   "agents": [
+[2026-05-30T17:18:32.421Z] [INFO]     "claude",
+[2026-05-30T17:18:32.421Z] [INFO]     "Explore",
+[2026-05-30T17:18:32.421Z] [INFO]     "general-purpose",
+[2026-05-30T17:18:32.421Z] [INFO]     "Plan",
+[2026-05-30T17:18:32.421Z] [INFO]     "statusline-setup"
+[2026-05-30T17:18:32.421Z] [INFO]   ],
+[2026-05-30T17:18:32.421Z] [INFO]   "skills": [
+[2026-05-30T17:18:32.421Z] [INFO]     "deep-research",
+[2026-05-30T17:18:32.421Z] [INFO]     "update-config",
+[2026-05-30T17:18:32.421Z] [INFO]     "verify",
+[2026-05-30T17:18:32.421Z] [INFO]     "debug",
+[2026-05-30T17:18:32.421Z] [INFO]     "code-review",
+[2026-05-30T17:18:32.421Z] [INFO]     "simplify",
+[2026-05-30T17:18:32.421Z] [INFO]     "batch",
+[2026-05-30T17:18:32.421Z] [INFO]     "fewer-permission-prompts",
+[2026-05-30T17:18:32.421Z] [INFO]     "schedule",
+[2026-05-30T17:18:32.421Z] [INFO]     "claude-api",
+[2026-05-30T17:18:32.421Z] [INFO]     "run",
+[2026-05-30T17:18:32.421Z] [INFO]     "run-skill-generator"
+[2026-05-30T17:18:32.421Z] [INFO]   ],
+[2026-05-30T17:18:32.421Z] [INFO]   "plugins": [],
+[2026-05-30T17:18:32.421Z] [INFO]   "analytics_disabled": false,
+[2026-05-30T17:18:32.421Z] [INFO]   "product_feedback_disabled": false,
+[2026-05-30T17:18:32.421Z] [INFO]   "uuid": "9147bda0-9aaa-4007-817a-f1be0a04fe0e",
+[2026-05-30T17:18:32.421Z] [INFO]   "fast_mode_state": "off"
+[2026-05-30T17:18:32.421Z] [INFO] }
+[2026-05-30T17:18:32.424Z] [INFO] 📌 Session ID: 45441128-80e2-48c1-a2ea-f81ede05030b
+[2026-05-30T17:18:32.432Z] [INFO] 📁 Log renamed to: /home/box/45441128-80e2-48c1-a2ea-f81ede05030b.log
+[2026-05-30T17:18:32.445Z] [INFO] [log_c4f1a0] sending request {
+[2026-05-30T17:18:32.448Z] [INFO]   method: "post",
+[2026-05-30T17:18:32.452Z] [INFO]   url: "https://api.anthropic.com/v1/messages?beta=true",
+[2026-05-30T17:18:32.453Z] [INFO]   options: {
+[2026-05-30T17:18:32.453Z] [INFO]     method: "post",
+[2026-05-30T17:18:32.456Z] [INFO]     path: "/v1/messages?beta=true",
+[2026-05-30T17:18:32.457Z] [INFO]     body: {
+[2026-05-30T17:18:32.458Z] [INFO]       model: "claude-opus-4-8",
+[2026-05-30T17:18:32.458Z] [INFO]       messages: [
+[2026-05-30T17:18:32.461Z] [INFO]         [Object ...], [Object ...]
+[2026-05-30T17:18:32.462Z] [INFO]       ],
+[2026-05-30T17:18:32.462Z] [INFO]       system: [
+[2026-05-30T17:18:32.464Z] [INFO]         [Object ...], [Object ...], [Object ...], [Object ...]
+[2026-05-30T17:18:32.465Z] [INFO]       ],
+[2026-05-30T17:18:32.466Z] [INFO]       tools: [
+[2026-05-30T17:18:32.468Z] [INFO]         [Object ...], [Object ...], [Object ...], [Object ...], [Object ...], [Object ...], [Object ...], [Object ...], [Object ...], [Object ...]
+[2026-05-30T17:18:32.468Z] [INFO]       ],
+[2026-05-30T17:18:32.470Z] [INFO]       tool_choice: undefined,
+[2026-05-30T17:18:32.470Z] [INFO]       metadata: [Object ...],
+[2026-05-30T17:18:32.471Z] [INFO]       max_tokens: 128000,
+[2026-05-30T17:18:32.471Z] [INFO]       thinking: [Object ...],
+[2026-05-30T17:18:32.471Z] [INFO]       context_management: [Object ...],
+[2026-05-30T17:18:32.474Z] [INFO]       output_config: [Object ...],
+[2026-05-30T17:18:32.474Z] [INFO]       diagnostics: [Object ...],
+[2026-05-30T17:18:32.474Z] [INFO]       stream: true,
+[2026-05-30T17:18:32.475Z] [INFO]     },
+[2026-05-30T17:18:32.475Z] [INFO]     timeout: 600000,
+[2026-05-30T17:18:32.475Z] [INFO]     signal: AbortSignal {
+[2026-05-30T17:18:32.476Z] [INFO]       [Symbol(events.maxEventTargetListeners)]: 50,
+[2026-05-30T17:18:32.478Z] [INFO]       [Symbol(events.maxEventTargetListenersWarned)]: false,
+[2026-05-30T17:18:32.479Z] [INFO]       aborted: false,
+[2026-05-30T17:18:32.480Z] [INFO]       reason: undefined,
+[2026-05-30T17:18:32.483Z] [INFO]       onabort: null,
+[2026-05-30T17:18:32.485Z] [INFO]       throwIfAborted: [Function: throwIfAborted],
+[2026-05-30T17:18:32.486Z] [INFO]       addEventListener: [Function: addEventListener],
+[2026-05-30T17:18:32.486Z] [INFO]       removeEventListener: [Function: removeEventListener],
+[2026-05-30T17:18:32.486Z] [INFO]       dispatchEvent: [Function: dispatchEvent],
+[2026-05-30T17:18:32.487Z] [INFO]     },
+[2026-05-30T17:18:32.487Z] [INFO]     stream: true,
+[2026-05-30T17:18:32.487Z] [INFO]   },
+[2026-05-30T17:18:32.487Z] [INFO]   headers: {
+[2026-05-30T17:18:32.487Z] [INFO]     accept: "application/json",
+[2026-05-30T17:18:32.488Z] [INFO]     "anthropic-beta": "claude-code-20250219,oauth-2025-04-20,interleaved-thinking-2025-05-14,thinking-token-count-2026-05-13,context-management-2025-06-27,prompt-caching-scope-2026-01-05,mid-conversation-system-2026-04-07,advisor-tool-2026-03-01,advanced-tool-use-2025-11-20,effort-2025-11-24,extended-cache-ttl-2025-04-11,cache-diagnosis-2026-04-07",
+[2026-05-30T17:18:32.488Z] [INFO]     "anthropic-dangerous-direct-browser-access": "true",
+[2026-05-30T17:18:32.489Z] [INFO]     "anthropic-version": "2023-06-01",
+[2026-05-30T17:18:32.489Z] [INFO]     authorization: "***",
+[2026-05-30T17:18:32.490Z] [INFO]     "content-type": "application/json",
+[2026-05-30T17:18:32.490Z] [INFO]     "user-agent": "claude-cli/2.1.158 (external, sdk-cli)",
+[2026-05-30T17:18:32.491Z] [INFO]     "x-app": "cli",
+[2026-05-30T17:18:32.491Z] [INFO]     "x-claude-code-session-id": "45441128-80e2-48c1-a2ea-f81ede05030b",
+[2026-05-30T17:18:32.492Z] [INFO]     "x-client-request-id": "6fd69f00-1683-41da-9cdf-b9f2c4b18303",
+[2026-05-30T17:18:32.493Z] [INFO]     "x-stainless-arch": "x64",
+[2026-05-30T17:18:32.493Z] [INFO]     "x-stainless-lang": "js",
+[2026-05-30T17:18:32.494Z] [INFO]     "x-stainless-os": "Linux",
+[2026-05-30T17:18:32.494Z] [INFO]     "x-stainless-package-version": "0.94.0",
+[2026-05-30T17:18:32.494Z] [INFO]     "x-stainless-retry-count": "0",
+[2026-05-30T17:18:32.495Z] [INFO]     "x-stainless-runtime": "node",
+[2026-05-30T17:18:32.495Z] [INFO]     "x-stainless-runtime-version": "v24.3.0",
+[2026-05-30T17:18:32.495Z] [INFO]     "x-stainless-timeout": "600",
+[2026-05-30T17:18:32.495Z] [INFO]   },
+[2026-05-30T17:18:32.495Z] [INFO] }
+[2026-05-30T17:18:33.945Z] [INFO] [log_c4f1a0, request-id: "req_011CbZ8muZFp8iRWaw4X9qqn"] post https://api.anthropic.com/v1/messages?beta=true succeeded with status 200 in 1502ms
+[2026-05-30T17:18:33.946Z] [INFO] [log_c4f1a0] response start {
+[2026-05-30T17:18:33.946Z] [INFO]   url: "https://api.anthropic.com/v1/messages?beta=true",
+[2026-05-30T17:18:33.947Z] [INFO]   status: 200,
+[2026-05-30T17:18:33.948Z] [INFO]   headers: {
+[2026-05-30T17:18:33.948Z] [INFO]     "anthropic-organization-id": "ebc2ac93-f86f-4d15-aff3-de8830d8d789",
+[2026-05-30T17:18:33.949Z] [INFO]     "anthropic-ratelimit-unified-5h-reset": "1780173000",
+[2026-05-30T17:18:33.949Z] [INFO]     "anthropic-ratelimit-unified-5h-status": "allowed",
+[2026-05-30T17:18:33.950Z] [INFO]     "anthropic-ratelimit-unified-5h-utilization": "0.25",
+[2026-05-30T17:18:33.950Z] [INFO]     "anthropic-ratelimit-unified-7d-reset": "1780398000",
+[2026-05-30T17:18:33.951Z] [INFO]     "anthropic-ratelimit-unified-7d-status": "allowed",
+[2026-05-30T17:18:33.951Z] [INFO]     "anthropic-ratelimit-unified-7d-utilization": "0.73",
+[2026-05-30T17:18:33.953Z] [INFO]     "anthropic-ratelimit-unified-fallback-percentage": "0.5",
+[2026-05-30T17:18:33.954Z] [INFO]     "anthropic-ratelimit-unified-overage-disabled-reason": "org_level_disabled",
+[2026-05-30T17:18:33.955Z] [INFO]     "anthropic-ratelimit-unified-overage-status": "rejected",
+[2026-05-30T17:18:33.956Z] [INFO]     "anthropic-ratelimit-unified-representative-claim": "five_hour",
+[2026-05-30T17:18:33.956Z] [INFO]     "anthropic-ratelimit-unified-reset": "1780173000",
+[2026-05-30T17:18:33.958Z] [INFO]     "anthropic-ratelimit-unified-status": "allowed",
+[2026-05-30T17:18:33.958Z] [INFO]     "cache-control": "no-cache",
+[2026-05-30T17:18:33.959Z] [INFO]     "cf-cache-status": "DYNAMIC",
+[2026-05-30T17:18:33.959Z] [INFO]     "cf-ray": "a03f660cd9a3d9d8-FRA",
+[2026-05-30T17:18:33.960Z] [INFO]     connection: "keep-alive",
+[2026-05-30T17:18:33.961Z] [INFO]     "content-encoding": "gzip",
+[2026-05-30T17:18:33.961Z] [INFO]     "content-security-policy": "default-src 'none'; frame-ancestors 'none'",
+[2026-05-30T17:18:33.962Z] [INFO]     "content-type": "text/event-stream; charset=utf-8",
+[2026-05-30T17:18:33.964Z] [INFO]     date: "Sat, 30 May 2026 17:18:33 GMT",
+[2026-05-30T17:18:33.965Z] [INFO]     "request-id": "req_011CbZ8muZFp8iRWaw4X9qqn",
+[2026-05-30T17:18:33.966Z] [INFO]     server: "cloudflare",
+[2026-05-30T17:18:33.967Z] [INFO]     "strict-transport-security": "max-age=31536000; includeSubDomains; preload",
+[2026-05-30T17:18:33.968Z] [INFO]     traceresponse: "00-68d11ffdbda7ae37d2f23f3cfe88a2b6-30f604dc917688e9-01",
+[2026-05-30T17:18:33.968Z] [INFO]     "transfer-encoding": "chunked",
+[2026-05-30T17:18:33.969Z] [INFO]     vary: "Accept-Encoding",
+[2026-05-30T17:18:33.970Z] [INFO]     "x-robots-tag": "none",
+[2026-05-30T17:18:33.971Z] [INFO]     "set-cookie": "***",
+[2026-05-30T17:18:33.971Z] [INFO]   },
+[2026-05-30T17:18:33.972Z] [INFO]   durationMs: 1502,
+[2026-05-30T17:18:33.973Z] [INFO] }
+[2026-05-30T17:18:33.973Z] [INFO] response 200 https://api.anthropic.com/v1/messages?beta=true Headers {
+[2026-05-30T17:18:33.973Z] [INFO]   "date": "Sat, 30 May 2026 17:18:33 GMT",
+[2026-05-30T17:18:33.974Z] [INFO]   "content-type": "text/event-stream; charset=utf-8",
+[2026-05-30T17:18:33.974Z] [INFO]   "transfer-encoding": "chunked",
+[2026-05-30T17:18:33.975Z] [INFO]   "connection": "keep-alive",
+[2026-05-30T17:18:33.975Z] [INFO]   "cache-control": "no-cache",
+[2026-05-30T17:18:33.976Z] [INFO]   "strict-transport-security": "max-age=31536000; includeSubDomains; preload",
+[2026-05-30T17:18:33.976Z] [INFO]   "content-encoding": "gzip",
+[2026-05-30T17:18:33.977Z] [INFO]   "vary": "Accept-Encoding",
+[2026-05-30T17:18:33.977Z] [INFO]   "content-security-policy": "default-src 'none'; frame-ancestors 'none'",
+[2026-05-30T17:18:33.977Z] [INFO]   "set-cookie": [ "_cfuvid=_pjX5MK6kADNMVUZYmpxYdjUY1kHkmGr3r5RLrlDQwY-1780161512.4567926-1.0.1.1-Y450xzAr65jfdEJVzodqaczhLMnfOhBTHg9MdxobBjY; HttpOnly; SameSite=None; Secure; Path=/; Domain=api.anthropic.com" ],
+[2026-05-30T17:18:33.978Z] [INFO]   "anthropic-ratelimit-unified-status": "allowed",
+[2026-05-30T17:18:33.978Z] [INFO]   "anthropic-ratelimit-unified-5h-status": "allowed",
+[2026-05-30T17:18:33.979Z] [INFO]   "anthropic-ratelimit-unified-5h-reset": "1780173000",
+[2026-05-30T17:18:33.979Z] [INFO]   "anthropic-ratelimit-unified-5h-utilization": "0.25",
+[2026-05-30T17:18:33.979Z] [INFO]   "anthropic-ratelimit-unified-7d-status": "allowed",
+[2026-05-30T17:18:33.980Z] [INFO]   "anthropic-ratelimit-unified-7d-reset": "1780398000",
+[2026-05-30T17:18:33.980Z] [INFO]   "anthropic-ratelimit-unified-7d-utilization": "0.73",
+[2026-05-30T17:18:33.980Z] [INFO]   "anthropic-ratelimit-unified-representative-claim": "five_hour",
+[2026-05-30T17:18:33.981Z] [INFO]   "anthropic-ratelimit-unified-fallback-percentage": "0.5",
+[2026-05-30T17:18:33.982Z] [INFO]   "anthropic-ratelimit-unified-reset": "1780173000",
+[2026-05-30T17:18:33.982Z] [INFO]   "anthropic-ratelimit-unified-overage-disabled-reason": "org_level_disabled",
+[2026-05-30T17:18:33.983Z] [INFO]   "anthropic-ratelimit-unified-overage-status": "rejected",
+[2026-05-30T17:18:33.983Z] [INFO]   "request-id": "req_011CbZ8muZFp8iRWaw4X9qqn",
+[2026-05-30T17:18:33.984Z] [INFO]   "anthropic-organization-id": "ebc2ac93-f86f-4d15-aff3-de8830d8d789",
+[2026-05-30T17:18:33.984Z] [INFO]   "traceresponse": "00-68d11ffdbda7ae37d2f23f3cfe88a2b6-30f604dc917688e9-01",
+[2026-05-30T17:18:33.984Z] [INFO]   "server": "cloudflare",
+[2026-05-30T17:18:33.985Z] [INFO]   "cf-cache-status": "DYNAMIC",
+[2026-05-30T17:18:33.985Z] [INFO]   "x-robots-tag": "none",
+[2026-05-30T17:18:33.985Z] [INFO]   "cf-ray": "a03f660cd9a3d9d8-FRA",
+[2026-05-30T17:18:33.986Z] [INFO] } ReadableStream {
+[2026-05-30T17:18:33.986Z] [INFO]   blob: [Function: blob],
+[2026-05-30T17:18:33.987Z] [INFO]   bytes: [Function: bytes],
+[2026-05-30T17:18:33.987Z] [INFO]   cancel: [Function],
+[2026-05-30T17:18:33.987Z] [INFO]   getReader: [Function],
+[2026-05-30T17:18:33.988Z] [INFO]   json: [Function: json],
+[2026-05-30T17:18:33.988Z] [INFO]   locked: [Getter],
+[2026-05-30T17:18:33.989Z] [INFO]   pipeThrough: [Function],
+[2026-05-30T17:18:33.989Z] [INFO]   pipeTo: [Function],
+[2026-05-30T17:18:33.990Z] [INFO]   tee: [Function],
+[2026-05-30T17:18:33.990Z] [INFO]   text: [Function: text],
+[2026-05-30T17:18:33.991Z] [INFO]   values: [Function],
+[2026-05-30T17:18:33.991Z] [INFO]   [Symbol(Symbol.asyncIterator)]: [Function],
+[2026-05-30T17:18:33.992Z] [INFO] }
+[2026-05-30T17:18:33.992Z] [INFO] [log_c4f1a0] response parsed {
+[2026-05-30T17:18:33.993Z] [INFO]   url: "https://api.anthropic.com/v1/messages?beta=true",
+[2026-05-30T17:18:33.994Z] [INFO]   status: 200,
+[2026-05-30T17:18:33.994Z] [INFO]   body: bR {
+[2026-05-30T17:18:33.994Z] [INFO]     iterator: [AsyncGeneratorFunction: z],
+[2026-05-30T17:18:33.994Z] [INFO]     controller: AbortController {
+[2026-05-30T17:18:33.995Z] [INFO]       signal: [AbortSignal ...],
+[2026-05-30T17:18:33.996Z] [INFO]       abort: [Function: abort],
+[2026-05-30T17:18:33.996Z] [INFO]     },
+[2026-05-30T17:18:33.997Z] [INFO]     [Symbol(Symbol.asyncIterator)]: [Function],
+[2026-05-30T17:18:33.997Z] [INFO]     tee: [Function: tee],
+[2026-05-30T17:18:33.997Z] [INFO]     toReadableStream: [Function: toReadableStream],
+[2026-05-30T17:18:33.997Z] [INFO]   },
+[2026-05-30T17:18:33.998Z] [INFO]   durationMs: 1503,
+[2026-05-30T17:18:33.998Z] [INFO] }
+[2026-05-30T17:18:34.504Z] [INFO] {
+[2026-05-30T17:18:34.504Z] [INFO]   "type": "assistant",
+[2026-05-30T17:18:34.504Z] [INFO]   "message": {
+[2026-05-30T17:18:34.504Z] [INFO]     "model": "claude-opus-4-8",
+[2026-05-30T17:18:34.504Z] [INFO]     "id": "msg_01S55JGdyF1CCyjobgvyAJdw",
+[2026-05-30T17:18:34.504Z] [INFO]     "type": "message",
+[2026-05-30T17:18:34.504Z] [INFO]     "role": "assistant",
+[2026-05-30T17:18:34.504Z] [INFO]     "content": [
+[2026-05-30T17:18:34.504Z] [INFO]       {
+[2026-05-30T17:18:34.504Z] [INFO]         "type": "thinking",
+[2026-05-30T17:18:34.504Z] [INFO]         "thinking": "",
+[2026-05-30T17:18:34.504Z] [INFO]         "signature": "Eo0CCmMIDhgCKkAZAfSuPNU9s24uV2uYv6PJqPTPRrUGLwR0FKvtto+NXEmbpAWXw4G3Kt3n8hREYug5u6u6iyZnDl6K5WvyFYvTMg9jbGF1ZGUtb3B1cy00LTg4AEIIdGhpbmtpbmcSDKwQwatLvTQ2EThnBhoM87c8HjtVH+ZLIVX9IjCxtMSR85rhjwj6LhsnJsHdX2aqdJC86dIHHAxxUNy7e2TCqS3/RB70YkL7ToBI0vQqWHtFCYbdc9AiQKNpBY6SaJDGN/Nm4JtjL3NFhk/z88E2Sc2qBilsjqahHxzd9AE31AJNqU7MYdtfDZi909GOBLt3P7mvbLTxbZlBk0EpmaUj+Wc8ub32cZ4YAQ=="
+[2026-05-30T17:18:34.504Z] [INFO]       }
+[2026-05-30T17:18:34.504Z] [INFO]     ],
+[2026-05-30T17:18:34.504Z] [INFO]     "stop_reason": null,
+[2026-05-30T17:18:34.504Z] [INFO]     "stop_sequence": null,
+[2026-05-30T17:18:34.504Z] [INFO]     "stop_details": null,
+[2026-05-30T17:18:34.504Z] [INFO]     "usage": {
+[2026-05-30T17:18:34.504Z] [INFO]       "input_tokens": 1746,
+[2026-05-30T17:18:34.504Z] [INFO]       "cache_creation_input_tokens": 6819,
+[2026-05-30T17:18:34.504Z] [INFO]       "cache_read_input_tokens": 14354,
+[2026-05-30T17:18:34.504Z] [INFO]       "cache_creation": {
+[2026-05-30T17:18:34.504Z] [INFO]         "ephemeral_5m_input_tokens": 0,
+[2026-05-30T17:18:34.504Z] [INFO]         "ephemeral_1h_input_tokens": 6819
+[2026-05-30T17:18:34.504Z] [INFO]       },
+[2026-05-30T17:18:34.504Z] [INFO]       "output_tokens": 7,
+[2026-05-30T17:18:34.504Z] [INFO]       "service_tier": "standard",
+[2026-05-30T17:18:34.504Z] [INFO]       "inference_geo": "not_available"
+[2026-05-30T17:18:34.504Z] [INFO]     },
+[2026-05-30T17:18:34.504Z] [INFO]     "diagnostics": null,
+[2026-05-30T17:18:34.504Z] [INFO]     "context_management": null
+[2026-05-30T17:18:34.504Z] [INFO]   },
+[2026-05-30T17:18:34.504Z] [INFO]   "parent_tool_use_id": null,
+[2026-05-30T17:18:34.504Z] [INFO]   "session_id": "45441128-80e2-48c1-a2ea-f81ede05030b",
+[2026-05-30T17:18:34.504Z] [INFO]   "uuid": "ba167fd7-f5b7-4c84-ae0f-738916e9dc29",
+[2026-05-30T17:18:34.504Z] [INFO]   "request_id": "req_011CbZ8muZFp8iRWaw4X9qqn"
+[2026-05-30T17:18:34.504Z] [INFO] }
+[2026-05-30T17:18:35.561Z] [INFO] {
+[2026-05-30T17:18:35.561Z] [INFO]   "type": "assistant",
+[2026-05-30T17:18:35.561Z] [INFO]   "message": {
+[2026-05-30T17:18:35.561Z] [INFO]     "model": "claude-opus-4-8",
+[2026-05-30T17:18:35.561Z] [INFO]     "id": "msg_01S55JGdyF1CCyjobgvyAJdw",
+[2026-05-30T17:18:35.561Z] [INFO]     "type": "message",
+[2026-05-30T17:18:35.561Z] [INFO]     "role": "assistant",
+[2026-05-30T17:18:35.561Z] [INFO]     "content": [
+[2026-05-30T17:18:35.561Z] [INFO]       {
+[2026-05-30T17:18:35.561Z] [INFO]         "type": "tool_use",
+[2026-05-30T17:18:35.561Z] [INFO]         "id": "toolu_01Xdt4HF3u5P6X3nb7qH2Brd",
+[2026-05-30T17:18:35.561Z] [INFO]         "name": "Bash",
+[2026-05-30T17:18:35.561Z] [INFO]         "input": {
+[2026-05-30T17:18:35.561Z] [INFO]           "command": "gh issue view https://github.com/xlabtg/teleton-agent/issues/502",
+[2026-05-30T17:18:35.561Z] [INFO]           "description": "View issue 502"
+[2026-05-30T17:18:35.561Z] [INFO]         },
+[2026-05-30T17:18:35.561Z] [INFO]         "caller": {
+[2026-05-30T17:18:35.561Z] [INFO]           "type": "direct"
+[2026-05-30T17:18:35.561Z] [INFO]         }
+[2026-05-30T17:18:35.561Z] [INFO]       }
+[2026-05-30T17:18:35.561Z] [INFO]     ],
+[2026-05-30T17:18:35.561Z] [INFO]     "stop_reason": null,
+[2026-05-30T17:18:35.561Z] [INFO]     "stop_sequence": null,
+[2026-05-30T17:18:35.561Z] [INFO]     "stop_details": null,
+[2026-05-30T17:18:35.561Z] [INFO]     "usage": {
+[2026-05-30T17:18:35.561Z] [INFO]       "input_tokens": 1746,
+[2026-05-30T17:18:35.561Z] [INFO]       "cache_creation_input_tokens": 6819,
+[2026-05-30T17:18:35.561Z] [INFO]       "cache_read_input_tokens": 14354,
+[2026-05-30T17:18:35.561Z] [INFO]       "cache_creation": {
+[2026-05-30T17:18:35.561Z] [INFO]         "ephemeral_5m_input_tokens": 0,
+[2026-05-30T17:18:35.561Z] [INFO]         "ephemeral_1h_input_tokens": 6819
+[2026-05-30T17:18:35.561Z] [INFO]       },
+[2026-05-30T17:18:35.561Z] [INFO]       "output_tokens": 7,
+[2026-05-30T17:18:35.561Z] [INFO]       "service_tier": "standard",
+[2026-05-30T17:18:35.561Z] [INFO]       "inference_geo": "not_available"
+[2026-05-30T17:18:35.561Z] [INFO]     },
+[2026-05-30T17:18:35.561Z] [INFO]     "diagnostics": null,
+[2026-05-30T17:18:35.561Z] [INFO]     "context_management": null
+[2026-05-30T17:18:35.561Z] [INFO]   },
+[2026-05-30T17:18:35.561Z] [INFO]   "parent_tool_use_id": null,
+[2026-05-30T17:18:35.561Z] [INFO]   "session_id": "45441128-80e2-48c1-a2ea-f81ede05030b",
+[2026-05-30T17:18:35.561Z] [INFO]   "uuid": "5dedb76f-e4c4-4ef2-838e-dc445040f7b9",
+[2026-05-30T17:18:35.561Z] [INFO]   "request_id": "req_011CbZ8muZFp8iRWaw4X9qqn"
+[2026-05-30T17:18:35.561Z] [INFO] }
+[2026-05-30T17:18:36.525Z] [INFO] {
+[2026-05-30T17:18:36.525Z] [INFO]   "type": "assistant",
+[2026-05-30T17:18:36.525Z] [INFO]   "message": {
+[2026-05-30T17:18:36.525Z] [INFO]     "model": "claude-opus-4-8",
+[2026-05-30T17:18:36.525Z] [INFO]     "id": "msg_01S55JGdyF1CCyjobgvyAJdw",
+[2026-05-30T17:18:36.525Z] [INFO]     "type": "message",
+[2026-05-30T17:18:36.525Z] [INFO]     "role": "assistant",
+[2026-05-30T17:18:36.525Z] [INFO]     "content": [
+[2026-05-30T17:18:36.525Z] [INFO]       {
+[2026-05-30T17:18:36.525Z] [INFO]         "type": "tool_use",
+[2026-05-30T17:18:36.525Z] [INFO]         "id": "toolu_01A1tFxtAKYgModxxDUUxfmE",
+[2026-05-30T17:18:36.525Z] [INFO]         "name": "Bash",
+[2026-05-30T17:18:36.525Z] [INFO]         "input": {
+[2026-05-30T17:18:36.525Z] [INFO]           "command": "gh pr view 519 --json title,body,state,mergeable,mergeStateStatus,statusCheckRollup",
+[2026-05-30T17:18:36.525Z] [INFO]           "description": "View PR 519 details"
+[2026-05-30T17:18:36.525Z] [INFO]         },
+[2026-05-30T17:18:36.525Z] [INFO]         "caller": {
+[2026-05-30T17:18:36.525Z] [INFO]           "type": "direct"
+[2026-05-30T17:18:36.525Z] [INFO]         }
+[2026-05-30T17:18:36.525Z] [INFO]       }
+[2026-05-30T17:18:36.525Z] [INFO]     ],
+[2026-05-30T17:18:36.525Z] [INFO]     "stop_reason": null,
+[2026-05-30T17:18:36.525Z] [INFO]     "stop_sequence": null,
+[2026-05-30T17:18:36.525Z] [INFO]     "stop_details": null,
+[2026-05-30T17:18:36.525Z] [INFO]     "usage": {
+[2026-05-30T17:18:36.525Z] [INFO]       "input_tokens": 1746,
+[2026-05-30T17:18:36.525Z] [INFO]       "cache_creation_input_tokens": 6819,
+[2026-05-30T17:18:36.525Z] [INFO]       "cache_read_input_tokens": 14354,
+[2026-05-30T17:18:36.525Z] [INFO]       "cache_creation": {
+[2026-05-30T17:18:36.525Z] [INFO]         "ephemeral_5m_input_tokens": 0,
+[2026-05-30T17:18:36.525Z] [INFO]         "ephemeral_1h_input_tokens": 6819
+[2026-05-30T17:18:36.525Z] [INFO]       },
+[2026-05-30T17:18:36.525Z] [INFO]       "output_tokens": 7,
+[2026-05-30T17:18:36.525Z] [INFO]       "service_tier": "standard",
+[2026-05-30T17:18:36.525Z] [INFO]       "inference_geo": "not_available"
+[2026-05-30T17:18:36.525Z] [INFO]     },
+[2026-05-30T17:18:36.525Z] [INFO]     "diagnostics": null,
+[2026-05-30T17:18:36.525Z] [INFO]     "context_management": null
+[2026-05-30T17:18:36.525Z] [INFO]   },
+[2026-05-30T17:18:36.525Z] [INFO]   "parent_tool_use_id": null,
+[2026-05-30T17:18:36.525Z] [INFO]   "session_id": "45441128-80e2-48c1-a2ea-f81ede05030b",
+[2026-05-30T17:18:36.525Z] [INFO]   "uuid": "2718fa8b-0fe4-4219-abe4-18f1dccb32de",
+[2026-05-30T17:18:36.525Z] [INFO]   "request_id": "req_011CbZ8muZFp8iRWaw4X9qqn"
+[2026-05-30T17:18:36.525Z] [INFO] }
+[2026-05-30T17:18:36.600Z] [INFO] {
+[2026-05-30T17:18:36.600Z] [INFO]   "type": "rate_limit_event",
+[2026-05-30T17:18:36.600Z] [INFO]   "rate_limit_info": {
+[2026-05-30T17:18:36.600Z] [INFO]     "status": "allowed",
+[2026-05-30T17:18:36.600Z] [INFO]     "resetsAt": 1780173000,
+[2026-05-30T17:18:36.600Z] [INFO]     "rateLimitType": "five_hour",
+[2026-05-30T17:18:36.600Z] [INFO]     "overageStatus": "rejected",
+[2026-05-30T17:18:36.600Z] [INFO]     "overageDisabledReason": "org_level_disabled",
+[2026-05-30T17:18:36.600Z] [INFO]     "isUsingOverage": false
+[2026-05-30T17:18:36.600Z] [INFO]   },
+[2026-05-30T17:18:36.600Z] [INFO]   "uuid": "ce961b41-15ee-4f98-ace7-69e9a2ef40e5",
+[2026-05-30T17:18:36.600Z] [INFO]   "session_id": "45441128-80e2-48c1-a2ea-f81ede05030b"
+[2026-05-30T17:18:36.600Z] [INFO] }
+[2026-05-30T17:18:38.134Z] [INFO] {
+[2026-05-30T17:18:38.134Z] [INFO]   "type": "user",
+[2026-05-30T17:18:38.134Z] [INFO]   "message": {
+[2026-05-30T17:18:38.134Z] [INFO]     "role": "user",
+[2026-05-30T17:18:38.134Z] [INFO]     "content": [
+[2026-05-30T17:18:38.134Z] [INFO]       {
+[2026-05-30T17:18:38.134Z] [INFO]         "tool_use_id": "toolu_01Xdt4HF3u5P6X3nb7qH2Brd",
+[2026-05-30T17:18:38.134Z] [INFO]         "type": "tool_result",
+[2026-05-30T17:18:38.134Z] [INFO]         "content": "title:\t[R13][P2] Community health files: Code of Conduct, PR template, issue chooser, governance\nstate:\tOPEN\nauthor:\tkonard (Konstantin Diachenko)\nlabels:\t\ncomments:\t0\nassignees:\t\nprojects:\t\nmilestone:\t\nnumber:\t502\n--\n## Summary\n\n**Priority:** P2 — Polish / sustaining  \n**Tags:** `readiness`, `documentation`  \n**Relates to:** #487 (readiness analysis)\n\n---\n\n## Problem\n\nThe project already has `CONTRIBUTING.md` and `SECURITY.md`, which is a good start. However, several GitHub community health files are still missing:\n- **Code of Conduct** — required for GitHub's community health checklist; signals a welcoming project\n- **Pull Request template** — without it, PRs arrive with no description, no checklist, no context\n- **Issue chooser / issue templates** — generic issue form leads to low-quality bug reports; feature requests mixed with bugs\n- **GitHub Discussions** — no async community space for questions, ideas, and show-and-tell\n- **Governance** — no documented decision-making process (who merges, who releases, how RFCs work)\n\n---\n\n## Tasks\n\n### Code of Conduct\n- [ ] Add `.github/CODE_OF_CONDUCT.md` (Contributor Covenant 2.1)\n- [ ] Link from README and CONTRIBUTING.md\n\n### Pull Request template\n- [ ] Add `.github/PULL_REQUEST_TEMPLATE.md` with:\n  - Description of change\n  - Type (bug fix / feature / refactor / docs)\n  - Testing done\n  - Checklist (tests pass, docs updated, CHANGELOG entry)\n\n### Issue templates\n- [ ] Add `.github/ISSUE_TEMPLATE/bug_report.yml` (structured bug report)\n- [ ] Add `.github/ISSUE_TEMPLATE/feature_request.yml` (feature proposal)\n- [ ] Add `.github/ISSUE_TEMPLATE/config.yml` (issue chooser with links to Discussions for questions)\n\n### GitHub Discussions\n- [ ] Enable Discussions on the repository\n- [ ] Create initial categories: Q&A, Ideas, Show & Tell, Announcements\n\n### Governance (optional lightweight)\n- [ ] Add `GOVERNANCE.md` documenting: maintainer list, merge policy, release cadence, RFC process\n\n---\n\n## Acceptance criteria\n\n- GitHub community health checklist shows 100% (Code of Conduct, Contributing, Security, Support)\n- New issues default to structured templates\n- PRs include the template checklist\n- Discussions are enabled and have at least the Q&A category",
+[2026-05-30T17:18:38.134Z] [INFO]         "is_error": false
+[2026-05-30T17:18:38.134Z] [INFO]       }
+[2026-05-30T17:18:38.134Z] [INFO]     ]
+[2026-05-30T17:18:38.134Z] [INFO]   },
+[2026-05-30T17:18:38.134Z] [INFO]   "parent_tool_use_id": null,
+[2026-05-30T17:18:38.134Z] [INFO]   "session_id": "45441128-80e2-48c1-a2ea-f81ede05030b",
+[2026-05-30T17:18:38.134Z] [INFO]   "uuid": "b5887b8b-06ee-4616-afe9-e981c59565e4",
+[2026-05-30T17:18:38.134Z] [INFO]   "timestamp": "2026-05-30T17:18:38.128Z",
+[2026-05-30T17:18:38.134Z] [INFO]   "tool_use_result": {
+[2026-05-30T17:18:38.134Z] [INFO]     "stdout": "title:\t[R13][P2] Community health files: Code of Conduct, PR template, issue chooser, governance\nstate:\tOPEN\nauthor:\tkonard (Konstantin Diachenko)\nlabels:\t\ncomments:\t0\nassignees:\t\nprojects:\t\nmilestone:\t\nnumber:\t502\n--\n## Summary\n\n**Priority:** P2 — Polish / sustaining  \n**Tags:** `readiness`, `documentation`  \n**Relates to:** #487 (readiness analysis)\n\n---\n\n## Problem\n\nThe project already has `CONTRIBUTING.md` and `SECURITY.md`, which is a good start. However, several GitHub community health files are still missing:\n- **Code of Conduct** — required for GitHub's community health checklist; signals a welcoming project\n- **Pull Request template** — without it, PRs arrive with no description, no checklist, no context\n- **Issue chooser / issue templates** — generic issue form leads to low-quality bug reports; feature requests mixed with bugs\n- **GitHub Discussions** — no async community space for questions, ideas, and show-and-tell\n- **Governance** — no documented decision-making process (who merges, who releases, how RFCs work)\n\n---\n\n## Tasks\n\n### Code of Conduct\n- [ ] Add `.github/CODE_OF_CONDUCT.md` (Contributor Covenant 2.1)\n- [ ] Link from README and CONTRIBUTING.md\n\n### Pull Request template\n- [ ] Add `.github/PULL_REQUEST_TEMPLATE.md` with:\n  - Description of change\n  - Type (bug fix / feature / refactor / docs)\n  - Testing done\n  - Checklist (tests pass, docs updated, CHANGELOG entry)\n\n### Issue templates\n- [ ] Add `.github/ISSUE_TEMPLATE/bug_report.yml` (structured bug report)\n- [ ] Add `.github/ISSUE_TEMPLATE/feature_request.yml` (feature proposal)\n- [ ] Add `.github/ISSUE_TEMPLATE/config.yml` (issue chooser with links to Discussions for questions)\n\n### GitHub Discussions\n- [ ] Enable Discussions on the repository\n- [ ] Create initial categories: Q&A, Ideas, Show & Tell, Announcements\n\n### Governance (optional lightweight)\n- [ ] Add `GOVERNANCE.md` documenting: maintainer list, merge policy, release cadence, RFC process\n\n---\n\n## Acceptance criteria\n\n- GitHub community health checklist shows 100% (Code of Conduct, Contributing, Security, Support)\n- New issues default to structured templates\n- PRs include the template checklist\n- Discussions are enabled and have at least the Q&A category",
+[2026-05-30T17:18:38.134Z] [INFO]     "stderr": "",
+[2026-05-30T17:18:38.134Z] [INFO]     "interrupted": false,
+[2026-05-30T17:18:38.134Z] [INFO]     "isImage": false,
+[2026-05-30T17:18:38.134Z] [INFO]     "noOutputExpected": false
+[2026-05-30T17:18:38.134Z] [INFO]   }
+[2026-05-30T17:18:38.134Z] [INFO] }
+[2026-05-30T17:18:39.352Z] [INFO] {
+[2026-05-30T17:18:39.352Z] [INFO]   "type": "user",
+[2026-05-30T17:18:39.352Z] [INFO]   "message": {
+[2026-05-30T17:18:39.352Z] [INFO]     "role": "user",
+[2026-05-30T17:18:39.352Z] [INFO]     "content": [
+[2026-05-30T17:18:39.352Z] [INFO]       {
+[2026-05-30T17:18:39.352Z] [INFO]         "tool_use_id": "toolu_01A1tFxtAKYgModxxDUUxfmE",
+[2026-05-30T17:18:39.352Z] [INFO]         "type": "tool_result",
+[2026-05-30T17:18:39.352Z] [INFO]         "content": "{\"body\":\"## 🤖 AI-Powered Solution Draft\\n\\nThis pull request is being automatically generated to solve issue xlabtg/teleton-agent#502.\\n\\n### 📋 Issue Reference\\nFixes xlabtg/teleton-agent#502\\n\\n### 🚧 Status\\n**Work in Progress** - The AI assistant is currently analyzing and implementing the solution draft.\\n\\n### 📝 Implementation Details\\n_Details will be added as the solution draft is developed..._\\n\\n---\\n*This PR was created automatically by the AI issue solver*\",\"mergeStateStatus\":\"UNSTABLE\",\"mergeable\":\"MERGEABLE\",\"state\":\"OPEN\",\"statusCheckRollup\":[{\"__typename\":\"CheckRun\",\"completedAt\":\"2026-05-30T16:58:30Z\",\"conclusion\":\"SKIPPED\",\"detailsUrl\":\"https://github.com/xlabtg/teleton-agent/actions/runs/26689643862/job/78663682574\",\"name\":\"E2E / WebUI (Playwright)\",\"startedAt\":\"2026-05-30T16:58:30Z\",\"status\":\"COMPLETED\",\"workflowName\":\"E2E\"},{\"__typename\":\"CheckRun\",\"completedAt\":\"2026-05-30T16:58:30Z\",\"conclusion\":\"SKIPPED\",\"detailsUrl\":\"https://github.com/xlabtg/teleton-agent/actions/runs/26689643829/job/78663682521\",\"name\":\"E2E / WebUI (Playwright)\",\"startedAt\":\"2026-05-30T16:58:30Z\",\"status\":\"COMPLETED\",\"workflowName\":\"E2E\"},{\"__typename\":\"CheckRun\",\"completedAt\":\"2026-05-30T16:59:21Z\",\"conclusion\":\"SUCCESS\",\"detailsUrl\":\"https://github.com/xlabtg/teleton-agent/actions/runs/26689643842/job/78663682406\",\"name\":\"CI / Build (Runtime) (20)\",\"startedAt\":\"2026-05-30T16:58:32Z\",\"status\":\"COMPLETED\",\"workflowName\":\"CI\"},{\"__typename\":\"CheckRun\",\"completedAt\":\"2026-05-30T16:59:20Z\",\"conclusion\":\"SUCCESS\",\"detailsUrl\":\"https://github.com/xlabtg/teleton-agent/actions/runs/26689643837/job/78663682356\",\"name\":\"CI / Build (Runtime) (20)\",\"startedAt\":\"2026-05-30T16:58:32Z\",\"status\":\"COMPLETED\",\"workflowName\":\"CI\"},{\"__typename\":\"CheckRun\",\"completedAt\":\"2026-05-30T16:59:11Z\",\"conclusion\":\"SUCCESS\",\"detailsUrl\":\"https://github.com/xlabtg/teleton-agent/actions/runs/26689643842/job/78663682409\",\"name\":\"CI / Build (Runtime) (22)\",\"startedAt\":\"2026-05-30T16:58:32Z\",\"status\":\"COMPLETED\",\"workflowName\":\"CI\"},{\"__typename\":\"CheckRun\",\"completedAt\":\"2026-05-30T16:59:23Z\",\"conclusion\":\"SUCCESS\",\"detailsUrl\":\"https://github.com/xlabtg/teleton-agent/actions/runs/26689643837/job/78663682359\",\"name\":\"CI / Build (Runtime) (22)\",\"startedAt\":\"2026-05-30T16:58:33Z\",\"status\":\"COMPLETED\",\"workflowName\":\"CI\"},{\"__typename\":\"CheckRun\",\"completedAt\":\"2026-05-30T16:59:08Z\",\"conclusion\":\"SUCCESS\",\"detailsUrl\":\"https://github.com/xlabtg/teleton-agent/actions/runs/26689643842/job/78663682377\",\"name\":\"CI / Build (SDK with DTS)\",\"startedAt\":\"2026-05-30T16:58:32Z\",\"status\":\"COMPLETED\",\"workflowName\":\"CI\"},{\"__typename\":\"CheckRun\",\"completedAt\":\"2026-05-30T16:59:08Z\",\"conclusion\":\"SUCCESS\",\"detailsUrl\":\"https://github.com/xlabtg/teleton-agent/actions/runs/26689643837/job/78663682361\",\"name\":\"CI / Build (SDK with DTS)\",\"startedAt\":\"2026-05-30T16:58:33Z\",\"status\":\"COMPLETED\",\"workflowName\":\"CI\"},{\"__typename\":\"CheckRun\",\"completedAt\":\"2026-05-30T16:59:44Z\",\"conclusion\":\"SUCCESS\",\"detailsUrl\":\"https://github.com/xlabtg/teleton-agent/actions/runs/26689643842/job/78663682388\",\"name\":\"CI / Lint\",\"startedAt\":\"2026-05-30T16:58:33Z\",\"status\":\"COMPLETED\",\"workflowName\":\"CI\"},{\"__typename\":\"CheckRun\",\"completedAt\":\"2026-05-30T16:59:48Z\",\"conclusion\":\"SUCCESS\",\"detailsUrl\":\"https://github.com/xlabtg/teleton-agent/actions/runs/26689643837/job/78663682353\",\"name\":\"CI / Lint\",\"startedAt\":\"2026-05-30T16:58:33Z\",\"status\":\"COMPLETED\",\"workflowName\":\"CI\"},{\"__typename\":\"CheckRun\",\"completedAt\":\"2026-05-30T16:59:08Z\",\"conclusion\":\"SUCCESS\",\"detailsUrl\":\"https://github.com/xlabtg/teleton-agent/actions/runs/26689643842/job/78663682380\",\"name\":\"CI / OpenAPI\",\"startedAt\":\"2026-05-30T16:58:32Z\",\"status\":\"COMPLETED\",\"workflowName\":\"CI\"},{\"__typename\":\"CheckRun\",\"completedAt\":\"2026-05-30T16:59:07Z\",\"conclusion\":\"SUCCESS\",\"detailsUrl\":\"https://github.com/xlabtg/teleton-agent/actions/runs/26689643837/job/78663682354\",\"name\":\"CI / OpenAPI\",\"startedAt\":\"2026-05-30T16:58:32Z\",\"status\":\"COMPLETED\",\"workflowName\":\"CI\"},{\"__typename\":\"CheckRun\",\"completedAt\":\"2026-05-30T17:00:00Z\",\"conclusion\":\"FAILURE\",\"detailsUrl\":\"https://github.com/xlabtg/teleton-agent/actions/runs/26689643842/job/78663682376\",\"name\":\"CI / Test\",\"startedAt\":\"2026-05-30T16:58:33Z\",\"status\":\"COMPLETED\",\"workflowName\":\"CI\"},{\"__typename\":\"CheckRun\",\"completedAt\":\"2026-05-30T16:59:54Z\",\"conclusion\":\"FAILURE\",\"detailsUrl\":\"https://github.com/xlabtg/teleton-agent/actions/runs/26689643837/job/78663682351\",\"name\":\"CI / Test\",\"startedAt\":\"2026-05-30T16:58:32Z\",\"status\":\"COMPLETED\",\"workflowName\":\"CI\"},{\"__typename\":\"CheckRun\",\"completedAt\":\"2026-05-30T16:59:19Z\",\"conclusion\":\"SUCCESS\",\"detailsUrl\":\"https://github.com/xlabtg/teleton-agent/actions/runs/26689643842/job/78663682372\",\"name\":\"CI / TypeScript\",\"startedAt\":\"2026-05-30T16:58:33Z\",\"status\":\"COMPLETED\",\"workflowName\":\"CI\"},{\"__typename\":\"CheckRun\",\"completedAt\":\"2026-05-30T16:59:19Z\",\"conclusion\":\"SUCCESS\",\"detailsUrl\":\"https://github.com/xlabtg/teleton-agent/actions/runs/26689643837/job/78663682370\",\"name\":\"CI / TypeScript\",\"startedAt\":\"2026-05-30T16:58:33Z\",\"status\":\"COMPLETED\",\"workflowName\":\"CI\"},{\"__typename\":\"CheckRun\",\"completedAt\":\"2026-05-30T16:59:06Z\",\"conclusion\":\"SUCCESS\",\"detailsUrl\":\"https://github.com/xlabtg/teleton-agent/actions/runs/26689643842/job/78663682408\",\"name\":\"Security audit\",\"startedAt\":\"2026-05-30T16:58:33Z\",\"status\":\"COMPLETED\",\"workflowName\":\"CI\"},{\"__typename\":\"CheckRun\",\"completedAt\":\"2026-05-30T16:59:01Z\",\"conclusion\":\"SUCCESS\",\"detailsUrl\":\"https://github.com/xlabtg/teleton-agent/actions/runs/26689643837/job/78663682350\",\"name\":\"Security audit\",\"startedAt\":\"2026-05-30T16:58:32Z\",\"status\":\"COMPLETED\",\"workflowName\":\"CI\"},{\"__typename\":\"CheckRun\",\"completedAt\":\"2026-05-30T16:58:38Z\",\"conclusion\":\"SUCCESS\",\"detailsUrl\":\"https://github.com/xlabtg/teleton-agent/actions/runs/26689643842/job/78663682397\",\"name\":\"CI / Deploy artifacts\",\"startedAt\":\"2026-05-30T16:58:32Z\",\"status\":\"COMPLETED\",\"workflowName\":\"CI\"},{\"__typename\":\"CheckRun\",\"completedAt\":\"2026-05-30T16:58:40Z\",\"conclusion\":\"SUCCESS\",\"detailsUrl\":\"https://github.com/xlabtg/teleton-agent/actions/runs/26689643837/job/78663682355\",\"name\":\"CI / Deploy artifacts\",\"startedAt\":\"2026-05-30T16:58:33Z\",\"status\":\"COMPLETED\",\"workflowName\":\"CI\"},{\"__typename\":\"CheckRun\",\"completedAt\":\"2026-05-30T16:58:30Z\",\"conclusion\":\"SKIPPED\",\"detailsUrl\":\"https://github.com/xlabtg/teleton-agent/actions/runs/26689643842/job/78663682502\",\"name\":\"CI / Quality (push)\",\"startedAt\":\"2026-05-30T16:58:30Z\",\"status\":\"COMPLETED\",\"workflowName\":\"CI\"},{\"__typename\":\"CheckRun\",\"completedAt\":\"2026-05-30T16:58:30Z\",\"conclusion\":\"SKIPPED\",\"detailsUrl\":\"https://github.com/xlabtg/teleton-agent/actions/runs/26689643837/job/78663682520\",\"name\":\"CI / Quality (push)\",\"startedAt\":\"2026-05-30T16:58:30Z\",\"status\":\"COMPLETED\",\"workflowName\":\"CI\"},{\"__typename\":\"CheckRun\",\"completedAt\":\"2026-05-30T16:59:21Z\",\"conclusion\":\"SKIPPED\",\"detailsUrl\":\"https://github.com/xlabtg/teleton-agent/actions/runs/26689643842/job/78663731362\",\"name\":\"Deploy to Vercel\",\"startedAt\":\"2026-05-30T16:59:22Z\",\"status\":\"COMPLETED\",\"workflowName\":\"CI\"},{\"__typename\":\"CheckRun\",\"completedAt\":\"2026-05-30T16:59:53Z\",\"conclusion\":\"SUCCESS\",\"detailsUrl\":\"https://github.com/xlabtg/teleton-agent/actions/runs/26689643837/job/78663732687\",\"name\":\"Deploy to Vercel\",\"startedAt\":\"2026-05-30T16:59:26Z\",\"status\":\"COMPLETED\",\"workflowName\":\"CI\"}],\"title\":\"[WIP] [R13][P2] Community health files: Code of Conduct, PR template, issue chooser, governance\"}",
+[2026-05-30T17:18:39.352Z] [INFO]         "is_error": false
+[2026-05-30T17:18:39.352Z] [INFO]       }
+[2026-05-30T17:18:39.352Z] [INFO]     ]
+[2026-05-30T17:18:39.352Z] [INFO]   },
+[2026-05-30T17:18:39.352Z] [INFO]   "parent_tool_use_id": null,
+[2026-05-30T17:18:39.352Z] [INFO]   "session_id": "45441128-80e2-48c1-a2ea-f81ede05030b",
+[2026-05-30T17:18:39.352Z] [INFO]   "uuid": "b02509f3-78c1-46ae-87c9-1d4ca59ad4fc",
+[2026-05-30T17:18:39.352Z] [INFO]   "timestamp": "2026-05-30T17:18:39.350Z",
+[2026-05-30T17:18:39.352Z] [INFO]   "tool_use_result": {
+[2026-05-30T17:18:39.352Z] [INFO]     "stdout": "{\"body\":\"## 🤖 AI-Powered Solution Draft\\n\\nThis pull request is being automatically generated to solve issue xlabtg/teleton-agent#502.\\n\\n### 📋 Issue Reference\\nFixes xlabtg/teleton-agent#502\\n\\n### 🚧 Status\\n**Work in Progress** - The AI assistant is currently analyzing and implementing the solution draft.\\n\\n### 📝 Implementation Details\\n_Details will be added as the solution draft is developed..._\\n\\n---\\n*This PR was created automatically by the AI issue solver*\",\"mergeStateStatus\":\"UNSTABLE\",\"mergeable\":\"MERGEABLE\",\"state\":\"OPEN\",\"statusCheckRollup\":[{\"__typename\":\"CheckRun\",\"completedAt\":\"2026-05-30T16:58:30Z\",\"conclusion\":\"SKIPPED\",\"detailsUrl\":\"https://github.com/xlabtg/teleton-agent/actions/runs/26689643862/job/78663682574\",\"name\":\"E2E / WebUI (Playwright)\",\"startedAt\":\"2026-05-30T16:58:30Z\",\"status\":\"COMPLETED\",\"workflowName\":\"E2E\"},{\"__typename\":\"CheckRun\",\"completedAt\":\"2026-05-30T16:58:30Z\",\"conclusion\":\"SKIPPED\",\"detailsUrl\":\"https://github.com/xlabtg/teleton-agent/actions/runs/26689643829/job/78663682521\",\"name\":\"E2E / WebUI (Playwright)\",\"startedAt\":\"2026-05-30T16:58:30Z\",\"status\":\"COMPLETED\",\"workflowName\":\"E2E\"},{\"__typename\":\"CheckRun\",\"completedAt\":\"2026-05-30T16:59:21Z\",\"conclusion\":\"SUCCESS\",\"detailsUrl\":\"https://github.com/xlabtg/teleton-agent/actions/runs/26689643842/job/78663682406\",\"name\":\"CI / Build (Runtime) (20)\",\"startedAt\":\"2026-05-30T16:58:32Z\",\"status\":\"COMPLETED\",\"workflowName\":\"CI\"},{\"__typename\":\"CheckRun\",\"completedAt\":\"2026-05-30T16:59:20Z\",\"conclusion\":\"SUCCESS\",\"detailsUrl\":\"https://github.com/xlabtg/teleton-agent/actions/runs/26689643837/job/78663682356\",\"name\":\"CI / Build (Runtime) (20)\",\"startedAt\":\"2026-05-30T16:58:32Z\",\"status\":\"COMPLETED\",\"workflowName\":\"CI\"},{\"__typename\":\"CheckRun\",\"completedAt\":\"2026-05-30T16:59:11Z\",\"conclusion\":\"SUCCESS\",\"detailsUrl\":\"https://github.com/xlabtg/teleton-agent/actions/runs/26689643842/job/78663682409\",\"name\":\"CI / Build (Runtime) (22)\",\"startedAt\":\"2026-05-30T16:58:32Z\",\"status\":\"COMPLETED\",\"workflowName\":\"CI\"},{\"__typename\":\"CheckRun\",\"completedAt\":\"2026-05-30T16:59:23Z\",\"conclusion\":\"SUCCESS\",\"detailsUrl\":\"https://github.com/xlabtg/teleton-agent/actions/runs/26689643837/job/78663682359\",\"name\":\"CI / Build (Runtime) (22)\",\"startedAt\":\"2026-05-30T16:58:33Z\",\"status\":\"COMPLETED\",\"workflowName\":\"CI\"},{\"__typename\":\"CheckRun\",\"completedAt\":\"2026-05-30T16:59:08Z\",\"conclusion\":\"SUCCESS\",\"detailsUrl\":\"https://github.com/xlabtg/teleton-agent/actions/runs/26689643842/job/78663682377\",\"name\":\"CI / Build (SDK with DTS)\",\"startedAt\":\"2026-05-30T16:58:32Z\",\"status\":\"COMPLETED\",\"workflowName\":\"CI\"},{\"__typename\":\"CheckRun\",\"completedAt\":\"2026-05-30T16:59:08Z\",\"conclusion\":\"SUCCESS\",\"detailsUrl\":\"https://github.com/xlabtg/teleton-agent/actions/runs/26689643837/job/78663682361\",\"name\":\"CI / Build (SDK with DTS)\",\"startedAt\":\"2026-05-30T16:58:33Z\",\"status\":\"COMPLETED\",\"workflowName\":\"CI\"},{\"__typename\":\"CheckRun\",\"completedAt\":\"2026-05-30T16:59:44Z\",\"conclusion\":\"SUCCESS\",\"detailsUrl\":\"https://github.com/xlabtg/teleton-agent/actions/runs/26689643842/job/78663682388\",\"name\":\"CI / Lint\",\"startedAt\":\"2026-05-30T16:58:33Z\",\"status\":\"COMPLETED\",\"workflowName\":\"CI\"},{\"__typename\":\"CheckRun\",\"completedAt\":\"2026-05-30T16:59:48Z\",\"conclusion\":\"SUCCESS\",\"detailsUrl\":\"https://github.com/xlabtg/teleton-agent/actions/runs/26689643837/job/78663682353\",\"name\":\"CI / Lint\",\"startedAt\":\"2026-05-30T16:58:33Z\",\"status\":\"COMPLETED\",\"workflowName\":\"CI\"},{\"__typename\":\"CheckRun\",\"completedAt\":\"2026-05-30T16:59:08Z\",\"conclusion\":\"SUCCESS\",\"detailsUrl\":\"https://github.com/xlabtg/teleton-agent/actions/runs/26689643842/job/78663682380\",\"name\":\"CI / OpenAPI\",\"startedAt\":\"2026-05-30T16:58:32Z\",\"status\":\"COMPLETED\",\"workflowName\":\"CI\"},{\"__typename\":\"CheckRun\",\"completedAt\":\"2026-05-30T16:59:07Z\",\"conclusion\":\"SUCCESS\",\"detailsUrl\":\"https://github.com/xlabtg/teleton-agent/actions/runs/26689643837/job/78663682354\",\"name\":\"CI / OpenAPI\",\"startedAt\":\"2026-05-30T16:58:32Z\",\"status\":\"COMPLETED\",\"workflowName\":\"CI\"},{\"__typename\":\"CheckRun\",\"completedAt\":\"2026-05-30T17:00:00Z\",\"conclusion\":\"FAILURE\",\"detailsUrl\":\"https://github.com/xlabtg/teleton-agent/actions/runs/26689643842/job/78663682376\",\"name\":\"CI / Test\",\"startedAt\":\"2026-05-30T16:58:33Z\",\"status\":\"COMPLETED\",\"workflowName\":\"CI\"},{\"__typename\":\"CheckRun\",\"completedAt\":\"2026-05-30T16:59:54Z\",\"conclusion\":\"FAILURE\",\"detailsUrl\":\"https://github.com/xlabtg/teleton-agent/actions/runs/26689643837/job/78663682351\",\"name\":\"CI / Test\",\"startedAt\":\"2026-05-30T16:58:32Z\",\"status\":\"COMPLETED\",\"workflowName\":\"CI\"},{\"__typename\":\"CheckRun\",\"completedAt\":\"2026-05-30T16:59:19Z\",\"conclusion\":\"SUCCESS\",\"detailsUrl\":\"https://github.com/xlabtg/teleton-agent/actions/runs/26689643842/job/78663682372\",\"name\":\"CI / TypeScript\",\"startedAt\":\"2026-05-30T16:58:33Z\",\"status\":\"COMPLETED\",\"workflowName\":\"CI\"},{\"__typename\":\"CheckRun\",\"completedAt\":\"2026-05-30T16:59:19Z\",\"conclusion\":\"SUCCESS\",\"detailsUrl\":\"https://github.com/xlabtg/teleton-agent/actions/runs/26689643837/job/78663682370\",\"name\":\"CI / TypeScript\",\"startedAt\":\"2026-05-30T16:58:33Z\",\"status\":\"COMPLETED\",\"workflowName\":\"CI\"},{\"__typename\":\"CheckRun\",\"completedAt\":\"2026-05-30T16:59:06Z\",\"conclusion\":\"SUCCESS\",\"detailsUrl\":\"https://github.com/xlabtg/teleton-agent/actions/runs/26689643842/job/78663682408\",\"name\":\"Security audit\",\"startedAt\":\"2026-05-30T16:58:33Z\",\"status\":\"COMPLETED\",\"workflowName\":\"CI\"},{\"__typename\":\"CheckRun\",\"completedAt\":\"2026-05-30T16:59:01Z\",\"conclusion\":\"SUCCESS\",\"detailsUrl\":\"https://github.com/xlabtg/teleton-agent/actions/runs/26689643837/job/78663682350\",\"name\":\"Security audit\",\"startedAt\":\"2026-05-30T16:58:32Z\",\"status\":\"COMPLETED\",\"workflowName\":\"CI\"},{\"__typename\":\"CheckRun\",\"completedAt\":\"2026-05-30T16:58:38Z\",\"conclusion\":\"SUCCESS\",\"detailsUrl\":\"https://github.com/xlabtg/teleton-agent/actions/runs/26689643842/job/78663682397\",\"name\":\"CI / Deploy artifacts\",\"startedAt\":\"2026-05-30T16:58:32Z\",\"status\":\"COMPLETED\",\"workflowName\":\"CI\"},{\"__typename\":\"CheckRun\",\"completedAt\":\"2026-05-30T16:58:40Z\",\"conclusion\":\"SUCCESS\",\"detailsUrl\":\"https://github.com/xlabtg/teleton-agent/actions/runs/26689643837/job/78663682355\",\"name\":\"CI / Deploy artifacts\",\"startedAt\":\"2026-05-30T16:58:33Z\",\"status\":\"COMPLETED\",\"workflowName\":\"CI\"},{\"__typename\":\"CheckRun\",\"completedAt\":\"2026-05-30T16:58:30Z\",\"conclusion\":\"SKIPPED\",\"detailsUrl\":\"https://github.com/xlabtg/teleton-agent/actions/runs/26689643842/job/78663682502\",\"name\":\"CI / Quality (push)\",\"startedAt\":\"2026-05-30T16:58:30Z\",\"status\":\"COMPLETED\",\"workflowName\":\"CI\"},{\"__typename\":\"CheckRun\",\"completedAt\":\"2026-05-30T16:58:30Z\",\"conclusion\":\"SKIPPED\",\"detailsUrl\":\"https://github.com/xlabtg/teleton-agent/actions/runs/26689643837/job/78663682520\",\"name\":\"CI / Quality (push)\",\"startedAt\":\"2026-05-30T16:58:30Z\",\"status\":\"COMPLETED\",\"workflowName\":\"CI\"},{\"__typename\":\"CheckRun\",\"completedAt\":\"2026-05-30T16:59:21Z\",\"conclusion\":\"SKIPPED\",\"detailsUrl\":\"https://github.com/xlabtg/teleton-agent/actions/runs/26689643842/job/78663731362\",\"name\":\"Deploy to Vercel\",\"startedAt\":\"2026-05-30T16:59:22Z\",\"status\":\"COMPLETED\",\"workflowName\":\"CI\"},{\"__typename\":\"CheckRun\",\"completedAt\":\"2026-05-30T16:59:53Z\",\"conclusion\":\"SUCCESS\",\"detailsUrl\":\"https://github.com/xlabtg/teleton-agent/actions/runs/26689643837/job/78663732687\",\"name\":\"Deploy to Vercel\",\"startedAt\":\"2026-05-30T16:59:26Z\",\"status\":\"COMPLETED\",\"workflowName\":\"CI\"}],\"title\":\"[WIP] [R13][P2] Community health files: Code of Conduct, PR template, issue chooser, governance\"}",
+[2026-05-30T17:18:39.352Z] [INFO]     "stderr": "",
+[2026-05-30T17:18:39.352Z] [INFO]     "interrupted": false,
+[2026-05-30T17:18:39.352Z] [INFO]     "isImage": false,
+[2026-05-30T17:18:39.352Z] [INFO]     "noOutputExpected": false
+[2026-05-30T17:18:39.352Z] [INFO]   }
+[2026-05-30T17:18:39.352Z] [INFO] }
+[2026-05-30T17:18:39.363Z] [INFO] [log_0fa479] sending request {
+[2026-05-30T17:18:39.364Z] [INFO]   method: "post",
+[2026-05-30T17:18:39.364Z] [INFO]   url: "https://api.anthropic.com/v1/messages?beta=true",
+[2026-05-30T17:18:39.365Z] [INFO]   options: {
+[2026-05-30T17:18:39.366Z] [INFO]     method: "post",
+[2026-05-30T17:18:39.366Z] [INFO]     path: "/v1/messages?beta=true",
+[2026-05-30T17:18:39.367Z] [INFO]     body: {
+[2026-05-30T17:18:39.368Z] [INFO]       model: "claude-opus-4-8",
+[2026-05-30T17:18:39.368Z] [INFO]       messages: [
+[2026-05-30T17:18:39.369Z] [INFO]         [Object ...], [Object ...], [Object ...], [Object ...]
+[2026-05-30T17:18:39.370Z] [INFO]       ],
+[2026-05-30T17:18:39.370Z] [INFO]       system: [
+[2026-05-30T17:18:39.371Z] [INFO]         [Object ...], [Object ...], [Object ...], [Object ...]
+[2026-05-30T17:18:39.371Z] [INFO]       ],
+[2026-05-30T17:18:39.372Z] [INFO]       tools: [
+[2026-05-30T17:18:39.373Z] [INFO]         [Object ...], [Object ...], [Object ...], [Object ...], [Object ...], [Object ...], [Object ...], [Object ...], [Object ...], [Object ...]
+[2026-05-30T17:18:39.373Z] [INFO]       ],
+[2026-05-30T17:18:39.373Z] [INFO]       tool_choice: undefined,
+[2026-05-30T17:18:39.375Z] [INFO]       metadata: [Object ...],
+[2026-05-30T17:18:39.375Z] [INFO]       max_tokens: 128000,
+[2026-05-30T17:18:39.376Z] [INFO]       thinking: [Object ...],
+[2026-05-30T17:18:39.376Z] [INFO]       context_management: [Object ...],
+[2026-05-30T17:18:39.376Z] [INFO]       output_config: [Object ...],
+[2026-05-30T17:18:39.377Z] [INFO]       diagnostics: [Object ...],
+[2026-05-30T17:18:39.377Z] [INFO]       stream: true,
+[2026-05-30T17:18:39.378Z] [INFO]     },
+[2026-05-30T17:18:39.378Z] [INFO]     timeout: 600000,
+[2026-05-30T17:18:39.379Z] [INFO]     signal: AbortSignal {
+[2026-05-30T17:18:39.380Z] [INFO]       [Symbol(events.maxEventTargetListeners)]: 50,
+[2026-05-30T17:18:39.380Z] [INFO]       [Symbol(events.maxEventTargetListenersWarned)]: false,
+[2026-05-30T17:18:39.381Z] [INFO]       aborted: false,
+[2026-05-30T17:18:39.382Z] [INFO]       reason: undefined,
+[2026-05-30T17:18:39.384Z] [INFO]       onabort: null,
+[2026-05-30T17:18:39.385Z] [INFO]       throwIfAborted: [Function: throwIfAborted],
+[2026-05-30T17:18:39.386Z] [INFO]       addEventListener: [Function: addEventListener],
+[2026-05-30T17:18:39.386Z] [INFO]       removeEventListener: [Function: removeEventListener],
+[2026-05-30T17:18:39.386Z] [INFO]       dispatchEvent: [Function: dispatchEvent],
+[2026-05-30T17:18:39.386Z] [INFO]     },
+[2026-05-30T17:18:39.387Z] [INFO]     stream: true,
+[2026-05-30T17:18:39.387Z] [INFO]   },
+[2026-05-30T17:18:39.388Z] [INFO]   headers: {
+[2026-05-30T17:18:39.388Z] [INFO]     accept: "application/json",
+[2026-05-30T17:18:39.389Z] [INFO]     "anthropic-beta": "claude-code-20250219,oauth-2025-04-20,interleaved-thinking-2025-05-14,thinking-token-count-2026-05-13,context-management-2025-06-27,prompt-caching-scope-2026-01-05,mid-conversation-system-2026-04-07,advisor-tool-2026-03-01,advanced-tool-use-2025-11-20,effort-2025-11-24,extended-cache-ttl-2025-04-11,cache-diagnosis-2026-04-07",
+[2026-05-30T17:18:39.389Z] [INFO]     "anthropic-dangerous-direct-browser-access": "true",
+[2026-05-30T17:18:39.389Z] [INFO]     "anthropic-version": "2023-06-01",
+[2026-05-30T17:18:39.390Z] [INFO]     authorization: "***",
+[2026-05-30T17:18:39.390Z] [INFO]     "content-type": "application/json",
+[2026-05-30T17:18:39.391Z] [INFO]     "user-agent": "claude-cli/2.1.158 (external, sdk-cli)",
+[2026-05-30T17:18:39.391Z] [INFO]     "x-app": "cli",
+[2026-05-30T17:18:39.391Z] [INFO]     "x-claude-code-session-id": "45441128-80e2-48c1-a2ea-f81ede05030b",
+[2026-05-30T17:18:39.392Z] [INFO]     "x-client-request-id": "ff9d8386-08eb-4db0-bcb0-31a7f6028e35",
+[2026-05-30T17:18:39.392Z] [INFO]     "x-stainless-arch": "x64",
+[2026-05-30T17:18:39.392Z] [INFO]     "x-stainless-lang": "js",
+[2026-05-30T17:18:39.393Z] [INFO]     "x-stainless-os": "Linux",
+[2026-05-30T17:18:39.393Z] [INFO]     "x-stainless-package-version": "0.94.0",
+[2026-05-30T17:18:39.393Z] [INFO]     "x-stainless-retry-count": "0",
+[2026-05-30T17:18:39.394Z] [INFO]     "x-stainless-runtime": "node",
+[2026-05-30T17:18:39.395Z] [INFO]     "x-stainless-runtime-version": "v24.3.0",
+[2026-05-30T17:18:39.396Z] [INFO]     "x-stainless-timeout": "600",
+[2026-05-30T17:18:39.397Z] [INFO]   },
+[2026-05-30T17:18:39.398Z] [INFO] }
+[2026-05-30T17:18:40.728Z] [INFO] [log_0fa479, request-id: "req_011CbZ8nRAVAhZdJicvkPYHE"] post https://api.anthropic.com/v1/messages?beta=true succeeded with status 200 in 1366ms
+[2026-05-30T17:18:40.734Z] [INFO] [log_0fa479] response start {
+[2026-05-30T17:18:40.735Z] [INFO]   url: "https://api.anthropic.com/v1/messages?beta=true",
+[2026-05-30T17:18:40.739Z] [INFO]   status: 200,
+[2026-05-30T17:18:40.740Z] [INFO]   headers: {
+[2026-05-30T17:18:40.740Z] [INFO]     "anthropic-organization-id": "ebc2ac93-f86f-4d15-aff3-de8830d8d789",
+[2026-05-30T17:18:40.740Z] [INFO]     "anthropic-ratelimit-unified-5h-reset": "1780173000",
+[2026-05-30T17:18:40.740Z] [INFO]     "anthropic-ratelimit-unified-5h-status": "allowed",
+[2026-05-30T17:18:40.741Z] [INFO]     "anthropic-ratelimit-unified-5h-utilization": "0.25",
+[2026-05-30T17:18:40.742Z] [INFO]     "anthropic-ratelimit-unified-7d-reset": "1780398000",
+[2026-05-30T17:18:40.742Z] [INFO]     "anthropic-ratelimit-unified-7d-status": "allowed",
+[2026-05-30T17:18:40.742Z] [INFO]     "anthropic-ratelimit-unified-7d-utilization": "0.73",
+[2026-05-30T17:18:40.742Z] [INFO]     "anthropic-ratelimit-unified-fallback-percentage": "0.5",
+[2026-05-30T17:18:40.743Z] [INFO]     "anthropic-ratelimit-unified-overage-disabled-reason": "org_level_disabled",
+[2026-05-30T17:18:40.744Z] [INFO]     "anthropic-ratelimit-unified-overage-status": "rejected",
+[2026-05-30T17:18:40.745Z] [INFO]     "anthropic-ratelimit-unified-representative-claim": "five_hour",
+[2026-05-30T17:18:40.745Z] [INFO]     "anthropic-ratelimit-unified-reset": "1780173000",
+[2026-05-30T17:18:40.745Z] [INFO]     "anthropic-ratelimit-unified-status": "allowed",
+[2026-05-30T17:18:40.745Z] [INFO]     "cache-control": "no-cache",
+[2026-05-30T17:18:40.746Z] [INFO]     "cf-cache-status": "DYNAMIC",
+[2026-05-30T17:18:40.746Z] [INFO]     "cf-ray": "a03f66381f44b10b-FRA",
+[2026-05-30T17:18:40.747Z] [INFO]     connection: "keep-alive",
+[2026-05-30T17:18:40.747Z] [INFO]     "content-encoding": "gzip",
+[2026-05-30T17:18:40.747Z] [INFO]     "content-security-policy": "default-src 'none'; frame-ancestors 'none'",
+[2026-05-30T17:18:40.747Z] [INFO]     "content-type": "text/event-stream; charset=utf-8",
+[2026-05-30T17:18:40.747Z] [INFO]     date: "Sat, 30 May 2026 17:18:40 GMT",
+[2026-05-30T17:18:40.747Z] [INFO]     "request-id": "req_011CbZ8nRAVAhZdJicvkPYHE",
+[2026-05-30T17:18:40.748Z] [INFO]     server: "cloudflare",
+[2026-05-30T17:18:40.748Z] [INFO]     "strict-transport-security": "max-age=31536000; includeSubDomains; preload",
+[2026-05-30T17:18:40.750Z] [INFO]     traceresponse: "00-731c79855a3716f54e2433d5c13b7607-5b350eef1190ce9d-01",
+[2026-05-30T17:18:40.753Z] [INFO]     "transfer-encoding": "chunked",
+[2026-05-30T17:18:40.754Z] [INFO]     vary: "Accept-Encoding",
+[2026-05-30T17:18:40.754Z] [INFO]     "x-robots-tag": "none",
+[2026-05-30T17:18:40.754Z] [INFO]     "set-cookie": "***",
+[2026-05-30T17:18:40.754Z] [INFO]   },
+[2026-05-30T17:18:40.755Z] [INFO]   durationMs: 1366,
+[2026-05-30T17:18:40.755Z] [INFO] }
+[2026-05-30T17:18:40.755Z] [INFO] response 200 https://api.anthropic.com/v1/messages?beta=true Headers {
+[2026-05-30T17:18:40.755Z] [INFO]   "date": "Sat, 30 May 2026 17:18:40 GMT",
+[2026-05-30T17:18:40.755Z] [INFO]   "content-type": "text/event-stream; charset=utf-8",
+[2026-05-30T17:18:40.755Z] [INFO]   "transfer-encoding": "chunked",
+[2026-05-30T17:18:40.756Z] [INFO]   "connection": "keep-alive",
+[2026-05-30T17:18:40.756Z] [INFO]   "cache-control": "no-cache",
+[2026-05-30T17:18:40.756Z] [INFO]   "strict-transport-security": "max-age=31536000; includeSubDomains; preload",
+[2026-05-30T17:18:40.756Z] [INFO]   "content-encoding": "gzip",
+[2026-05-30T17:18:40.756Z] [INFO]   "vary": "Accept-Encoding",
+[2026-05-30T17:18:40.756Z] [INFO]   "content-security-policy": "default-src 'none'; frame-ancestors 'none'",
+[2026-05-30T17:18:40.757Z] [INFO]   "set-cookie": [ "_cfuvid=GqjAUV0UOc9LKT4ijhn5ZKacyj.glcJMaeKtPFjekSs-1780161519.3766425-1.0.1.1-LwiFt5zhMmt2B9yU4oXHy89F8h28MsYXtigQ_CL2GiA; HttpOnly; SameSite=None; Secure; Path=/; Domain=api.anthropic.com" ],
+[2026-05-30T17:18:40.757Z] [INFO]   "anthropic-ratelimit-unified-status": "allowed",
+[2026-05-30T17:18:40.757Z] [INFO]   "anthropic-ratelimit-unified-5h-status": "allowed",
+[2026-05-30T17:18:40.757Z] [INFO]   "anthropic-ratelimit-unified-5h-reset": "1780173000",
+[2026-05-30T17:18:40.757Z] [INFO]   "anthropic-ratelimit-unified-5h-utilization": "0.25",
+[2026-05-30T17:18:40.758Z] [INFO]   "anthropic-ratelimit-unified-7d-status": "allowed",
+[2026-05-30T17:18:40.758Z] [INFO]   "anthropic-ratelimit-unified-7d-reset": "1780398000",
+[2026-05-30T17:18:40.758Z] [INFO]   "anthropic-ratelimit-unified-7d-utilization": "0.73",
+[2026-05-30T17:18:40.758Z] [INFO]   "anthropic-ratelimit-unified-representative-claim": "five_hour",
+[2026-05-30T17:18:40.758Z] [INFO]   "anthropic-ratelimit-unified-fallback-percentage": "0.5",
+[2026-05-30T17:18:40.759Z] [INFO]   "anthropic-ratelimit-unified-reset": "1780173000",
+[2026-05-30T17:18:40.759Z] [INFO]   "anthropic-ratelimit-unified-overage-disabled-reason": "org_level_disabled",
+[2026-05-30T17:18:40.760Z] [INFO]   "anthropic-ratelimit-unified-overage-status": "rejected",
+[2026-05-30T17:18:40.760Z] [INFO]   "request-id": "req_011CbZ8nRAVAhZdJicvkPYHE",
+[2026-05-30T17:18:40.762Z] [INFO]   "anthropic-organization-id": "ebc2ac93-f86f-4d15-aff3-de8830d8d789",
+[2026-05-30T17:18:40.763Z] [INFO]   "traceresponse": "00-731c79855a3716f54e2433d5c13b7607-5b350eef1190ce9d-01",
+[2026-05-30T17:18:40.763Z] [INFO]   "server": "cloudflare",
+[2026-05-30T17:18:40.763Z] [INFO]   "cf-cache-status": "DYNAMIC",
+[2026-05-30T17:18:40.763Z] [INFO]   "x-robots-tag": "none",
+[2026-05-30T17:18:40.763Z] [INFO]   "cf-ray": "a03f66381f44b10b-FRA",
+[2026-05-30T17:18:40.763Z] [INFO] } ReadableStream {
+[2026-05-30T17:18:40.764Z] [INFO]   blob: [Function: blob],
+[2026-05-30T17:18:40.764Z] [INFO]   bytes: [Function: bytes],
+[2026-05-30T17:18:40.764Z] [INFO]   cancel: [Function],
+[2026-05-30T17:18:40.765Z] [INFO]   getReader: [Function],
+[2026-05-30T17:18:40.765Z] [INFO]   json: [Function: json],
+[2026-05-30T17:18:40.765Z] [INFO]   locked: [Getter],
+[2026-05-30T17:18:40.765Z] [INFO]   pipeThrough: [Function],
+[2026-05-30T17:18:40.765Z] [INFO]   pipeTo: [Function],
+[2026-05-30T17:18:40.766Z] [INFO]   tee: [Function],
+[2026-05-30T17:18:40.766Z] [INFO]   text: [Function: text],
+[2026-05-30T17:18:40.766Z] [INFO]   values: [Function: values],
+[2026-05-30T17:18:40.766Z] [INFO]   [Symbol(Symbol.asyncIterator)]: [Function: asyncIterator2],
+[2026-05-30T17:18:40.766Z] [INFO] }
+[2026-05-30T17:18:40.767Z] [INFO] [log_0fa479] response parsed {
+[2026-05-30T17:18:40.767Z] [INFO]   url: "https://api.anthropic.com/v1/messages?beta=true",
+[2026-05-30T17:18:40.767Z] [INFO]   status: 200,
+[2026-05-30T17:18:40.768Z] [INFO]   body: bR {
+[2026-05-30T17:18:40.768Z] [INFO]     iterator: [AsyncGeneratorFunction: z],
+[2026-05-30T17:18:40.771Z] [INFO]     controller: AbortController {
+[2026-05-30T17:18:40.776Z] [INFO]       signal: [AbortSignal ...],
+[2026-05-30T17:18:40.778Z] [INFO]       abort: [Function: abort],
+[2026-05-30T17:18:40.779Z] [INFO]     },
+[2026-05-30T17:18:40.780Z] [INFO]     [Symbol(Symbol.asyncIterator)]: [Function],
+[2026-05-30T17:18:40.781Z] [INFO]     tee: [Function: tee],
+[2026-05-30T17:18:40.783Z] [INFO]     toReadableStream: [Function: toReadableStream],
+[2026-05-30T17:18:40.784Z] [INFO]   },
+[2026-05-30T17:18:40.786Z] [INFO]   durationMs: 1367,
+[2026-05-30T17:18:40.786Z] [INFO] }
+[2026-05-30T17:18:42.180Z] [INFO] {
+[2026-05-30T17:18:42.180Z] [INFO]   "type": "system",
+[2026-05-30T17:18:42.180Z] [INFO]   "subtype": "thinking_tokens",
+[2026-05-30T17:18:42.180Z] [INFO]   "estimated_tokens": 50,
+[2026-05-30T17:18:42.180Z] [INFO]   "estimated_tokens_delta": 50,
+[2026-05-30T17:18:42.180Z] [INFO]   "uuid": "ccf99eed-4182-4479-96d5-bcae27634d3c",
+[2026-05-30T17:18:42.180Z] [INFO]   "session_id": "45441128-80e2-48c1-a2ea-f81ede05030b"
+[2026-05-30T17:18:42.180Z] [INFO] }
+[2026-05-30T17:18:42.181Z] [INFO] {
+[2026-05-30T17:18:42.181Z] [INFO]   "type": "assistant",
+[2026-05-30T17:18:42.181Z] [INFO]   "message": {
+[2026-05-30T17:18:42.181Z] [INFO]     "model": "claude-opus-4-8",
+[2026-05-30T17:18:42.181Z] [INFO]     "id": "msg_016usAxp32dJLu2vf9jYtRM2",
+[2026-05-30T17:18:42.181Z] [INFO]     "type": "message",
+[2026-05-30T17:18:42.181Z] [INFO]     "role": "assistant",
+[2026-05-30T17:18:42.181Z] [INFO]     "content": [
+[2026-05-30T17:18:42.181Z] [INFO]       {
+[2026-05-30T17:18:42.181Z] [INFO]         "type": "thinking",
+[2026-05-30T17:18:42.181Z] [INFO]         "thinking": "",
+[2026-05-30T17:18:42.181Z] [INFO]         "signature": "EtEDCmMIDhgCKkAg0XNdYr5D+4PL4LGSD5cPMpOmSGog+lsn7UT65/eqyoTAkoWJsli1ECOtqaZ48I9nfVgFuoK9Hr7kvE5NopjcMg9jbGF1ZGUtb3B1cy00LTg4AEIIdGhpbmtpbmcSDEutcShrY6eOKyxRXBoMgJS1XaO2kwJ7Gl6qIjB+5JRq2ZCWLgYLlHdtuOShwUtKuWiQKLglFZIAigkM7yruJ08TGDjf27zk4FEiw+IqmwLhvqLEa/t+8FaR5lRoQmTuZOlrXKF9vcN3YNPqpBSE2c3YkD9s2F/aOQbplRo3Ov2cMdG6gKlm9MoBgNi97JhR61EspOpYJ8xKpQh1+HH47vHRzHjn0ENbDf8HuJeYfImFaPSoODeB3WjyFks11KucQ9dTKqKGfR7Q2uwjo3XERroWrgKF5fx3hru3786NNvao61UPziI3mXD7vVoeeveCnL3FJkWCOfpqgnV/P4p6MbxIYZFy+DsKO/efzb+Nz6ydX4/2MbxT53vU4gSZy7F1kTSTeWFxjVo+b8HRjCZz2+3Aa5dWeuAhIUhWp+M30of1ol1Lflc/V0NNTUXxWT6272cjADbep6Y/lOJiDG5e+OgeM7/H1Gc9blevGAE="
+[2026-05-30T17:18:42.181Z] [INFO]       }
+[2026-05-30T17:18:42.181Z] [INFO]     ],
+[2026-05-30T17:18:42.181Z] [INFO]     "stop_reason": null,
+[2026-05-30T17:18:42.181Z] [INFO]     "stop_sequence": null,
+[2026-05-30T17:18:42.181Z] [INFO]     "stop_details": null,
+[2026-05-30T17:18:42.181Z] [INFO]     "usage": {
+[2026-05-30T17:18:42.181Z] [INFO]       "input_tokens": 2,
+[2026-05-30T17:18:42.181Z] [INFO]       "cache_creation_input_tokens": 6764,
+[2026-05-30T17:18:42.181Z] [INFO]       "cache_read_input_tokens": 21173,
+[2026-05-30T17:18:42.181Z] [INFO]       "cache_creation": {
+[2026-05-30T17:18:42.181Z] [INFO]         "ephemeral_5m_input_tokens": 0,
+[2026-05-30T17:18:42.181Z] [INFO]         "ephemeral_1h_input_tokens": 6764
+[2026-05-30T17:18:42.181Z] [INFO]       },
+[2026-05-30T17:18:42.181Z] [INFO]       "output_tokens": 10,
+[2026-05-30T17:18:42.181Z] [INFO]       "service_tier": "standard",
+[2026-05-30T17:18:42.181Z] [INFO]       "inference_geo": "not_available"
+[2026-05-30T17:18:42.181Z] [INFO]     },
+[2026-05-30T17:18:42.181Z] [INFO]     "diagnostics": null,
+[2026-05-30T17:18:42.181Z] [INFO]     "context_management": null
+[2026-05-30T17:18:42.181Z] [INFO]   },
+[2026-05-30T17:18:42.181Z] [INFO]   "parent_tool_use_id": null,
+[2026-05-30T17:18:42.181Z] [INFO]   "session_id": "45441128-80e2-48c1-a2ea-f81ede05030b",
+[2026-05-30T17:18:42.181Z] [INFO]   "uuid": "2a01e0ea-879e-4b67-9f0f-369a7a2c0436",
+[2026-05-30T17:18:42.181Z] [INFO]   "request_id": "req_011CbZ8nRAVAhZdJicvkPYHE"
+[2026-05-30T17:18:42.181Z] [INFO] }
+[2026-05-30T17:18:43.628Z] [INFO] {
+[2026-05-30T17:18:43.628Z] [INFO]   "type": "assistant",
+[2026-05-30T17:18:43.628Z] [INFO]   "message": {
+[2026-05-30T17:18:43.628Z] [INFO]     "model": "claude-opus-4-8",
+[2026-05-30T17:18:43.628Z] [INFO]     "id": "msg_016usAxp32dJLu2vf9jYtRM2",
+[2026-05-30T17:18:43.628Z] [INFO]     "type": "message",
+[2026-05-30T17:18:43.628Z] [INFO]     "role": "assistant",
+[2026-05-30T17:18:43.628Z] [INFO]     "content": [
+[2026-05-30T17:18:43.628Z] [INFO]       {
+[2026-05-30T17:18:43.628Z] [INFO]         "type": "tool_use",
+[2026-05-30T17:18:43.628Z] [INFO]         "id": "toolu_01BsKokDoKsjApGSPZ1zaYAk",
+[2026-05-30T17:18:43.628Z] [INFO]         "name": "Bash",
+[2026-05-30T17:18:43.628Z] [INFO]         "input": {
+[2026-05-30T17:18:43.628Z] [INFO]           "command": "git log --oneline main..HEAD && echo \"---DIFF STAT---\" && git diff --stat main..HEAD",
+[2026-05-30T17:18:43.628Z] [INFO]           "description": "Show commits and diff vs main"
+[2026-05-30T17:18:43.628Z] [INFO]         },
+[2026-05-30T17:18:43.628Z] [INFO]         "caller": {
+[2026-05-30T17:18:43.628Z] [INFO]           "type": "direct"
+[2026-05-30T17:18:43.628Z] [INFO]         }
+[2026-05-30T17:18:43.628Z] [INFO]       }
+[2026-05-30T17:18:43.628Z] [INFO]     ],
+[2026-05-30T17:18:43.628Z] [INFO]     "stop_reason": null,
+[2026-05-30T17:18:43.628Z] [INFO]     "stop_sequence": null,
+[2026-05-30T17:18:43.628Z] [INFO]     "stop_details": null,
+[2026-05-30T17:18:43.628Z] [INFO]     "usage": {
+[2026-05-30T17:18:43.628Z] [INFO]       "input_tokens": 2,
+[2026-05-30T17:18:43.628Z] [INFO]       "cache_creation_input_tokens": 6764,
+[2026-05-30T17:18:43.628Z] [INFO]       "cache_read_input_tokens": 21173,
+[2026-05-30T17:18:43.628Z] [INFO]       "cache_creation": {
+[2026-05-30T17:18:43.628Z] [INFO]         "ephemeral_5m_input_tokens": 0,
+[2026-05-30T17:18:43.628Z] [INFO]         "ephemeral_1h_input_tokens": 6764
+[2026-05-30T17:18:43.628Z] [INFO]       },
+[2026-05-30T17:18:43.628Z] [INFO]       "output_tokens": 10,
+[2026-05-30T17:18:43.628Z] [INFO]       "service_tier": "standard",
+[2026-05-30T17:18:43.628Z] [INFO]       "inference_geo": "not_available"
+[2026-05-30T17:18:43.628Z] [INFO]     },
+[2026-05-30T17:18:43.628Z] [INFO]     "diagnostics": null,
+[2026-05-30T17:18:43.628Z] [INFO]     "context_management": null
+[2026-05-30T17:18:43.628Z] [INFO]   },
+[2026-05-30T17:18:43.628Z] [INFO]   "parent_tool_use_id": null,
+[2026-05-30T17:18:43.628Z] [INFO]   "session_id": "45441128-80e2-48c1-a2ea-f81ede05030b",
+[2026-05-30T17:18:43.628Z] [INFO]   "uuid": "6097ecb9-68a6-4908-a83c-a515d3ff280e",
+[2026-05-30T17:18:43.628Z] [INFO]   "request_id": "req_011CbZ8nRAVAhZdJicvkPYHE"
+[2026-05-30T17:18:43.628Z] [INFO] }
+[2026-05-30T17:18:44.569Z] [INFO] {
+[2026-05-30T17:18:44.569Z] [INFO]   "type": "user",
+[2026-05-30T17:18:44.569Z] [INFO]   "message": {
+[2026-05-30T17:18:44.569Z] [INFO]     "role": "user",
+[2026-05-30T17:18:44.569Z] [INFO]     "content": [
+[2026-05-30T17:18:44.569Z] [INFO]       {
+[2026-05-30T17:18:44.569Z] [INFO]         "tool_use_id": "toolu_01BsKokDoKsjApGSPZ1zaYAk",
+[2026-05-30T17:18:44.569Z] [INFO]         "type": "tool_result",
+[2026-05-30T17:18:44.569Z] [INFO]         "content": "8264934 Initial commit with task details\n---DIFF STAT---\n .gitkeep | 3 ++-\n 1 file changed, 2 insertions(+), 1 deletion(-)",
+[2026-05-30T17:18:44.569Z] [INFO]         "is_error": false
+[2026-05-30T17:18:44.569Z] [INFO]       }
+[2026-05-30T17:18:44.569Z] [INFO]     ]
+[2026-05-30T17:18:44.569Z] [INFO]   },
+[2026-05-30T17:18:44.569Z] [INFO]   "parent_tool_use_id": null,
+[2026-05-30T17:18:44.569Z] [INFO]   "session_id": "45441128-80e2-48c1-a2ea-f81ede05030b",
+[2026-05-30T17:18:44.569Z] [INFO]   "uuid": "52d32e11-4b46-4b77-8284-3d1c33021463",
+[2026-05-30T17:18:44.569Z] [INFO]   "timestamp": "2026-05-30T17:18:44.309Z",
+[2026-05-30T17:18:44.569Z] [INFO]   "tool_use_result": {
+[2026-05-30T17:18:44.569Z] [INFO]     "stdout": "8264934 Initial commit with task details\n---DIFF STAT---\n .gitkeep | 3 ++-\n 1 file changed, 2 insertions(+), 1 deletion(-)",
+[2026-05-30T17:18:44.569Z] [INFO]     "stderr": "",
+[2026-05-30T17:18:44.569Z] [INFO]     "interrupted": false,
+[2026-05-30T17:18:44.569Z] [INFO]     "isImage": false,
+[2026-05-30T17:18:44.569Z] [INFO]     "noOutputExpected": false
+[2026-05-30T17:18:44.569Z] [INFO]   }
+[2026-05-30T17:18:44.569Z] [INFO] }
+[2026-05-30T17:18:44.596Z] [INFO] {
+[2026-05-30T17:18:44.596Z] [INFO]   "type": "assistant",
+[2026-05-30T17:18:44.596Z] [INFO]   "message": {
+[2026-05-30T17:18:44.596Z] [INFO]     "model": "claude-opus-4-8",
+[2026-05-30T17:18:44.596Z] [INFO]     "id": "msg_016usAxp32dJLu2vf9jYtRM2",
+[2026-05-30T17:18:44.596Z] [INFO]     "type": "message",
+[2026-05-30T17:18:44.596Z] [INFO]     "role": "assistant",
+[2026-05-30T17:18:44.596Z] [INFO]     "content": [
+[2026-05-30T17:18:44.596Z] [INFO]       {
+[2026-05-30T17:18:44.596Z] [INFO]         "type": "tool_use",
+[2026-05-30T17:18:44.596Z] [INFO]         "id": "toolu_01VPhHDoJTCqR7of3bw2U5Np",
+[2026-05-30T17:18:44.596Z] [INFO]         "name": "Bash",
+[2026-05-30T17:18:44.596Z] [INFO]         "input": {
+[2026-05-30T17:18:44.596Z] [INFO]           "command": "ls -la .github/ && echo \"---ISSUE_TEMPLATE---\" && ls -la .github/ISSUE_TEMPLATE/ 2>/dev/null",
+[2026-05-30T17:18:44.596Z] [INFO]           "description": "List .github contents"
+[2026-05-30T17:18:44.596Z] [INFO]         },
+[2026-05-30T17:18:44.596Z] [INFO]         "caller": {
+[2026-05-30T17:18:44.596Z] [INFO]           "type": "direct"
+[2026-05-30T17:18:44.596Z] [INFO]         }
+[2026-05-30T17:18:44.596Z] [INFO]       }
+[2026-05-30T17:18:44.596Z] [INFO]     ],
+[2026-05-30T17:18:44.596Z] [INFO]     "stop_reason": null,
+[2026-05-30T17:18:44.596Z] [INFO]     "stop_sequence": null,
+[2026-05-30T17:18:44.596Z] [INFO]     "stop_details": null,
+[2026-05-30T17:18:44.596Z] [INFO]     "usage": {
+[2026-05-30T17:18:44.596Z] [INFO]       "input_tokens": 2,
+[2026-05-30T17:18:44.596Z] [INFO]       "cache_creation_input_tokens": 6764,
+[2026-05-30T17:18:44.596Z] [INFO]       "cache_read_input_tokens": 21173,
+[2026-05-30T17:18:44.596Z] [INFO]       "cache_creation": {
+[2026-05-30T17:18:44.596Z] [INFO]         "ephemeral_5m_input_tokens": 0,
+[2026-05-30T17:18:44.596Z] [INFO]         "ephemeral_1h_input_tokens": 6764
+[2026-05-30T17:18:44.596Z] [INFO]       },
+[2026-05-30T17:18:44.596Z] [INFO]       "output_tokens": 10,
+[2026-05-30T17:18:44.596Z] [INFO]       "service_tier": "standard",
+[2026-05-30T17:18:44.596Z] [INFO]       "inference_geo": "not_available"
+[2026-05-30T17:18:44.596Z] [INFO]     },
+[2026-05-30T17:18:44.596Z] [INFO]     "diagnostics": null,
+[2026-05-30T17:18:44.596Z] [INFO]     "context_management": null
+[2026-05-30T17:18:44.596Z] [INFO]   },
+[2026-05-30T17:18:44.596Z] [INFO]   "parent_tool_use_id": null,
+[2026-05-30T17:18:44.596Z] [INFO]   "session_id": "45441128-80e2-48c1-a2ea-f81ede05030b",
+[2026-05-30T17:18:44.596Z] [INFO]   "uuid": "bc33f112-6184-4e5f-87d2-1e18b3c258b4",
+[2026-05-30T17:18:44.596Z] [INFO]   "request_id": "req_011CbZ8nRAVAhZdJicvkPYHE"
+[2026-05-30T17:18:44.596Z] [INFO] }
+[2026-05-30T17:18:45.338Z] [INFO] {
+[2026-05-30T17:18:45.338Z] [INFO]   "type": "user",
+[2026-05-30T17:18:45.338Z] [INFO]   "message": {
+[2026-05-30T17:18:45.338Z] [INFO]     "role": "user",
+[2026-05-30T17:18:45.338Z] [INFO]     "content": [
+[2026-05-30T17:18:45.338Z] [INFO]       {
+[2026-05-30T17:18:45.338Z] [INFO]         "tool_use_id": "toolu_01VPhHDoJTCqR7of3bw2U5Np",
+[2026-05-30T17:18:45.338Z] [INFO]         "type": "tool_result",
+[2026-05-30T17:18:45.338Z] [INFO]         "content": "total 20\ndrwxr-xr-x  4 box box 4096 May 30 17:18 .\ndrwxr-xr-x 20 box box 4096 May 30 17:18 ..\ndrwxr-xr-x  2 box box 4096 May 30 17:18 ISSUE_TEMPLATE\n-rw-r--r--  1 box box  739 May 30 17:18 PULL_REQUEST_TEMPLATE.md\ndrwxr-xr-x  2 box box 4096 May 30 17:18 workflows\n---ISSUE_TEMPLATE---\ntotal 16\ndrwxr-xr-x 2 box box 4096 May 30 17:18 .\ndrwxr-xr-x 4 box box 4096 May 30 17:18 ..\n-rw-r--r-- 1 box box  655 May 30 17:18 bug_report.md\n-rw-r--r-- 1 box box  508 May 30 17:18 feature_request.md",
+[2026-05-30T17:18:45.338Z] [INFO]         "is_error": false
+[2026-05-30T17:18:45.338Z] [INFO]       }
+[2026-05-30T17:18:45.338Z] [INFO]     ]
+[2026-05-30T17:18:45.338Z] [INFO]   },
+[2026-05-30T17:18:45.338Z] [INFO]   "parent_tool_use_id": null,
+[2026-05-30T17:18:45.338Z] [INFO]   "session_id": "45441128-80e2-48c1-a2ea-f81ede05030b",
+[2026-05-30T17:18:45.338Z] [INFO]   "uuid": "4068cfd1-6de8-48cb-a9be-12058a6d0e37",
+[2026-05-30T17:18:45.338Z] [INFO]   "timestamp": "2026-05-30T17:18:45.337Z",
+[2026-05-30T17:18:45.338Z] [INFO]   "tool_use_result": {
+[2026-05-30T17:18:45.338Z] [INFO]     "stdout": "total 20\ndrwxr-xr-x  4 box box 4096 May 30 17:18 .\ndrwxr-xr-x 20 box box 4096 May 30 17:18 ..\ndrwxr-xr-x  2 box box 4096 May 30 17:18 ISSUE_TEMPLATE\n-rw-r--r--  1 box box  739 May 30 17:18 PULL_REQUEST_TEMPLATE.md\ndrwxr-xr-x  2 box box 4096 May 30 17:18 workflows\n---ISSUE_TEMPLATE---\ntotal 16\ndrwxr-xr-x 2 box box 4096 May 30 17:18 .\ndrwxr-xr-x 4 box box 4096 May 30 17:18 ..\n-rw-r--r-- 1 box box  655 May 30 17:18 bug_report.md\n-rw-r--r-- 1 box box  508 May 30 17:18 feature_request.md",
+[2026-05-30T17:18:45.338Z] [INFO]     "stderr": "",
+[2026-05-30T17:18:45.338Z] [INFO]     "interrupted": false,
+[2026-05-30T17:18:45.338Z] [INFO]     "isImage": false,
+[2026-05-30T17:18:45.338Z] [INFO]     "noOutputExpected": false
+[2026-05-30T17:18:45.338Z] [INFO]   }
+[2026-05-30T17:18:45.338Z] [INFO] }
+[2026-05-30T17:18:45.351Z] [INFO] [log_0f9876] sending request {
+[2026-05-30T17:18:45.352Z] [INFO]   method: "post",
+[2026-05-30T17:18:45.353Z] [INFO]   url: "https://api.anthropic.com/v1/messages?beta=true",
+[2026-05-30T17:18:45.354Z] [INFO]   options: {
+[2026-05-30T17:18:45.354Z] [INFO]     method: "post",
+[2026-05-30T17:18:45.354Z] [INFO]     path: "/v1/messages?beta=true",
+[2026-05-30T17:18:45.354Z] [INFO]     body: {
+[2026-05-30T17:18:45.355Z] [INFO]       model: "claude-opus-4-8",
+[2026-05-30T17:18:45.355Z] [INFO]       messages: [
+[2026-05-30T17:18:45.355Z] [INFO]         [Object ...], [Object ...], [Object ...], [Object ...], [Object ...], [Object ...], [Object ...]
+[2026-05-30T17:18:45.356Z] [INFO]       ],
+[2026-05-30T17:18:45.356Z] [INFO]       system: [
+[2026-05-30T17:18:45.356Z] [INFO]         [Object ...], [Object ...], [Object ...], [Object ...]
+[2026-05-30T17:18:45.357Z] [INFO]       ],
+[2026-05-30T17:18:45.357Z] [INFO]       tools: [
+[2026-05-30T17:18:45.358Z] [INFO]         [Object ...], [Object ...], [Object ...], [Object ...], [Object ...], [Object ...], [Object ...], [Object ...], [Object ...], [Object ...]
+[2026-05-30T17:18:45.358Z] [INFO]       ],
+[2026-05-30T17:18:45.359Z] [INFO]       tool_choice: undefined,
+[2026-05-30T17:18:45.359Z] [INFO]       metadata: [Object ...],
+[2026-05-30T17:18:45.359Z] [INFO]       max_tokens: 128000,
+[2026-05-30T17:18:45.359Z] [INFO]       thinking: [Object ...],
+[2026-05-30T17:18:45.360Z] [INFO]       context_management: [Object ...],
+[2026-05-30T17:18:45.360Z] [INFO]       output_config: [Object ...],
+[2026-05-30T17:18:45.360Z] [INFO]       diagnostics: [Object ...],
+[2026-05-30T17:18:45.360Z] [INFO]       stream: true,
+[2026-05-30T17:18:45.361Z] [INFO]     },
+[2026-05-30T17:18:45.361Z] [INFO]     timeout: 600000,
+[2026-05-30T17:18:45.361Z] [INFO]     signal: AbortSignal {
+[2026-05-30T17:18:45.361Z] [INFO]       [Symbol(events.maxEventTargetListeners)]: 50,
+[2026-05-30T17:18:45.362Z] [INFO]       [Symbol(events.maxEventTargetListenersWarned)]: false,
+[2026-05-30T17:18:45.362Z] [INFO]       aborted: false,
+[2026-05-30T17:18:45.362Z] [INFO]       reason: undefined,
+[2026-05-30T17:18:45.362Z] [INFO]       onabort: null,
+[2026-05-30T17:18:45.363Z] [INFO]       throwIfAborted: [Function: throwIfAborted],
+[2026-05-30T17:18:45.363Z] [INFO]       addEventListener: [Function: addEventListener],
+[2026-05-30T17:18:45.363Z] [INFO]       removeEventListener: [Function: removeEventListener],
+[2026-05-30T17:18:45.363Z] [INFO]       dispatchEvent: [Function: dispatchEvent],
+[2026-05-30T17:18:45.364Z] [INFO]     },
+[2026-05-30T17:18:45.364Z] [INFO]     stream: true,
+[2026-05-30T17:18:45.364Z] [INFO]   },
+[2026-05-30T17:18:45.364Z] [INFO]   headers: {
+[2026-05-30T17:18:45.365Z] [INFO]     accept: "application/json",
+[2026-05-30T17:18:45.366Z] [INFO]     "anthropic-beta": "claude-code-20250219,oauth-2025-04-20,interleaved-thinking-2025-05-14,thinking-token-count-2026-05-13,context-management-2025-06-27,prompt-caching-scope-2026-01-05,mid-conversation-system-2026-04-07,advisor-tool-2026-03-01,advanced-tool-use-2025-11-20,effort-2025-11-24,extended-cache-ttl-2025-04-11,cache-diagnosis-2026-04-07",
+[2026-05-30T17:18:45.366Z] [INFO]     "anthropic-dangerous-direct-browser-access": "true",
+[2026-05-30T17:18:45.366Z] [INFO]     "anthropic-version": "2023-06-01",
+[2026-05-30T17:18:45.366Z] [INFO]     authorization: "***",
+[2026-05-30T17:18:45.366Z] [INFO]     "content-type": "application/json",
+[2026-05-30T17:18:45.367Z] [INFO]     "user-agent": "claude-cli/2.1.158 (external, sdk-cli)",
+[2026-05-30T17:18:45.367Z] [INFO]     "x-app": "cli",
+[2026-05-30T17:18:45.367Z] [INFO]     "x-claude-code-session-id": "45441128-80e2-48c1-a2ea-f81ede05030b",
+[2026-05-30T17:18:45.367Z] [INFO]     "x-client-request-id": "a049790b-49ca-42ef-86ad-6b7fede73b7e",
+[2026-05-30T17:18:45.367Z] [INFO]     "x-stainless-arch": "x64",
+[2026-05-30T17:18:45.368Z] [INFO]     "x-stainless-lang": "js",
+[2026-05-30T17:18:45.368Z] [INFO]     "x-stainless-os": "Linux",
+[2026-05-30T17:18:45.368Z] [INFO]     "x-stainless-package-version": "0.94.0",
+[2026-05-30T17:18:45.369Z] [INFO]     "x-stainless-retry-count": "0",
+[2026-05-30T17:18:45.369Z] [INFO]     "x-stainless-runtime": "node",
+[2026-05-30T17:18:45.369Z] [INFO]     "x-stainless-runtime-version": "v24.3.0",
+[2026-05-30T17:18:45.369Z] [INFO]     "x-stainless-timeout": "600",
+[2026-05-30T17:18:45.369Z] [INFO]   },
+[2026-05-30T17:18:45.370Z] [INFO] }
+[2026-05-30T17:18:46.628Z] [INFO] [log_0f9876, request-id: "req_011CbZ8nrksGjy9Pxdx9gVxt"] post https://api.anthropic.com/v1/messages?beta=true succeeded with status 200 in 1275ms
+[2026-05-30T17:18:46.629Z] [INFO] [log_0f9876] response start {
+[2026-05-30T17:18:46.629Z] [INFO]   url: "https://api.anthropic.com/v1/messages?beta=true",
+[2026-05-30T17:18:46.630Z] [INFO]   status: 200,
+[2026-05-30T17:18:46.631Z] [INFO]   headers: {
+[2026-05-30T17:18:46.631Z] [INFO]     "anthropic-organization-id": "ebc2ac93-f86f-4d15-aff3-de8830d8d789",
+[2026-05-30T17:18:46.631Z] [INFO]     "anthropic-ratelimit-unified-5h-reset": "1780173000",
+[2026-05-30T17:18:46.632Z] [INFO]     "anthropic-ratelimit-unified-5h-status": "allowed",
+[2026-05-30T17:18:46.633Z] [INFO]     "anthropic-ratelimit-unified-5h-utilization": "0.25",
+[2026-05-30T17:18:46.634Z] [INFO]     "anthropic-ratelimit-unified-7d-reset": "1780398000",
+[2026-05-30T17:18:46.634Z] [INFO]     "anthropic-ratelimit-unified-7d-status": "allowed",
+[2026-05-30T17:18:46.634Z] [INFO]     "anthropic-ratelimit-unified-7d-utilization": "0.73",
+[2026-05-30T17:18:46.635Z] [INFO]     "anthropic-ratelimit-unified-fallback-percentage": "0.5",
+[2026-05-30T17:18:46.635Z] [INFO]     "anthropic-ratelimit-unified-overage-disabled-reason": "org_level_disabled",
+[2026-05-30T17:18:46.635Z] [INFO]     "anthropic-ratelimit-unified-overage-status": "rejected",
+[2026-05-30T17:18:46.635Z] [INFO]     "anthropic-ratelimit-unified-representative-claim": "five_hour",
+[2026-05-30T17:18:46.636Z] [INFO]     "anthropic-ratelimit-unified-reset": "1780173000",
+[2026-05-30T17:18:46.636Z] [INFO]     "anthropic-ratelimit-unified-status": "allowed",
+[2026-05-30T17:18:46.636Z] [INFO]     "cache-control": "no-cache",
+[2026-05-30T17:18:46.637Z] [INFO]     "cf-cache-status": "DYNAMIC",
+[2026-05-30T17:18:46.637Z] [INFO]     "cf-ray": "a03f665d8908d9d8-FRA",
+[2026-05-30T17:18:46.637Z] [INFO]     connection: "keep-alive",
+[2026-05-30T17:18:46.638Z] [INFO]     "content-encoding": "gzip",
+[2026-05-30T17:18:46.639Z] [INFO]     "content-security-policy": "default-src 'none'; frame-ancestors 'none'",
+[2026-05-30T17:18:46.639Z] [INFO]     "content-type": "text/event-stream; charset=utf-8",
+[2026-05-30T17:18:46.641Z] [INFO]     date: "Sat, 30 May 2026 17:18:46 GMT",
+[2026-05-30T17:18:46.641Z] [INFO]     "request-id": "req_011CbZ8nrksGjy9Pxdx9gVxt",
+[2026-05-30T17:18:46.641Z] [INFO]     server: "cloudflare",
+[2026-05-30T17:18:46.641Z] [INFO]     "strict-transport-security": "max-age=31536000; includeSubDomains; preload",
+[2026-05-30T17:18:46.642Z] [INFO]     traceresponse: "00-a1710ebc96ad1016f12ae8951c4a408b-dc94fe93a93df9f5-01",
+[2026-05-30T17:18:46.642Z] [INFO]     "transfer-encoding": "chunked",
+[2026-05-30T17:18:46.643Z] [INFO]     vary: "Accept-Encoding",
+[2026-05-30T17:18:46.643Z] [INFO]     "x-robots-tag": "none",
+[2026-05-30T17:18:46.643Z] [INFO]     "set-cookie": "***",
+[2026-05-30T17:18:46.643Z] [INFO]   },
+[2026-05-30T17:18:46.644Z] [INFO]   durationMs: 1275,
+[2026-05-30T17:18:46.645Z] [INFO] }
+[2026-05-30T17:18:46.645Z] [INFO] response 200 https://api.anthropic.com/v1/messages?beta=true Headers {
+[2026-05-30T17:18:46.646Z] [INFO]   "date": "Sat, 30 May 2026 17:18:46 GMT",
+[2026-05-30T17:18:46.646Z] [INFO]   "content-type": "text/event-stream; charset=utf-8",
+[2026-05-30T17:18:46.647Z] [INFO]   "transfer-encoding": "chunked",
+[2026-05-30T17:18:46.647Z] [INFO]   "connection": "keep-alive",
+[2026-05-30T17:18:46.648Z] [INFO]   "cache-control": "no-cache",
+[2026-05-30T17:18:46.648Z] [INFO]   "strict-transport-security": "max-age=31536000; includeSubDomains; preload",
+[2026-05-30T17:18:46.649Z] [INFO]   "content-encoding": "gzip",
+[2026-05-30T17:18:46.649Z] [INFO]   "vary": "Accept-Encoding",
+[2026-05-30T17:18:46.650Z] [INFO]   "content-security-policy": "default-src 'none'; frame-ancestors 'none'",
+[2026-05-30T17:18:46.651Z] [INFO]   "set-cookie": [ "_cfuvid=2VU17h0CnHff9nLZZ9fOfWVUhPZac0LGIOCHQXs4.BI-1780161525.3614132-1.0.1.1-6XRaLa1wc0A1fIRwOYcDHJFrrWiaaJe1rKFNlrbAYIw; HttpOnly; SameSite=None; Secure; Path=/; Domain=api.anthropic.com" ],
+[2026-05-30T17:18:46.651Z] [INFO]   "anthropic-ratelimit-unified-status": "allowed",
+[2026-05-30T17:18:46.651Z] [INFO]   "anthropic-ratelimit-unified-5h-status": "allowed",
+[2026-05-30T17:18:46.652Z] [INFO]   "anthropic-ratelimit-unified-5h-reset": "1780173000",
+[2026-05-30T17:18:46.652Z] [INFO]   "anthropic-ratelimit-unified-5h-utilization": "0.25",
+[2026-05-30T17:18:46.652Z] [INFO]   "anthropic-ratelimit-unified-7d-status": "allowed",
+[2026-05-30T17:18:46.652Z] [INFO]   "anthropic-ratelimit-unified-7d-reset": "1780398000",
+[2026-05-30T17:18:46.653Z] [INFO]   "anthropic-ratelimit-unified-7d-utilization": "0.73",
+[2026-05-30T17:18:46.653Z] [INFO]   "anthropic-ratelimit-unified-representative-claim": "five_hour",
+[2026-05-30T17:18:46.653Z] [INFO]   "anthropic-ratelimit-unified-fallback-percentage": "0.5",
+[2026-05-30T17:18:46.654Z] [INFO]   "anthropic-ratelimit-unified-reset": "1780173000",
+[2026-05-30T17:18:46.654Z] [INFO]   "anthropic-ratelimit-unified-overage-disabled-reason": "org_level_disabled",
+[2026-05-30T17:18:46.654Z] [INFO]   "anthropic-ratelimit-unified-overage-status": "rejected",
+[2026-05-30T17:18:46.655Z] [INFO]   "request-id": "req_011CbZ8nrksGjy9Pxdx9gVxt",
+[2026-05-30T17:18:46.655Z] [INFO]   "anthropic-organization-id": "ebc2ac93-f86f-4d15-aff3-de8830d8d789",
+[2026-05-30T17:18:46.656Z] [INFO]   "traceresponse": "00-a1710ebc96ad1016f12ae8951c4a408b-dc94fe93a93df9f5-01",
+[2026-05-30T17:18:46.656Z] [INFO]   "server": "cloudflare",
+[2026-05-30T17:18:46.657Z] [INFO]   "cf-cache-status": "DYNAMIC",
+[2026-05-30T17:18:46.657Z] [INFO]   "x-robots-tag": "none",
+[2026-05-30T17:18:46.657Z] [INFO]   "cf-ray": "a03f665d8908d9d8-FRA",
+[2026-05-30T17:18:46.657Z] [INFO] } ReadableStream {
+[2026-05-30T17:18:46.658Z] [INFO]   blob: [Function: blob],
+[2026-05-30T17:18:46.658Z] [INFO]   bytes: [Function: bytes],
+[2026-05-30T17:18:46.659Z] [INFO]   cancel: [Function],
+[2026-05-30T17:18:46.660Z] [INFO]   getReader: [Function],
+[2026-05-30T17:18:46.661Z] [INFO]   json: [Function: json],
+[2026-05-30T17:18:46.661Z] [INFO]   locked: [Getter],
+[2026-05-30T17:18:46.661Z] [INFO]   pipeThrough: [Function],
+[2026-05-30T17:18:46.662Z] [INFO]   pipeTo: [Function],
+[2026-05-30T17:18:46.662Z] [INFO]   tee: [Function],
+[2026-05-30T17:18:46.662Z] [INFO]   text: [Function: text],
+[2026-05-30T17:18:46.662Z] [INFO]   values: [Function: values],
+[2026-05-30T17:18:46.662Z] [INFO]   [Symbol(Symbol.asyncIterator)]: [Function: asyncIterator2],
+[2026-05-30T17:18:46.663Z] [INFO] }
+[2026-05-30T17:18:46.663Z] [INFO] [log_0f9876] response parsed {
+[2026-05-30T17:18:46.663Z] [INFO]   url: "https://api.anthropic.com/v1/messages?beta=true",
+[2026-05-30T17:18:46.663Z] [INFO]   status: 200,
+[2026-05-30T17:18:46.664Z] [INFO]   body: bR {
+[2026-05-30T17:18:46.664Z] [INFO]     iterator: [AsyncGeneratorFunction: z],
+[2026-05-30T17:18:46.664Z] [INFO]     controller: AbortController {
+[2026-05-30T17:18:46.665Z] [INFO]       signal: [AbortSignal ...],
+[2026-05-30T17:18:46.665Z] [INFO]       abort: [Function: abort],
+[2026-05-30T17:18:46.665Z] [INFO]     },
+[2026-05-30T17:18:46.666Z] [INFO]     [Symbol(Symbol.asyncIterator)]: [Function],
+[2026-05-30T17:18:46.666Z] [INFO]     tee: [Function: tee],
+[2026-05-30T17:18:46.666Z] [INFO]     toReadableStream: [Function: toReadableStream],
+[2026-05-30T17:18:46.667Z] [INFO]   },
+[2026-05-30T17:18:46.667Z] [INFO]   durationMs: 1276,
+[2026-05-30T17:18:46.668Z] [INFO] }
+[2026-05-30T17:18:48.075Z] [INFO] {
+[2026-05-30T17:18:48.075Z] [INFO]   "type": "system",
+[2026-05-30T17:18:48.075Z] [INFO]   "subtype": "thinking_tokens",
+[2026-05-30T17:18:48.075Z] [INFO]   "estimated_tokens": 50,
+[2026-05-30T17:18:48.075Z] [INFO]   "estimated_tokens_delta": 50,
+[2026-05-30T17:18:48.075Z] [INFO]   "uuid": "90957a35-d145-465b-a0ee-23539551e0c8",
+[2026-05-30T17:18:48.075Z] [INFO]   "session_id": "45441128-80e2-48c1-a2ea-f81ede05030b"
+[2026-05-30T17:18:48.075Z] [INFO] }
+[2026-05-30T17:18:49.500Z] [INFO] {
+[2026-05-30T17:18:49.500Z] [INFO]   "type": "system",
+[2026-05-30T17:18:49.500Z] [INFO]   "subtype": "thinking_tokens",
+[2026-05-30T17:18:49.500Z] [INFO]   "estimated_tokens": 150,
+[2026-05-30T17:18:49.500Z] [INFO]   "estimated_tokens_delta": 100,
+[2026-05-30T17:18:49.500Z] [INFO]   "uuid": "2a6cfd48-559f-47c8-8a24-0886754347f4",
+[2026-05-30T17:18:49.500Z] [INFO]   "session_id": "45441128-80e2-48c1-a2ea-f81ede05030b"
+[2026-05-30T17:18:49.500Z] [INFO] }
+[2026-05-30T17:18:50.909Z] [INFO] {
+[2026-05-30T17:18:50.909Z] [INFO]   "type": "system",
+[2026-05-30T17:18:50.909Z] [INFO]   "subtype": "thinking_tokens",
+[2026-05-30T17:18:50.909Z] [INFO]   "estimated_tokens": 250,
+[2026-05-30T17:18:50.909Z] [INFO]   "estimated_tokens_delta": 100,
+[2026-05-30T17:18:50.909Z] [INFO]   "uuid": "95a41e5e-b903-4e40-a0d2-39eb49182d21",
+[2026-05-30T17:18:50.909Z] [INFO]   "session_id": "45441128-80e2-48c1-a2ea-f81ede05030b"
+[2026-05-30T17:18:50.909Z] [INFO] }
+[2026-05-30T17:18:50.912Z] [INFO] {
+[2026-05-30T17:18:50.912Z] [INFO]   "type": "assistant",
+[2026-05-30T17:18:50.912Z] [INFO]   "message": {
+[2026-05-30T17:18:50.912Z] [INFO]     "model": "claude-opus-4-8",
+[2026-05-30T17:18:50.912Z] [INFO]     "id": "msg_01PnEsTzbU6XcB7qJP1TkZuM",
+[2026-05-30T17:18:50.912Z] [INFO]     "type": "message",
+[2026-05-30T17:18:50.912Z] [INFO]     "role": "assistant",
+[2026-05-30T17:18:50.912Z] [INFO]     "content": [
+[2026-05-30T17:18:50.912Z] [INFO]       {
+[2026-05-30T17:18:50.912Z] [INFO]         "type": "thinking",
+[2026-05-30T17:18:50.912Z] [INFO]         "thinking": "",
+[2026-05-30T17:18:50.912Z] [INFO]         "signature": "EqUICmMIDhgCKkC95j+YSLRwOXg41xVmy+a/VzczRA4vNbKujskKQHZBZlAIrDQh6WY3rhqhc8u+wu8zXc9rsKcTMBXeTBvMYN6pMg9jbGF1ZGUtb3B1cy00LTg4AEIIdGhpbmtpbmcSDMMNL/ltuz1nQlb4ABoMWB/BhLP0BWvyFho8IjA4rw/RIowr33uGp4hJ5tYFoR1NNCPDo5rEuDpbTh3dWPy0f0UNQ0Asf5yGx5SCxZMq7wb76ul3adMIT7/yp7We0deqqkPkYkDOX6uz5fHykZ9hyNSQqOI8Pl5ZRltUKhLEYrSfLsBKUcMObKjSFeEi8S2m/h7OnM094eUNQG7E9lRLU3JxHnWF31A1B8Getzvj0OQe7FG6lKcz2EVBhkw+Uu73JE2wJYyaQAxwC8oguUHdFVB0Hp4tS87rCOd0hY5BWtjl0d1tyP6zHyCX6nMKMTpiPuIWB7axsa+cOEZ7vNX3A8JH4SLxv+VFEJRDn0EXPQ+wJj6RCtsplaB8UuaBcb7dSbq9tnzKec25lYeIqoYas0XUB6BNeznWw/rzzvWIPaMoLpc+7mGT6qzzbRd11gH7T5NVjOv6GpMLKOjLUVzYEkA1mOpjmjDdV4QMu0pJbeh4TOxx9luh2FB31z6HheXSLCIWGGOyYUUcOys+uBMj8q/ZGuH3i7cavxyNtusahWHFRkwjuzZNJsWtaET3GC2wU6925cNcr27o9jVYySlfZmRea/qEY4V4bcDsj8h1xQs2YVP+yDESIkOsMbI2EVUFurlYcvBDkBSoupJdTqW04CpJM6sp7L/O/RMDVJ6yiHdQgzP458SpJxNQpDQiOGQHKTr+prZ/DcSoaz5T+lQ9V2E7rxRyyqzAqPaKcSZLnTHcJZNwKB5zVXRAXPY4F1gF+FxiK8gZMiRpxo45SW+2dPGfP9vRUaI87MbqjVAoQhxIZD5rviWyCYA1Q/dCchGMhfid0qwNoasemU6Rp6BCTEoKMbIvo5TQkHED1pV3+9xPMgNSdiP6cxcexP8wf4QOeikRklYFdrlKQ8izbD+l7oYPD6ybiaZyFQ7nQm+ftXLUqK3XiXVnpd/+NESDy4Foj2cbBpjL9oaEnqiNTywTWhBefCPCmwJ+lwH8qeap+Qlb7kT/qBxQ6M5/vPk9xsRfEEtyRuB58u+/5gCPP/+ht5/ChlbllnN2IlYqkTWbx6co0wAXn1R7fV8+T4YvGFCUCipyUhERFvuQq982jMvU1GJrUDXRVRCdWTK4LZKLN/HGYyqyF5t3vnEHNW2vmHtCVjEO+42jwA4Pgi/MZPmDG0wHVBVNlXWNnQGcCFpUaDtdtOw8nzpkc2cmiibaTLpDIKK6VvcAX6fvDngyUnYSDmmAeEgbc/AVnAsfXnuCpgiwdI58HGQVUGbuTLJMw2cYAQ=="
+[2026-05-30T17:18:50.912Z] [INFO]       }
+[2026-05-30T17:18:50.912Z] [INFO]     ],
+[2026-05-30T17:18:50.912Z] [INFO]     "stop_reason": null,
+[2026-05-30T17:18:50.912Z] [INFO]     "stop_sequence": null,
+[2026-05-30T17:18:50.912Z] [INFO]     "stop_details": null,
+[2026-05-30T17:18:50.912Z] [INFO]     "usage": {
+[2026-05-30T17:18:50.912Z] [INFO]       "input_tokens": 442,
+[2026-05-30T17:18:50.912Z] [INFO]       "cache_creation_input_tokens": 761,
+[2026-05-30T17:18:50.912Z] [INFO]       "cache_read_input_tokens": 27937,
+[2026-05-30T17:18:50.912Z] [INFO]       "cache_creation": {
+[2026-05-30T17:18:50.912Z] [INFO]         "ephemeral_5m_input_tokens": 0,
+[2026-05-30T17:18:50.912Z] [INFO]         "ephemeral_1h_input_tokens": 761
+[2026-05-30T17:18:50.912Z] [INFO]       },
+[2026-05-30T17:18:50.912Z] [INFO]       "output_tokens": 5,
+[2026-05-30T17:18:50.912Z] [INFO]       "service_tier": "standard",
+[2026-05-30T17:18:50.912Z] [INFO]       "inference_geo": "not_available"
+[2026-05-30T17:18:50.912Z] [INFO]     },
+[2026-05-30T17:18:50.912Z] [INFO]     "diagnostics": null,
+[2026-05-30T17:18:50.912Z] [INFO]     "context_management": null
+[2026-05-30T17:18:50.912Z] [INFO]   },
+[2026-05-30T17:18:50.912Z] [INFO]   "parent_tool_use_id": null,
+[2026-05-30T17:18:50.912Z] [INFO]   "session_id": "45441128-80e2-48c1-a2ea-f81ede05030b",
+[2026-05-30T17:18:50.912Z] [INFO]   "uuid": "6a6121c2-643f-403c-9930-58549014928b",
+[2026-05-30T17:18:50.912Z] [INFO]   "request_id": "req_011CbZ8nrksGjy9Pxdx9gVxt"
+[2026-05-30T17:18:50.912Z] [INFO] }
+[2026-05-30T17:18:51.852Z] [INFO] {
+[2026-05-30T17:18:51.852Z] [INFO]   "type": "assistant",
+[2026-05-30T17:18:51.852Z] [INFO]   "message": {
+[2026-05-30T17:18:51.852Z] [INFO]     "model": "claude-opus-4-8",
+[2026-05-30T17:18:51.852Z] [INFO]     "id": "msg_01PnEsTzbU6XcB7qJP1TkZuM",
+[2026-05-30T17:18:51.852Z] [INFO]     "type": "message",
+[2026-05-30T17:18:51.852Z] [INFO]     "role": "assistant",
+[2026-05-30T17:18:51.852Z] [INFO]     "content": [
+[2026-05-30T17:18:51.852Z] [INFO]       {
+[2026-05-30T17:18:51.852Z] [INFO]         "type": "text",
+[2026-05-30T17:18:51.852Z] [INFO]         "text": "The branch has no real changes yet — the .github files (PR template, issue templates) already exist in main. Let me examine them and check the failing CI tests."
+[2026-05-30T17:18:51.852Z] [INFO]       }
+[2026-05-30T17:18:51.852Z] [INFO]     ],
+[2026-05-30T17:18:51.852Z] [INFO]     "stop_reason": null,
+[2026-05-30T17:18:51.852Z] [INFO]     "stop_sequence": null,
+[2026-05-30T17:18:51.852Z] [INFO]     "stop_details": null,
+[2026-05-30T17:18:51.852Z] [INFO]     "usage": {
+[2026-05-30T17:18:51.852Z] [INFO]       "input_tokens": 442,
+[2026-05-30T17:18:51.852Z] [INFO]       "cache_creation_input_tokens": 761,
+[2026-05-30T17:18:51.852Z] [INFO]       "cache_read_input_tokens": 27937,
+[2026-05-30T17:18:51.852Z] [INFO]       "cache_creation": {
+[2026-05-30T17:18:51.852Z] [INFO]         "ephemeral_5m_input_tokens": 0,
+[2026-05-30T17:18:51.852Z] [INFO]         "ephemeral_1h_input_tokens": 761
+[2026-05-30T17:18:51.852Z] [INFO]       },
+[2026-05-30T17:18:51.852Z] [INFO]       "output_tokens": 5,
+[2026-05-30T17:18:51.852Z] [INFO]       "service_tier": "standard",
+[2026-05-30T17:18:51.852Z] [INFO]       "inference_geo": "not_available"
+[2026-05-30T17:18:51.852Z] [INFO]     },
+[2026-05-30T17:18:51.852Z] [INFO]     "diagnostics": null,
+[2026-05-30T17:18:51.852Z] [INFO]     "context_management": null
+[2026-05-30T17:18:51.852Z] [INFO]   },
+[2026-05-30T17:18:51.852Z] [INFO]   "parent_tool_use_id": null,
+[2026-05-30T17:18:51.852Z] [INFO]   "session_id": "45441128-80e2-48c1-a2ea-f81ede05030b",
+[2026-05-30T17:18:51.852Z] [INFO]   "uuid": "f86e695d-a000-4834-8fbb-57c1efe50f5e",
+[2026-05-30T17:18:51.852Z] [INFO]   "request_id": "req_011CbZ8nrksGjy9Pxdx9gVxt"
+[2026-05-30T17:18:51.852Z] [INFO] }
+[2026-05-30T17:18:54.685Z] [INFO] {
+[2026-05-30T17:18:54.685Z] [INFO]   "type": "assistant",
+[2026-05-30T17:18:54.685Z] [INFO]   "message": {
+[2026-05-30T17:18:54.685Z] [INFO]     "model": "claude-opus-4-8",
+[2026-05-30T17:18:54.685Z] [INFO]     "id": "msg_01PnEsTzbU6XcB7qJP1TkZuM",
+[2026-05-30T17:18:54.685Z] [INFO]     "type": "message",
+[2026-05-30T17:18:54.685Z] [INFO]     "role": "assistant",
+[2026-05-30T17:18:54.685Z] [INFO]     "content": [
+[2026-05-30T17:18:54.685Z] [INFO]       {
+[2026-05-30T17:18:54.685Z] [INFO]         "type": "tool_use",
+[2026-05-30T17:18:54.685Z] [INFO]         "id": "toolu_01Xmv6Hk5fP6XXJ32nCenv8S",
+[2026-05-30T17:18:54.685Z] [INFO]         "name": "Bash",
+[2026-05-30T17:18:54.685Z] [INFO]         "input": {
+[2026-05-30T17:18:54.685Z] [INFO]           "command": "cd /tmp/gh-issue-solver-1780161489554\necho \"=== PULL_REQUEST_TEMPLATE.md ===\"; cat .github/PULL_REQUEST_TEMPLATE.md\necho \"=== bug_report.md ===\"; cat .github/ISSUE_TEMPLATE/bug_report.md\necho \"=== feature_request.md ===\"; cat .github/ISSUE_TEMPLATE/feature_request.md\necho \"=== README head ===\"; head -40 README.md 2>/dev/null\necho \"=== root files ===\"; ls -la | grep -iE \"contributing|security|code_of|governance|readme\"",
+[2026-05-30T17:18:54.685Z] [INFO]           "description": "Inspect existing community files"
+[2026-05-30T17:18:54.685Z] [INFO]         },
+[2026-05-30T17:18:54.685Z] [INFO]         "caller": {
+[2026-05-30T17:18:54.685Z] [INFO]           "type": "direct"
+[2026-05-30T17:18:54.685Z] [INFO]         }
+[2026-05-30T17:18:54.685Z] [INFO]       }
+[2026-05-30T17:18:54.685Z] [INFO]     ],
+[2026-05-30T17:18:54.685Z] [INFO]     "stop_reason": null,
+[2026-05-30T17:18:54.685Z] [INFO]     "stop_sequence": null,
+[2026-05-30T17:18:54.685Z] [INFO]     "stop_details": null,
+[2026-05-30T17:18:54.685Z] [INFO]     "usage": {
+[2026-05-30T17:18:54.685Z] [INFO]       "input_tokens": 442,
+[2026-05-30T17:18:54.685Z] [INFO]       "cache_creation_input_tokens": 761,
+[2026-05-30T17:18:54.685Z] [INFO]       "cache_read_input_tokens": 27937,
+[2026-05-30T17:18:54.685Z] [INFO]       "cache_creation": {
+[2026-05-30T17:18:54.685Z] [INFO]         "ephemeral_5m_input_tokens": 0,
+[2026-05-30T17:18:54.685Z] [INFO]         "ephemeral_1h_input_tokens": 761
+[2026-05-30T17:18:54.685Z] [INFO]       },
+[2026-05-30T17:18:54.685Z] [INFO]       "output_tokens": 5,
+[2026-05-30T17:18:54.685Z] [INFO]       "service_tier": "standard",
+[2026-05-30T17:18:54.685Z] [INFO]       "inference_geo": "not_available"
+[2026-05-30T17:18:54.685Z] [INFO]     },
+[2026-05-30T17:18:54.685Z] [INFO]     "diagnostics": null,
+[2026-05-30T17:18:54.685Z] [INFO]     "context_management": null
+[2026-05-30T17:18:54.685Z] [INFO]   },
+[2026-05-30T17:18:54.685Z] [INFO]   "parent_tool_use_id": null,
+[2026-05-30T17:18:54.685Z] [INFO]   "session_id": "45441128-80e2-48c1-a2ea-f81ede05030b",
+[2026-05-30T17:18:54.685Z] [INFO]   "uuid": "e61f67ed-3459-47a2-83e3-5daeaa099215",
+[2026-05-30T17:18:54.685Z] [INFO]   "request_id": "req_011CbZ8nrksGjy9Pxdx9gVxt"
+[2026-05-30T17:18:54.685Z] [INFO] }
+[2026-05-30T17:18:55.624Z] [INFO] {
+[2026-05-30T17:18:55.624Z] [INFO]   "type": "user",
+[2026-05-30T17:18:55.624Z] [INFO]   "message": {
+[2026-05-30T17:18:55.624Z] [INFO]     "role": "user",
+[2026-05-30T17:18:55.624Z] [INFO]     "content": [
+[2026-05-30T17:18:55.624Z] [INFO]       {
+[2026-05-30T17:18:55.624Z] [INFO]         "tool_use_id": "toolu_01Xmv6Hk5fP6XXJ32nCenv8S",
+[2026-05-30T17:18:55.624Z] [INFO]         "type": "tool_result",
+[2026-05-30T17:18:55.624Z] [INFO]         "content": "=== PULL_REQUEST_TEMPLATE.md ===\n## Description\n\nBrief description of the changes and their motivation.\n\n## Type of Change\n\n- [ ] Bug fix (non-breaking change that fixes an issue)\n- [ ] New feature (non-breaking change that adds functionality)\n- [ ] Breaking change (fix or feature that would cause existing functionality to change)\n- [ ] Documentation update\n- [ ] Refactoring (no functional changes)\n\n## Checklist\n\n- [ ] I have read the [Contributing Guide](../CONTRIBUTING.md)\n- [ ] My PR targets the `dev` branch (not `main`)\n- [ ] `npm run typecheck` passes\n- [ ] `npm run lint` passes\n- [ ] `npm test` passes\n- [ ] I have added tests for new functionality (if applicable)\n- [ ] I have updated documentation (if applicable)\n\n## Related Issues\n\nCloses #(issue number)\n=== bug_report.md ===\n---\nname: Bug Report\nabout: Report a bug or unexpected behavior\nlabels: bug\n---\n\n## Description\n\nA clear description of the bug.\n\n## Steps to Reproduce\n\n1. Step one\n2. Step two\n3. ...\n\n## Expected Behavior\n\nWhat you expected to happen.\n\n## Actual Behavior\n\nWhat actually happened. Include error messages or logs if available.\n\n## Environment\n\n- **OS**: (e.g., Ubuntu 22.04, macOS 14)\n- **Node.js**: (e.g., 22.0.0)\n- **Teleton version**: (e.g., 0.5.2)\n- **Installation method**: (npm global / Docker / from source)\n- **LLM provider**: (e.g., anthropic, openai, google)\n\n## Additional Context\n\nAny other context, screenshots, or logs relevant to the issue.\n=== feature_request.md ===\n---\nname: Feature Request\nabout: Suggest an idea or improvement\nlabels: enhancement\n---\n\n## Description\n\nA clear description of the feature or improvement.\n\n## Use Case\n\nDescribe the problem this would solve or the workflow it would improve.\n\n## Proposed Solution\n\nHow you think this should work. Include examples if possible.\n\n## Alternatives Considered\n\nAny alternative approaches or workarounds you've considered.\n\n## Additional Context\n\nAny other context, mockups, or references relevant to the request.\n=== README head ===\n<p align=\"center\">\n  <img src=\"./logo_dark.png\" alt=\"Teleton Agent\" width=\"700\" />\n</p>\n\n<p align=\"center\"><b>Autonomous AI agent platform for Telegram with native TON blockchain integration</b></p>\n\n<p align=\"center\">\n  <a href=\"https://opensource.org/licenses/MIT\"><img src=\"https://img.shields.io/badge/License-MIT-yellow.svg\" alt=\"License: MIT\"></a>\n  <a href=\"https://nodejs.org/\"><img src=\"https://img.shields.io/badge/node-%3E%3D20.0.0-brightgreen\" alt=\"Node.js\"></a>\n  <a href=\"https://codecov.io/gh/xlabtg/teleton-agent\"><img src=\"https://codecov.io/gh/xlabtg/teleton-agent/branch/main/graph/badge.svg\" alt=\"Coverage\"></a>\n  <a href=\"https://www.typescriptlang.org/\"><img src=\"https://img.shields.io/badge/TypeScript-5.7-blue\" alt=\"TypeScript\"></a>\n  <a href=\"https://teletonagent.dev\"><img src=\"https://img.shields.io/badge/Website-teletonagent.dev-ff6600\" alt=\"Website\"></a>\n  <a href=\"https://docs.teletonagent.dev\"><img src=\"https://img.shields.io/badge/docs-Teleton%20Agents-blue\" alt=\"Documentation\"></a>\n  <a href=\"https://ton.org\"><img src=\"https://img.shields.io/badge/Built_on-TON-0098EA?logo=ton&logoColor=white\" alt=\"Built on TON\"></a>\n</p>\n\n---\n\n<p align=\"center\">Teleton is an autonomous AI agent platform that operates as a real Telegram user account or a Telegram Bot. It thinks through an agentic loop with tool calling, remembers conversations across sessions with hybrid RAG, and natively integrates the TON blockchain: send crypto, swap on DEXs, bid on domains, verify payments - all from a chat message. It can schedule tasks, run long autonomous goals, coordinate with other agents, and expose its operator console through a local-first WebUI. It ships with 135+ built-in tools, supports 16 LLM providers, and exposes a Plugin SDK so you can build your own tools on top of the platform.</p>\n\n### Key Highlights\n\n<table>\n<tr>\n<td align=\"center\" width=\"33%\"><br><b><ins>Full Telegram Access</ins></b><br>Real user via MTProto,<br>not a bot<br><br></td>\n<td align=\"center\" width=\"33%\"><br><b><ins>Agentic Loop</ins></b><br>Think, act, observe, repeat<br>until the task is done<br><br></td>\n<td align=\"center\" width=\"33%\"><br><b><ins>16 LLM Providers</ins></b><br>Anthropic, OpenAI, Google, xAI, Groq, and more<br><br></td>\n</tr>\n<tr>\n<td align=\"center\"><br><b><ins>TON Blockchain</ins></b><br>Wallet, jettons, DEX swaps, DNS, NFTs<br><br></td>\n<td align=\"center\"><br><b><ins>Persistent Memory</ins></b><br>Hybrid RAG, vector + keyword, auto-compaction<br><br></td>\n<td align=\"center\"><br><b><ins>135+ Built-in Tools</ins></b><br>Messaging, media, crypto, DEX, DNS, files<br><br></td>\n</tr>\n<tr>\n<td align=\"center\"><br><b><ins>Plugin SDK</ins></b><br>Custom tools, isolated DBs, secrets, hooks<br><br></td>\n<td align=\"center\"><br><b><ins>23-Page WebUI</ins></b><br>Agents, pipelines, events, security, network<br><br></td>\n<td align=\"center\"><br><b><ins>Secure by Design</ins></b><br>Sandbox, signed ingress, prompt defense<br><br></td>\n</tr>\n</table>\n\n=== root files ===\n-rw-r--r--  1 box  box   11683 May 30 17:18 CONTRIBUTING.md\n-rw-r--r--  1 box  box   46274 May 30 17:18 README.md\n-rw-r--r--  1 box  box    4035 May 30 17:18 SECURITY.md",
+[2026-05-30T17:18:55.624Z] [INFO]         "is_error": false
+[2026-05-30T17:18:55.624Z] [INFO]       }
+[2026-05-30T17:18:55.624Z] [INFO]     ]
+[2026-05-30T17:18:55.624Z] [INFO]   },
+[2026-05-30T17:18:55.624Z] [INFO]   "parent_tool_use_id": null,
+[2026-05-30T17:18:55.624Z] [INFO]   "session_id": "45441128-80e2-48c1-a2ea-f81ede05030b",
+[2026-05-30T17:18:55.624Z] [INFO]   "uuid": "9dc17585-b125-4212-8c7a-e4e3d3e2f4a4",
+[2026-05-30T17:18:55.624Z] [INFO]   "timestamp": "2026-05-30T17:18:55.423Z",
+[2026-05-30T17:18:55.624Z] [INFO]   "tool_use_result": {
+[2026-05-30T17:18:55.624Z] [INFO]     "stdout": "=== PULL_REQUEST_TEMPLATE.md ===\n## Description\n\nBrief description of the changes and their motivation.\n\n## Type of Change\n\n- [ ] Bug fix (non-breaking change that fixes an issue)\n- [ ] New feature (non-breaking change that adds functionality)\n- [ ] Breaking change (fix or feature that would cause existing functionality to change)\n- [ ] Documentation update\n- [ ] Refactoring (no functional changes)\n\n## Checklist\n\n- [ ] I have read the [Contributing Guide](../CONTRIBUTING.md)\n- [ ] My PR targets the `dev` branch (not `main`)\n- [ ] `npm run typecheck` passes\n- [ ] `npm run lint` passes\n- [ ] `npm test` passes\n- [ ] I have added tests for new functionality (if applicable)\n- [ ] I have updated documentation (if applicable)\n\n## Related Issues\n\nCloses #(issue number)\n=== bug_report.md ===\n---\nname: Bug Report\nabout: Report a bug or unexpected behavior\nlabels: bug\n---\n\n## Description\n\nA clear description of the bug.\n\n## Steps to Reproduce\n\n1. Step one\n2. Step two\n3. ...\n\n## Expected Behavior\n\nWhat you expected to happen.\n\n## Actual Behavior\n\nWhat actually happened. Include error messages or logs if available.\n\n## Environment\n\n- **OS**: (e.g., Ubuntu 22.04, macOS 14)\n- **Node.js**: (e.g., 22.0.0)\n- **Teleton version**: (e.g., 0.5.2)\n- **Installation method**: (npm global / Docker / from source)\n- **LLM provider**: (e.g., anthropic, openai, google)\n\n## Additional Context\n\nAny other context, screenshots, or logs relevant to the issue.\n=== feature_request.md ===\n---\nname: Feature Request\nabout: Suggest an idea or improvement\nlabels: enhancement\n---\n\n## Description\n\nA clear description of the feature or improvement.\n\n## Use Case\n\nDescribe the problem this would solve or the workflow it would improve.\n\n## Proposed Solution\n\nHow you think this should work. Include examples if possible.\n\n## Alternatives Considered\n\nAny alternative approaches or workarounds you've considered.\n\n## Additional Context\n\nAny other context, mockups, or references relevant to the request.\n=== README head ===\n<p align=\"center\">\n  <img src=\"./logo_dark.png\" alt=\"Teleton Agent\" width=\"700\" />\n</p>\n\n<p align=\"center\"><b>Autonomous AI agent platform for Telegram with native TON blockchain integration</b></p>\n\n<p align=\"center\">\n  <a href=\"https://opensource.org/licenses/MIT\"><img src=\"https://img.shields.io/badge/License-MIT-yellow.svg\" alt=\"License: MIT\"></a>\n  <a href=\"https://nodejs.org/\"><img src=\"https://img.shields.io/badge/node-%3E%3D20.0.0-brightgreen\" alt=\"Node.js\"></a>\n  <a href=\"https://codecov.io/gh/xlabtg/teleton-agent\"><img src=\"https://codecov.io/gh/xlabtg/teleton-agent/branch/main/graph/badge.svg\" alt=\"Coverage\"></a>\n  <a href=\"https://www.typescriptlang.org/\"><img src=\"https://img.shields.io/badge/TypeScript-5.7-blue\" alt=\"TypeScript\"></a>\n  <a href=\"https://teletonagent.dev\"><img src=\"https://img.shields.io/badge/Website-teletonagent.dev-ff6600\" alt=\"Website\"></a>\n  <a href=\"https://docs.teletonagent.dev\"><img src=\"https://img.shields.io/badge/docs-Teleton%20Agents-blue\" alt=\"Documentation\"></a>\n  <a href=\"https://ton.org\"><img src=\"https://img.shields.io/badge/Built_on-TON-0098EA?logo=ton&logoColor=white\" alt=\"Built on TON\"></a>\n</p>\n\n---\n\n<p align=\"center\">Teleton is an autonomous AI agent platform that operates as a real Telegram user account or a Telegram Bot. It thinks through an agentic loop with tool calling, remembers conversations across sessions with hybrid RAG, and natively integrates the TON blockchain: send crypto, swap on DEXs, bid on domains, verify payments - all from a chat message. It can schedule tasks, run long autonomous goals, coordinate with other agents, and expose its operator console through a local-first WebUI. It ships with 135+ built-in tools, supports 16 LLM providers, and exposes a Plugin SDK so you can build your own tools on top of the platform.</p>\n\n### Key Highlights\n\n<table>\n<tr>\n<td align=\"center\" width=\"33%\"><br><b><ins>Full Telegram Access</ins></b><br>Real user via MTProto,<br>not a bot<br><br></td>\n<td align=\"center\" width=\"33%\"><br><b><ins>Agentic Loop</ins></b><br>Think, act, observe, repeat<br>until the task is done<br><br></td>\n<td align=\"center\" width=\"33%\"><br><b><ins>16 LLM Providers</ins></b><br>Anthropic, OpenAI, Google, xAI, Groq, and more<br><br></td>\n</tr>\n<tr>\n<td align=\"center\"><br><b><ins>TON Blockchain</ins></b><br>Wallet, jettons, DEX swaps, DNS, NFTs<br><br></td>\n<td align=\"center\"><br><b><ins>Persistent Memory</ins></b><br>Hybrid RAG, vector + keyword, auto-compaction<br><br></td>\n<td align=\"center\"><br><b><ins>135+ Built-in Tools</ins></b><br>Messaging, media, crypto, DEX, DNS, files<br><br></td>\n</tr>\n<tr>\n<td align=\"center\"><br><b><ins>Plugin SDK</ins></b><br>Custom tools, isolated DBs, secrets, hooks<br><br></td>\n<td align=\"center\"><br><b><ins>23-Page WebUI</ins></b><br>Agents, pipelines, events, security, network<br><br></td>\n<td align=\"center\"><br><b><ins>Secure by Design</ins></b><br>Sandbox, signed ingress, prompt defense<br><br></td>\n</tr>\n</table>\n\n=== root files ===\n-rw-r--r--  1 box  box   11683 May 30 17:18 CONTRIBUTING.md\n-rw-r--r--  1 box  box   46274 May 30 17:18 README.md\n-rw-r--r--  1 box  box    4035 May 30 17:18 SECURITY.md",
+[2026-05-30T17:18:55.624Z] [INFO]     "stderr": "",
+[2026-05-30T17:18:55.624Z] [INFO]     "interrupted": false,
+[2026-05-30T17:18:55.624Z] [INFO]     "isImage": false,
+[2026-05-30T17:18:55.624Z] [INFO]     "noOutputExpected": false
+[2026-05-30T17:18:55.624Z] [INFO]   }
+[2026-05-30T17:18:55.624Z] [INFO] }
+[2026-05-30T17:18:55.808Z] [INFO] {
+[2026-05-30T17:18:55.808Z] [INFO]   "type": "assistant",
+[2026-05-30T17:18:55.808Z] [INFO]   "message": {
+[2026-05-30T17:18:55.808Z] [INFO]     "model": "claude-opus-4-8",
+[2026-05-30T17:18:55.808Z] [INFO]     "id": "msg_01PnEsTzbU6XcB7qJP1TkZuM",
+[2026-05-30T17:18:55.808Z] [INFO]     "type": "message",
+[2026-05-30T17:18:55.808Z] [INFO]     "role": "assistant",
+[2026-05-30T17:18:55.808Z] [INFO]     "content": [
+[2026-05-30T17:18:55.808Z] [INFO]       {
+[2026-05-30T17:18:55.808Z] [INFO]         "type": "tool_use",
+[2026-05-30T17:18:55.808Z] [INFO]         "id": "toolu_01W1DuHb9HkmNMuqGyuPwtV6",
+[2026-05-30T17:18:55.808Z] [INFO]         "name": "Bash",
+[2026-05-30T17:18:55.808Z] [INFO]         "input": {
+[2026-05-30T17:18:55.808Z] [INFO]           "command": "cd /tmp/gh-issue-solver-1780161489554\ngh run view 26689643842 --repo xlabtg/teleton-agent --log-failed 2>/dev/null | head -80",
+[2026-05-30T17:18:55.808Z] [INFO]           "description": "View failing test logs"
+[2026-05-30T17:18:55.808Z] [INFO]         },
+[2026-05-30T17:18:55.808Z] [INFO]         "caller": {
+[2026-05-30T17:18:55.808Z] [INFO]           "type": "direct"
+[2026-05-30T17:18:55.808Z] [INFO]         }
+[2026-05-30T17:18:55.808Z] [INFO]       }
+[2026-05-30T17:18:55.808Z] [INFO]     ],
+[2026-05-30T17:18:55.808Z] [INFO]     "stop_reason": null,
+[2026-05-30T17:18:55.808Z] [INFO]     "stop_sequence": null,
+[2026-05-30T17:18:55.808Z] [INFO]     "stop_details": null,
+[2026-05-30T17:18:55.808Z] [INFO]     "usage": {
+[2026-05-30T17:18:55.808Z] [INFO]       "input_tokens": 442,
+[2026-05-30T17:18:55.808Z] [INFO]       "cache_creation_input_tokens": 761,
+[2026-05-30T17:18:55.808Z] [INFO]       "cache_read_input_tokens": 27937,
+[2026-05-30T17:18:55.808Z] [INFO]       "cache_creation": {
+[2026-05-30T17:18:55.808Z] [INFO]         "ephemeral_5m_input_tokens": 0,
+[2026-05-30T17:18:55.808Z] [INFO]         "ephemeral_1h_input_tokens": 761
+[2026-05-30T17:18:55.808Z] [INFO]       },
+[2026-05-30T17:18:55.808Z] [INFO]       "output_tokens": 5,
+[2026-05-30T17:18:55.808Z] [INFO]       "service_tier": "standard",
+[2026-05-30T17:18:55.808Z] [INFO]       "inference_geo": "not_available"
+[2026-05-30T17:18:55.808Z] [INFO]     },
+[2026-05-30T17:18:55.808Z] [INFO]     "diagnostics": null,
+[2026-05-30T17:18:55.808Z] [INFO]     "context_management": null
+[2026-05-30T17:18:55.808Z] [INFO]   },
+[2026-05-30T17:18:55.808Z] [INFO]   "parent_tool_use_id": null,
+[2026-05-30T17:18:55.808Z] [INFO]   "session_id": "45441128-80e2-48c1-a2ea-f81ede05030b",
+[2026-05-30T17:18:55.808Z] [INFO]   "uuid": "861e646f-88d5-45e8-bf09-65beae5e2863",
+[2026-05-30T17:18:55.808Z] [INFO]   "request_id": "req_011CbZ8nrksGjy9Pxdx9gVxt"
+[2026-05-30T17:18:55.808Z] [INFO] }
+[2026-05-30T17:18:59.926Z] [INFO] {
+[2026-05-30T17:18:59.926Z] [INFO]   "type": "system",
+[2026-05-30T17:18:59.926Z] [INFO]   "subtype": "task_started",
+[2026-05-30T17:18:59.926Z] [INFO]   "task_id": "blyjzgeln",
+[2026-05-30T17:18:59.926Z] [INFO]   "tool_use_id": "toolu_01W1DuHb9HkmNMuqGyuPwtV6",
+[2026-05-30T17:18:59.926Z] [INFO]   "description": "View failing test logs",
+[2026-05-30T17:18:59.926Z] [INFO]   "task_type": "local_bash",
+[2026-05-30T17:18:59.926Z] [INFO]   "uuid": "1b584094-6c85-45f2-83f6-1da50441ead6",
+[2026-05-30T17:18:59.926Z] [INFO]   "session_id": "45441128-80e2-48c1-a2ea-f81ede05030b"
+[2026-05-30T17:18:59.926Z] [INFO] }
+[2026-05-30T17:18:59.927Z] [INFO] {
+[2026-05-30T17:18:59.927Z] [INFO]   "type": "system",
+[2026-05-30T17:18:59.927Z] [INFO]   "subtype": "task_notification",
+[2026-05-30T17:18:59.927Z] [INFO]   "task_id": "blyjzgeln",
+[2026-05-30T17:18:59.927Z] [INFO]   "tool_use_id": "toolu_01W1DuHb9HkmNMuqGyuPwtV6",
+[2026-05-30T17:18:59.927Z] [INFO]   "status": "completed",
+[2026-05-30T17:18:59.927Z] [INFO]   "output_file": "",
+[2026-05-30T17:18:59.927Z] [INFO]   "summary": "View failing test logs",
+[2026-05-30T17:18:59.927Z] [INFO]   "uuid": "fe0b78b5-57f6-407e-ac8b-cda01f9325c7",
+[2026-05-30T17:18:59.927Z] [INFO]   "session_id": "45441128-80e2-48c1-a2ea-f81ede05030b"
+[2026-05-30T17:18:59.927Z] [INFO] }
+[2026-05-30T17:18:59.928Z] [INFO] {
+[2026-05-30T17:18:59.928Z] [INFO]   "type": "user",
+[2026-05-30T17:18:59.928Z] [INFO]   "message": {
+[2026-05-30T17:18:59.928Z] [INFO]     "role": "user",
+[2026-05-30T17:18:59.928Z] [INFO]     "content": [
+[2026-05-30T17:18:59.928Z] [INFO]       {
+[2026-05-30T17:18:59.928Z] [INFO]         "tool_use_id": "toolu_01W1DuHb9HkmNMuqGyuPwtV6",
+[2026-05-30T17:18:59.928Z] [INFO]         "type": "tool_result",
+[2026-05-30T17:18:59.928Z] [INFO]         "content": "CI / Test\tUNKNOWN STEP\t﻿2026-05-30T16:58:34.0440107Z Current runner version: '2.334.0'\nCI / Test\tUNKNOWN STEP\t2026-05-30T16:58:34.0464112Z ##[group]Runner Image Provisioner\nCI / Test\tUNKNOWN STEP\t2026-05-30T16:58:34.0464972Z Hosted Compute Agent\nCI / Test\tUNKNOWN STEP\t2026-05-30T16:58:34.0465618Z Version: 20260520.533\nCI / Test\tUNKNOWN STEP\t2026-05-30T16:58:34.0466270Z Commit: 189110e25284a9812c124fd27b339e2fb4f2f9db\nCI / Test\tUNKNOWN STEP\t2026-05-30T16:58:34.0466993Z Build Date: 2026-05-20T17:44:04Z\nCI / Test\tUNKNOWN STEP\t2026-05-30T16:58:34.0467776Z Worker ID: {ee1e120f-4743-4e2a-ab7a-7b1ed6332168}\nCI / Test\tUNKNOWN STEP\t2026-05-30T16:58:34.0468505Z Azure Region: westcentralus\nCI / Test\tUNKNOWN STEP\t2026-05-30T16:58:34.0469124Z ##[endgroup]\nCI / Test\tUNKNOWN STEP\t2026-05-30T16:58:34.0470880Z ##[group]Operating System\nCI / Test\tUNKNOWN STEP\t2026-05-30T16:58:34.0471543Z Ubuntu\nCI / Test\tUNKNOWN STEP\t2026-05-30T16:58:34.0472190Z 24.04.4\nCI / Test\tUNKNOWN STEP\t2026-05-30T16:58:34.0472698Z LTS\nCI / Test\tUNKNOWN STEP\t2026-05-30T16:58:34.0473291Z ##[endgroup]\nCI / Test\tUNKNOWN STEP\t2026-05-30T16:58:34.0473905Z ##[group]Runner Image\nCI / Test\tUNKNOWN STEP\t2026-05-30T16:58:34.0474554Z Image: ubuntu-24.04\nCI / Test\tUNKNOWN STEP\t2026-05-30T16:58:34.0475187Z Version: 20260525.161.1\nCI / Test\tUNKNOWN STEP\t2026-05-30T16:58:34.0476489Z Included Software: https://github.com/actions/runner-images/blob/ubuntu24/20260525.161/images/ubuntu/Ubuntu2404-Readme.md\nCI / Test\tUNKNOWN STEP\t2026-05-30T16:58:34.0478056Z Image Release: https://github.com/actions/runner-images/releases/tag/ubuntu24%2F20260525.161\nCI / Test\tUNKNOWN STEP\t2026-05-30T16:58:34.0479017Z ##[endgroup]\nCI / Test\tUNKNOWN STEP\t2026-05-30T16:58:34.0482029Z ##[group]GITHUB_TOKEN Permissions\nCI / Test\tUNKNOWN STEP\t2026-05-30T16:58:34.0484088Z Actions: read\nCI / Test\tUNKNOWN STEP\t2026-05-30T16:58:34.0484836Z ArtifactMetadata: read\nCI / Test\tUNKNOWN STEP\t2026-05-30T16:58:34.0485470Z Attestations: read\nCI / Test\tUNKNOWN STEP\t2026-05-30T16:58:34.0486065Z Checks: read\nCI / Test\tUNKNOWN STEP\t2026-05-30T16:58:34.0486712Z CodeQuality: read\nCI / Test\tUNKNOWN STEP\t2026-05-30T16:58:34.0487271Z Contents: read\nCI / Test\tUNKNOWN STEP\t2026-05-30T16:58:34.0487852Z Deployments: read\nCI / Test\tUNKNOWN STEP\t2026-05-30T16:58:34.0488437Z Discussions: read\nCI / Test\tUNKNOWN STEP\t2026-05-30T16:58:34.0489000Z Issues: read\nCI / Test\tUNKNOWN STEP\t2026-05-30T16:58:34.0489598Z Metadata: read\nCI / Test\tUNKNOWN STEP\t2026-05-30T16:58:34.0490134Z Models: read\nCI / Test\tUNKNOWN STEP\t2026-05-30T16:58:34.0490850Z Packages: read\nCI / Test\tUNKNOWN STEP\t2026-05-30T16:58:34.0491567Z Pages: read\nCI / Test\tUNKNOWN STEP\t2026-05-30T16:58:34.0492106Z PullRequests: read\nCI / Test\tUNKNOWN STEP\t2026-05-30T16:58:34.0492750Z RepositoryProjects: read\nCI / Test\tUNKNOWN STEP\t2026-05-30T16:58:34.0493374Z SecurityEvents: read\nCI / Test\tUNKNOWN STEP\t2026-05-30T16:58:34.0493978Z Statuses: read\nCI / Test\tUNKNOWN STEP\t2026-05-30T16:58:34.0494602Z VulnerabilityAlerts: read\nCI / Test\tUNKNOWN STEP\t2026-05-30T16:58:34.0495198Z ##[endgroup]\nCI / Test\tUNKNOWN STEP\t2026-05-30T16:58:34.0497341Z Secret source: None\nCI / Test\tUNKNOWN STEP\t2026-05-30T16:58:34.0498090Z Prepare workflow directory\nCI / Test\tUNKNOWN STEP\t2026-05-30T16:58:34.0838668Z Prepare all required actions\nCI / Test\tUNKNOWN STEP\t2026-05-30T16:58:34.0876706Z Getting action download info\nCI / Test\tUNKNOWN STEP\t2026-05-30T16:58:34.5974613Z Download action repository 'actions/checkout@v4' (SHA:34e114876b0b11c390a56381ad16ebd13914f8d5)\nCI / Test\tUNKNOWN STEP\t2026-05-30T16:58:34.7057584Z Download action repository 'actions/setup-node@v4' (SHA:49933ea5288caeca8642d1e84afbd3f7d6820020)\nCI / Test\tUNKNOWN STEP\t2026-05-30T16:58:34.7985388Z Download action repository 'actions/upload-artifact@v4' (SHA:ea165f8d65b6e75b540449e92b4886f43607fa02)\nCI / Test\tUNKNOWN STEP\t2026-05-30T16:58:34.9034766Z Download action repository 'codecov/codecov-action@v4' (SHA:b9fd7d16f6d7d1b5d2bec1a2887e65ceed900238)\nCI / Test\tUNKNOWN STEP\t2026-05-30T16:58:35.6575284Z Complete job name: CI / Test\nCI / Test\tUNKNOWN STEP\t2026-05-30T16:58:35.7492157Z ##[group]Run actions/checkout@v4\nCI / Test\tUNKNOWN STEP\t2026-05-30T16:58:35.7493610Z with:\nCI / Test\tUNKNOWN STEP\t2026-05-30T16:58:35.7494529Z   ref: 826**********************************60a\nCI / Test\tUNKNOWN STEP\t2026-05-30T16:58:35.7495809Z   repository: xlabtg/teleton-agent\nCI / Test\tUNKNOWN STEP\t2026-05-30T16:58:35.7507602Z   token: ***\nCI / Test\tUNKNOWN STEP\t2026-05-30T16:58:35.7508501Z   ssh-strict: true\nCI / Test\tUNKNOWN STEP\t2026-05-30T16:58:35.7509387Z   ssh-user: git\nCI / Test\tUNKNOWN STEP\t2026-05-30T16:58:35.7510293Z   persist-credentials: true\nCI / Test\tUNKNOWN STEP\t2026-05-30T16:58:35.7511441Z   clean: true\nCI / Test\tUNKNOWN STEP\t2026-05-30T16:58:35.7512354Z   sparse-checkout-cone-mode: true\nCI / Test\tUNKNOWN STEP\t2026-05-30T16:58:35.7513455Z   fetch-depth: 1\nCI / Test\tUNKNOWN STEP\t2026-05-30T16:58:35.7514327Z   fetch-tags: false\nCI / Test\tUNKNOWN STEP\t2026-05-30T16:58:35.7515244Z   show-progress: true\nCI / Test\tUNKNOWN STEP\t2026-05-30T16:58:35.7516154Z   lfs: false\nCI / Test\tUNKNOWN STEP\t2026-05-30T16:58:35.7516992Z   submodules: false\nCI / Test\tUNKNOWN STEP\t2026-05-30T16:58:35.7517902Z   set-safe-directory: true\nCI / Test\tUNKNOWN STEP\t2026-05-30T16:58:35.7519228Z ##[endgroup]\nCI / Test\tUNKNOWN STEP\t2026-05-30T16:58:35.8665502Z Syncing repository: xlabtg/teleton-agent\nCI / Test\tUNKNOWN STEP\t2026-05-30T16:58:35.8668342Z ##[group]Getting Git version info\nCI / Test\tUNKNOWN STEP\t2026-05-30T16:58:35.8669954Z Working directory is '/home/runner/work/teleton-agent/teleton-agent'\nCI / Test\tUNKNOWN STEP\t2026-05-30T16:58:35.8672636Z [command]/usr/bin/git version\nCI / Test\tUNKNOWN STEP\t2026-05-30T16:58:35.8736804Z git version 2.54.0\nCI / Test\tUNKNOWN STEP\t2026-05-30T16:58:35.8763314Z ##[endgroup]\nCI / Test\tUNKNOWN STEP\t2026-05-30T16:58:35.8778321Z Temporarily overriding HOME='/home/runner/work/_temp/91767f35-90db-47b8-957a-239d081ebc62' before making global git config changes\nCI / Test\tUNKNOWN STEP\t2026-05-30T16:58:35.8782554Z Adding repository directory to the temporary git global config as a safe directory\nCI / Test\tUNKNOWN STEP\t2026-05-30T16:58:35.8785023Z [command]/usr/bin/git config --global --add safe.directory /home/runner/work/teleton-agent/teleton-agent\nCI / Test\tUNKNOWN STEP\t2026-05-30T16:58:35.8828885Z Deleting the contents of '/home/runner/work/teleton-agent/teleton-agent'\nCI / Test\tUNKNOWN STEP\t2026-05-30T16:58:35.8832667Z ##[group]Initializing the repository\nCI / Test\tUNKNOWN STEP\t2026-05-30T16:58:35.8903073Z [command]/usr/bin/git init /home/runner/work/teleton-agent/teleton-agent\nCI / Test\tUNKNOWN STEP\t2026-05-30T16:58:35.8945042Z hint: Using 'master' as the name for the initial branch. This default branch name\nCI / Test\tUNKNOWN STEP\t2026-05-30T16:58:35.8948170Z hint: will change to \"main\" in Git 3.0. To configure the initial branch name",
+[2026-05-30T17:18:59.928Z] [INFO]         "is_error": false
+[2026-05-30T17:18:59.928Z] [INFO]       }
+[2026-05-30T17:18:59.928Z] [INFO]     ]
+[2026-05-30T17:18:59.928Z] [INFO]   },
+[2026-05-30T17:18:59.928Z] [INFO]   "parent_tool_use_id": null,
+[2026-05-30T17:18:59.928Z] [INFO]   "session_id": "45441128-80e2-48c1-a2ea-f81ede05030b",
+[2026-05-30T17:18:59.928Z] [INFO]   "uuid": "a24bb9c1-34ab-45e5-ad03-31bcc8d5cd2a",
+[2026-05-30T17:18:59.928Z] [INFO]   "timestamp": "2026-05-30T17:18:59.925Z",
+[2026-05-30T17:18:59.928Z] [INFO]   "tool_use_result": {
+[2026-05-30T17:18:59.928Z] [INFO]     "stdout": "CI / Test\tUNKNOWN STEP\t﻿2026-05-30T16:58:34.0440107Z Current runner version: '2.334.0'\nCI / Test\tUNKNOWN STEP\t2026-05-30T16:58:34.0464112Z ##[group]Runner Image Provisioner\nCI / Test\tUNKNOWN STEP\t2026-05-30T16:58:34.0464972Z Hosted Compute Agent\nCI / Test\tUNKNOWN STEP\t2026-05-30T16:58:34.0465618Z Version: 20260520.533\nCI / Test\tUNKNOWN STEP\t2026-05-30T16:58:34.0466270Z Commit: 189110e25284a9812c124fd27b339e2fb4f2f9db\nCI / Test\tUNKNOWN STEP\t2026-05-30T16:58:34.0466993Z Build Date: 2026-05-20T17:44:04Z\nCI / Test\tUNKNOWN STEP\t2026-05-30T16:58:34.0467776Z Worker ID: {ee1e120f-4743-4e2a-ab7a-7b1ed6332168}\nCI / Test\tUNKNOWN STEP\t2026-05-30T16:58:34.0468505Z Azure Region: westcentralus\nCI / Test\tUNKNOWN STEP\t2026-05-30T16:58:34.0469124Z ##[endgroup]\nCI / Test\tUNKNOWN STEP\t2026-05-30T16:58:34.0470880Z ##[group]Operating System\nCI / Test\tUNKNOWN STEP\t2026-05-30T16:58:34.0471543Z Ubuntu\nCI / Test\tUNKNOWN STEP\t2026-05-30T16:58:34.0472190Z 24.04.4\nCI / Test\tUNKNOWN STEP\t2026-05-30T16:58:34.0472698Z LTS\nCI / Test\tUNKNOWN STEP\t2026-05-30T16:58:34.0473291Z ##[endgroup]\nCI / Test\tUNKNOWN STEP\t2026-05-30T16:58:34.0473905Z ##[group]Runner Image\nCI / Test\tUNKNOWN STEP\t2026-05-30T16:58:34.0474554Z Image: ubuntu-24.04\nCI / Test\tUNKNOWN STEP\t2026-05-30T16:58:34.0475187Z Version: 20260525.161.1\nCI / Test\tUNKNOWN STEP\t2026-05-30T16:58:34.0476489Z Included Software: https://github.com/actions/runner-images/blob/ubuntu24/20260525.161/images/ubuntu/Ubuntu2404-Readme.md\nCI / Test\tUNKNOWN STEP\t2026-05-30T16:58:34.0478056Z Image Release: https://github.com/actions/runner-images/releases/tag/ubuntu24%2F20260525.161\nCI / Test\tUNKNOWN STEP\t2026-05-30T16:58:34.0479017Z ##[endgroup]\nCI / Test\tUNKNOWN STEP\t2026-05-30T16:58:34.0482029Z ##[group]GITHUB_TOKEN Permissions\nCI / Test\tUNKNOWN STEP\t2026-05-30T16:58:34.0484088Z Actions: read\nCI / Test\tUNKNOWN STEP\t2026-05-30T16:58:34.0484836Z ArtifactMetadata: read\nCI / Test\tUNKNOWN STEP\t2026-05-30T16:58:34.0485470Z Attestations: read\nCI / Test\tUNKNOWN STEP\t2026-05-30T16:58:34.0486065Z Checks: read\nCI / Test\tUNKNOWN STEP\t2026-05-30T16:58:34.0486712Z CodeQuality: read\nCI / Test\tUNKNOWN STEP\t2026-05-30T16:58:34.0487271Z Contents: read\nCI / Test\tUNKNOWN STEP\t2026-05-30T16:58:34.0487852Z Deployments: read\nCI / Test\tUNKNOWN STEP\t2026-05-30T16:58:34.0488437Z Discussions: read\nCI / Test\tUNKNOWN STEP\t2026-05-30T16:58:34.0489000Z Issues: read\nCI / Test\tUNKNOWN STEP\t2026-05-30T16:58:34.0489598Z Metadata: read\nCI / Test\tUNKNOWN STEP\t2026-05-30T16:58:34.0490134Z Models: read\nCI / Test\tUNKNOWN STEP\t2026-05-30T16:58:34.0490850Z Packages: read\nCI / Test\tUNKNOWN STEP\t2026-05-30T16:58:34.0491567Z Pages: read\nCI / Test\tUNKNOWN STEP\t2026-05-30T16:58:34.0492106Z PullRequests: read\nCI / Test\tUNKNOWN STEP\t2026-05-30T16:58:34.0492750Z RepositoryProjects: read\nCI / Test\tUNKNOWN STEP\t2026-05-30T16:58:34.0493374Z SecurityEvents: read\nCI / Test\tUNKNOWN STEP\t2026-05-30T16:58:34.0493978Z Statuses: read\nCI / Test\tUNKNOWN STEP\t2026-05-30T16:58:34.0494602Z VulnerabilityAlerts: read\nCI / Test\tUNKNOWN STEP\t2026-05-30T16:58:34.0495198Z ##[endgroup]\nCI / Test\tUNKNOWN STEP\t2026-05-30T16:58:34.0497341Z Secret source: None\nCI / Test\tUNKNOWN STEP\t2026-05-30T16:58:34.0498090Z Prepare workflow directory\nCI / Test\tUNKNOWN STEP\t2026-05-30T16:58:34.0838668Z Prepare all required actions\nCI / Test\tUNKNOWN STEP\t2026-05-30T16:58:34.0876706Z Getting action download info\nCI / Test\tUNKNOWN STEP\t2026-05-30T16:58:34.5974613Z Download action repository 'actions/checkout@v4' (SHA:34e114876b0b11c390a56381ad16ebd13914f8d5)\nCI / Test\tUNKNOWN STEP\t2026-05-30T16:58:34.7057584Z Download action repository 'actions/setup-node@v4' (SHA:49933ea5288caeca8642d1e84afbd3f7d6820020)\nCI / Test\tUNKNOWN STEP\t2026-05-30T16:58:34.7985388Z Download action repository 'actions/upload-artifact@v4' (SHA:ea165f8d65b6e75b540449e92b4886f43607fa02)\nCI / Test\tUNKNOWN STEP\t2026-05-30T16:58:34.9034766Z Download action repository 'codecov/codecov-action@v4' (SHA:b9fd7d16f6d7d1b5d2bec1a2887e65ceed900238)\nCI / Test\tUNKNOWN STEP\t2026-05-30T16:58:35.6575284Z Complete job name: CI / Test\nCI / Test\tUNKNOWN STEP\t2026-05-30T16:58:35.7492157Z ##[group]Run actions/checkout@v4\nCI / Test\tUNKNOWN STEP\t2026-05-30T16:58:35.7493610Z with:\nCI / Test\tUNKNOWN STEP\t2026-05-30T16:58:35.7494529Z   ref: 826**********************************60a\nCI / Test\tUNKNOWN STEP\t2026-05-30T16:58:35.7495809Z   repository: xlabtg/teleton-agent\nCI / Test\tUNKNOWN STEP\t2026-05-30T16:58:35.7507602Z   token: ***\nCI / Test\tUNKNOWN STEP\t2026-05-30T16:58:35.7508501Z   ssh-strict: true\nCI / Test\tUNKNOWN STEP\t2026-05-30T16:58:35.7509387Z   ssh-user: git\nCI / Test\tUNKNOWN STEP\t2026-05-30T16:58:35.7510293Z   persist-credentials: true\nCI / Test\tUNKNOWN STEP\t2026-05-30T16:58:35.7511441Z   clean: true\nCI / Test\tUNKNOWN STEP\t2026-05-30T16:58:35.7512354Z   sparse-checkout-cone-mode: true\nCI / Test\tUNKNOWN STEP\t2026-05-30T16:58:35.7513455Z   fetch-depth: 1\nCI / Test\tUNKNOWN STEP\t2026-05-30T16:58:35.7514327Z   fetch-tags: false\nCI / Test\tUNKNOWN STEP\t2026-05-30T16:58:35.7515244Z   show-progress: true\nCI / Test\tUNKNOWN STEP\t2026-05-30T16:58:35.7516154Z   lfs: false\nCI / Test\tUNKNOWN STEP\t2026-05-30T16:58:35.7516992Z   submodules: false\nCI / Test\tUNKNOWN STEP\t2026-05-30T16:58:35.7517902Z   set-safe-directory: true\nCI / Test\tUNKNOWN STEP\t2026-05-30T16:58:35.7519228Z ##[endgroup]\nCI / Test\tUNKNOWN STEP\t2026-05-30T16:58:35.8665502Z Syncing repository: xlabtg/teleton-agent\nCI / Test\tUNKNOWN STEP\t2026-05-30T16:58:35.8668342Z ##[group]Getting Git version info\nCI / Test\tUNKNOWN STEP\t2026-05-30T16:58:35.8669954Z Working directory is '/home/runner/work/teleton-agent/teleton-agent'\nCI / Test\tUNKNOWN STEP\t2026-05-30T16:58:35.8672636Z [command]/usr/bin/git version\nCI / Test\tUNKNOWN STEP\t2026-05-30T16:58:35.8736804Z git version 2.54.0\nCI / Test\tUNKNOWN STEP\t2026-05-30T16:58:35.8763314Z ##[endgroup]\nCI / Test\tUNKNOWN STEP\t2026-05-30T16:58:35.8778321Z Temporarily overriding HOME='/home/runner/work/_temp/91767f35-90db-47b8-957a-239d081ebc62' before making global git config changes\nCI / Test\tUNKNOWN STEP\t2026-05-30T16:58:35.8782554Z Adding repository directory to the temporary git global config as a safe directory\nCI / Test\tUNKNOWN STEP\t2026-05-30T16:58:35.8785023Z [command]/usr/bin/git config --global --add safe.directory /home/runner/work/teleton-agent/teleton-agent\nCI / Test\tUNKNOWN STEP\t2026-05-30T16:58:35.8828885Z Deleting the contents of '/home/runner/work/teleton-agent/teleton-agent'\nCI / Test\tUNKNOWN STEP\t2026-05-30T16:58:35.8832667Z ##[group]Initializing the repository\nCI / Test\tUNKNOWN STEP\t2026-05-30T16:58:35.8903073Z [command]/usr/bin/git init /home/runner/work/teleton-agent/teleton-agent\nCI / Test\tUNKNOWN STEP\t2026-05-30T16:58:35.8945042Z hint: Using 'master' as the name for the initial branch. This default branch name\nCI / Test\tUNKNOWN STEP\t2026-05-30T16:58:35.8948170Z hint: will change to \"main\" in Git 3.0. To configure the initial branch name",
+[2026-05-30T17:18:59.928Z] [INFO]     "stderr": "",
+[2026-05-30T17:18:59.928Z] [INFO]     "interrupted": false,
+[2026-05-30T17:18:59.928Z] [INFO]     "isImage": false,
+[2026-05-30T17:18:59.928Z] [INFO]     "noOutputExpected": false
+[2026-05-30T17:18:59.928Z] [INFO]   }
+[2026-05-30T17:18:59.928Z] [INFO] }
+[2026-05-30T17:18:59.939Z] [INFO] [log_20c70b] sending request {
+[2026-05-30T17:18:59.940Z] [INFO]   method: "post",
+[2026-05-30T17:18:59.940Z] [INFO]   url: "https://api.anthropic.com/v1/messages?beta=true",
+[2026-05-30T17:18:59.941Z] [INFO]   options: {
+[2026-05-30T17:18:59.941Z] [INFO]     method: "post",
+[2026-05-30T17:18:59.942Z] [INFO]     path: "/v1/messages?beta=true",
+[2026-05-30T17:18:59.943Z] [INFO]     body: {
+[2026-05-30T17:18:59.943Z] [INFO]       model: "claude-opus-4-8",
+[2026-05-30T17:18:59.943Z] [INFO]       messages: [
+[2026-05-30T17:18:59.944Z] [INFO]         [Object ...], [Object ...], [Object ...], [Object ...], [Object ...], [Object ...], [Object ...], [Object ...], [Object ...]
+[2026-05-30T17:18:59.944Z] [INFO]       ],
+[2026-05-30T17:18:59.944Z] [INFO]       system: [
+[2026-05-30T17:18:59.944Z] [INFO]         [Object ...], [Object ...], [Object ...], [Object ...]
+[2026-05-30T17:18:59.945Z] [INFO]       ],
+[2026-05-30T17:18:59.945Z] [INFO]       tools: [
+[2026-05-30T17:18:59.946Z] [INFO]         [Object ...], [Object ...], [Object ...], [Object ...], [Object ...], [Object ...], [Object ...], [Object ...], [Object ...], [Object ...]
+[2026-05-30T17:18:59.946Z] [INFO]       ],
+[2026-05-30T17:18:59.947Z] [INFO]       tool_choice: undefined,
+[2026-05-30T17:18:59.947Z] [INFO]       metadata: [Object ...],
+[2026-05-30T17:18:59.947Z] [INFO]       max_tokens: 128000,
+[2026-05-30T17:18:59.947Z] [INFO]       thinking: [Object ...],
+[2026-05-30T17:18:59.948Z] [INFO]       context_management: [Object ...],
+[2026-05-30T17:18:59.948Z] [INFO]       output_config: [Object ...],
+[2026-05-30T17:18:59.948Z] [INFO]       diagnostics: [Object ...],
+[2026-05-30T17:18:59.949Z] [INFO]       stream: true,
+[2026-05-30T17:18:59.949Z] [INFO]     },
+[2026-05-30T17:18:59.950Z] [INFO]     timeout: 600000,
+[2026-05-30T17:18:59.950Z] [INFO]     signal: AbortSignal {
+[2026-05-30T17:18:59.950Z] [INFO]       [Symbol(events.maxEventTargetListeners)]: 50,
+[2026-05-30T17:18:59.951Z] [INFO]       [Symbol(events.maxEventTargetListenersWarned)]: false,
+[2026-05-30T17:18:59.951Z] [INFO]       aborted: false,
+[2026-05-30T17:18:59.951Z] [INFO]       reason: undefined,
+[2026-05-30T17:18:59.952Z] [INFO]       onabort: null,
+[2026-05-30T17:18:59.952Z] [INFO]       throwIfAborted: [Function: throwIfAborted],
+[2026-05-30T17:18:59.952Z] [INFO]       addEventListener: [Function: addEventListener],
+[2026-05-30T17:18:59.953Z] [INFO]       removeEventListener: [Function: removeEventListener],
+[2026-05-30T17:18:59.953Z] [INFO]       dispatchEvent: [Function: dispatchEvent],
+[2026-05-30T17:18:59.954Z] [INFO]     },
+[2026-05-30T17:18:59.954Z] [INFO]     stream: true,
+[2026-05-30T17:18:59.955Z] [INFO]   },
+[2026-05-30T17:18:59.955Z] [INFO]   headers: {
+[2026-05-30T17:18:59.957Z] [INFO]     accept: "application/json",
+[2026-05-30T17:18:59.957Z] [INFO]     "anthropic-beta": "claude-code-20250219,oauth-2025-04-20,interleaved-thinking-2025-05-14,thinking-token-count-2026-05-13,context-management-2025-06-27,prompt-caching-scope-2026-01-05,mid-conversation-system-2026-04-07,advisor-tool-2026-03-01,advanced-tool-use-2025-11-20,effort-2025-11-24,extended-cache-ttl-2025-04-11,cache-diagnosis-2026-04-07",
+[2026-05-30T17:18:59.958Z] [INFO]     "anthropic-dangerous-direct-browser-access": "true",
+[2026-05-30T17:18:59.958Z] [INFO]     "anthropic-version": "2023-06-01",
+[2026-05-30T17:18:59.959Z] [INFO]     authorization: "***",
+[2026-05-30T17:18:59.959Z] [INFO]     "content-type": "application/json",
+[2026-05-30T17:18:59.959Z] [INFO]     "user-agent": "claude-cli/2.1.158 (external, sdk-cli)",
+[2026-05-30T17:18:59.960Z] [INFO]     "x-app": "cli",
+[2026-05-30T17:18:59.960Z] [INFO]     "x-claude-code-session-id": "45441128-80e2-48c1-a2ea-f81ede05030b",
+[2026-05-30T17:18:59.960Z] [INFO]     "x-client-request-id": "37ef05ce-9751-4dd2-a608-afeb2e51b2d6",
+[2026-05-30T17:18:59.961Z] [INFO]     "x-stainless-arch": "x64",
+[2026-05-30T17:18:59.961Z] [INFO]     "x-stainless-lang": "js",
+[2026-05-30T17:18:59.961Z] [INFO]     "x-stainless-os": "Linux",
+[2026-05-30T17:18:59.961Z] [INFO]     "x-stainless-package-version": "0.94.0",
+[2026-05-30T17:18:59.961Z] [INFO]     "x-stainless-retry-count": "0",
+[2026-05-30T17:18:59.962Z] [INFO]     "x-stainless-runtime": "node",
+[2026-05-30T17:18:59.962Z] [INFO]     "x-stainless-runtime-version": "v24.3.0",
+[2026-05-30T17:18:59.962Z] [INFO]     "x-stainless-timeout": "600",
+[2026-05-30T17:18:59.963Z] [INFO]   },
+[2026-05-30T17:18:59.963Z] [INFO] }
+[2026-05-30T17:19:01.303Z] [INFO] [log_20c70b, request-id: "req_011CbZ8ow5qzaenwTEc7a7yL"] post https://api.anthropic.com/v1/messages?beta=true succeeded with status 200 in 1364ms
+[2026-05-30T17:19:01.304Z] [INFO] [log_20c70b] response start {
+[2026-05-30T17:19:01.304Z] [INFO]   url: "https://api.anthropic.com/v1/messages?beta=true",
+[2026-05-30T17:19:01.304Z] [INFO]   status: 200,
+[2026-05-30T17:19:01.305Z] [INFO]   headers: {
+[2026-05-30T17:19:01.305Z] [INFO]     "anthropic-organization-id": "ebc2ac93-f86f-4d15-aff3-de8830d8d789",
+[2026-05-30T17:19:01.306Z] [INFO]     "anthropic-ratelimit-unified-5h-reset": "1780173000",
+[2026-05-30T17:19:01.306Z] [INFO]     "anthropic-ratelimit-unified-5h-status": "allowed",
+[2026-05-30T17:19:01.307Z] [INFO]     "anthropic-ratelimit-unified-5h-utilization": "0.25",
+[2026-05-30T17:19:01.307Z] [INFO]     "anthropic-ratelimit-unified-7d-reset": "1780398000",
+[2026-05-30T17:19:01.308Z] [INFO]     "anthropic-ratelimit-unified-7d-status": "allowed",
+[2026-05-30T17:19:01.308Z] [INFO]     "anthropic-ratelimit-unified-7d-utilization": "0.73",
+[2026-05-30T17:19:01.308Z] [INFO]     "anthropic-ratelimit-unified-fallback-percentage": "0.5",
+[2026-05-30T17:19:01.309Z] [INFO]     "anthropic-ratelimit-unified-overage-disabled-reason": "org_level_disabled",
+[2026-05-30T17:19:01.309Z] [INFO]     "anthropic-ratelimit-unified-overage-status": "rejected",
+[2026-05-30T17:19:01.309Z] [INFO]     "anthropic-ratelimit-unified-representative-claim": "five_hour",
+[2026-05-30T17:19:01.310Z] [INFO]     "anthropic-ratelimit-unified-reset": "1780173000",
+[2026-05-30T17:19:01.310Z] [INFO]     "anthropic-ratelimit-unified-status": "allowed",
+[2026-05-30T17:19:01.311Z] [INFO]     "cache-control": "no-cache",
+[2026-05-30T17:19:01.311Z] [INFO]     "cf-cache-status": "DYNAMIC",
+[2026-05-30T17:19:01.311Z] [INFO]     "cf-ray": "a03f66b8ac4eb10b-FRA",
+[2026-05-30T17:19:01.312Z] [INFO]     connection: "keep-alive",
+[2026-05-30T17:19:01.312Z] [INFO]     "content-encoding": "gzip",
+[2026-05-30T17:19:01.313Z] [INFO]     "content-security-policy": "default-src 'none'; frame-ancestors 'none'",
+[2026-05-30T17:19:01.313Z] [INFO]     "content-type": "text/event-stream; charset=utf-8",
+[2026-05-30T17:19:01.313Z] [INFO]     date: "Sat, 30 May 2026 17:19:01 GMT",
+[2026-05-30T17:19:01.313Z] [INFO]     "request-id": "req_011CbZ8ow5qzaenwTEc7a7yL",
+[2026-05-30T17:19:01.313Z] [INFO]     server: "cloudflare",
+[2026-05-30T17:19:01.313Z] [INFO]     "strict-transport-security": "max-age=31536000; includeSubDomains; preload",
+[2026-05-30T17:19:01.314Z] [INFO]     traceresponse: "00-a3547a53b01f14b12c9879623fc4c88b-800bb67bf721ad19-01",
+[2026-05-30T17:19:01.314Z] [INFO]     "transfer-encoding": "chunked",
+[2026-05-30T17:19:01.314Z] [INFO]     vary: "Accept-Encoding",
+[2026-05-30T17:19:01.314Z] [INFO]     "x-robots-tag": "none",
+[2026-05-30T17:19:01.315Z] [INFO]     "set-cookie": "***",
+[2026-05-30T17:19:01.315Z] [INFO]   },
+[2026-05-30T17:19:01.315Z] [INFO]   durationMs: 1364,
+[2026-05-30T17:19:01.316Z] [INFO] }
+[2026-05-30T17:19:01.316Z] [INFO] response 200 https://api.anthropic.com/v1/messages?beta=true Headers {
+[2026-05-30T17:19:01.316Z] [INFO]   "date": "Sat, 30 May 2026 17:19:01 GMT",
+[2026-05-30T17:19:01.316Z] [INFO]   "content-type": "text/event-stream; charset=utf-8",
+[2026-05-30T17:19:01.317Z] [INFO]   "transfer-encoding": "chunked",
+[2026-05-30T17:19:01.317Z] [INFO]   "connection": "keep-alive",
+[2026-05-30T17:19:01.317Z] [INFO]   "cache-control": "no-cache",
+[2026-05-30T17:19:01.317Z] [INFO]   "strict-transport-security": "max-age=31536000; includeSubDomains; preload",
+[2026-05-30T17:19:01.318Z] [INFO]   "content-encoding": "gzip",
+[2026-05-30T17:19:01.318Z] [INFO]   "vary": "Accept-Encoding",
+[2026-05-30T17:19:01.319Z] [INFO]   "content-security-policy": "default-src 'none'; frame-ancestors 'none'",
+[2026-05-30T17:19:01.319Z] [INFO]   "set-cookie": [ "_cfuvid=k_lC9Qf7vCKwg9tRcJAEXiU.NLw_xw6bFjTI_eUY6sY-1780161539.948951-1.0.1.1-QZz0XfijFZGJtUN5517PPFvrUKvqRa0it5QUqgjGoWw; HttpOnly; SameSite=None; Secure; Path=/; Domain=api.anthropic.com" ],
+[2026-05-30T17:19:01.321Z] [INFO]   "anthropic-ratelimit-unified-status": "allowed",
+[2026-05-30T17:19:01.321Z] [INFO]   "anthropic-ratelimit-unified-5h-status": "allowed",
+[2026-05-30T17:19:01.322Z] [INFO]   "anthropic-ratelimit-unified-5h-reset": "1780173000",
+[2026-05-30T17:19:01.322Z] [INFO]   "anthropic-ratelimit-unified-5h-utilization": "0.25",
+[2026-05-30T17:19:01.324Z] [INFO]   "anthropic-ratelimit-unified-7d-status": "allowed",
+[2026-05-30T17:19:01.325Z] [INFO]   "anthropic-ratelimit-unified-7d-reset": "1780398000",
+[2026-05-30T17:19:01.325Z] [INFO]   "anthropic-ratelimit-unified-7d-utilization": "0.73",
+[2026-05-30T17:19:01.326Z] [INFO]   "anthropic-ratelimit-unified-representative-claim": "five_hour",
+[2026-05-30T17:19:01.327Z] [INFO]   "anthropic-ratelimit-unified-fallback-percentage": "0.5",
+[2026-05-30T17:19:01.327Z] [INFO]   "anthropic-ratelimit-unified-reset": "1780173000",
+[2026-05-30T17:19:01.327Z] [INFO]   "anthropic-ratelimit-unified-overage-disabled-reason": "org_level_disabled",
+[2026-05-30T17:19:01.328Z] [INFO]   "anthropic-ratelimit-unified-overage-status": "rejected",
+[2026-05-30T17:19:01.329Z] [INFO]   "request-id": "req_011CbZ8ow5qzaenwTEc7a7yL",
+[2026-05-30T17:19:01.329Z] [INFO]   "anthropic-organization-id": "ebc2ac93-f86f-4d15-aff3-de8830d8d789",
+[2026-05-30T17:19:01.329Z] [INFO]   "traceresponse": "00-a3547a53b01f14b12c9879623fc4c88b-800bb67bf721ad19-01",
+[2026-05-30T17:19:01.329Z] [INFO]   "server": "cloudflare",
+[2026-05-30T17:19:01.329Z] [INFO]   "cf-cache-status": "DYNAMIC",
+[2026-05-30T17:19:01.330Z] [INFO]   "x-robots-tag": "none",
+[2026-05-30T17:19:01.330Z] [INFO]   "cf-ray": "a03f66b8ac4eb10b-FRA",
+[2026-05-30T17:19:01.330Z] [INFO] } ReadableStream {
+[2026-05-30T17:19:01.330Z] [INFO]   blob: [Function: blob],
+[2026-05-30T17:19:01.331Z] [INFO]   bytes: [Function: bytes],
+[2026-05-30T17:19:01.332Z] [INFO]   cancel: [Function],
+[2026-05-30T17:19:01.333Z] [INFO]   getReader: [Function],
+[2026-05-30T17:19:01.335Z] [INFO]   json: [Function: json],
+[2026-05-30T17:19:01.336Z] [INFO]   locked: [Getter],
+[2026-05-30T17:19:01.336Z] [INFO]   pipeThrough: [Function],
+[2026-05-30T17:19:01.337Z] [INFO]   pipeTo: [Function],
+[2026-05-30T17:19:01.338Z] [INFO]   tee: [Function],
+[2026-05-30T17:19:01.339Z] [INFO]   text: [Function: text],
+[2026-05-30T17:19:01.340Z] [INFO]   values: [Function: values],
+[2026-05-30T17:19:01.340Z] [INFO]   [Symbol(Symbol.asyncIterator)]: [Function: asyncIterator2],
+[2026-05-30T17:19:01.342Z] [INFO] }
+[2026-05-30T17:19:01.343Z] [INFO] [log_20c70b] response parsed {
+[2026-05-30T17:19:01.343Z] [INFO]   url: "https://api.anthropic.com/v1/messages?beta=true",
+[2026-05-30T17:19:01.344Z] [INFO]   status: 200,
+[2026-05-30T17:19:01.345Z] [INFO]   body: bR {
+[2026-05-30T17:19:01.345Z] [INFO]     iterator: [AsyncGeneratorFunction: z],
+[2026-05-30T17:19:01.345Z] [INFO]     controller: AbortController {
+[2026-05-30T17:19:01.346Z] [INFO]       signal: [AbortSignal ...],
+[2026-05-30T17:19:01.346Z] [INFO]       abort: [Function: abort],
+[2026-05-30T17:19:01.346Z] [INFO]     },
+[2026-05-30T17:19:01.347Z] [INFO]     [Symbol(Symbol.asyncIterator)]: [Function],
+[2026-05-30T17:19:01.348Z] [INFO]     tee: [Function: tee],
+[2026-05-30T17:19:01.348Z] [INFO]     toReadableStream: [Function: toReadableStream],
+[2026-05-30T17:19:01.349Z] [INFO]   },
+[2026-05-30T17:19:01.350Z] [INFO]   durationMs: 1365,
+[2026-05-30T17:19:01.351Z] [INFO] }
+[2026-05-30T17:19:02.301Z] [INFO] {
+[2026-05-30T17:19:02.301Z] [INFO]   "type": "assistant",
+[2026-05-30T17:19:02.301Z] [INFO]   "message": {
+[2026-05-30T17:19:02.301Z] [INFO]     "model": "claude-opus-4-8",
+[2026-05-30T17:19:02.301Z] [INFO]     "id": "msg_0125qjyovTTWWy1rLmwMasNQ",
+[2026-05-30T17:19:02.301Z] [INFO]     "type": "message",
+[2026-05-30T17:19:02.301Z] [INFO]     "role": "assistant",
+[2026-05-30T17:19:02.301Z] [INFO]     "content": [
+[2026-05-30T17:19:02.301Z] [INFO]       {
+[2026-05-30T17:19:02.301Z] [INFO]         "type": "thinking",
+[2026-05-30T17:19:02.301Z] [INFO]         "thinking": "",
+[2026-05-30T17:19:02.301Z] [INFO]         "signature": "EqYDCmMIDhgCKkCNH9XTkSGGFUZ4vl4MS1+WACQC7Dqb/zDI7grMAz+g9W/gOo/i6LCu8Y74EZbICNXv0K011BC+9ik6RM3NIWEiMg9jbGF1ZGUtb3B1cy00LTg4AEIIdGhpbmtpbmcSDMtSgy8c/DellBeONhoM4sBQnOzBBY7j8qtsIjBzT3RoPaPVPyuKqRTxr6MeRqOOJKqZB69o+dDO1z5jGMtIodtSSUulS+HxhjrR52sq8AFrhatJ3lyHWgQ4pzf8SI9goEfU7HxUc4U/jUbtOZ3fyIdyX08I0V9X9lTkbnxqDAYQi6Wxc+8E+MQ4n94K7o5yXXRF5XMLuS7LUNXxGtetI/3Snrnl7QSqkCnBU/R+MCTvZ+5fSJ4xSl+CqAchxxLtbKMTH4ZbBSiIYtNNHSQ7EhGtBqSYZWwngkKSb6Akp6F45HLhrUXgpdH/P6tzVK/puqDxbputleVc3OwMrEyJOsJVZYLVV4VvRL7CC4V34Z9YEh4tlkIN0yl537JGqQdMDHlnOKhzaJNM4zf01g45MMzCamfSIb6FWRHaKUJohywYAQ=="
+[2026-05-30T17:19:02.301Z] [INFO]       }
+[2026-05-30T17:19:02.301Z] [INFO]     ],
+[2026-05-30T17:19:02.301Z] [INFO]     "stop_reason": null,
+[2026-05-30T17:19:02.301Z] [INFO]     "stop_sequence": null,
+[2026-05-30T17:19:02.301Z] [INFO]     "stop_details": null,
+[2026-05-30T17:19:02.301Z] [INFO]     "usage": {
+[2026-05-30T17:19:02.301Z] [INFO]       "input_tokens": 2,
+[2026-05-30T17:19:02.301Z] [INFO]       "cache_creation_input_tokens": 7625,
+[2026-05-30T17:19:02.301Z] [INFO]       "cache_read_input_tokens": 28698,
+[2026-05-30T17:19:02.301Z] [INFO]       "cache_creation": {
+[2026-05-30T17:19:02.301Z] [INFO]         "ephemeral_5m_input_tokens": 0,
+[2026-05-30T17:19:02.301Z] [INFO]         "ephemeral_1h_input_tokens": 7625
+[2026-05-30T17:19:02.301Z] [INFO]       },
+[2026-05-30T17:19:02.301Z] [INFO]       "output_tokens": 5,
+[2026-05-30T17:19:02.301Z] [INFO]       "service_tier": "standard",
+[2026-05-30T17:19:02.301Z] [INFO]       "inference_geo": "not_available"
+[2026-05-30T17:19:02.301Z] [INFO]     },
+[2026-05-30T17:19:02.301Z] [INFO]     "diagnostics": null,
+[2026-05-30T17:19:02.301Z] [INFO]     "context_management": null
+[2026-05-30T17:19:02.301Z] [INFO]   },
+[2026-05-30T17:19:02.301Z] [INFO]   "parent_tool_use_id": null,
+[2026-05-30T17:19:02.301Z] [INFO]   "session_id": "45441128-80e2-48c1-a2ea-f81ede05030b",
+[2026-05-30T17:19:02.301Z] [INFO]   "uuid": "e0c0ac47-6556-4587-9a72-cca6a640808b",
+[2026-05-30T17:19:02.301Z] [INFO]   "request_id": "req_011CbZ8ow5qzaenwTEc7a7yL"
+[2026-05-30T17:19:02.301Z] [INFO] }
+[2026-05-30T17:19:02.770Z] [INFO] {
+[2026-05-30T17:19:02.770Z] [INFO]   "type": "assistant",
+[2026-05-30T17:19:02.770Z] [INFO]   "message": {
+[2026-05-30T17:19:02.770Z] [INFO]     "model": "claude-opus-4-8",
+[2026-05-30T17:19:02.770Z] [INFO]     "id": "msg_0125qjyovTTWWy1rLmwMasNQ",
+[2026-05-30T17:19:02.770Z] [INFO]     "type": "message",
+[2026-05-30T17:19:02.770Z] [INFO]     "role": "assistant",
+[2026-05-30T17:19:02.770Z] [INFO]     "content": [
+[2026-05-30T17:19:02.770Z] [INFO]       {
+[2026-05-30T17:19:02.770Z] [INFO]         "type": "text",
+[2026-05-30T17:19:02.770Z] [INFO]         "text": "Let me find the actual test failure in the log."
+[2026-05-30T17:19:02.770Z] [INFO]       }
+[2026-05-30T17:19:02.770Z] [INFO]     ],
+[2026-05-30T17:19:02.770Z] [INFO]     "stop_reason": null,
+[2026-05-30T17:19:02.770Z] [INFO]     "stop_sequence": null,
+[2026-05-30T17:19:02.770Z] [INFO]     "stop_details": null,
+[2026-05-30T17:19:02.770Z] [INFO]     "usage": {
+[2026-05-30T17:19:02.770Z] [INFO]       "input_tokens": 2,
+[2026-05-30T17:19:02.770Z] [INFO]       "cache_creation_input_tokens": 7625,
+[2026-05-30T17:19:02.770Z] [INFO]       "cache_read_input_tokens": 28698,
+[2026-05-30T17:19:02.770Z] [INFO]       "cache_creation": {
+[2026-05-30T17:19:02.770Z] [INFO]         "ephemeral_5m_input_tokens": 0,
+[2026-05-30T17:19:02.770Z] [INFO]         "ephemeral_1h_input_tokens": 7625
+[2026-05-30T17:19:02.770Z] [INFO]       },
+[2026-05-30T17:19:02.770Z] [INFO]       "output_tokens": 5,
+[2026-05-30T17:19:02.770Z] [INFO]       "service_tier": "standard",
+[2026-05-30T17:19:02.770Z] [INFO]       "inference_geo": "not_available"
+[2026-05-30T17:19:02.770Z] [INFO]     },
+[2026-05-30T17:19:02.770Z] [INFO]     "diagnostics": null,
+[2026-05-30T17:19:02.770Z] [INFO]     "context_management": null
+[2026-05-30T17:19:02.770Z] [INFO]   },
+[2026-05-30T17:19:02.770Z] [INFO]   "parent_tool_use_id": null,
+[2026-05-30T17:19:02.770Z] [INFO]   "session_id": "45441128-80e2-48c1-a2ea-f81ede05030b",
+[2026-05-30T17:19:02.770Z] [INFO]   "uuid": "7b9c296a-32c0-45cd-86f0-de5c9d07f500",
+[2026-05-30T17:19:02.770Z] [INFO]   "request_id": "req_011CbZ8ow5qzaenwTEc7a7yL"
+[2026-05-30T17:19:02.770Z] [INFO] }
+[2026-05-30T17:19:05.092Z] [INFO] {
+[2026-05-30T17:19:05.092Z] [INFO]   "type": "assistant",
+[2026-05-30T17:19:05.092Z] [INFO]   "message": {
+[2026-05-30T17:19:05.092Z] [INFO]     "model": "claude-opus-4-8",
+[2026-05-30T17:19:05.092Z] [INFO]     "id": "msg_0125qjyovTTWWy1rLmwMasNQ",
+[2026-05-30T17:19:05.092Z] [INFO]     "type": "message",
+[2026-05-30T17:19:05.092Z] [INFO]     "role": "assistant",
+[2026-05-30T17:19:05.092Z] [INFO]     "content": [
+[2026-05-30T17:19:05.092Z] [INFO]       {
+[2026-05-30T17:19:05.092Z] [INFO]         "type": "tool_use",
+[2026-05-30T17:19:05.092Z] [INFO]         "id": "toolu_01Kqccq6Qrodda9aTosbWPnZ",
+[2026-05-30T17:19:05.092Z] [INFO]         "name": "Bash",
+[2026-05-30T17:19:05.092Z] [INFO]         "input": {
+[2026-05-30T17:19:05.092Z] [INFO]           "command": "cd /tmp/gh-issue-solver-1780161489554\ngh run view 26689643842 --repo xlabtg/teleton-agent --log-failed 2>/dev/null | grep -iE \"fail|error|✗|✓.*test|FAIL|Error:|not ok|expect\" | head -60",
+[2026-05-30T17:19:05.092Z] [INFO]           "description": "Grep failures from log"
+[2026-05-30T17:19:05.092Z] [INFO]         },
+[2026-05-30T17:19:05.092Z] [INFO]         "caller": {
+[2026-05-30T17:19:05.092Z] [INFO]           "type": "direct"
+[2026-05-30T17:19:05.092Z] [INFO]         }
+[2026-05-30T17:19:05.092Z] [INFO]       }
+[2026-05-30T17:19:05.092Z] [INFO]     ],
+[2026-05-30T17:19:05.092Z] [INFO]     "stop_reason": null,
+[2026-05-30T17:19:05.092Z] [INFO]     "stop_sequence": null,
+[2026-05-30T17:19:05.092Z] [INFO]     "stop_details": null,
+[2026-05-30T17:19:05.092Z] [INFO]     "usage": {
+[2026-05-30T17:19:05.092Z] [INFO]       "input_tokens": 2,
+[2026-05-30T17:19:05.092Z] [INFO]       "cache_creation_input_tokens": 7625,
+[2026-05-30T17:19:05.092Z] [INFO]       "cache_read_input_tokens": 28698,
+[2026-05-30T17:19:05.092Z] [INFO]       "cache_creation": {
+[2026-05-30T17:19:05.092Z] [INFO]         "ephemeral_5m_input_tokens": 0,
+[2026-05-30T17:19:05.092Z] [INFO]         "ephemeral_1h_input_tokens": 7625
+[2026-05-30T17:19:05.092Z] [INFO]       },
+[2026-05-30T17:19:05.092Z] [INFO]       "output_tokens": 5,
+[2026-05-30T17:19:05.092Z] [INFO]       "service_tier": "standard",
+[2026-05-30T17:19:05.092Z] [INFO]       "inference_geo": "not_available"
+[2026-05-30T17:19:05.092Z] [INFO]     },
+[2026-05-30T17:19:05.092Z] [INFO]     "diagnostics": null,
+[2026-05-30T17:19:05.092Z] [INFO]     "context_management": null
+[2026-05-30T17:19:05.092Z] [INFO]   },
+[2026-05-30T17:19:05.092Z] [INFO]   "parent_tool_use_id": null,
+[2026-05-30T17:19:05.092Z] [INFO]   "session_id": "45441128-80e2-48c1-a2ea-f81ede05030b",
+[2026-05-30T17:19:05.092Z] [INFO]   "uuid": "b847463d-f123-4bbe-a176-3d0a3c5a267c",
+[2026-05-30T17:19:05.092Z] [INFO]   "request_id": "req_011CbZ8ow5qzaenwTEc7a7yL"
+[2026-05-30T17:19:05.092Z] [INFO] }
+[2026-05-30T17:19:07.889Z] [INFO] {
+[2026-05-30T17:19:07.889Z] [INFO]   "type": "user",
+[2026-05-30T17:19:07.889Z] [INFO]   "message": {
+[2026-05-30T17:19:07.889Z] [INFO]     "role": "user",
+[2026-05-30T17:19:07.889Z] [INFO]     "content": [
+[2026-05-30T17:19:07.889Z] [INFO]       {
+[2026-05-30T17:19:07.889Z] [INFO]         "tool_use_id": "toolu_01Kqccq6Qrodda9aTosbWPnZ",
+[2026-05-30T17:19:07.889Z] [INFO]         "type": "tool_result",
+[2026-05-30T17:19:07.889Z] [INFO]         "content": "CI / Test\tUNKNOWN STEP\t2026-05-30T16:59:09.5103252Z  ^[[32m✓^[[39m src/api/__tests__/api-server.test.ts ^[[2m(^[[22m^[[2m69 tests^[[22m^[[2m)^[[22m^[[33m 356^[[2mms^[[22m^[[39m\nCI / Test\tUNKNOWN STEP\t2026-05-30T16:59:09.6001225Z  ^[[32m✓^[[39m src/sdk/__tests__/ton.test.ts ^[[2m(^[[22m^[[2m139 tests^[[22m^[[2m)^[[22m^[[32m 107^[[2mms^[[22m^[[39m\nCI / Test\tUNKNOWN STEP\t2026-05-30T16:59:09.9543835Z  ^[[32m✓^[[39m src/memory/__tests__/schema.test.ts ^[[2m(^[[22m^[[2m81 tests^[[22m^[[2m)^[[22m^[[33m 883^[[2mms^[[22m^[[39m\nCI / Test\tUNKNOWN STEP\t2026-05-30T16:59:10.0882515Z  ^[[32m✓^[[39m src/sdk/__tests__/telegram-social.test.ts ^[[2m(^[[22m^[[2m80 tests^[[22m^[[2m)^[[22m^[[32m 78^[[2mms^[[22m^[[39m\nCI / Test\tUNKNOWN STEP\t2026-05-30T16:59:10.4014445Z  ^[[32m✓^[[39m src/webui/__tests__/setup-routes.test.ts ^[[2m(^[[22m^[[2m63 tests^[[22m^[[2m)^[[22m^[[32m 210^[[2mms^[[22m^[[39m\nCI / Test\tUNKNOWN STEP\t2026-05-30T16:59:10.7131348Z  ^[[32m✓^[[39m src/config/__tests__/loader.test.ts ^[[2m(^[[22m^[[2m57 tests^[[22m^[[2m)^[[22m^[[32m 237^[[2mms^[[22m^[[39m\nCI / Test\tUNKNOWN STEP\t2026-05-30T16:59:11.0148395Z  ^[[32m✓^[[39m src/webui/__tests__/hooks-routes.test.ts ^[[2m(^[[22m^[[2m47 tests^[[22m^[[2m)^[[22m^[[32m 194^[[2mms^[[22m^[[39m\nCI / Test\tUNKNOWN STEP\t2026-05-30T16:59:11.3352066Z  ^[[32m✓^[[39m src/utils/__tests__/sanitize.test.ts ^[[2m(^[[22m^[[2m144 tests^[[22m^[[2m)^[[22m^[[32m 35^[[2mms^[[22m^[[39m\nCI / Test\tUNKNOWN STEP\t2026-05-30T16:59:11.3376870Z  ^[[32m✓^[[39m src/telegram/__tests__/handlers.test.ts ^[[2m(^[[22m^[[2m53 tests^[[22m^[[2m)^[[22m^[[32m 210^[[2mms^[[22m^[[39m\nCI / Test\tUNKNOWN STEP\t2026-05-30T16:59:11.7023396Z  ^[[32m✓^[[39m src/agent/__tests__/runtime-hooks.test.ts ^[[2m(^[[22m^[[2m28 tests^[[22m^[[2m)^[[22m^[[32m 97^[[2mms^[[22m^[[39m\nCI / Test\tUNKNOWN STEP\t2026-05-30T16:59:11.8305882Z  ^[[32m✓^[[39m src/agent/__tests__/runtime-utils.test.ts ^[[2m(^[[22m^[[2m87 tests^[[22m^[[2m)^[[22m^[[32m 41^[[2mms^[[22m^[[39m\nCI / Test\tUNKNOWN STEP\t2026-05-30T16:59:12.1571642Z  ^[[32m✓^[[39m src/workspace/__tests__/validator.test.ts ^[[2m(^[[22m^[[2m78 tests^[[22m^[[2m)^[[22m^[[32m 178^[[2mms^[[22m^[[39m\nCI / Test\tUNKNOWN STEP\t2026-05-30T16:59:12.2024562Z  ^[[32m✓^[[39m src/telegram/__tests__/client-proxy.test.ts ^[[2m(^[[22m^[[2m21 tests^[[22m^[[2m)^[[22m^[[32m 33^[[2mms^[[22m^[[39m\nCI / Test\tUNKNOWN STEP\t2026-05-30T16:59:12.5623115Z  ^[[32m✓^[[39m src/sdk/__tests__/telegram-messages.test.ts ^[[2m(^[[22m^[[2m54 tests^[[22m^[[2m)^[[22m^[[32m 40^[[2mms^[[22m^[[39m\nCI / Test\tUNKNOWN STEP\t2026-05-30T16:59:12.7162943Z  ^[[32m✓^[[39m src/webui/__tests__/security-routes.test.ts ^[[2m(^[[22m^[[2m35 tests^[[22m^[[2m)^[[22m^[[32m 104^[[2mms^[[22m^[[39m\nCI / Test\tUNKNOWN STEP\t2026-05-30T16:59:13.1864582Z  ^[[32m✓^[[39m src/webui/__tests__/agents-routes.test.ts ^[[2m(^[[22m^[[2m18 tests^[[22m^[[2m)^[[22m^[[32m 112^[[2mms^[[22m^[[39m\nCI / Test\tUNKNOWN STEP\t2026-05-30T16:59:13.5149228Z [16:59:13] ^[[31mERROR^[[39m: ^[[36m[Memory] Vector search error (knowledge)^[[39m\nCI / Test\tUNKNOWN STEP\t2026-05-30T16:59:13.5150410Z       \"type\": \"SqliteError\",\nCI / Test\tUNKNOWN STEP\t2026-05-30T16:59:13.5152233Z           SqliteError: no such table: knowledge_vec\nCI / Test\tUNKNOWN STEP\t2026-05-30T16:59:13.5160059Z       \"code\": \"SQLITE_ERROR\"\nCI / Test\tUNKNOWN STEP\t2026-05-30T16:59:13.5161439Z [16:59:13] ^[[31mERROR^[[39m: ^[[36m[Memory] Vector search error (messages)^[[39m\nCI / Test\tUNKNOWN STEP\t2026-05-30T16:59:13.5162078Z       \"type\": \"SqliteError\",\nCI / Test\tUNKNOWN STEP\t2026-05-30T16:59:13.5163209Z           SqliteError: no such table: tg_messages_vec\nCI / Test\tUNKNOWN STEP\t2026-05-30T16:59:13.5175243Z       \"code\": \"SQLITE_ERROR\"\nCI / Test\tUNKNOWN STEP\t2026-05-30T16:59:13.5176533Z [16:59:13] ^[[31mERROR^[[39m: ^[[36m[Memory] Vector search error (knowledge)^[[39m\nCI / Test\tUNKNOWN STEP\t2026-05-30T16:59:13.5177558Z       \"type\": \"SqliteError\",\nCI / Test\tUNKNOWN STEP\t2026-05-30T16:59:13.5179183Z           SqliteError: no such table: knowledge_vec\nCI / Test\tUNKNOWN STEP\t2026-05-30T16:59:13.5185219Z       \"code\": \"SQLITE_ERROR\"\nCI / Test\tUNKNOWN STEP\t2026-05-30T16:59:13.5414217Z  ^[[32m✓^[[39m src/memory/__tests__/hybrid-search.test.ts ^[[2m(^[[22m^[[2m43 tests^[[22m^[[2m)^[[22m^[[33m 382^[[2mms^[[22m^[[39m\nCI / Test\tUNKNOWN STEP\t2026-05-30T16:59:14.0457772Z  ^[[32m✓^[[39m src/webui/__tests__/network-routes.test.ts ^[[2m(^[[22m^[[2m13 tests^[[22m^[[2m)^[[22m^[[32m 283^[[2mms^[[22m^[[39m\nCI / Test\tUNKNOWN STEP\t2026-05-30T16:59:14.0911866Z [16:59:14] ^[[31mERROR^[[39m: ^[[36m[Registry] Error executing tool error_tool^[[39m\nCI / Test\tUNKNOWN STEP\t2026-05-30T16:59:14.0944393Z       \"type\": \"Error\",\nCI / Test\tUNKNOWN STEP\t2026-05-30T16:59:14.0945459Z       \"message\": \"Execution failed\",\nCI / Test\tUNKNOWN STEP\t2026-05-30T16:59:14.0946960Z           Error: Execution failed\nCI / Test\tUNKNOWN STEP\t2026-05-30T16:59:14.1891550Z  ^[[32m✓^[[39m src/agent/tools/__tests__/registry.test.ts ^[[2m(^[[22m^[[2m67 tests^[[22m^[[2m)^[[22m^[[32m 90^[[2mms^[[22m^[[39m\nCI / Test\tUNKNOWN STEP\t2026-05-30T16:59:14.2086704Z [17:00:44] ^[[31mERROR^[[39m: ^[[36m[Registry] Error executing tool slow_tool^[[39m\nCI / Test\tUNKNOWN STEP\t2026-05-30T16:59:14.2088343Z       \"type\": \"Error\",\nCI / Test\tUNKNOWN STEP\t2026-05-30T16:59:14.2090377Z           Error: Tool \"slow_tool\" timed out after 90s\nCI / Test\tUNKNOWN STEP\t2026-05-30T16:59:14.6401685Z  ^[[32m✓^[[39m src/webui/__tests__/soul-routes.test.ts ^[[2m(^[[22m^[[2m32 tests^[[22m^[[2m)^[[22m^[[32m 142^[[2mms^[[22m^[[39m\nCI / Test\tUNKNOWN STEP\t2026-05-30T16:59:14.9863138Z  ^[[32m✓^[[39m src/webui/__tests__/sessions-routes.test.ts ^[[2m(^[[22m^[[2m21 tests^[[22m^[[2m)^[[22m^[[32m 94^[[2mms^[[22m^[[39m\nCI / Test\tUNKNOWN STEP\t2026-05-30T16:59:15.1505536Z  ^[[32m✓^[[39m src/autonomous/__tests__/manager.test.ts ^[[2m(^[[22m^[[2m19 tests^[[22m^[[2m)^[[22m^[[33m 1197^[[2mms^[[22m^[[39m\nCI / Test\tUNKNOWN STEP\t2026-05-30T16:59:15.2543283Z  ^[[32m✓^[[39m src/services/__tests__/analytics.test.ts ^[[2m(^[[22m^[[2m39 tests^[[22m^[[2m)^[[22m^[[32m 46^[[2mms^[[22m^[[39m\nCI / Test\tUNKNOWN STEP\t2026-05-30T16:59:15.2705525Z [16:59:15] ^[[31mERROR^[[39m: ^[[36m[AutonomousIntegration] failed to deliver escalation to Telegram admin^[[39m\nCI / Test\tUNKNOWN STEP\t2026-05-30T16:59:15.2708215Z       \"type\": \"Error\",\nCI / Test\tUNKNOWN STEP\t2026-05-30T16:59:15.2709885Z           Error: bridge offline\nCI / Test\tUNKNOWN STEP\t2026-05-30T16:59:15.3587179Z  ^[[32m✓^[[39m src/autonomous/__tests__/integration.test.ts ^[[2m(^[[22m^[[2m19 tests^[[22m^[[2m)^[[22m^[[32m 185^[[2mms^[[22m^[[39m\nCI / Test\tUNKNOWN STEP\t2026-05-30T16:59:16.0816653Z  ^[[32m✓^[[39m src/memory/__tests__/tasks.test.ts ^[[2m(^[[22m^[[2m42 tests^[[22m^[[2m)^[[22m^[[33m 487^[[2mms^[[22m^[[39m\nCI / Test\tUNKNOWN STEP\t2026-05-30T16:59:16.4384420Z  ^[[32m✓^[[39m src/agent/tools/telegram/tasks/__tests__/recurring-and-update-tasks.test.ts ^[[2m(^[[22m^[[2m28 tests^[[22m^[[2m)^[[22m^[[32m 257^[[2mms^[[22m^[[39m\nCI / Test\tUNKNOWN STEP\t2026-05-30T16:59:16.6285517Z  ^[[32m✓^[[39m src/agent/__tests__/lifecycle-e2e.test.ts ^[[2m(^[[22m^[[2m10 tests^[[22m^[[2m)^[[22m^[[33m 317^[[2mms^[[22m^[[39m\nCI / Test\tUNKNOWN STEP\t2026-05-30T16:59:17.0164460Z [16:59:17] ^[[31mERROR^[[39m: ^[[36m[AutonomousLoop] Hit global max-iteration safety cap — this is not a normal maxIterations stop^[[39m\nCI / Test\tUNKNOWN STEP\t2026-05-30T16:59:17.0305651Z  ^[[32m✓^[[39m src/autonomous/__tests__/loop.test.ts ^[[2m(^[[22m^[[2m15 tests^[[22m^[[2m)^[[22m^[[32m 283^[[2mms^[[22m^[[39m\nCI / Test\tUNKNOWN STEP\t2026-05-30T16:59:17.1942517Z  ^[[32m✓^[[39m src/autonomous/__tests__/autonomous-tasks.test.ts ^[[2m(^[[22m^[[2m30 tests^[[22m^[[2m)^[[22m^[[32m 292^[[2mms^[[22m^[[39m\nCI / Test\tUNKNOWN STEP\t2026-05-30T16:59:17.6138138Z  ^[[32m✓^[[39m src/agent/tools/exec/__tests__/tools.test.ts ^[[2m(^[[22m^[[2m40 tests^[[22m^[[2m)^[[22m^[[32m 161^[[2mms^[[22m^[[39m\nCI / Test\tUNKNOWN STEP\t2026-05-30T16:59:17.6432827Z  ^[[32m✓^[[39m src/config/__tests__/configurable-keys.test.ts ^[[2m(^[[22m^[[2m72 tests^[[22m^[[2m)^[[22m^[[32m 22^[[2mms^[[22m^[[39m\nCI / Test\tUNKNOWN STEP\t2026-05-30T16:59:17.9196187Z  ^[[32m✓^[[39m src/services/pipeline/__tests__/executor.test.ts ^[[2m(^[[22m^[[2m9 tests^[[22m^[[2m)^[[22m^[[32m 66^[[2mms^[[22m^[[39m\nCI / Test\tUNKNOWN STEP\t2026-05-30T16:59:18.2832646Z [16:59:18] ^[[33mWARN^[[39m: ^[[36m[memory-routes] Memory route search embedding failed; using keyword fallback^[[39m\nCI / Test\tUNKNOWN STEP\t2026-05-30T16:59:18.2834052Z       \"type\": \"Error\",\nCI / Test\tUNKNOWN STEP\t2026-05-30T16:59:18.2835441Z           Error: embedding unavailable\nCI / Test\tUNKNOWN STEP\t2026-05-30T16:59:18.2851149Z [16:59:18] ^[[33mWARN^[[39m: ^[[36m[Memory] Semantic Memory: Fallback Mode (Upstash Vector search failed)^[[39m\nCI / Test\tUNKNOWN STEP\t2026-05-30T16:59:18.2852409Z       \"type\": \"Error\",",
+[2026-05-30T17:19:07.889Z] [INFO]         "is_error": false
+[2026-05-30T17:19:07.889Z] [INFO]       }
+[2026-05-30T17:19:07.889Z] [INFO]     ]
+[2026-05-30T17:19:07.889Z] [INFO]   },
+[2026-05-30T17:19:07.889Z] [INFO]   "parent_tool_use_id": null,
+[2026-05-30T17:19:07.889Z] [INFO]   "session_id": "45441128-80e2-48c1-a2ea-f81ede05030b",
+[2026-05-30T17:19:07.889Z] [INFO]   "uuid": "159c646e-2d76-4971-86a3-402ab75f2ae6",
+[2026-05-30T17:19:07.889Z] [INFO]   "timestamp": "2026-05-30T17:19:07.886Z",
+[2026-05-30T17:19:07.889Z] [INFO]   "tool_use_result": {
+[2026-05-30T17:19:07.889Z] [INFO]     "stdout": "CI / Test\tUNKNOWN STEP\t2026-05-30T16:59:09.5103252Z  ^[[32m✓^[[39m src/api/__tests__/api-server.test.ts ^[[2m(^[[22m^[[2m69 tests^[[22m^[[2m)^[[22m^[[33m 356^[[2mms^[[22m^[[39m\nCI / Test\tUNKNOWN STEP\t2026-05-30T16:59:09.6001225Z  ^[[32m✓^[[39m src/sdk/__tests__/ton.test.ts ^[[2m(^[[22m^[[2m139 tests^[[22m^[[2m)^[[22m^[[32m 107^[[2mms^[[22m^[[39m\nCI / Test\tUNKNOWN STEP\t2026-05-30T16:59:09.9543835Z  ^[[32m✓^[[39m src/memory/__tests__/schema.test.ts ^[[2m(^[[22m^[[2m81 tests^[[22m^[[2m)^[[22m^[[33m 883^[[2mms^[[22m^[[39m\nCI / Test\tUNKNOWN STEP\t2026-05-30T16:59:10.0882515Z  ^[[32m✓^[[39m src/sdk/__tests__/telegram-social.test.ts ^[[2m(^[[22m^[[2m80 tests^[[22m^[[2m)^[[22m^[[32m 78^[[2mms^[[22m^[[39m\nCI / Test\tUNKNOWN STEP\t2026-05-30T16:59:10.4014445Z  ^[[32m✓^[[39m src/webui/__tests__/setup-routes.test.ts ^[[2m(^[[22m^[[2m63 tests^[[22m^[[2m)^[[22m^[[32m 210^[[2mms^[[22m^[[39m\nCI / Test\tUNKNOWN STEP\t2026-05-30T16:59:10.7131348Z  ^[[32m✓^[[39m src/config/__tests__/loader.test.ts ^[[2m(^[[22m^[[2m57 tests^[[22m^[[2m)^[[22m^[[32m 237^[[2mms^[[22m^[[39m\nCI / Test\tUNKNOWN STEP\t2026-05-30T16:59:11.0148395Z  ^[[32m✓^[[39m src/webui/__tests__/hooks-routes.test.ts ^[[2m(^[[22m^[[2m47 tests^[[22m^[[2m)^[[22m^[[32m 194^[[2mms^[[22m^[[39m\nCI / Test\tUNKNOWN STEP\t2026-05-30T16:59:11.3352066Z  ^[[32m✓^[[39m src/utils/__tests__/sanitize.test.ts ^[[2m(^[[22m^[[2m144 tests^[[22m^[[2m)^[[22m^[[32m 35^[[2mms^[[22m^[[39m\nCI / Test\tUNKNOWN STEP\t2026-05-30T16:59:11.3376870Z  ^[[32m✓^[[39m src/telegram/__tests__/handlers.test.ts ^[[2m(^[[22m^[[2m53 tests^[[22m^[[2m)^[[22m^[[32m 210^[[2mms^[[22m^[[39m\nCI / Test\tUNKNOWN STEP\t2026-05-30T16:59:11.7023396Z  ^[[32m✓^[[39m src/agent/__tests__/runtime-hooks.test.ts ^[[2m(^[[22m^[[2m28 tests^[[22m^[[2m)^[[22m^[[32m 97^[[2mms^[[22m^[[39m\nCI / Test\tUNKNOWN STEP\t2026-05-30T16:59:11.8305882Z  ^[[32m✓^[[39m src/agent/__tests__/runtime-utils.test.ts ^[[2m(^[[22m^[[2m87 tests^[[22m^[[2m)^[[22m^[[32m 41^[[2mms^[[22m^[[39m\nCI / Test\tUNKNOWN STEP\t2026-05-30T16:59:12.1571642Z  ^[[32m✓^[[39m src/workspace/__tests__/validator.test.ts ^[[2m(^[[22m^[[2m78 tests^[[22m^[[2m)^[[22m^[[32m 178^[[2mms^[[22m^[[39m\nCI / Test\tUNKNOWN STEP\t2026-05-30T16:59:12.2024562Z  ^[[32m✓^[[39m src/telegram/__tests__/client-proxy.test.ts ^[[2m(^[[22m^[[2m21 tests^[[22m^[[2m)^[[22m^[[32m 33^[[2mms^[[22m^[[39m\nCI / Test\tUNKNOWN STEP\t2026-05-30T16:59:12.5623115Z  ^[[32m✓^[[39m src/sdk/__tests__/telegram-messages.test.ts ^[[2m(^[[22m^[[2m54 tests^[[22m^[[2m)^[[22m^[[32m 40^[[2mms^[[22m^[[39m\nCI / Test\tUNKNOWN STEP\t2026-05-30T16:59:12.7162943Z  ^[[32m✓^[[39m src/webui/__tests__/security-routes.test.ts ^[[2m(^[[22m^[[2m35 tests^[[22m^[[2m)^[[22m^[[32m 104^[[2mms^[[22m^[[39m\nCI / Test\tUNKNOWN STEP\t2026-05-30T16:59:13.1864582Z  ^[[32m✓^[[39m src/webui/__tests__/agents-routes.test.ts ^[[2m(^[[22m^[[2m18 tests^[[22m^[[2m)^[[22m^[[32m 112^[[2mms^[[22m^[[39m\nCI / Test\tUNKNOWN STEP\t2026-05-30T16:59:13.5149228Z [16:59:13] ^[[31mERROR^[[39m: ^[[36m[Memory] Vector search error (knowledge)^[[39m\nCI / Test\tUNKNOWN STEP\t2026-05-30T16:59:13.5150410Z       \"type\": \"SqliteError\",\nCI / Test\tUNKNOWN STEP\t2026-05-30T16:59:13.5152233Z           SqliteError: no such table: knowledge_vec\nCI / Test\tUNKNOWN STEP\t2026-05-30T16:59:13.5160059Z       \"code\": \"SQLITE_ERROR\"\nCI / Test\tUNKNOWN STEP\t2026-05-30T16:59:13.5161439Z [16:59:13] ^[[31mERROR^[[39m: ^[[36m[Memory] Vector search error (messages)^[[39m\nCI / Test\tUNKNOWN STEP\t2026-05-30T16:59:13.5162078Z       \"type\": \"SqliteError\",\nCI / Test\tUNKNOWN STEP\t2026-05-30T16:59:13.5163209Z           SqliteError: no such table: tg_messages_vec\nCI / Test\tUNKNOWN STEP\t2026-05-30T16:59:13.5175243Z       \"code\": \"SQLITE_ERROR\"\nCI / Test\tUNKNOWN STEP\t2026-05-30T16:59:13.5176533Z [16:59:13] ^[[31mERROR^[[39m: ^[[36m[Memory] Vector search error (knowledge)^[[39m\nCI / Test\tUNKNOWN STEP\t2026-05-30T16:59:13.5177558Z       \"type\": \"SqliteError\",\nCI / Test\tUNKNOWN STEP\t2026-05-30T16:59:13.5179183Z           SqliteError: no such table: knowledge_vec\nCI / Test\tUNKNOWN STEP\t2026-05-30T16:59:13.5185219Z       \"code\": \"SQLITE_ERROR\"\nCI / Test\tUNKNOWN STEP\t2026-05-30T16:59:13.5414217Z  ^[[32m✓^[[39m src/memory/__tests__/hybrid-search.test.ts ^[[2m(^[[22m^[[2m43 tests^[[22m^[[2m)^[[22m^[[33m 382^[[2mms^[[22m^[[39m\nCI / Test\tUNKNOWN STEP\t2026-05-30T16:59:14.0457772Z  ^[[32m✓^[[39m src/webui/__tests__/network-routes.test.ts ^[[2m(^[[22m^[[2m13 tests^[[22m^[[2m)^[[22m^[[32m 283^[[2mms^[[22m^[[39m\nCI / Test\tUNKNOWN STEP\t2026-05-30T16:59:14.0911866Z [16:59:14] ^[[31mERROR^[[39m: ^[[36m[Registry] Error executing tool error_tool^[[39m\nCI / Test\tUNKNOWN STEP\t2026-05-30T16:59:14.0944393Z       \"type\": \"Error\",\nCI / Test\tUNKNOWN STEP\t2026-05-30T16:59:14.0945459Z       \"message\": \"Execution failed\",\nCI / Test\tUNKNOWN STEP\t2026-05-30T16:59:14.0946960Z           Error: Execution failed\nCI / Test\tUNKNOWN STEP\t2026-05-30T16:59:14.1891550Z  ^[[32m✓^[[39m src/agent/tools/__tests__/registry.test.ts ^[[2m(^[[22m^[[2m67 tests^[[22m^[[2m)^[[22m^[[32m 90^[[2mms^[[22m^[[39m\nCI / Test\tUNKNOWN STEP\t2026-05-30T16:59:14.2086704Z [17:00:44] ^[[31mERROR^[[39m: ^[[36m[Registry] Error executing tool slow_tool^[[39m\nCI / Test\tUNKNOWN STEP\t2026-05-30T16:59:14.2088343Z       \"type\": \"Error\",\nCI / Test\tUNKNOWN STEP\t2026-05-30T16:59:14.2090377Z           Error: Tool \"slow_tool\" timed out after 90s\nCI / Test\tUNKNOWN STEP\t2026-05-30T16:59:14.6401685Z  ^[[32m✓^[[39m src/webui/__tests__/soul-routes.test.ts ^[[2m(^[[22m^[[2m32 tests^[[22m^[[2m)^[[22m^[[32m 142^[[2mms^[[22m^[[39m\nCI / Test\tUNKNOWN STEP\t2026-05-30T16:59:14.9863138Z  ^[[32m✓^[[39m src/webui/__tests__/sessions-routes.test.ts ^[[2m(^[[22m^[[2m21 tests^[[22m^[[2m)^[[22m^[[32m 94^[[2mms^[[22m^[[39m\nCI / Test\tUNKNOWN STEP\t2026-05-30T16:59:15.1505536Z  ^[[32m✓^[[39m src/autonomous/__tests__/manager.test.ts ^[[2m(^[[22m^[[2m19 tests^[[22m^[[2m)^[[22m^[[33m 1197^[[2mms^[[22m^[[39m\nCI / Test\tUNKNOWN STEP\t2026-05-30T16:59:15.2543283Z  ^[[32m✓^[[39m src/services/__tests__/analytics.test.ts ^[[2m(^[[22m^[[2m39 tests^[[22m^[[2m)^[[22m^[[32m 46^[[2mms^[[22m^[[39m\nCI / Test\tUNKNOWN STEP\t2026-05-30T16:59:15.2705525Z [16:59:15] ^[[31mERROR^[[39m: ^[[36m[AutonomousIntegration] failed to deliver escalation to Telegram admin^[[39m\nCI / Test\tUNKNOWN STEP\t2026-05-30T16:59:15.2708215Z       \"type\": \"Error\",\nCI / Test\tUNKNOWN STEP\t2026-05-30T16:59:15.2709885Z           Error: bridge offline\nCI / Test\tUNKNOWN STEP\t2026-05-30T16:59:15.3587179Z  ^[[32m✓^[[39m src/autonomous/__tests__/integration.test.ts ^[[2m(^[[22m^[[2m19 tests^[[22m^[[2m)^[[22m^[[32m 185^[[2mms^[[22m^[[39m\nCI / Test\tUNKNOWN STEP\t2026-05-30T16:59:16.0816653Z  ^[[32m✓^[[39m src/memory/__tests__/tasks.test.ts ^[[2m(^[[22m^[[2m42 tests^[[22m^[[2m)^[[22m^[[33m 487^[[2mms^[[22m^[[39m\nCI / Test\tUNKNOWN STEP\t2026-05-30T16:59:16.4384420Z  ^[[32m✓^[[39m src/agent/tools/telegram/tasks/__tests__/recurring-and-update-tasks.test.ts ^[[2m(^[[22m^[[2m28 tests^[[22m^[[2m)^[[22m^[[32m 257^[[2mms^[[22m^[[39m\nCI / Test\tUNKNOWN STEP\t2026-05-30T16:59:16.6285517Z  ^[[32m✓^[[39m src/agent/__tests__/lifecycle-e2e.test.ts ^[[2m(^[[22m^[[2m10 tests^[[22m^[[2m)^[[22m^[[33m 317^[[2mms^[[22m^[[39m\nCI / Test\tUNKNOWN STEP\t2026-05-30T16:59:17.0164460Z [16:59:17] ^[[31mERROR^[[39m: ^[[36m[AutonomousLoop] Hit global max-iteration safety cap — this is not a normal maxIterations stop^[[39m\nCI / Test\tUNKNOWN STEP\t2026-05-30T16:59:17.0305651Z  ^[[32m✓^[[39m src/autonomous/__tests__/loop.test.ts ^[[2m(^[[22m^[[2m15 tests^[[22m^[[2m)^[[22m^[[32m 283^[[2mms^[[22m^[[39m\nCI / Test\tUNKNOWN STEP\t2026-05-30T16:59:17.1942517Z  ^[[32m✓^[[39m src/autonomous/__tests__/autonomous-tasks.test.ts ^[[2m(^[[22m^[[2m30 tests^[[22m^[[2m)^[[22m^[[32m 292^[[2mms^[[22m^[[39m\nCI / Test\tUNKNOWN STEP\t2026-05-30T16:59:17.6138138Z  ^[[32m✓^[[39m src/agent/tools/exec/__tests__/tools.test.ts ^[[2m(^[[22m^[[2m40 tests^[[22m^[[2m)^[[22m^[[32m 161^[[2mms^[[22m^[[39m\nCI / Test\tUNKNOWN STEP\t2026-05-30T16:59:17.6432827Z  ^[[32m✓^[[39m src/config/__tests__/configurable-keys.test.ts ^[[2m(^[[22m^[[2m72 tests^[[22m^[[2m)^[[22m^[[32m 22^[[2mms^[[22m^[[39m\nCI / Test\tUNKNOWN STEP\t2026-05-30T16:59:17.9196187Z  ^[[32m✓^[[39m src/services/pipeline/__tests__/executor.test.ts ^[[2m(^[[22m^[[2m9 tests^[[22m^[[2m)^[[22m^[[32m 66^[[2mms^[[22m^[[39m\nCI / Test\tUNKNOWN STEP\t2026-05-30T16:59:18.2832646Z [16:59:18] ^[[33mWARN^[[39m: ^[[36m[memory-routes] Memory route search embedding failed; using keyword fallback^[[39m\nCI / Test\tUNKNOWN STEP\t2026-05-30T16:59:18.2834052Z       \"type\": \"Error\",\nCI / Test\tUNKNOWN STEP\t2026-05-30T16:59:18.2835441Z           Error: embedding unavailable\nCI / Test\tUNKNOWN STEP\t2026-05-30T16:59:18.2851149Z [16:59:18] ^[[33mWARN^[[39m: ^[[36m[Memory] Semantic Memory: Fallback Mode (Upstash Vector search failed)^[[39m\nCI / Test\tUNKNOWN STEP\t2026-05-30T16:59:18.2852409Z       \"type\": \"Error\",",
+[2026-05-30T17:19:07.889Z] [INFO]     "stderr": "",
+[2026-05-30T17:19:07.889Z] [INFO]     "interrupted": false,
+[2026-05-30T17:19:07.889Z] [INFO]     "isImage": false,
+[2026-05-30T17:19:07.889Z] [INFO]     "noOutputExpected": false
+[2026-05-30T17:19:07.889Z] [INFO]   }
+[2026-05-30T17:19:07.889Z] [INFO] }
+[2026-05-30T17:19:07.900Z] [INFO] [log_b40243] sending request {
+[2026-05-30T17:19:07.901Z] [INFO]   method: "post",
+[2026-05-30T17:19:07.901Z] [INFO]   url: "https://api.anthropic.com/v1/messages?beta=true",
+[2026-05-30T17:19:07.901Z] [INFO]   options: {
+[2026-05-30T17:19:07.902Z] [INFO]     method: "post",
+[2026-05-30T17:19:07.902Z] [INFO]     path: "/v1/messages?beta=true",
+[2026-05-30T17:19:07.902Z] [INFO]     body: {
+[2026-05-30T17:19:07.903Z] [INFO]       model: "claude-opus-4-8",
+[2026-05-30T17:19:07.903Z] [INFO]       messages: [
+[2026-05-30T17:19:07.904Z] [INFO]         [Object ...], [Object ...], [Object ...], [Object ...], [Object ...], [Object ...], [Object ...], [Object ...], [Object ...], [Object ...], [Object ...]
+[2026-05-30T17:19:07.904Z] [INFO]       ],
+[2026-05-30T17:19:07.904Z] [INFO]       system: [
+[2026-05-30T17:19:07.905Z] [INFO]         [Object ...], [Object ...], [Object ...], [Object ...]
+[2026-05-30T17:19:07.905Z] [INFO]       ],
+[2026-05-30T17:19:07.905Z] [INFO]       tools: [
+[2026-05-30T17:19:07.906Z] [INFO]         [Object ...], [Object ...], [Object ...], [Object ...], [Object ...], [Object ...], [Object ...], [Object ...], [Object ...], [Object ...]
+[2026-05-30T17:19:07.906Z] [INFO]       ],
+[2026-05-30T17:19:07.906Z] [INFO]       tool_choice: undefined,
+[2026-05-30T17:19:07.906Z] [INFO]       metadata: [Object ...],
+[2026-05-30T17:19:07.907Z] [INFO]       max_tokens: 128000,
+[2026-05-30T17:19:07.907Z] [INFO]       thinking: [Object ...],
+[2026-05-30T17:19:07.907Z] [INFO]       context_management: [Object ...],
+[2026-05-30T17:19:07.908Z] [INFO]       output_config: [Object ...],
+[2026-05-30T17:19:07.908Z] [INFO]       diagnostics: [Object ...],
+[2026-05-30T17:19:07.909Z] [INFO]       stream: true,
+[2026-05-30T17:19:07.910Z] [INFO]     },
+[2026-05-30T17:19:07.910Z] [INFO]     timeout: 600000,
+[2026-05-30T17:19:07.911Z] [INFO]     signal: AbortSignal {
+[2026-05-30T17:19:07.912Z] [INFO]       [Symbol(events.maxEventTargetListeners)]: 50,
+[2026-05-30T17:19:07.912Z] [INFO]       [Symbol(events.maxEventTargetListenersWarned)]: false,
+[2026-05-30T17:19:07.913Z] [INFO]       aborted: false,
+[2026-05-30T17:19:07.913Z] [INFO]       reason: undefined,
+[2026-05-30T17:19:07.914Z] [INFO]       onabort: null,
+[2026-05-30T17:19:07.914Z] [INFO]       throwIfAborted: [Function: throwIfAborted],
+[2026-05-30T17:19:07.914Z] [INFO]       addEventListener: [Function: addEventListener],
+[2026-05-30T17:19:07.915Z] [INFO]       removeEventListener: [Function: removeEventListener],
+[2026-05-30T17:19:07.915Z] [INFO]       dispatchEvent: [Function: dispatchEvent],
+[2026-05-30T17:19:07.916Z] [INFO]     },
+[2026-05-30T17:19:07.916Z] [INFO]     stream: true,
+[2026-05-30T17:19:07.916Z] [INFO]   },
+[2026-05-30T17:19:07.917Z] [INFO]   headers: {
+[2026-05-30T17:19:07.917Z] [INFO]     accept: "application/json",
+[2026-05-30T17:19:07.918Z] [INFO]     "anthropic-beta": "claude-code-20250219,oauth-2025-04-20,interleaved-thinking-2025-05-14,thinking-token-count-2026-05-13,context-management-2025-06-27,prompt-caching-scope-2026-01-05,mid-conversation-system-2026-04-07,advisor-tool-2026-03-01,advanced-tool-use-2025-11-20,effort-2025-11-24,extended-cache-ttl-2025-04-11,cache-diagnosis-2026-04-07",
+[2026-05-30T17:19:07.918Z] [INFO]     "anthropic-dangerous-direct-browser-access": "true",
+[2026-05-30T17:19:07.918Z] [INFO]     "anthropic-version": "2023-06-01",
+[2026-05-30T17:19:07.918Z] [INFO]     authorization: "***",
+[2026-05-30T17:19:07.919Z] [INFO]     "content-type": "application/json",
+[2026-05-30T17:19:07.919Z] [INFO]     "user-agent": "claude-cli/2.1.158 (external, sdk-cli)",
+[2026-05-30T17:19:07.920Z] [INFO]     "x-app": "cli",
+[2026-05-30T17:19:07.920Z] [INFO]     "x-claude-code-session-id": "45441128-80e2-48c1-a2ea-f81ede05030b",
+[2026-05-30T17:19:07.920Z] [INFO]     "x-client-request-id": "88351719-b842-425a-a361-d9b4780fd4c3",
+[2026-05-30T17:19:07.921Z] [INFO]     "x-stainless-arch": "x64",
+[2026-05-30T17:19:07.921Z] [INFO]     "x-stainless-lang": "js",
+[2026-05-30T17:19:07.922Z] [INFO]     "x-stainless-os": "Linux",
+[2026-05-30T17:19:07.922Z] [INFO]     "x-stainless-package-version": "0.94.0",
+[2026-05-30T17:19:07.922Z] [INFO]     "x-stainless-retry-count": "0",
+[2026-05-30T17:19:07.922Z] [INFO]     "x-stainless-runtime": "node",
+[2026-05-30T17:19:07.923Z] [INFO]     "x-stainless-runtime-version": "v24.3.0",
+[2026-05-30T17:19:07.923Z] [INFO]     "x-stainless-timeout": "600",
+[2026-05-30T17:19:07.923Z] [INFO]   },
+[2026-05-30T17:19:07.924Z] [INFO] }
+[2026-05-30T17:19:09.199Z] [INFO] [log_b40243, request-id: "req_011CbZ8pX9DJAEwYQAKMfVLa"] post https://api.anthropic.com/v1/messages?beta=true succeeded with status 200 in 1298ms
+[2026-05-30T17:19:09.200Z] [INFO] [log_b40243] response start {
+[2026-05-30T17:19:09.200Z] [INFO]   url: "https://api.anthropic.com/v1/messages?beta=true",
+[2026-05-30T17:19:09.201Z] [INFO]   status: 200,
+[2026-05-30T17:19:09.201Z] [INFO]   headers: {
+[2026-05-30T17:19:09.201Z] [INFO]     "anthropic-organization-id": "ebc2ac93-f86f-4d15-aff3-de8830d8d789",
+[2026-05-30T17:19:09.202Z] [INFO]     "anthropic-ratelimit-unified-5h-reset": "1780173000",
+[2026-05-30T17:19:09.203Z] [INFO]     "anthropic-ratelimit-unified-5h-status": "allowed",
+[2026-05-30T17:19:09.203Z] [INFO]     "anthropic-ratelimit-unified-5h-utilization": "0.25",
+[2026-05-30T17:19:09.203Z] [INFO]     "anthropic-ratelimit-unified-7d-reset": "1780398000",
+[2026-05-30T17:19:09.204Z] [INFO]     "anthropic-ratelimit-unified-7d-status": "allowed",
+[2026-05-30T17:19:09.205Z] [INFO]     "anthropic-ratelimit-unified-7d-utilization": "0.73",
+[2026-05-30T17:19:09.205Z] [INFO]     "anthropic-ratelimit-unified-fallback-percentage": "0.5",
+[2026-05-30T17:19:09.205Z] [INFO]     "anthropic-ratelimit-unified-overage-disabled-reason": "org_level_disabled",
+[2026-05-30T17:19:09.206Z] [INFO]     "anthropic-ratelimit-unified-overage-status": "rejected",
+[2026-05-30T17:19:09.206Z] [INFO]     "anthropic-ratelimit-unified-representative-claim": "five_hour",
+[2026-05-30T17:19:09.207Z] [INFO]     "anthropic-ratelimit-unified-reset": "1780173000",
+[2026-05-30T17:19:09.208Z] [INFO]     "anthropic-ratelimit-unified-status": "allowed",
+[2026-05-30T17:19:09.208Z] [INFO]     "cache-control": "no-cache",
+[2026-05-30T17:19:09.208Z] [INFO]     "cf-cache-status": "DYNAMIC",
+[2026-05-30T17:19:09.209Z] [INFO]     "cf-ray": "a03f66ea6ed8976a-FRA",
+[2026-05-30T17:19:09.209Z] [INFO]     connection: "keep-alive",
+[2026-05-30T17:19:09.209Z] [INFO]     "content-encoding": "gzip",
+[2026-05-30T17:19:09.209Z] [INFO]     "content-security-policy": "default-src 'none'; frame-ancestors 'none'",
+[2026-05-30T17:19:09.210Z] [INFO]     "content-type": "text/event-stream; charset=utf-8",
+[2026-05-30T17:19:09.210Z] [INFO]     date: "Sat, 30 May 2026 17:19:09 GMT",
+[2026-05-30T17:19:09.210Z] [INFO]     "request-id": "req_011CbZ8pX9DJAEwYQAKMfVLa",
+[2026-05-30T17:19:09.210Z] [INFO]     server: "cloudflare",
+[2026-05-30T17:19:09.211Z] [INFO]     "strict-transport-security": "max-age=31536000; includeSubDomains; preload",
+[2026-05-30T17:19:09.211Z] [INFO]     traceresponse: "00-964f2ad99d2baf694f8b608ada39b482-2bc32e2bca5dee4a-01",
+[2026-05-30T17:19:09.213Z] [INFO]     "transfer-encoding": "chunked",
+[2026-05-30T17:19:09.213Z] [INFO]     vary: "Accept-Encoding",
+[2026-05-30T17:19:09.214Z] [INFO]     "x-robots-tag": "none",
+[2026-05-30T17:19:09.214Z] [INFO]     "set-cookie": "***",
+[2026-05-30T17:19:09.215Z] [INFO]   },
+[2026-05-30T17:19:09.215Z] [INFO]   durationMs: 1298,
+[2026-05-30T17:19:09.215Z] [INFO] }
+[2026-05-30T17:19:09.216Z] [INFO] response 200 https://api.anthropic.com/v1/messages?beta=true Headers {
+[2026-05-30T17:19:09.218Z] [INFO]   "date": "Sat, 30 May 2026 17:19:09 GMT",
+[2026-05-30T17:19:09.220Z] [INFO]   "content-type": "text/event-stream; charset=utf-8",
+[2026-05-30T17:19:09.221Z] [INFO]   "transfer-encoding": "chunked",
+[2026-05-30T17:19:09.221Z] [INFO]   "connection": "keep-alive",
+[2026-05-30T17:19:09.222Z] [INFO]   "cache-control": "no-cache",
+[2026-05-30T17:19:09.223Z] [INFO]   "strict-transport-security": "max-age=31536000; includeSubDomains; preload",
+[2026-05-30T17:19:09.223Z] [INFO]   "content-encoding": "gzip",
+[2026-05-30T17:19:09.224Z] [INFO]   "vary": "Accept-Encoding",
+[2026-05-30T17:19:09.225Z] [INFO]   "content-security-policy": "default-src 'none'; frame-ancestors 'none'",
+[2026-05-30T17:19:09.225Z] [INFO]   "set-cookie": [ "_cfuvid=ZlEX_qrDidRDq6pRZvDGGb7Kk3zzx2skBd0CRZhFgDE-1780161547.9097733-1.0.1.1-PRoMHUnkt1GcPpr2GaY7dt9suu9tiObnUpcJO40dwLU; HttpOnly; SameSite=None; Secure; Path=/; Domain=api.anthropic.com" ],
+[2026-05-30T17:19:09.227Z] [INFO]   "anthropic-ratelimit-unified-status": "allowed",
+[2026-05-30T17:19:09.227Z] [INFO]   "anthropic-ratelimit-unified-5h-status": "allowed",
+[2026-05-30T17:19:09.228Z] [INFO]   "anthropic-ratelimit-unified-5h-reset": "1780173000",
+[2026-05-30T17:19:09.228Z] [INFO]   "anthropic-ratelimit-unified-5h-utilization": "0.25",
+[2026-05-30T17:19:09.229Z] [INFO]   "anthropic-ratelimit-unified-7d-status": "allowed",
+[2026-05-30T17:19:09.229Z] [INFO]   "anthropic-ratelimit-unified-7d-reset": "1780398000",
+[2026-05-30T17:19:09.230Z] [INFO]   "anthropic-ratelimit-unified-7d-utilization": "0.73",
+[2026-05-30T17:19:09.230Z] [INFO]   "anthropic-ratelimit-unified-representative-claim": "five_hour",
+[2026-05-30T17:19:09.231Z] [INFO]   "anthropic-ratelimit-unified-fallback-percentage": "0.5",
+[2026-05-30T17:19:09.232Z] [INFO]   "anthropic-ratelimit-unified-reset": "1780173000",
+[2026-05-30T17:19:09.232Z] [INFO]   "anthropic-ratelimit-unified-overage-disabled-reason": "org_level_disabled",
+[2026-05-30T17:19:09.234Z] [INFO]   "anthropic-ratelimit-unified-overage-status": "rejected",
+[2026-05-30T17:19:09.234Z] [INFO]   "request-id": "req_011CbZ8pX9DJAEwYQAKMfVLa",
+[2026-05-30T17:19:09.235Z] [INFO]   "anthropic-organization-id": "ebc2ac93-f86f-4d15-aff3-de8830d8d789",
+[2026-05-30T17:19:09.235Z] [INFO]   "traceresponse": "00-964f2ad99d2baf694f8b608ada39b482-2bc32e2bca5dee4a-01",
+[2026-05-30T17:19:09.235Z] [INFO]   "server": "cloudflare",
+[2026-05-30T17:19:09.235Z] [INFO]   "cf-cache-status": "DYNAMIC",
+[2026-05-30T17:19:09.236Z] [INFO]   "x-robots-tag": "none",
+[2026-05-30T17:19:09.238Z] [INFO]   "cf-ray": "a03f66ea6ed8976a-FRA",
+[2026-05-30T17:19:09.239Z] [INFO] } ReadableStream {
+[2026-05-30T17:19:09.240Z] [INFO]   blob: [Function: blob],
+[2026-05-30T17:19:09.240Z] [INFO]   bytes: [Function: bytes],
+[2026-05-30T17:19:09.241Z] [INFO]   cancel: [Function],
+[2026-05-30T17:19:09.242Z] [INFO]   getReader: [Function],
+[2026-05-30T17:19:09.242Z] [INFO]   json: [Function: json],
+[2026-05-30T17:19:09.243Z] [INFO]   locked: [Getter],
+[2026-05-30T17:19:09.243Z] [INFO]   pipeThrough: [Function],
+[2026-05-30T17:19:09.243Z] [INFO]   pipeTo: [Function],
+[2026-05-30T17:19:09.243Z] [INFO]   tee: [Function],
+[2026-05-30T17:19:09.244Z] [INFO]   text: [Function: text],
+[2026-05-30T17:19:09.244Z] [INFO]   values: [Function: values],
+[2026-05-30T17:19:09.244Z] [INFO]   [Symbol(Symbol.asyncIterator)]: [Function: asyncIterator2],
+[2026-05-30T17:19:09.245Z] [INFO] }
+[2026-05-30T17:19:09.245Z] [INFO] [log_b40243] response parsed {
+[2026-05-30T17:19:09.246Z] [INFO]   url: "https://api.anthropic.com/v1/messages?beta=true",
+[2026-05-30T17:19:09.246Z] [INFO]   status: 200,
+[2026-05-30T17:19:09.247Z] [INFO]   body: bR {
+[2026-05-30T17:19:09.247Z] [INFO]     iterator: [AsyncGeneratorFunction: z],
+[2026-05-30T17:19:09.247Z] [INFO]     controller: AbortController {
+[2026-05-30T17:19:09.248Z] [INFO]       signal: [AbortSignal ...],
+[2026-05-30T17:19:09.248Z] [INFO]       abort: [Function: abort],
+[2026-05-30T17:19:09.248Z] [INFO]     },
+[2026-05-30T17:19:09.249Z] [INFO]     [Symbol(Symbol.asyncIterator)]: [Function],
+[2026-05-30T17:19:09.249Z] [INFO]     tee: [Function: tee],
+[2026-05-30T17:19:09.249Z] [INFO]     toReadableStream: [Function: toReadableStream],
+[2026-05-30T17:19:09.250Z] [INFO]   },
+[2026-05-30T17:19:09.250Z] [INFO]   durationMs: 1298,
+[2026-05-30T17:19:09.250Z] [INFO] }
+[2026-05-30T17:19:10.280Z] [INFO] {
+[2026-05-30T17:19:10.280Z] [INFO]   "type": "assistant",
+[2026-05-30T17:19:10.280Z] [INFO]   "message": {
+[2026-05-30T17:19:10.280Z] [INFO]     "model": "claude-opus-4-8",
+[2026-05-30T17:19:10.280Z] [INFO]     "id": "msg_01LqJEFrHsJRCxRih8fumSb3",
+[2026-05-30T17:19:10.280Z] [INFO]     "type": "message",
+[2026-05-30T17:19:10.280Z] [INFO]     "role": "assistant",
+[2026-05-30T17:19:10.280Z] [INFO]     "content": [
+[2026-05-30T17:19:10.280Z] [INFO]       {
+[2026-05-30T17:19:10.280Z] [INFO]         "type": "thinking",
+[2026-05-30T17:19:10.280Z] [INFO]         "thinking": "",
+[2026-05-30T17:19:10.280Z] [INFO]         "signature": "Es4CCmMIDhgCKkCd12IuWJIP1wgLikBKf3TasYOgnQ1D8d33cw7BEY7rc2hDWJFOZ6twQIcfgPaPK9wUfZh4uHkT1qbWxACBbUvbMg9jbGF1ZGUtb3B1cy00LTg4AEIIdGhpbmtpbmcSDE7sZZyUBTaKU2wTjBoMURlyNyxBqmc3GwoTIjD0Fd2iDP1gY66FOC7Xp1hOheP9Mkwn9G9JT3h1A+9e25txpwhB6+ejCrieRqs5gZsqmAGnB91uxf3Hul2IIp3iAyfyp5FESg9nQBV8U5LbLjGK2FZaWjj9Zh8Sy+7yyjEvGJtZHqmVCDfM4/TnN6YzYx5vlD0xl7bA3gC1yYh5HplVu2AHyGHClZPAaSqAjc4K4nUb8PRb7+nQVc+emx0880XQydn7wb+cXvPyKTOkJA9bvVJ9PX/1Ze7PKLh9mFeE/1fyx/khwCEkiBgB"
+[2026-05-30T17:19:10.280Z] [INFO]       }
+[2026-05-30T17:19:10.280Z] [INFO]     ],
+[2026-05-30T17:19:10.280Z] [INFO]     "stop_reason": null,
+[2026-05-30T17:19:10.280Z] [INFO]     "stop_sequence": null,
+[2026-05-30T17:19:10.280Z] [INFO]     "stop_details": null,
+[2026-05-30T17:19:10.280Z] [INFO]     "usage": {
+[2026-05-30T17:19:10.280Z] [INFO]       "input_tokens": 2,
+[2026-05-30T17:19:10.280Z] [INFO]       "cache_creation_input_tokens": 6179,
+[2026-05-30T17:19:10.280Z] [INFO]       "cache_read_input_tokens": 36323,
+[2026-05-30T17:19:10.280Z] [INFO]       "cache_creation": {
+[2026-05-30T17:19:10.280Z] [INFO]         "ephemeral_5m_input_tokens": 0,
+[2026-05-30T17:19:10.280Z] [INFO]         "ephemeral_1h_input_tokens": 6179
+[2026-05-30T17:19:10.280Z] [INFO]       },
+[2026-05-30T17:19:10.280Z] [INFO]       "output_tokens": 4,
+[2026-05-30T17:19:10.280Z] [INFO]       "service_tier": "standard",
+[2026-05-30T17:19:10.280Z] [INFO]       "inference_geo": "not_available"
+[2026-05-30T17:19:10.280Z] [INFO]     },
+[2026-05-30T17:19:10.280Z] [INFO]     "diagnostics": null,
+[2026-05-30T17:19:10.280Z] [INFO]     "context_management": null
+[2026-05-30T17:19:10.280Z] [INFO]   },
+[2026-05-30T17:19:10.280Z] [INFO]   "parent_tool_use_id": null,
+[2026-05-30T17:19:10.280Z] [INFO]   "session_id": "45441128-80e2-48c1-a2ea-f81ede05030b",
+[2026-05-30T17:19:10.280Z] [INFO]   "uuid": "524ee6f0-1f05-4e0e-b6c2-120258e19f81",
+[2026-05-30T17:19:10.280Z] [INFO]   "request_id": "req_011CbZ8pX9DJAEwYQAKMfVLa"
+[2026-05-30T17:19:10.280Z] [INFO] }
+[2026-05-30T17:19:13.086Z] [INFO] {
+[2026-05-30T17:19:13.086Z] [INFO]   "type": "assistant",
+[2026-05-30T17:19:13.086Z] [INFO]   "message": {
+[2026-05-30T17:19:13.086Z] [INFO]     "model": "claude-opus-4-8",
+[2026-05-30T17:19:13.086Z] [INFO]     "id": "msg_01LqJEFrHsJRCxRih8fumSb3",
+[2026-05-30T17:19:13.086Z] [INFO]     "type": "message",
+[2026-05-30T17:19:13.086Z] [INFO]     "role": "assistant",
+[2026-05-30T17:19:13.086Z] [INFO]     "content": [
+[2026-05-30T17:19:13.086Z] [INFO]       {
+[2026-05-30T17:19:13.086Z] [INFO]         "type": "tool_use",
+[2026-05-30T17:19:13.086Z] [INFO]         "id": "toolu_01GPn7euYM8SLQuimzs4r43N",
+[2026-05-30T17:19:13.086Z] [INFO]         "name": "Bash",
+[2026-05-30T17:19:13.086Z] [INFO]         "input": {
+[2026-05-30T17:19:13.086Z] [INFO]           "command": "cd /tmp/gh-issue-solver-1780161489554\ngh run view 26689643842 --repo xlabtg/teleton-agent --log-failed 2>/dev/null > /tmp/test-fail.log\ngrep -nE \"✗|FAIL |Test Files|Tests |failed|Process completed with exit\" /tmp/test-fail.log | head -40",
+[2026-05-30T17:19:13.086Z] [INFO]           "description": "Find failing test summary"
+[2026-05-30T17:19:13.086Z] [INFO]         },
+[2026-05-30T17:19:13.086Z] [INFO]         "caller": {
+[2026-05-30T17:19:13.086Z] [INFO]           "type": "direct"
+[2026-05-30T17:19:13.086Z] [INFO]         }
+[2026-05-30T17:19:13.086Z] [INFO]       }
+[2026-05-30T17:19:13.086Z] [INFO]     ],
+[2026-05-30T17:19:13.086Z] [INFO]     "stop_reason": null,
+[2026-05-30T17:19:13.086Z] [INFO]     "stop_sequence": null,
+[2026-05-30T17:19:13.086Z] [INFO]     "stop_details": null,
+[2026-05-30T17:19:13.086Z] [INFO]     "usage": {
+[2026-05-30T17:19:13.086Z] [INFO]       "input_tokens": 2,
+[2026-05-30T17:19:13.086Z] [INFO]       "cache_creation_input_tokens": 6179,
+[2026-05-30T17:19:13.086Z] [INFO]       "cache_read_input_tokens": 36323,
+[2026-05-30T17:19:13.086Z] [INFO]       "cache_creation": {
+[2026-05-30T17:19:13.086Z] [INFO]         "ephemeral_5m_input_tokens": 0,
+[2026-05-30T17:19:13.086Z] [INFO]         "ephemeral_1h_input_tokens": 6179
+[2026-05-30T17:19:13.086Z] [INFO]       },
+[2026-05-30T17:19:13.086Z] [INFO]       "output_tokens": 4,
+[2026-05-30T17:19:13.086Z] [INFO]       "service_tier": "standard",
+[2026-05-30T17:19:13.086Z] [INFO]       "inference_geo": "not_available"
+[2026-05-30T17:19:13.086Z] [INFO]     },
+[2026-05-30T17:19:13.086Z] [INFO]     "diagnostics": null,
+[2026-05-30T17:19:13.086Z] [INFO]     "context_management": null
+[2026-05-30T17:19:13.086Z] [INFO]   },
+[2026-05-30T17:19:13.086Z] [INFO]   "parent_tool_use_id": null,
+[2026-05-30T17:19:13.086Z] [INFO]   "session_id": "45441128-80e2-48c1-a2ea-f81ede05030b",
+[2026-05-30T17:19:13.086Z] [INFO]   "uuid": "ce0ee23f-56fa-4fb1-8a1d-a239421a5f67",
+[2026-05-30T17:19:13.086Z] [INFO]   "request_id": "req_011CbZ8pX9DJAEwYQAKMfVLa"
+[2026-05-30T17:19:13.086Z] [INFO] }
+[2026-05-30T17:19:15.840Z] [INFO] {
+[2026-05-30T17:19:15.840Z] [INFO]   "type": "user",
+[2026-05-30T17:19:15.840Z] [INFO]   "message": {
+[2026-05-30T17:19:15.840Z] [INFO]     "role": "user",
+[2026-05-30T17:19:15.840Z] [INFO]     "content": [
+[2026-05-30T17:19:15.840Z] [INFO]       {
+[2026-05-30T17:19:15.840Z] [INFO]         "tool_use_id": "toolu_01GPn7euYM8SLQuimzs4r43N",
+[2026-05-30T17:19:15.840Z] [INFO]         "type": "tool_result",
+[2026-05-30T17:19:15.840Z] [INFO]         "content": "1110:CI / Test\tUNKNOWN STEP\t2026-05-30T16:59:14.0945459Z       \"message\": \"Execution failed\",\n1112:CI / Test\tUNKNOWN STEP\t2026-05-30T16:59:14.0946960Z           Error: Execution failed\n1663:CI / Test\tUNKNOWN STEP\t2026-05-30T16:59:15.2705525Z [16:59:15] ^[[31mERROR^[[39m: ^[[36m[AutonomousIntegration] failed to deliver escalation to Telegram admin^[[39m\n1833:CI / Test\tUNKNOWN STEP\t2026-05-30T16:59:18.2832646Z [16:59:18] ^[[33mWARN^[[39m: ^[[36m[memory-routes] Memory route search embedding failed; using keyword fallback^[[39m\n1850:CI / Test\tUNKNOWN STEP\t2026-05-30T16:59:18.2851149Z [16:59:18] ^[[33mWARN^[[39m: ^[[36m[Memory] Semantic Memory: Fallback Mode (Upstash Vector search failed)^[[39m\n1988:CI / Test\tUNKNOWN STEP\t2026-05-30T16:59:24.9691349Z [16:59:24] ^[[31mERROR^[[39m: ^[[36m[InlineRouter] Plugin \"fail\" inline query handler failed^[[39m\n2013:CI / Test\tUNKNOWN STEP\t2026-05-30T16:59:24.9745877Z [16:59:24] ^[[31mERROR^[[39m: ^[[36m[InlineRouter] Plugin \"buggy\" inline query handler failed^[[39m\n2279:CI / Test\tUNKNOWN STEP\t2026-05-30T16:59:27.5501970Z [16:59:27] ^[[33mWARN^[[39m: ^[[36m[Tools] Groq STT failed for msg 42, falling back to Telegram native^[[39m\n2356:CI / Test\tUNKNOWN STEP\t2026-05-30T16:59:34.0161731Z [16:59:34] ^[[33mWARN^[[39m: ^[[36m[ClaudeCodeCreds] OAuth token refresh failed: 400 Bad Request^[[39m\n2357:CI / Test\tUNKNOWN STEP\t2026-05-30T16:59:34.0173157Z [16:59:34] ^[[33mWARN^[[39m: ^[[36m[ClaudeCodeCreds] OAuth refresh failed, falling back to disk read^[[39m\n2361:CI / Test\tUNKNOWN STEP\t2026-05-30T16:59:34.1481109Z [16:59:34] ^[[33mWARN^[[39m: ^[[36m[ClaudeCodeCreds] OAuth token refresh failed: 400 Bad Request^[[39m\n2362:CI / Test\tUNKNOWN STEP\t2026-05-30T16:59:34.1502024Z [16:59:34] ^[[33mWARN^[[39m: ^[[36m[ClaudeCodeCreds] OAuth refresh failed, falling back to disk read^[[39m\n2560:CI / Test\tUNKNOWN STEP\t2026-05-30T16:59:52.5762924Z  ^[[31m❯^[[39m src/docs/__tests__/readme.test.ts ^[[2m(^[[22m^[[2m3 tests^[[22m^[[2m | ^[[22m^[[31m1 failed^[[39m^[[2m)^[[22m^[[32m 20^[[2mms^[[22m^[[39m\n2582:CI / Test\tUNKNOWN STEP\t2026-05-30T16:59:58.2682779Z ^[[31m⎯⎯⎯⎯⎯⎯⎯^[[39m^[[1m^[[41m Failed Tests 1 ^[[49m^[[22m^[[31m⎯⎯⎯⎯⎯⎯⎯^[[39m\n2584:CI / Test\tUNKNOWN STEP\t2026-05-30T16:59:58.2684796Z ^[[41m^[[1m FAIL ^[[22m^[[49m src/docs/__tests__/readme.test.ts^[[2m > ^[[22mroot README^[[2m > ^[[22mdocuments the current fork version and WebUI surface\n3418:CI / Test\tUNKNOWN STEP\t2026-05-30T16:59:58.3398576Z ^[[2m Test Files ^[[22m ^[[1m^[[31m1 failed^[[39m^[[22m^[[2m | ^[[22m^[[1m^[[32m215 passed^[[39m^[[22m^[[90m (216)^[[39m\n3419:CI / Test\tUNKNOWN STEP\t2026-05-30T16:59:58.3399395Z ^[[2m      Tests ^[[22m ^[[1m^[[31m1 failed^[[39m^[[22m^[[2m | ^[[22m^[[1m^[[32m3577 passed^[[39m^[[22m^[[90m (3578)^[[39m\n3485:CI / Test\tUNKNOWN STEP\t2026-05-30T16:59:58.3748566Z ##[error]Process completed with exit code 1.",
+[2026-05-30T17:19:15.840Z] [INFO]         "is_error": false
+[2026-05-30T17:19:15.840Z] [INFO]       }
+[2026-05-30T17:19:15.840Z] [INFO]     ]
+[2026-05-30T17:19:15.840Z] [INFO]   },
+[2026-05-30T17:19:15.840Z] [INFO]   "parent_tool_use_id": null,
+[2026-05-30T17:19:15.840Z] [INFO]   "session_id": "45441128-80e2-48c1-a2ea-f81ede05030b",
+[2026-05-30T17:19:15.840Z] [INFO]   "uuid": "38270d7f-8719-4db3-b8d8-499d2e9200a5",
+[2026-05-30T17:19:15.840Z] [INFO]   "timestamp": "2026-05-30T17:19:15.838Z",
+[2026-05-30T17:19:15.840Z] [INFO]   "tool_use_result": {
+[2026-05-30T17:19:15.840Z] [INFO]     "stdout": "1110:CI / Test\tUNKNOWN STEP\t2026-05-30T16:59:14.0945459Z       \"message\": \"Execution failed\",\n1112:CI / Test\tUNKNOWN STEP\t2026-05-30T16:59:14.0946960Z           Error: Execution failed\n1663:CI / Test\tUNKNOWN STEP\t2026-05-30T16:59:15.2705525Z [16:59:15] ^[[31mERROR^[[39m: ^[[36m[AutonomousIntegration] failed to deliver escalation to Telegram admin^[[39m\n1833:CI / Test\tUNKNOWN STEP\t2026-05-30T16:59:18.2832646Z [16:59:18] ^[[33mWARN^[[39m: ^[[36m[memory-routes] Memory route search embedding failed; using keyword fallback^[[39m\n1850:CI / Test\tUNKNOWN STEP\t2026-05-30T16:59:18.2851149Z [16:59:18] ^[[33mWARN^[[39m: ^[[36m[Memory] Semantic Memory: Fallback Mode (Upstash Vector search failed)^[[39m\n1988:CI / Test\tUNKNOWN STEP\t2026-05-30T16:59:24.9691349Z [16:59:24] ^[[31mERROR^[[39m: ^[[36m[InlineRouter] Plugin \"fail\" inline query handler failed^[[39m\n2013:CI / Test\tUNKNOWN STEP\t2026-05-30T16:59:24.9745877Z [16:59:24] ^[[31mERROR^[[39m: ^[[36m[InlineRouter] Plugin \"buggy\" inline query handler failed^[[39m\n2279:CI / Test\tUNKNOWN STEP\t2026-05-30T16:59:27.5501970Z [16:59:27] ^[[33mWARN^[[39m: ^[[36m[Tools] Groq STT failed for msg 42, falling back to Telegram native^[[39m\n2356:CI / Test\tUNKNOWN STEP\t2026-05-30T16:59:34.0161731Z [16:59:34] ^[[33mWARN^[[39m: ^[[36m[ClaudeCodeCreds] OAuth token refresh failed: 400 Bad Request^[[39m\n2357:CI / Test\tUNKNOWN STEP\t2026-05-30T16:59:34.0173157Z [16:59:34] ^[[33mWARN^[[39m: ^[[36m[ClaudeCodeCreds] OAuth refresh failed, falling back to disk read^[[39m\n2361:CI / Test\tUNKNOWN STEP\t2026-05-30T16:59:34.1481109Z [16:59:34] ^[[33mWARN^[[39m: ^[[36m[ClaudeCodeCreds] OAuth token refresh failed: 400 Bad Request^[[39m\n2362:CI / Test\tUNKNOWN STEP\t2026-05-30T16:59:34.1502024Z [16:59:34] ^[[33mWARN^[[39m: ^[[36m[ClaudeCodeCreds] OAuth refresh failed, falling back to disk read^[[39m\n2560:CI / Test\tUNKNOWN STEP\t2026-05-30T16:59:52.5762924Z  ^[[31m❯^[[39m src/docs/__tests__/readme.test.ts ^[[2m(^[[22m^[[2m3 tests^[[22m^[[2m | ^[[22m^[[31m1 failed^[[39m^[[2m)^[[22m^[[32m 20^[[2mms^[[22m^[[39m\n2582:CI / Test\tUNKNOWN STEP\t2026-05-30T16:59:58.2682779Z ^[[31m⎯⎯⎯⎯⎯⎯⎯^[[39m^[[1m^[[41m Failed Tests 1 ^[[49m^[[22m^[[31m⎯⎯⎯⎯⎯⎯⎯^[[39m\n2584:CI / Test\tUNKNOWN STEP\t2026-05-30T16:59:58.2684796Z ^[[41m^[[1m FAIL ^[[22m^[[49m src/docs/__tests__/readme.test.ts^[[2m > ^[[22mroot README^[[2m > ^[[22mdocuments the current fork version and WebUI surface\n3418:CI / Test\tUNKNOWN STEP\t2026-05-30T16:59:58.3398576Z ^[[2m Test Files ^[[22m ^[[1m^[[31m1 failed^[[39m^[[22m^[[2m | ^[[22m^[[1m^[[32m215 passed^[[39m^[[22m^[[90m (216)^[[39m\n3419:CI / Test\tUNKNOWN STEP\t2026-05-30T16:59:58.3399395Z ^[[2m      Tests ^[[22m ^[[1m^[[31m1 failed^[[39m^[[22m^[[2m | ^[[22m^[[1m^[[32m3577 passed^[[39m^[[22m^[[90m (3578)^[[39m\n3485:CI / Test\tUNKNOWN STEP\t2026-05-30T16:59:58.3748566Z ##[error]Process completed with exit code 1.",
+[2026-05-30T17:19:15.840Z] [INFO]     "stderr": "",
+[2026-05-30T17:19:15.840Z] [INFO]     "interrupted": false,
+[2026-05-30T17:19:15.840Z] [INFO]     "isImage": false,
+[2026-05-30T17:19:15.840Z] [INFO]     "noOutputExpected": false
+[2026-05-30T17:19:15.840Z] [INFO]   }
+[2026-05-30T17:19:15.840Z] [INFO] }
+[2026-05-30T17:19:15.852Z] [INFO] [log_9309c6] sending request {
+[2026-05-30T17:19:15.853Z] [INFO]   method: "post",
+[2026-05-30T17:19:15.854Z] [INFO]   url: "https://api.anthropic.com/v1/messages?beta=true",
+[2026-05-30T17:19:15.854Z] [INFO]   options: {
+[2026-05-30T17:19:15.854Z] [INFO]     method: "post",
+[2026-05-30T17:19:15.855Z] [INFO]     path: "/v1/messages?beta=true",
+[2026-05-30T17:19:15.855Z] [INFO]     body: {
+[2026-05-30T17:19:15.855Z] [INFO]       model: "claude-opus-4-8",
+[2026-05-30T17:19:15.856Z] [INFO]       messages: [
+[2026-05-30T17:19:15.856Z] [INFO]         [Object ...], [Object ...], [Object ...], [Object ...], [Object ...], [Object ...], [Object ...], [Object ...], [Object ...], [Object ...], [Object ...], [Object ...], [Object ...], [Object ...]
+[2026-05-30T17:19:15.856Z] [INFO]       ],
+[2026-05-30T17:19:15.856Z] [INFO]       system: [
+[2026-05-30T17:19:15.857Z] [INFO]         [Object ...], [Object ...], [Object ...], [Object ...]
+[2026-05-30T17:19:15.858Z] [INFO]       ],
+[2026-05-30T17:19:15.858Z] [INFO]       tools: [
+[2026-05-30T17:19:15.858Z] [INFO]         [Object ...], [Object ...], [Object ...], [Object ...], [Object ...], [Object ...], [Object ...], [Object ...], [Object ...], [Object ...]
+[2026-05-30T17:19:15.859Z] [INFO]       ],
+[2026-05-30T17:19:15.859Z] [INFO]       tool_choice: undefined,
+[2026-05-30T17:19:15.861Z] [INFO]       metadata: [Object ...],
+[2026-05-30T17:19:15.861Z] [INFO]       max_tokens: 128000,
+[2026-05-30T17:19:15.861Z] [INFO]       thinking: [Object ...],
+[2026-05-30T17:19:15.862Z] [INFO]       context_management: [Object ...],
+[2026-05-30T17:19:15.862Z] [INFO]       output_config: [Object ...],
+[2026-05-30T17:19:15.862Z] [INFO]       diagnostics: [Object ...],
+[2026-05-30T17:19:15.863Z] [INFO]       stream: true,
+[2026-05-30T17:19:15.863Z] [INFO]     },
+[2026-05-30T17:19:15.863Z] [INFO]     timeout: 600000,
+[2026-05-30T17:19:15.863Z] [INFO]     signal: AbortSignal {
+[2026-05-30T17:19:15.864Z] [INFO]       [Symbol(events.maxEventTargetListeners)]: 50,
+[2026-05-30T17:19:15.864Z] [INFO]       [Symbol(events.maxEventTargetListenersWarned)]: false,
+[2026-05-30T17:19:15.864Z] [INFO]       aborted: false,
+[2026-05-30T17:19:15.864Z] [INFO]       reason: undefined,
+[2026-05-30T17:19:15.864Z] [INFO]       onabort: null,
+[2026-05-30T17:19:15.864Z] [INFO]       throwIfAborted: [Function: throwIfAborted],
+[2026-05-30T17:19:15.865Z] [INFO]       addEventListener: [Function: addEventListener],
+[2026-05-30T17:19:15.865Z] [INFO]       removeEventListener: [Function: removeEventListener],
+[2026-05-30T17:19:15.865Z] [INFO]       dispatchEvent: [Function: dispatchEvent],
+[2026-05-30T17:19:15.865Z] [INFO]     },
+[2026-05-30T17:19:15.865Z] [INFO]     stream: true,
+[2026-05-30T17:19:15.866Z] [INFO]   },
+[2026-05-30T17:19:15.866Z] [INFO]   headers: {
+[2026-05-30T17:19:15.866Z] [INFO]     accept: "application/json",
+[2026-05-30T17:19:15.866Z] [INFO]     "anthropic-beta": "claude-code-20250219,oauth-2025-04-20,interleaved-thinking-2025-05-14,thinking-token-count-2026-05-13,context-management-2025-06-27,prompt-caching-scope-2026-01-05,mid-conversation-system-2026-04-07,advisor-tool-2026-03-01,advanced-tool-use-2025-11-20,effort-2025-11-24,extended-cache-ttl-2025-04-11,cache-diagnosis-2026-04-07",
+[2026-05-30T17:19:15.866Z] [INFO]     "anthropic-dangerous-direct-browser-access": "true",
+[2026-05-30T17:19:15.866Z] [INFO]     "anthropic-version": "2023-06-01",
+[2026-05-30T17:19:15.867Z] [INFO]     authorization: "***",
+[2026-05-30T17:19:15.867Z] [INFO]     "content-type": "application/json",
+[2026-05-30T17:19:15.867Z] [INFO]     "user-agent": "claude-cli/2.1.158 (external, sdk-cli)",
+[2026-05-30T17:19:15.867Z] [INFO]     "x-app": "cli",
+[2026-05-30T17:19:15.868Z] [INFO]     "x-claude-code-session-id": "45441128-80e2-48c1-a2ea-f81ede05030b",
+[2026-05-30T17:19:15.868Z] [INFO]     "x-client-request-id": "ce440fb5-3d34-4310-a10f-6f0483ff4522",
+[2026-05-30T17:19:15.869Z] [INFO]     "x-stainless-arch": "x64",
+[2026-05-30T17:19:15.869Z] [INFO]     "x-stainless-lang": "js",
+[2026-05-30T17:19:15.870Z] [INFO]     "x-stainless-os": "Linux",
+[2026-05-30T17:19:15.870Z] [INFO]     "x-stainless-package-version": "0.94.0",
+[2026-05-30T17:19:15.870Z] [INFO]     "x-stainless-retry-count": "0",
+[2026-05-30T17:19:15.871Z] [INFO]     "x-stainless-runtime": "node",
+[2026-05-30T17:19:15.871Z] [INFO]     "x-stainless-runtime-version": "v24.3.0",
+[2026-05-30T17:19:15.871Z] [INFO]     "x-stainless-timeout": "600",
+[2026-05-30T17:19:15.872Z] [INFO]   },
+[2026-05-30T17:19:15.872Z] [INFO] }
+[2026-05-30T17:19:17.556Z] [INFO] [log_9309c6, request-id: "req_011CbZ8q79bzxsEt4rHKGaJD"] post https://api.anthropic.com/v1/messages?beta=true succeeded with status 200 in 1703ms
+[2026-05-30T17:19:17.557Z] [INFO] [log_9309c6] response start {
+[2026-05-30T17:19:17.558Z] [INFO]   url: "https://api.anthropic.com/v1/messages?beta=true",
+[2026-05-30T17:19:17.559Z] [INFO]   status: 200,
+[2026-05-30T17:19:17.563Z] [INFO]   headers: {
+[2026-05-30T17:19:17.563Z] [INFO]     "anthropic-organization-id": "ebc2ac93-f86f-4d15-aff3-de8830d8d789",
+[2026-05-30T17:19:17.571Z] [INFO]     "anthropic-ratelimit-unified-5h-reset": "1780173000",
+[2026-05-30T17:19:17.571Z] [INFO]     "anthropic-ratelimit-unified-5h-status": "allowed",
+[2026-05-30T17:19:17.571Z] [INFO]     "anthropic-ratelimit-unified-5h-utilization": "0.25",
+[2026-05-30T17:19:17.572Z] [INFO]     "anthropic-ratelimit-unified-7d-reset": "1780398000",
+[2026-05-30T17:19:17.572Z] [INFO]     "anthropic-ratelimit-unified-7d-status": "allowed",
+[2026-05-30T17:19:17.575Z] [INFO]     "anthropic-ratelimit-unified-7d-utilization": "0.73",
+[2026-05-30T17:19:17.576Z] [INFO]     "anthropic-ratelimit-unified-fallback-percentage": "0.5",
+[2026-05-30T17:19:17.576Z] [INFO]     "anthropic-ratelimit-unified-overage-disabled-reason": "org_level_disabled",
+[2026-05-30T17:19:17.577Z] [INFO]     "anthropic-ratelimit-unified-overage-status": "rejected",
+[2026-05-30T17:19:17.577Z] [INFO]     "anthropic-ratelimit-unified-representative-claim": "five_hour",
+[2026-05-30T17:19:17.578Z] [INFO]     "anthropic-ratelimit-unified-reset": "1780173000",
+[2026-05-30T17:19:17.578Z] [INFO]     "anthropic-ratelimit-unified-status": "allowed",
+[2026-05-30T17:19:17.578Z] [INFO]     "cache-control": "no-cache",
+[2026-05-30T17:19:17.579Z] [INFO]     "cf-cache-status": "DYNAMIC",
+[2026-05-30T17:19:17.579Z] [INFO]     "cf-ray": "a03f671c29e7976a-FRA",
+[2026-05-30T17:19:17.582Z] [INFO]     connection: "keep-alive",
+[2026-05-30T17:19:17.583Z] [INFO]     "content-encoding": "gzip",
+[2026-05-30T17:19:17.584Z] [INFO]     "content-security-policy": "default-src 'none'; frame-ancestors 'none'",
+[2026-05-30T17:19:17.584Z] [INFO]     "content-type": "text/event-stream; charset=utf-8",
+[2026-05-30T17:19:17.585Z] [INFO]     date: "Sat, 30 May 2026 17:19:17 GMT",
+[2026-05-30T17:19:17.590Z] [INFO]     "request-id": "req_011CbZ8q79bzxsEt4rHKGaJD",
+[2026-05-30T17:19:17.591Z] [INFO]     server: "cloudflare",
+[2026-05-30T17:19:17.593Z] [INFO]     "strict-transport-security": "max-age=31536000; includeSubDomains; preload",
+[2026-05-30T17:19:17.594Z] [INFO]     traceresponse: "00-b5b21ea77b56dcb913cc4116573f01e6-a42b2f5606b3a159-01",
+[2026-05-30T17:19:17.598Z] [INFO]     "transfer-encoding": "chunked",
+[2026-05-30T17:19:17.599Z] [INFO]     vary: "Accept-Encoding",
+[2026-05-30T17:19:17.599Z] [INFO]     "x-robots-tag": "none",
+[2026-05-30T17:19:17.600Z] [INFO]     "set-cookie": "***",
+[2026-05-30T17:19:17.601Z] [INFO]   },
+[2026-05-30T17:19:17.603Z] [INFO]   durationMs: 1703,
+[2026-05-30T17:19:17.604Z] [INFO] }
+[2026-05-30T17:19:17.606Z] [INFO] response 200 https://api.anthropic.com/v1/messages?beta=true Headers {
+[2026-05-30T17:19:17.606Z] [INFO]   "date": "Sat, 30 May 2026 17:19:17 GMT",
+[2026-05-30T17:19:17.618Z] [INFO]   "content-type": "text/event-stream; charset=utf-8",
+[2026-05-30T17:19:17.620Z] [INFO]   "transfer-encoding": "chunked",
+[2026-05-30T17:19:17.621Z] [INFO]   "connection": "keep-alive",
+[2026-05-30T17:19:17.622Z] [INFO]   "cache-control": "no-cache",
+[2026-05-30T17:19:17.622Z] [INFO]   "strict-transport-security": "max-age=31536000; includeSubDomains; preload",
+[2026-05-30T17:19:17.622Z] [INFO]   "content-encoding": "gzip",
+[2026-05-30T17:19:17.623Z] [INFO]   "vary": "Accept-Encoding",
+[2026-05-30T17:19:17.623Z] [INFO]   "content-security-policy": "default-src 'none'; frame-ancestors 'none'",
+[2026-05-30T17:19:17.624Z] [INFO]   "set-cookie": [ "_cfuvid=HEsECO16_3jm5stniIJ3rsWFKD5BMyOJV2EkIP72V_w-1780161555.8629723-1.0.1.1-BzsxqgjI6musr5W0ZbULA6NgaURheqNbPwiQwZdatow; HttpOnly; SameSite=None; Secure; Path=/; Domain=api.anthropic.com" ],
+[2026-05-30T17:19:17.624Z] [INFO]   "anthropic-ratelimit-unified-status": "allowed",
+[2026-05-30T17:19:17.625Z] [INFO]   "anthropic-ratelimit-unified-5h-status": "allowed",
+[2026-05-30T17:19:17.625Z] [INFO]   "anthropic-ratelimit-unified-5h-reset": "1780173000",
+[2026-05-30T17:19:17.625Z] [INFO]   "anthropic-ratelimit-unified-5h-utilization": "0.25",
+[2026-05-30T17:19:17.626Z] [INFO]   "anthropic-ratelimit-unified-7d-status": "allowed",
+[2026-05-30T17:19:17.626Z] [INFO]   "anthropic-ratelimit-unified-7d-reset": "1780398000",
+[2026-05-30T17:19:17.627Z] [INFO]   "anthropic-ratelimit-unified-7d-utilization": "0.73",
+[2026-05-30T17:19:17.627Z] [INFO]   "anthropic-ratelimit-unified-representative-claim": "five_hour",
+[2026-05-30T17:19:17.628Z] [INFO]   "anthropic-ratelimit-unified-fallback-percentage": "0.5",
+[2026-05-30T17:19:17.628Z] [INFO]   "anthropic-ratelimit-unified-reset": "1780173000",
+[2026-05-30T17:19:17.628Z] [INFO]   "anthropic-ratelimit-unified-overage-disabled-reason": "org_level_disabled",
+[2026-05-30T17:19:17.629Z] [INFO]   "anthropic-ratelimit-unified-overage-status": "rejected",
+[2026-05-30T17:19:17.629Z] [INFO]   "request-id": "req_011CbZ8q79bzxsEt4rHKGaJD",
+[2026-05-30T17:19:17.630Z] [INFO]   "anthropic-organization-id": "ebc2ac93-f86f-4d15-aff3-de8830d8d789",
+[2026-05-30T17:19:17.631Z] [INFO]   "traceresponse": "00-b5b21ea77b56dcb913cc4116573f01e6-a42b2f5606b3a159-01",
+[2026-05-30T17:19:17.632Z] [INFO]   "server": "cloudflare",
+[2026-05-30T17:19:17.634Z] [INFO]   "cf-cache-status": "DYNAMIC",
+[2026-05-30T17:19:17.635Z] [INFO]   "x-robots-tag": "none",
+[2026-05-30T17:19:17.636Z] [INFO]   "cf-ray": "a03f671c29e7976a-FRA",
+[2026-05-30T17:19:17.638Z] [INFO] } ReadableStream {
+[2026-05-30T17:19:17.638Z] [INFO]   blob: [Function: blob],
+[2026-05-30T17:19:17.639Z] [INFO]   bytes: [Function: bytes],
+[2026-05-30T17:19:17.639Z] [INFO]   cancel: [Function],
+[2026-05-30T17:19:17.639Z] [INFO]   getReader: [Function],
+[2026-05-30T17:19:17.640Z] [INFO]   json: [Function: json],
+[2026-05-30T17:19:17.640Z] [INFO]   locked: [Getter],
+[2026-05-30T17:19:17.641Z] [INFO]   pipeThrough: [Function],
+[2026-05-30T17:19:17.642Z] [INFO]   pipeTo: [Function],
+[2026-05-30T17:19:17.644Z] [INFO]   tee: [Function],
+[2026-05-30T17:19:17.645Z] [INFO]   text: [Function: text],
+[2026-05-30T17:19:17.648Z] [INFO]   values: [Function: values],
+[2026-05-30T17:19:17.649Z] [INFO]   [Symbol(Symbol.asyncIterator)]: [Function: asyncIterator2],
+[2026-05-30T17:19:17.649Z] [INFO] }
+[2026-05-30T17:19:17.649Z] [INFO] [log_9309c6] response parsed {
+[2026-05-30T17:19:17.650Z] [INFO]   url: "https://api.anthropic.com/v1/messages?beta=true",
+[2026-05-30T17:19:17.650Z] [INFO]   status: 200,
+[2026-05-30T17:19:17.651Z] [INFO]   body: bR {
+[2026-05-30T17:19:17.653Z] [INFO]     iterator: [AsyncGeneratorFunction: z],
+[2026-05-30T17:19:17.653Z] [INFO]     controller: AbortController {
+[2026-05-30T17:19:17.653Z] [INFO]       signal: [AbortSignal ...],
+[2026-05-30T17:19:17.654Z] [INFO]       abort: [Function: abort],
+[2026-05-30T17:19:17.655Z] [INFO]     },
+[2026-05-30T17:19:17.656Z] [INFO]     [Symbol(Symbol.asyncIterator)]: [Function],
+[2026-05-30T17:19:17.656Z] [INFO]     tee: [Function: tee],
+[2026-05-30T17:19:17.657Z] [INFO]     toReadableStream: [Function: toReadableStream],
+[2026-05-30T17:19:17.658Z] [INFO]   },
+[2026-05-30T17:19:17.659Z] [INFO]   durationMs: 1703,
+[2026-05-30T17:19:17.659Z] [INFO] }
+[2026-05-30T17:19:18.514Z] [INFO] {
+[2026-05-30T17:19:18.514Z] [INFO]   "type": "system",
+[2026-05-30T17:19:18.514Z] [INFO]   "subtype": "thinking_tokens",
+[2026-05-30T17:19:18.514Z] [INFO]   "estimated_tokens": 50,
+[2026-05-30T17:19:18.514Z] [INFO]   "estimated_tokens_delta": 50,
+[2026-05-30T17:19:18.514Z] [INFO]   "uuid": "aba859fd-dd29-4630-8cc4-525a52ea73d3",
+[2026-05-30T17:19:18.514Z] [INFO]   "session_id": "45441128-80e2-48c1-a2ea-f81ede05030b"
+[2026-05-30T17:19:18.514Z] [INFO] }
+[2026-05-30T17:19:18.982Z] [INFO] {
+[2026-05-30T17:19:18.982Z] [INFO]   "type": "assistant",
+[2026-05-30T17:19:18.982Z] [INFO]   "message": {
+[2026-05-30T17:19:18.982Z] [INFO]     "model": "claude-opus-4-8",
+[2026-05-30T17:19:18.982Z] [INFO]     "id": "msg_01Y2RCADNozy2G6VDxvTSGFN",
+[2026-05-30T17:19:18.982Z] [INFO]     "type": "message",
+[2026-05-30T17:19:18.982Z] [INFO]     "role": "assistant",
+[2026-05-30T17:19:18.982Z] [INFO]     "content": [
+[2026-05-30T17:19:18.982Z] [INFO]       {
+[2026-05-30T17:19:18.982Z] [INFO]         "type": "thinking",
+[2026-05-30T17:19:18.982Z] [INFO]         "thinking": "",
+[2026-05-30T17:19:18.982Z] [INFO]         "signature": "EtsDCmMIDhgCKkCRAh5/emEVlKS+eM4wmMNUD/8YdMzmFFYlekPq8WFILAv7eYzk/25VchtfQjn1gn80GOamwV+9hMuoAyxgUePZMg9jbGF1ZGUtb3B1cy00LTg4AEIIdGhpbmtpbmcSDIIY73PgfHp+WFvixhoMV2kBSJ257enVb1hzIjCdE/U+NBRSUvAHE2EiKk6ztrhg0nYaoN17gTaNcbLWbEVCj7iDv9n0nV4M0c8hSOgqpQJYggqaG6u1ZvG+qOrSeHx40uXA0LNyFCZRsn7j5aRWDIpf6y1l7oCl4AAlVRTyYPWibSjrsGSrpJb8YM6howkEU8V5TUZw3OepGSgqqnchLeefOOdQMSFGNBp89LPWHr7JMx3VSFnpj5I4DMPNssvTuNmXiBSuA0pTxa/Q1qeHvI1LNfiANIooaipHlUWdithMb3y0qic0xSMYYhjypilUxlsrtUhRZER0wMb54HNZsFs9CzkZVJ00eb76LTxnHQNL5vniUQMtJFNqmS+wnIIBi+Ug0l67l8gY9SXA+AdclYJncyUPKjQ5Fxr9+Z648X5OJ7YBEjMUWSk/QiYvJjQ3RkS5sJXRypFBe5HJ0ZmwjoTeMLR/s+Kwq8Mkg7nvkLnjt11HZhgB"
+[2026-05-30T17:19:18.982Z] [INFO]       }
+[2026-05-30T17:19:18.982Z] [INFO]     ],
+[2026-05-30T17:19:18.982Z] [INFO]     "stop_reason": null,
+[2026-05-30T17:19:18.982Z] [INFO]     "stop_sequence": null,
+[2026-05-30T17:19:18.982Z] [INFO]     "stop_details": null,
+[2026-05-30T17:19:18.982Z] [INFO]     "usage": {
+[2026-05-30T17:19:18.982Z] [INFO]       "input_tokens": 131,
+[2026-05-30T17:19:18.982Z] [INFO]       "cache_creation_input_tokens": 2074,
+[2026-05-30T17:19:18.982Z] [INFO]       "cache_read_input_tokens": 42502,
+[2026-05-30T17:19:18.982Z] [INFO]       "cache_creation": {
+[2026-05-30T17:19:18.982Z] [INFO]         "ephemeral_5m_input_tokens": 0,
+[2026-05-30T17:19:18.982Z] [INFO]         "ephemeral_1h_input_tokens": 2074
+[2026-05-30T17:19:18.982Z] [INFO]       },
+[2026-05-30T17:19:18.982Z] [INFO]       "output_tokens": 8,
+[2026-05-30T17:19:18.982Z] [INFO]       "service_tier": "standard",
+[2026-05-30T17:19:18.982Z] [INFO]       "inference_geo": "not_available"
+[2026-05-30T17:19:18.982Z] [INFO]     },
+[2026-05-30T17:19:18.982Z] [INFO]     "diagnostics": null,
+[2026-05-30T17:19:18.982Z] [INFO]     "context_management": null
+[2026-05-30T17:19:18.982Z] [INFO]   },
+[2026-05-30T17:19:18.982Z] [INFO]   "parent_tool_use_id": null,
+[2026-05-30T17:19:18.982Z] [INFO]   "session_id": "45441128-80e2-48c1-a2ea-f81ede05030b",
+[2026-05-30T17:19:18.982Z] [INFO]   "uuid": "0141ac3c-0e3c-4518-a5f8-eca84a12e2d1",
+[2026-05-30T17:19:18.982Z] [INFO]   "request_id": "req_011CbZ8q79bzxsEt4rHKGaJD"
+[2026-05-30T17:19:18.982Z] [INFO] }
+[2026-05-30T17:19:19.451Z] [INFO] {
+[2026-05-30T17:19:19.451Z] [INFO]   "type": "assistant",
+[2026-05-30T17:19:19.451Z] [INFO]   "message": {
+[2026-05-30T17:19:19.451Z] [INFO]     "model": "claude-opus-4-8",
+[2026-05-30T17:19:19.451Z] [INFO]     "id": "msg_01Y2RCADNozy2G6VDxvTSGFN",
+[2026-05-30T17:19:19.451Z] [INFO]     "type": "message",
+[2026-05-30T17:19:19.451Z] [INFO]     "role": "assistant",
+[2026-05-30T17:19:19.451Z] [INFO]     "content": [
+[2026-05-30T17:19:19.451Z] [INFO]       {
+[2026-05-30T17:19:19.451Z] [INFO]         "type": "text",
+[2026-05-30T17:19:19.451Z] [INFO]         "text": "The failing test is `src/docs/__tests__/readme.test.ts`. Let me see the full failure detail and the test itself."
+[2026-05-30T17:19:19.451Z] [INFO]       }
+[2026-05-30T17:19:19.451Z] [INFO]     ],
+[2026-05-30T17:19:19.451Z] [INFO]     "stop_reason": null,
+[2026-05-30T17:19:19.451Z] [INFO]     "stop_sequence": null,
+[2026-05-30T17:19:19.451Z] [INFO]     "stop_details": null,
+[2026-05-30T17:19:19.451Z] [INFO]     "usage": {
+[2026-05-30T17:19:19.451Z] [INFO]       "input_tokens": 131,
+[2026-05-30T17:19:19.451Z] [INFO]       "cache_creation_input_tokens": 2074,
+[2026-05-30T17:19:19.451Z] [INFO]       "cache_read_input_tokens": 42502,
+[2026-05-30T17:19:19.451Z] [INFO]       "cache_creation": {
+[2026-05-30T17:19:19.451Z] [INFO]         "ephemeral_5m_input_tokens": 0,
+[2026-05-30T17:19:19.451Z] [INFO]         "ephemeral_1h_input_tokens": 2074
+[2026-05-30T17:19:19.451Z] [INFO]       },
+[2026-05-30T17:19:19.451Z] [INFO]       "output_tokens": 8,
+[2026-05-30T17:19:19.451Z] [INFO]       "service_tier": "standard",
+[2026-05-30T17:19:19.451Z] [INFO]       "inference_geo": "not_available"
+[2026-05-30T17:19:19.451Z] [INFO]     },
+[2026-05-30T17:19:19.451Z] [INFO]     "diagnostics": null,
+[2026-05-30T17:19:19.451Z] [INFO]     "context_management": null
+[2026-05-30T17:19:19.451Z] [INFO]   },
+[2026-05-30T17:19:19.451Z] [INFO]   "parent_tool_use_id": null,
+[2026-05-30T17:19:19.451Z] [INFO]   "session_id": "45441128-80e2-48c1-a2ea-f81ede05030b",
+[2026-05-30T17:19:19.451Z] [INFO]   "uuid": "a1001485-83a8-4b22-a84b-ae7d7d524136",
+[2026-05-30T17:19:19.451Z] [INFO]   "request_id": "req_011CbZ8q79bzxsEt4rHKGaJD"
+[2026-05-30T17:19:19.451Z] [INFO] }
+[2026-05-30T17:19:20.899Z] [INFO] {
+[2026-05-30T17:19:20.899Z] [INFO]   "type": "assistant",
+[2026-05-30T17:19:20.899Z] [INFO]   "message": {
+[2026-05-30T17:19:20.899Z] [INFO]     "model": "claude-opus-4-8",
+[2026-05-30T17:19:20.899Z] [INFO]     "id": "msg_01Y2RCADNozy2G6VDxvTSGFN",
+[2026-05-30T17:19:20.899Z] [INFO]     "type": "message",
+[2026-05-30T17:19:20.899Z] [INFO]     "role": "assistant",
+[2026-05-30T17:19:20.899Z] [INFO]     "content": [
+[2026-05-30T17:19:20.899Z] [INFO]       {
+[2026-05-30T17:19:20.899Z] [INFO]         "type": "tool_use",
+[2026-05-30T17:19:20.899Z] [INFO]         "id": "toolu_01DdVq14Cg5PjEXH947ZNDDg",
+[2026-05-30T17:19:20.899Z] [INFO]         "name": "Bash",
+[2026-05-30T17:19:20.899Z] [INFO]         "input": {
+[2026-05-30T17:19:20.899Z] [INFO]           "command": "cd /tmp/gh-issue-solver-1780161489554\nsed -n '2582,2720p' /tmp/test-fail.log | sed 's/\\x1b\\[[0-9;]*m//g'",
+[2026-05-30T17:19:20.899Z] [INFO]           "description": "Show readme test failure detail"
+[2026-05-30T17:19:20.899Z] [INFO]         },
+[2026-05-30T17:19:20.899Z] [INFO]         "caller": {
+[2026-05-30T17:19:20.899Z] [INFO]           "type": "direct"
+[2026-05-30T17:19:20.899Z] [INFO]         }
+[2026-05-30T17:19:20.899Z] [INFO]       }
+[2026-05-30T17:19:20.899Z] [INFO]     ],
+[2026-05-30T17:19:20.899Z] [INFO]     "stop_reason": null,
+[2026-05-30T17:19:20.899Z] [INFO]     "stop_sequence": null,
+[2026-05-30T17:19:20.899Z] [INFO]     "stop_details": null,
+[2026-05-30T17:19:20.899Z] [INFO]     "usage": {
+[2026-05-30T17:19:20.899Z] [INFO]       "input_tokens": 131,
+[2026-05-30T17:19:20.899Z] [INFO]       "cache_creation_input_tokens": 2074,
+[2026-05-30T17:19:20.899Z] [INFO]       "cache_read_input_tokens": 42502,
+[2026-05-30T17:19:20.899Z] [INFO]       "cache_creation": {
+[2026-05-30T17:19:20.899Z] [INFO]         "ephemeral_5m_input_tokens": 0,
+[2026-05-30T17:19:20.899Z] [INFO]         "ephemeral_1h_input_tokens": 2074
+[2026-05-30T17:19:20.899Z] [INFO]       },
+[2026-05-30T17:19:20.899Z] [INFO]       "output_tokens": 8,
+[2026-05-30T17:19:20.899Z] [INFO]       "service_tier": "standard",
+[2026-05-30T17:19:20.899Z] [INFO]       "inference_geo": "not_available"
+[2026-05-30T17:19:20.899Z] [INFO]     },
+[2026-05-30T17:19:20.899Z] [INFO]     "diagnostics": null,
+[2026-05-30T17:19:20.899Z] [INFO]     "context_management": null
+[2026-05-30T17:19:20.899Z] [INFO]   },
+[2026-05-30T17:19:20.899Z] [INFO]   "parent_tool_use_id": null,
+[2026-05-30T17:19:20.899Z] [INFO]   "session_id": "45441128-80e2-48c1-a2ea-f81ede05030b",
+[2026-05-30T17:19:20.899Z] [INFO]   "uuid": "90b1382c-58cc-4467-b56f-b16b5fa1f3cd",
+[2026-05-30T17:19:20.899Z] [INFO]   "request_id": "req_011CbZ8q79bzxsEt4rHKGaJD"
+[2026-05-30T17:19:20.899Z] [INFO] }
+[2026-05-30T17:19:21.606Z] [INFO] {
+[2026-05-30T17:19:21.606Z] [INFO]   "type": "assistant",
+[2026-05-30T17:19:21.606Z] [INFO]   "message": {
+[2026-05-30T17:19:21.606Z] [INFO]     "model": "claude-opus-4-8",
+[2026-05-30T17:19:21.606Z] [INFO]     "id": "msg_01Y2RCADNozy2G6VDxvTSGFN",
+[2026-05-30T17:19:21.606Z] [INFO]     "type": "message",
+[2026-05-30T17:19:21.606Z] [INFO]     "role": "assistant",
+[2026-05-30T17:19:21.606Z] [INFO]     "content": [
+[2026-05-30T17:19:21.606Z] [INFO]       {
+[2026-05-30T17:19:21.606Z] [INFO]         "type": "tool_use",
+[2026-05-30T17:19:21.606Z] [INFO]         "id": "toolu_01FFYtYzN5VvbvgLVgWcAHUB",
+[2026-05-30T17:19:21.606Z] [INFO]         "name": "Bash",
+[2026-05-30T17:19:21.606Z] [INFO]         "input": {
+[2026-05-30T17:19:21.606Z] [INFO]           "command": "cd /tmp/gh-issue-solver-1780161489554\ncat src/docs/__tests__/readme.test.ts",
+[2026-05-30T17:19:21.606Z] [INFO]           "description": "Read readme test"
+[2026-05-30T17:19:21.606Z] [INFO]         },
+[2026-05-30T17:19:21.606Z] [INFO]         "caller": {
+[2026-05-30T17:19:21.606Z] [INFO]           "type": "direct"
+[2026-05-30T17:19:21.606Z] [INFO]         }
+[2026-05-30T17:19:21.606Z] [INFO]       }
+[2026-05-30T17:19:21.606Z] [INFO]     ],
+[2026-05-30T17:19:21.606Z] [INFO]     "stop_reason": null,
+[2026-05-30T17:19:21.606Z] [INFO]     "stop_sequence": null,
+[2026-05-30T17:19:21.606Z] [INFO]     "stop_details": null,
+[2026-05-30T17:19:21.606Z] [INFO]     "usage": {
+[2026-05-30T17:19:21.606Z] [INFO]       "input_tokens": 131,
+[2026-05-30T17:19:21.606Z] [INFO]       "cache_creation_input_tokens": 2074,
+[2026-05-30T17:19:21.606Z] [INFO]       "cache_read_input_tokens": 42502,
+[2026-05-30T17:19:21.606Z] [INFO]       "cache_creation": {
+[2026-05-30T17:19:21.606Z] [INFO]         "ephemeral_5m_input_tokens": 0,
+[2026-05-30T17:19:21.606Z] [INFO]         "ephemeral_1h_input_tokens": 2074
+[2026-05-30T17:19:21.606Z] [INFO]       },
+[2026-05-30T17:19:21.606Z] [INFO]       "output_tokens": 8,
+[2026-05-30T17:19:21.606Z] [INFO]       "service_tier": "standard",
+[2026-05-30T17:19:21.606Z] [INFO]       "inference_geo": "not_available"
+[2026-05-30T17:19:21.606Z] [INFO]     },
+[2026-05-30T17:19:21.606Z] [INFO]     "diagnostics": null,
+[2026-05-30T17:19:21.606Z] [INFO]     "context_management": null
+[2026-05-30T17:19:21.606Z] [INFO]   },
+[2026-05-30T17:19:21.606Z] [INFO]   "parent_tool_use_id": null,
+[2026-05-30T17:19:21.606Z] [INFO]   "session_id": "45441128-80e2-48c1-a2ea-f81ede05030b",
+[2026-05-30T17:19:21.606Z] [INFO]   "uuid": "f0474e4a-f9f9-455f-9796-220bf93149c2",
+[2026-05-30T17:19:21.606Z] [INFO]   "request_id": "req_011CbZ8q79bzxsEt4rHKGaJD"
+[2026-05-30T17:19:21.606Z] [INFO] }
+[2026-05-30T17:19:22.283Z] [INFO] {
+[2026-05-30T17:19:22.283Z] [INFO]   "type": "user",
+[2026-05-30T17:19:22.283Z] [INFO]   "message": {
+[2026-05-30T17:19:22.283Z] [INFO]     "role": "user",
+[2026-05-30T17:19:22.283Z] [INFO]     "content": [
+[2026-05-30T17:19:22.283Z] [INFO]       {
+[2026-05-30T17:19:22.283Z] [INFO]         "tool_use_id": "toolu_01DdVq14Cg5PjEXH947ZNDDg",
+[2026-05-30T17:19:22.283Z] [INFO]         "type": "tool_result",
+[2026-05-30T17:19:22.283Z] [INFO]         "content": "CI / Test\tUNKNOWN STEP\t2026-05-30T16:59:58.2682779Z ^[[31m⎯⎯⎯⎯⎯⎯⎯^[[39m^[[1m^[[41m Failed Tests 1 ^[[49m^[[22m^[[31m⎯⎯⎯⎯⎯⎯⎯^[[39m\nCI / Test\tUNKNOWN STEP\t2026-05-30T16:59:58.2683215Z \nCI / Test\tUNKNOWN STEP\t2026-05-30T16:59:58.2684796Z ^[[41m^[[1m FAIL ^[[22m^[[49m src/docs/__tests__/readme.test.ts^[[2m > ^[[22mroot README^[[2m > ^[[22mdocuments the current fork version and WebUI surface\nCI / Test\tUNKNOWN STEP\t2026-05-30T16:59:58.2693052Z ^[[31m^[[1mAssertionError^[[22m: expected '<p align=\"center\">\\n  <img src=\"./log…' to contain 'Current fork version: `0.8.22`'^[[39m\nCI / Test\tUNKNOWN STEP\t2026-05-30T16:59:58.2694179Z \nCI / Test\tUNKNOWN STEP\t2026-05-30T16:59:58.2694795Z ^[[32m- Expected^[[39m\nCI / Test\tUNKNOWN STEP\t2026-05-30T16:59:58.2695380Z ^[[31m+ Received^[[39m\nCI / Test\tUNKNOWN STEP\t2026-05-30T16:59:58.2695630Z \nCI / Test\tUNKNOWN STEP\t2026-05-30T16:59:58.2695994Z ^[[32m- Current fork version: `0.8.22`^[[39m\nCI / Test\tUNKNOWN STEP\t2026-05-30T16:59:58.2696666Z ^[[31m+ <p align=\"center\">^[[39m\nCI / Test\tUNKNOWN STEP\t2026-05-30T16:59:58.2697559Z ^[[31m+   <img src=\"./logo_dark.png\" alt=\"Teleton Agent\" width=\"700\" />^[[39m\nCI / Test\tUNKNOWN STEP\t2026-05-30T16:59:58.2698263Z ^[[31m+ </p>^[[39m\nCI / Test\tUNKNOWN STEP\t2026-05-30T16:59:58.2698659Z ^[[31m+^[[39m\nCI / Test\tUNKNOWN STEP\t2026-05-30T16:59:58.2699857Z ^[[31m+ <p align=\"center\"><b>Autonomous AI agent platform for Telegram with native TON blockchain integration</b></p>^[[39m\nCI / Test\tUNKNOWN STEP\t2026-05-30T16:59:58.2701013Z ^[[31m+^[[39m\nCI / Test\tUNKNOWN STEP\t2026-05-30T16:59:58.2701492Z ^[[31m+ <p align=\"center\">^[[39m\nCI / Test\tUNKNOWN STEP\t2026-05-30T16:59:58.2703018Z ^[[31m+   <a href=\"https://opensource.org/licenses/MIT\"><img src=\"https://img.shields.io/badge/License-MIT-yellow.svg\" alt=\"License: MIT\"></a>^[[39m\nCI / Test\tUNKNOWN STEP\t2026-05-30T16:59:58.2704439Z ^[[31m+   <a href=\"https://nodejs.org/\"><img src=\"https://img.shields.io/badge/node-%3E%3D20.0.0-brightgreen\" alt=\"Node.js\"></a>^[[39m\nCI / Test\tUNKNOWN STEP\t2026-05-30T16:59:58.2705754Z ^[[31m+   <a href=\"https://codecov.io/gh/xlabtg/teleton-agent\"><img src=\"https://codecov.io/gh/xlabtg/teleton-agent/branch/main/graph/badge.svg\" alt=\"Coverage\"></a>^[[39m\nCI / Test\tUNKNOWN STEP\t2026-05-30T16:59:58.2707015Z ^[[31m+   <a href=\"https://www.typescriptlang.org/\"><img src=\"https://img.shields.io/badge/TypeScript-5.7-blue\" alt=\"TypeScript\"></a>^[[39m\nCI / Test\tUNKNOWN STEP\t2026-05-30T16:59:58.2708149Z ^[[31m+   <a href=\"https://teletonagent.dev\"><img src=\"https://img.shields.io/badge/Website-teletonagent.dev-ff6600\" alt=\"Website\"></a>^[[39m\nCI / Test\tUNKNOWN STEP\t2026-05-30T16:59:58.2709317Z ^[[31m+   <a href=\"https://docs.teletonagent.dev\"><img src=\"https://img.shields.io/badge/docs-Teleton%20Agents-blue\" alt=\"Documentation\"></a>^[[39m\nCI / Test\tUNKNOWN STEP\t2026-05-30T16:59:58.2710737Z ^[[31m+   <a href=\"https://ton.org\"><img src=\"https://img.shields.io/badge/Built_on-TON-0098EA?logo=ton&logoColor=white\" alt=\"Built on TON\"></a>^[[39m\nCI / Test\tUNKNOWN STEP\t2026-05-30T16:59:58.2711922Z ^[[31m+ </p>^[[39m\nCI / Test\tUNKNOWN STEP\t2026-05-30T16:59:58.2712188Z ^[[31m+^[[39m\nCI / Test\tUNKNOWN STEP\t2026-05-30T16:59:58.2712417Z ^[[31m+ ---^[[39m\nCI / Test\tUNKNOWN STEP\t2026-05-30T16:59:58.2712662Z ^[[31m+^[[39m\nCI / Test\tUNKNOWN STEP\t2026-05-30T16:59:58.2715900Z ^[[31m+ <p align=\"center\">Teleton is an autonomous AI agent platform that operates as a real Telegram user account or a Telegram Bot. It thinks through an agentic loop with tool calling, remembers conversations across sessions with hybrid RAG, and natively integrates the TON blockchain: send crypto, swap on DEXs, bid on domains, verify payments - all from a chat message. It can schedule tasks, run long autonomous goals, coordinate with other agents, and expose its operator console through a local-first WebUI. It ships with 135+ built-in tools, supports 16 LLM providers, and exposes a Plugin SDK so you can build your own tools on top of the platform.</p>^[[39m\nCI / Test\tUNKNOWN STEP\t2026-05-30T16:59:58.2718215Z ^[[31m+^[[39m\nCI / Test\tUNKNOWN STEP\t2026-05-30T16:59:58.2718494Z ^[[31m+ ### Key Highlights^[[39m\nCI / Test\tUNKNOWN STEP\t2026-05-30T16:59:58.2718770Z ^[[31m+^[[39m\nCI / Test\tUNKNOWN STEP\t2026-05-30T16:59:58.2719008Z ^[[31m+ <table>^[[39m\nCI / Test\tUNKNOWN STEP\t2026-05-30T16:59:58.2719260Z ^[[31m+ <tr>^[[39m\nCI / Test\tUNKNOWN STEP\t2026-05-30T16:59:58.2720199Z ^[[31m+ <td align=\"center\" width=\"33%\"><br><b><ins>Full Telegram Access</ins></b><br>Real user via MTProto,<br>not a bot<br><br></td>^[[39m\nCI / Test\tUNKNOWN STEP\t2026-05-30T16:59:58.2721495Z ^[[31m+ <td align=\"center\" width=\"33%\"><br><b><ins>Agentic Loop</ins></b><br>Think, act, observe, repeat<br>until the task is done<br><br></td>^[[39m\nCI / Test\tUNKNOWN STEP\t2026-05-30T16:59:58.2722602Z ^[[31m+ <td align=\"center\" width=\"33%\"><br><b><ins>16 LLM Providers</ins></b><br>Anthropic, OpenAI, Google, xAI, Groq, and more<br><br></td>^[[39m\nCI / Test\tUNKNOWN STEP\t2026-05-30T16:59:58.2723205Z ^[[31m+ </tr>^[[39m\nCI / Test\tUNKNOWN STEP\t2026-05-30T16:59:58.2723441Z ^[[31m+ <tr>^[[39m\nCI / Test\tUNKNOWN STEP\t2026-05-30T16:59:58.2724080Z ^[[31m+ <td align=\"center\"><br><b><ins>TON Blockchain</ins></b><br>Wallet, jettons, DEX swaps, DNS, NFTs<br><br></td>^[[39m\nCI / Test\tUNKNOWN STEP\t2026-05-30T16:59:58.2725059Z ^[[31m+ <td align=\"center\"><br><b><ins>Persistent Memory</ins></b><br>Hybrid RAG, vector + keyword, auto-compaction<br><br></td>^[[39m\nCI / Test\tUNKNOWN STEP\t2026-05-30T16:59:58.2726221Z ^[[31m+ <td align=\"center\"><br><b><ins>135+ Built-in Tools</ins></b><br>Messaging, media, crypto, DEX, DNS, files<br><br></td>^[[39m\nCI / Test\tUNKNOWN STEP\t2026-05-30T16:59:58.2726777Z ^[[31m+ </tr>^[[39m\nCI / Test\tUNKNOWN STEP\t2026-05-30T16:59:58.2727014Z ^[[31m+ <tr>^[[39m\nCI / Test\tUNKNOWN STEP\t2026-05-30T16:59:58.2727647Z ^[[31m+ <td align=\"center\"><br><b><ins>Plugin SDK</ins></b><br>Custom tools, isolated DBs, secrets, hooks<br><br></td>^[[39m\nCI / Test\tUNKNOWN STEP\t2026-05-30T16:59:58.2728586Z ^[[31m+ <td align=\"center\"><br><b><ins>23-Page WebUI</ins></b><br>Agents, pipelines, events, security, network<br><br></td>^[[39m\nCI / Test\tUNKNOWN STEP\t2026-05-30T16:59:58.2729536Z ^[[31m+ <td align=\"center\"><br><b><ins>Secure by Design</ins></b><br>Sandbox, signed ingress, prompt defense<br><br></td>^[[39m\nCI / Test\tUNKNOWN STEP\t2026-05-30T16:59:58.2730067Z ^[[31m+ </tr>^[[39m\nCI / Test\tUNKNOWN STEP\t2026-05-30T16:59:58.2730311Z ^[[31m+ </table>^[[39m\nCI / Test\tUNKNOWN STEP\t2026-05-30T16:59:58.2730804Z ^[[31m+^[[39m\nCI / Test\tUNKNOWN STEP\t2026-05-30T16:59:58.2731100Z ^[[31m+ ---^[[39m\nCI / Test\tUNKNOWN STEP\t2026-05-30T16:59:58.2731525Z ^[[31m+^[[39m\nCI / Test\tUNKNOWN STEP\t2026-05-30T16:59:58.2732029Z ^[[31m+ ## Current Fork Status^[[39m\nCI / Test\tUNKNOWN STEP\t2026-05-30T16:59:58.2732525Z ^[[31m+^[[39m\nCI / Test\tUNKNOWN STEP\t2026-05-30T16:59:58.2733062Z ^[[31m+ Current fork version: `0.8.21`.^[[39m\nCI / Test\tUNKNOWN STEP\t2026-05-30T16:59:58.2733579Z ^[[31m+^[[39m\nCI / Test\tUNKNOWN STEP\t2026-05-30T16:59:58.2737562Z ^[[31m+ This README reflects the `xlabtg/teleton-agent` fork through merged PR [#480](https://github.com/xlabtg/teleton-agent/pull/480) / closed issue [#479](https://github.com/xlabtg/teleton-agent/issues/479). It was refreshed from the closed work history available at issue [#481](https://github.com/xlabtg/teleton-agent/issues/481): 236 closed issues and the 200 most recent merged pull requests as of the latest analyzed run.^[[39m\nCI / Test\tUNKNOWN STEP\t2026-05-30T16:59:58.2739562Z ^[[31m+^[[39m\nCI / Test\tUNKNOWN STEP\t2026-05-30T16:59:58.2740133Z ^[[31m+ The current WebUI ships with 23 WebUI pages and 42 authenticated WebUI API route groups.^[[39m\nCI / Test\tUNKNOWN STEP\t2026-05-30T16:59:58.2740898Z ^[[31m+^[[39m\nCI / Test\tUNKNOWN STEP\t2026-05-30T16:59:58.2741222Z ^[[31m+ ### Closed-Work Summary^[[39m\nCI / Test\tUNKNOWN STEP\t2026-05-30T16:59:58.2741513Z ^[[31m+^[[39m\nCI / Test\tUNKNOWN STEP\t2026-05-30T16:59:58.2741818Z ^[[31m+ | Area | Implemented outcomes |^[[39m\nCI / Test\tUNKNOWN STEP\t2026-05-30T16:59:58.2742214Z ^[[31m+ | ---- | -------------------- |^[[39m\nCI / Test\tUNKNOWN STEP\t2026-05-30T16:59:58.2744679Z ^[[31m+ | **Autonomous mode** | Autonomous Task Engine, natural-language task parser, policy persistence, checkpoint cleanup, pause/resume hardening, reflection-success completion, Saved Messages task triggers, and restored autonomous-task foreign keys. |^[[39m\nCI / Test\tUNKNOWN STEP\t2026-05-30T16:59:58.2748540Z ^[[31m+ | **V2 platform features** | Semantic vector memory, associative memory graph, memory prioritization, prediction engine, predictive cache, anomaly detection, agent registry, task delegation, pipeline execution, self-correction loop, temporal context, zero-trust execution, audit trail, integrations, event bus/webhooks, dynamic dashboards, AI widget generator, feedback learning, adaptive prompting, and multi-agent network. |^[[39m\nCI / Test\tUNKNOWN STEP\t2026-05-30T16:59:58.2751690Z ^[[31m+ | **WebUI** | Dashboard widgets, tools controls, plugins marketplace, Soul editor, Memory, Workspace, Tasks, Workflows, Pipelines, Events, MCP, Integrations, Network, Hooks, Sessions, Analytics, Feedback, Security, Self-Improve, Autonomous Mode, Configuration, setup/login flow, and bilingual user guide. |^[[39m\nCI / Test\tUNKNOWN STEP\t2026-05-30T16:59:58.2755071Z ^[[31m+ | **Network and agents** | Managed agent runtimes with personal/bot auth, signed inter-agent messages, trust levels, replay protection, allowlist/recipient enforcement, manual inbox fallback, remote setup docs, and local-agent visibility in Network status totals. |^[[39m\nCI / Test\tUNKNOWN STEP\t2026-05-30T16:59:58.2760881Z ^[[31m+ | **Telegram and providers** | MTProto proxy recovery, Bot API proxy support, startup resilience when Telegram is unavailable, ffmpeg-free Telegram voice notes (pure-JS OGG/Opus encoder; no system ffmpeg required), Groq STT/TTS support including streaming WAV header fix (`0xFFFFFFFF` placeholder), NVIDIA NIM provider support, OpenRouter free models, and 16-provider model catalog. |^[[39m\nCI / Test\tUNKNOWN STEP\t2026-05-30T16:59:58.2766319Z ^[[31m+ | **Security and reliability** | Wallet encryption, plugin isolation, exec allowlist mode, shell-free allowlist execution, TON-proxy checksum verification, SSRF guards, path/symlink hardening, auth-token hashing, CSRF fixes, restart locks, transcript caps, session TTL enforcement, CI restoration, and audit reports. |^[[39m\nCI / Test\tUNKNOWN STEP\t2026-05-30T16:59:58.2768200Z ^[[31m+^[[39m\nCI / Test\tUNKNOWN STEP\t2026-05-30T16:59:58.2768449Z ^[[31m+ ---^[[39m\nCI / Test\tUNKNOWN STEP\t2026-05-30T16:59:58.2768686Z ^[[31m+^[[39m\nCI / Test\tUNKNOWN STEP\t2026-05-30T16:59:58.2768933Z ^[[31m+ ## Features^[[39m\nCI / Test\tUNKNOWN STEP\t2026-05-30T16:59:58.2769192Z ^[[31m+^[[39m\nCI / Test\tUNKNOWN STEP\t2026-05-30T16:59:58.2769468Z ^[[31m+ ### Tool Categories^[[39m\nCI / Test\tUNKNOWN STEP\t2026-05-30T16:59:58.2769736Z ^[[31m+^[[39m\nCI / Test\tUNKNOWN STEP\t2026-05-30T16:59:58.2770263Z ^[[31m+ | Category      | Tools | Description                                                    |^[[39m\nCI / Test\tUNKNOWN STEP\t2026-05-30T16:59:58.2771277Z ^[[31m+ | ------------- | ----- | -------------------------------------------------------------- |^[[39m\nCI / Test\tUNKNOWN STEP\t2026-05-30T16:59:58.2772025Z ^[[31m+ | Telegram      | 80    | Messages, media, chats, polls, stickers, gifts, stars, stories |^[[39m\nCI / Test\tUNKNOWN STEP\t2026-05-30T16:59:58.2772801Z ^[[31m+ | TON & Jettons | 15    | Wallet, send/receive, balances, prices, NFTs, DEX router       |^[[39m\nCI / Test\tUNKNOWN STEP\t2026-05-30T16:59:58.2773562Z ^[[31m+ | STON.fi DEX   | 5     | Swap, quote, search, trending, pools                           |^[[39m\nCI / Test\tUNKNOWN STEP\t2026-05-30T16:59:58.2774408Z ^[[31m+ | DeDust DEX    | 5     | Swap, quote, pools, prices, token analytics                    |^[[39m\nCI / Test\tUNKNOWN STEP\t2026-05-30T16:59:58.2775891Z ^[[31m+ | TON DNS       | 8     | Auctions, bidding, linking, TON Sites, resolution              |^[[39m\nCI / Test\tUNKNOWN STEP\t2026-05-30T16:59:58.2777383Z ^[[31m+ | Deals         | 5     | P2P escrow, on-chain verification, anti double-spend           |^[[39m\nCI / Test\tUNKNOWN STEP\t2026-05-30T16:59:58.2778888Z ^[[31m+ | Journal       | 3     | Trade logging, P&L tracking, natural language queries          |^[[39m\nCI / Test\tUNKNOWN STEP\t2026-05-30T16:59:58.2780416Z ^[[31m+ | Web           | 3     | Search, page extraction (Tavily), binary file download         |^[[39m\nCI / Test\tUNKNOWN STEP\t2026-05-30T16:59:58.2782170Z ^[[31m+ | Workspace     | 6     | Sandboxed file operations, path traversal protection           |^[[39m\nCI / Test\tUNKNOWN STEP\t2026-05-30T16:59:58.2783645Z ^[[31m+ | Exec          | 4     | Shell, files, processes (off by default, admin-only)           |^[[39m\nCI / Test\tUNKNOWN STEP\t2026-05-30T16:59:58.2785089Z ^[[31m+ | Bot           | 1     | Inline bot message sending for plugin interactions             |^[[39m\nCI / Test\tUNKNOWN STEP\t2026-05-30T16:59:58.2785941Z ^[[31m+^[[39m\nCI / Test\tUNKNOWN STEP\t2026-05-30T16:59:58.2786521Z ^[[31m+ ### Advanced Capabilities^[[39m\nCI / Test\tUNKNOWN STEP\t2026-05-30T16:59:58.2786862Z ^[[31m+^[[39m\nCI / Test\tUNKNOWN STEP\t2026-05-30T16:59:58.2787162Z ^[[31m+ | Capability | Description |^[[39m\nCI / Test\tUNKNOWN STEP\t2026-05-30T16:59:58.2787597Z ^[[31m+ | ---------- | ----------- |^[[39m\nCI / Test\tUNKNOWN STEP\t2026-05-30T16:59:58.2788360Z ^[[31m+ | **Multi-Provider LLM** | 16 providers with hot-swap from CLI/WebUI and 100+ model presets in the shared catalog. |^[[39m\nCI / Test\tUNKNOWN STEP\t2026-05-30T16:59:58.2789453Z ^[[31m+ | **RAG + Semantic Memory** | Local SQLite FTS5 + sqlite-vec plus optional Upstash Vector sync and dimension mismatch detection. |^[[39m\nCI / Test\tUNKNOWN STEP\t2026-05-30T16:59:58.2790842Z ^[[31m+ | **Memory Graph + Prioritization** | Entity graph, priority scoring, cleanup candidates, pinning, and retention controls. |^[[39m\nCI / Test\tUNKNOWN STEP\t2026-05-30T16:59:58.2791982Z ^[[31m+ | **Auto-Compaction** | AI summarizes old context, preserves critical identifiers, and writes compaction audit entries. |^[[39m\nCI / Test\tUNKNOWN STEP\t2026-05-30T16:59:58.2793213Z ^[[31m+ | **Observation Masking** | Compresses old tool results while preserving recent tool outputs for reasoning. |^[[39m\nCI / Test\tUNKNOWN STEP\t2026-05-30T16:59:58.2794360Z ^[[31m+ | **Autonomous Mode** | Long-running goals with planning, policy checks, retries, checkpoints, reflection, pause/resume, and escalation. |^[[39m\nCI / Test\tUNKNOWN STEP\t2026-05-30T16:59:58.2795557Z ^[[31m+ | **Workflow Automation** | Cron/event/webhook workflows and DAG pipelines with bounded timeouts and delegated-agent result waiting. |^[[39m\nCI / Test\tUNKNOWN STEP\t2026-05-30T16:59:58.2796750Z ^[[31m+ | **Multi-Agent Network** | Signed Ed25519 messages, trust levels, allowlist/blocklist controls, replay protection, and task delegation. |^[[39m\nCI / Test\tUNKNOWN STEP\t2026-05-30T16:59:58.2797895Z ^[[31m+ | **Managed Agents** | Create, clone, start/stop, authenticate, and monitor personal-account or bot-mode agents from WebUI. |^[[39m\nCI / Test\tUNKNOWN STEP\t2026-05-30T16:59:58.2798952Z ^[[31m+ | **Plugin SDK** | Frozen SDK, isolated DBs, scoped secrets, lifecycle hooks, bot inline callbacks, and custom tools. |^[[39m\nCI / Test\tUNKNOWN STEP\t2026-05-30T16:59:58.2800050Z ^[[31m+ | **MCP Client** | stdio, SSE, and Streamable HTTP servers with namespaced tools and WebUI management. |^[[39m\nCI / Test\tUNKNOWN STEP\t2026-05-30T16:59:58.2801328Z ^[[31m+ | **Smart DEX Router** | Compares STON.fi and DeDust, supports wallet, jettons, NFTs, DNS, and payment verification. |^[[39m\nCI / Test\tUNKNOWN STEP\t2026-05-30T16:59:58.2802443Z ^[[31m+ | **Prediction + Feedback** | Behavior predictions, dashboard suggestions, feedback capture, and adaptive prompting experiments. |^[[39m\nCI / Test\tUNKNOWN STEP\t2026-05-30T16:59:58.2803554Z ^[[31m+ | **Security Center** | Audit trail, approvals, zero-trust execution policy, secrets, auth hardening, and anomaly alerts. |^[[39m\nCI / Test\tUNKNOWN STEP\t2026-05-30T16:59:58.2804584Z ^[[31m+ | **System Execution** | Exec tools are off by default; allowlist and YOLO modes are audited and admin-scoped. |^[[39m\nCI / Test\tUNKNOWN STEP\t2026-05-30T16:59:58.2805690Z ^[[31m+ | **Management API** | HTTPS control plane for remote admin, bootstrap mode, lifecycle control, logs, memory, and reused WebUI routes. |^[[39m\nCI / Test\tUNKNOWN STEP\t2026-05-30T16:59:58.2806803Z ^[[31m+ | **TON Proxy + MTProto Proxy** | .ton HTTP proxy lifecycle plus MTProto/Bot API proxy support for restricted networks. |^[[39m\nCI / Test\tUNKNOWN STEP\t2026-05-30T16:59:58.2807775Z ^[[31m+ | **Heartbeat** | Autonomous periodic wake-up with configurable prompt and safe admin-id handling. |^[[39m\nCI / Test\tUNKNOWN STEP\t2026-05-30T16:59:58.2808292Z ^[[31m+^[[39m\nCI / Test\tUNKNOWN STEP\t2026-05-30T16:59:58.2808520Z ^[[31m+ ---^[[39m\nCI / Test\tUNKNOWN STEP\t2026-05-30T16:59:58.2808755Z ^[[31m+^[[39m\nCI / Test\tUNKNOWN STEP\t2026-05-30T16:59:58.2809014Z ^[[31m+ ## Prerequisites^[[39m\nCI / Test\tUNKNOWN STEP\t2026-05-30T16:59:58.2809285Z ^[[31m+^[[39m\nCI / Test\tUNKNOWN STEP\t2026-05-30T16:59:58.2809695Z ^[[31m+ - **Node.js 20.0.0+** - [Download](https://nodejs.org/)^[[39m\nCI / Test\tUNKNOWN STEP\t2026-05-30T16:59:58.2813230Z ^[[31m+ - **LLM API Key** - One of: [Anthropic](https://console.anthropic.com/) (recommended), [OpenAI](https://platform.openai.com/), [Google](https://aistudio.google.com/), [xAI](https://console.x.ai/), [Groq](https://console.groq.com/), [OpenRouter](https://openrouter.ai/), [Moonshot](https://platform.moonshot.ai/), [Mistral](https://console.mistral.ai/), [Cerebras](https://cloud.cerebras.ai/), [ZAI](https://open.bigmodel.cn/), [MiniMax](https://platform.minimaxi.com/), [Hugging Face](https://huggingface.co/settings/tokens), [NVIDIA NIM](https://build.nvidia.com/) — or keyless: Claude Code (auto-detect), Cocoon (TON), Local (Ollama/vLLM)^[[39m\nCI / Test\tUNKNOWN STEP\t2026-05-30T16:59:58.2817836Z ^[[31m+ - **Telegram Account** - Dedicated account recommended for security^[[39m\nCI / Test\tUNKNOWN STEP\t2026-05-30T16:59:58.2819269Z ^[[31m+ - **Telegram API Credentials** - From [my.telegram.org/apps](https://my.telegram.org/apps)^[[39m\nCI / Test\tUNKNOWN STEP\t2026-05-30T16:59:58.2820920Z ^[[31m+ - **Your Telegram User ID** - Message [@userinfobot](https://t.me/userinfobot)^[[39m\nCI / Test\tUNKNOWN STEP\t2026-05-30T16:59:58.2822458Z ^[[31m+ - **Bot Token** *(optional)* - From [@BotFather](https://t.me/BotFather) for inline bot features (deals)^[[39m\nCI / Test\tUNKNOWN STEP\t2026-05-30T16:59:58.2823365Z ^[[31m+^[[39m\nCI / Test\tUNKNOWN STEP\t2026-05-30T16:59:58.2824193Z ^[[31m+ > **Security Warning**: The agent will have full control over the Telegram account. Use a dedicated account, not your main one.^[[39m\nCI / Test\tUNKNOWN STEP\t2026-05-30T16:59:58.2824812Z ^[[31m+^[[39m\nCI / Test\tUNKNOWN STEP\t2026-05-30T16:59:58.2825043Z ^[[31m+ ---^[[39m\nCI / Test\tUNKNOWN STEP\t2026-05-30T16:59:58.2825270Z ^[[31m+^[[39m\nCI / Test\tUNKNOWN STEP\t2026-05-30T16:59:58.2825706Z ^[[31m+ ## Quick Start^[[39m\nCI / Test\tUNKNOWN STEP\t2026-05-30T16:59:58.2825977Z ^[[31m+^[[39m\nCI / Test\tUNKNOWN STEP\t2026-05-30T16:59:58.2826256Z ^[[31m+ ### 1. Installation^[[39m\nCI / Test\tUNKNOWN STEP\t2026-05-30T16:59:58.2826525Z ^[[31m+^[[39m\nCI / Test\tUNKNOWN STEP\t2026-05-30T16:59:58.2826810Z ^[[31m+ **npm (recommended):**^[[39m\nCI / Test\tUNKNOWN STEP\t2026-05-30T16:59:58.2827109Z ^[[31m+ ```bash^[[39m\nCI / Test\tUNKNOWN STEP\t2026-05-30T16:59:58.2827435Z ^[[31m+ npm install -g teleton@latest^[[39m\nCI / Test\tUNKNOWN STEP\t2026-05-30T16:59:58.2827744Z ^[[31m+ ```^[[39m\nCI / Test\tUNKNOWN STEP\t2026-05-30T16:59:58.2827967Z ^[[31m+^[[39m\nCI / Test\tUNKNOWN STEP\t2026-05-30T16:59:58.2828205Z ^[[31m+ **Docker:**^[[39m\nCI / Test\tUNKNOWN STEP\t2026-05-30T16:59:58.2828469Z ^[[31m+ ```bash^[[39m",
+[2026-05-30T17:19:22.283Z] [INFO]         "is_error": false
+[2026-05-30T17:19:22.283Z] [INFO]       }
+[2026-05-30T17:19:22.283Z] [INFO]     ]
+[2026-05-30T17:19:22.283Z] [INFO]   },
+[2026-05-30T17:19:22.283Z] [INFO]   "parent_tool_use_id": null,
+[2026-05-30T17:19:22.283Z] [INFO]   "session_id": "45441128-80e2-48c1-a2ea-f81ede05030b",
+[2026-05-30T17:19:22.283Z] [INFO]   "uuid": "7b0d2d09-c9e9-42d6-8cbc-0709c7fe97e7",
+[2026-05-30T17:19:22.283Z] [INFO]   "timestamp": "2026-05-30T17:19:22.274Z",
+[2026-05-30T17:19:22.283Z] [INFO]   "tool_use_result": {
+[2026-05-30T17:19:22.283Z] [INFO]     "stdout": "CI / Test\tUNKNOWN STEP\t2026-05-30T16:59:58.2682779Z ^[[31m⎯⎯⎯⎯⎯⎯⎯^[[39m^[[1m^[[41m Failed Tests 1 ^[[49m^[[22m^[[31m⎯⎯⎯⎯⎯⎯⎯^[[39m\nCI / Test\tUNKNOWN STEP\t2026-05-30T16:59:58.2683215Z \nCI / Test\tUNKNOWN STEP\t2026-05-30T16:59:58.2684796Z ^[[41m^[[1m FAIL ^[[22m^[[49m src/docs/__tests__/readme.test.ts^[[2m > ^[[22mroot README^[[2m > ^[[22mdocuments the current fork version and WebUI surface\nCI / Test\tUNKNOWN STEP\t2026-05-30T16:59:58.2693052Z ^[[31m^[[1mAssertionError^[[22m: expected '<p align=\"center\">\\n  <img src=\"./log…' to contain 'Current fork version: `0.8.22`'^[[39m\nCI / Test\tUNKNOWN STEP\t2026-05-30T16:59:58.2694179Z \nCI / Test\tUNKNOWN STEP\t2026-05-30T16:59:58.2694795Z ^[[32m- Expected^[[39m\nCI / Test\tUNKNOWN STEP\t2026-05-30T16:59:58.2695380Z ^[[31m+ Received^[[39m\nCI / Test\tUNKNOWN STEP\t2026-05-30T16:59:58.2695630Z \nCI / Test\tUNKNOWN STEP\t2026-05-30T16:59:58.2695994Z ^[[32m- Current fork version: `0.8.22`^[[39m\nCI / Test\tUNKNOWN STEP\t2026-05-30T16:59:58.2696666Z ^[[31m+ <p align=\"center\">^[[39m\nCI / Test\tUNKNOWN STEP\t2026-05-30T16:59:58.2697559Z ^[[31m+   <img src=\"./logo_dark.png\" alt=\"Teleton Agent\" width=\"700\" />^[[39m\nCI / Test\tUNKNOWN STEP\t2026-05-30T16:59:58.2698263Z ^[[31m+ </p>^[[39m\nCI / Test\tUNKNOWN STEP\t2026-05-30T16:59:58.2698659Z ^[[31m+^[[39m\nCI / Test\tUNKNOWN STEP\t2026-05-30T16:59:58.2699857Z ^[[31m+ <p align=\"center\"><b>Autonomous AI agent platform for Telegram with native TON blockchain integration</b></p>^[[39m\nCI / Test\tUNKNOWN STEP\t2026-05-30T16:59:58.2701013Z ^[[31m+^[[39m\nCI / Test\tUNKNOWN STEP\t2026-05-30T16:59:58.2701492Z ^[[31m+ <p align=\"center\">^[[39m\nCI / Test\tUNKNOWN STEP\t2026-05-30T16:59:58.2703018Z ^[[31m+   <a href=\"https://opensource.org/licenses/MIT\"><img src=\"https://img.shields.io/badge/License-MIT-yellow.svg\" alt=\"License: MIT\"></a>^[[39m\nCI / Test\tUNKNOWN STEP\t2026-05-30T16:59:58.2704439Z ^[[31m+   <a href=\"https://nodejs.org/\"><img src=\"https://img.shields.io/badge/node-%3E%3D20.0.0-brightgreen\" alt=\"Node.js\"></a>^[[39m\nCI / Test\tUNKNOWN STEP\t2026-05-30T16:59:58.2705754Z ^[[31m+   <a href=\"https://codecov.io/gh/xlabtg/teleton-agent\"><img src=\"https://codecov.io/gh/xlabtg/teleton-agent/branch/main/graph/badge.svg\" alt=\"Coverage\"></a>^[[39m\nCI / Test\tUNKNOWN STEP\t2026-05-30T16:59:58.2707015Z ^[[31m+   <a href=\"https://www.typescriptlang.org/\"><img src=\"https://img.shields.io/badge/TypeScript-5.7-blue\" alt=\"TypeScript\"></a>^[[39m\nCI / Test\tUNKNOWN STEP\t2026-05-30T16:59:58.2708149Z ^[[31m+   <a href=\"https://teletonagent.dev\"><img src=\"https://img.shields.io/badge/Website-teletonagent.dev-ff6600\" alt=\"Website\"></a>^[[39m\nCI / Test\tUNKNOWN STEP\t2026-05-30T16:59:58.2709317Z ^[[31m+   <a href=\"https://docs.teletonagent.dev\"><img src=\"https://img.shields.io/badge/docs-Teleton%20Agents-blue\" alt=\"Documentation\"></a>^[[39m\nCI / Test\tUNKNOWN STEP\t2026-05-30T16:59:58.2710737Z ^[[31m+   <a href=\"https://ton.org\"><img src=\"https://img.shields.io/badge/Built_on-TON-0098EA?logo=ton&logoColor=white\" alt=\"Built on TON\"></a>^[[39m\nCI / Test\tUNKNOWN STEP\t2026-05-30T16:59:58.2711922Z ^[[31m+ </p>^[[39m\nCI / Test\tUNKNOWN STEP\t2026-05-30T16:59:58.2712188Z ^[[31m+^[[39m\nCI / Test\tUNKNOWN STEP\t2026-05-30T16:59:58.2712417Z ^[[31m+ ---^[[39m\nCI / Test\tUNKNOWN STEP\t2026-05-30T16:59:58.2712662Z ^[[31m+^[[39m\nCI / Test\tUNKNOWN STEP\t2026-05-30T16:59:58.2715900Z ^[[31m+ <p align=\"center\">Teleton is an autonomous AI agent platform that operates as a real Telegram user account or a Telegram Bot. It thinks through an agentic loop with tool calling, remembers conversations across sessions with hybrid RAG, and natively integrates the TON blockchain: send crypto, swap on DEXs, bid on domains, verify payments - all from a chat message. It can schedule tasks, run long autonomous goals, coordinate with other agents, and expose its operator console through a local-first WebUI. It ships with 135+ built-in tools, supports 16 LLM providers, and exposes a Plugin SDK so you can build your own tools on top of the platform.</p>^[[39m\nCI / Test\tUNKNOWN STEP\t2026-05-30T16:59:58.2718215Z ^[[31m+^[[39m\nCI / Test\tUNKNOWN STEP\t2026-05-30T16:59:58.2718494Z ^[[31m+ ### Key Highlights^[[39m\nCI / Test\tUNKNOWN STEP\t2026-05-30T16:59:58.2718770Z ^[[31m+^[[39m\nCI / Test\tUNKNOWN STEP\t2026-05-30T16:59:58.2719008Z ^[[31m+ <table>^[[39m\nCI / Test\tUNKNOWN STEP\t2026-05-30T16:59:58.2719260Z ^[[31m+ <tr>^[[39m\nCI / Test\tUNKNOWN STEP\t2026-05-30T16:59:58.2720199Z ^[[31m+ <td align=\"center\" width=\"33%\"><br><b><ins>Full Telegram Access</ins></b><br>Real user via MTProto,<br>not a bot<br><br></td>^[[39m\nCI / Test\tUNKNOWN STEP\t2026-05-30T16:59:58.2721495Z ^[[31m+ <td align=\"center\" width=\"33%\"><br><b><ins>Agentic Loop</ins></b><br>Think, act, observe, repeat<br>until the task is done<br><br></td>^[[39m\nCI / Test\tUNKNOWN STEP\t2026-05-30T16:59:58.2722602Z ^[[31m+ <td align=\"center\" width=\"33%\"><br><b><ins>16 LLM Providers</ins></b><br>Anthropic, OpenAI, Google, xAI, Groq, and more<br><br></td>^[[39m\nCI / Test\tUNKNOWN STEP\t2026-05-30T16:59:58.2723205Z ^[[31m+ </tr>^[[39m\nCI / Test\tUNKNOWN STEP\t2026-05-30T16:59:58.2723441Z ^[[31m+ <tr>^[[39m\nCI / Test\tUNKNOWN STEP\t2026-05-30T16:59:58.2724080Z ^[[31m+ <td align=\"center\"><br><b><ins>TON Blockchain</ins></b><br>Wallet, jettons, DEX swaps, DNS, NFTs<br><br></td>^[[39m\nCI / Test\tUNKNOWN STEP\t2026-05-30T16:59:58.2725059Z ^[[31m+ <td align=\"center\"><br><b><ins>Persistent Memory</ins></b><br>Hybrid RAG, vector + keyword, auto-compaction<br><br></td>^[[39m\nCI / Test\tUNKNOWN STEP\t2026-05-30T16:59:58.2726221Z ^[[31m+ <td align=\"center\"><br><b><ins>135+ Built-in Tools</ins></b><br>Messaging, media, crypto, DEX, DNS, files<br><br></td>^[[39m\nCI / Test\tUNKNOWN STEP\t2026-05-30T16:59:58.2726777Z ^[[31m+ </tr>^[[39m\nCI / Test\tUNKNOWN STEP\t2026-05-30T16:59:58.2727014Z ^[[31m+ <tr>^[[39m\nCI / Test\tUNKNOWN STEP\t2026-05-30T16:59:58.2727647Z ^[[31m+ <td align=\"center\"><br><b><ins>Plugin SDK</ins></b><br>Custom tools, isolated DBs, secrets, hooks<br><br></td>^[[39m\nCI / Test\tUNKNOWN STEP\t2026-05-30T16:59:58.2728586Z ^[[31m+ <td align=\"center\"><br><b><ins>23-Page WebUI</ins></b><br>Agents, pipelines, events, security, network<br><br></td>^[[39m\nCI / Test\tUNKNOWN STEP\t2026-05-30T16:59:58.2729536Z ^[[31m+ <td align=\"center\"><br><b><ins>Secure by Design</ins></b><br>Sandbox, signed ingress, prompt defense<br><br></td>^[[39m\nCI / Test\tUNKNOWN STEP\t2026-05-30T16:59:58.2730067Z ^[[31m+ </tr>^[[39m\nCI / Test\tUNKNOWN STEP\t2026-05-30T16:59:58.2730311Z ^[[31m+ </table>^[[39m\nCI / Test\tUNKNOWN STEP\t2026-05-30T16:59:58.2730804Z ^[[31m+^[[39m\nCI / Test\tUNKNOWN STEP\t2026-05-30T16:59:58.2731100Z ^[[31m+ ---^[[39m\nCI / Test\tUNKNOWN STEP\t2026-05-30T16:59:58.2731525Z ^[[31m+^[[39m\nCI / Test\tUNKNOWN STEP\t2026-05-30T16:59:58.2732029Z ^[[31m+ ## Current Fork Status^[[39m\nCI / Test\tUNKNOWN STEP\t2026-05-30T16:59:58.2732525Z ^[[31m+^[[39m\nCI / Test\tUNKNOWN STEP\t2026-05-30T16:59:58.2733062Z ^[[31m+ Current fork version: `0.8.21`.^[[39m\nCI / Test\tUNKNOWN STEP\t2026-05-30T16:59:58.2733579Z ^[[31m+^[[39m\nCI / Test\tUNKNOWN STEP\t2026-05-30T16:59:58.2737562Z ^[[31m+ This README reflects the `xlabtg/teleton-agent` fork through merged PR [#480](https://github.com/xlabtg/teleton-agent/pull/480) / closed issue [#479](https://github.com/xlabtg/teleton-agent/issues/479). It was refreshed from the closed work history available at issue [#481](https://github.com/xlabtg/teleton-agent/issues/481): 236 closed issues and the 200 most recent merged pull requests as of the latest analyzed run.^[[39m\nCI / Test\tUNKNOWN STEP\t2026-05-30T16:59:58.2739562Z ^[[31m+^[[39m\nCI / Test\tUNKNOWN STEP\t2026-05-30T16:59:58.2740133Z ^[[31m+ The current WebUI ships with 23 WebUI pages and 42 authenticated WebUI API route groups.^[[39m\nCI / Test\tUNKNOWN STEP\t2026-05-30T16:59:58.2740898Z ^[[31m+^[[39m\nCI / Test\tUNKNOWN STEP\t2026-05-30T16:59:58.2741222Z ^[[31m+ ### Closed-Work Summary^[[39m\nCI / Test\tUNKNOWN STEP\t2026-05-30T16:59:58.2741513Z ^[[31m+^[[39m\nCI / Test\tUNKNOWN STEP\t2026-05-30T16:59:58.2741818Z ^[[31m+ | Area | Implemented outcomes |^[[39m\nCI / Test\tUNKNOWN STEP\t2026-05-30T16:59:58.2742214Z ^[[31m+ | ---- | -------------------- |^[[39m\nCI / Test\tUNKNOWN STEP\t2026-05-30T16:59:58.2744679Z ^[[31m+ | **Autonomous mode** | Autonomous Task Engine, natural-language task parser, policy persistence, checkpoint cleanup, pause/resume hardening, reflection-success completion, Saved Messages task triggers, and restored autonomous-task foreign keys. |^[[39m\nCI / Test\tUNKNOWN STEP\t2026-05-30T16:59:58.2748540Z ^[[31m+ | **V2 platform features** | Semantic vector memory, associative memory graph, memory prioritization, prediction engine, predictive cache, anomaly detection, agent registry, task delegation, pipeline execution, self-correction loop, temporal context, zero-trust execution, audit trail, integrations, event bus/webhooks, dynamic dashboards, AI widget generator, feedback learning, adaptive prompting, and multi-agent network. |^[[39m\nCI / Test\tUNKNOWN STEP\t2026-05-30T16:59:58.2751690Z ^[[31m+ | **WebUI** | Dashboard widgets, tools controls, plugins marketplace, Soul editor, Memory, Workspace, Tasks, Workflows, Pipelines, Events, MCP, Integrations, Network, Hooks, Sessions, Analytics, Feedback, Security, Self-Improve, Autonomous Mode, Configuration, setup/login flow, and bilingual user guide. |^[[39m\nCI / Test\tUNKNOWN STEP\t2026-05-30T16:59:58.2755071Z ^[[31m+ | **Network and agents** | Managed agent runtimes with personal/bot auth, signed inter-agent messages, trust levels, replay protection, allowlist/recipient enforcement, manual inbox fallback, remote setup docs, and local-agent visibility in Network status totals. |^[[39m\nCI / Test\tUNKNOWN STEP\t2026-05-30T16:59:58.2760881Z ^[[31m+ | **Telegram and providers** | MTProto proxy recovery, Bot API proxy support, startup resilience when Telegram is unavailable, ffmpeg-free Telegram voice notes (pure-JS OGG/Opus encoder; no system ffmpeg required), Groq STT/TTS support including streaming WAV header fix (`0xFFFFFFFF` placeholder), NVIDIA NIM provider support, OpenRouter free models, and 16-provider model catalog. |^[[39m\nCI / Test\tUNKNOWN STEP\t2026-05-30T16:59:58.2766319Z ^[[31m+ | **Security and reliability** | Wallet encryption, plugin isolation, exec allowlist mode, shell-free allowlist execution, TON-proxy checksum verification, SSRF guards, path/symlink hardening, auth-token hashing, CSRF fixes, restart locks, transcript caps, session TTL enforcement, CI restoration, and audit reports. |^[[39m\nCI / Test\tUNKNOWN STEP\t2026-05-30T16:59:58.2768200Z ^[[31m+^[[39m\nCI / Test\tUNKNOWN STEP\t2026-05-30T16:59:58.2768449Z ^[[31m+ ---^[[39m\nCI / Test\tUNKNOWN STEP\t2026-05-30T16:59:58.2768686Z ^[[31m+^[[39m\nCI / Test\tUNKNOWN STEP\t2026-05-30T16:59:58.2768933Z ^[[31m+ ## Features^[[39m\nCI / Test\tUNKNOWN STEP\t2026-05-30T16:59:58.2769192Z ^[[31m+^[[39m\nCI / Test\tUNKNOWN STEP\t2026-05-30T16:59:58.2769468Z ^[[31m+ ### Tool Categories^[[39m\nCI / Test\tUNKNOWN STEP\t2026-05-30T16:59:58.2769736Z ^[[31m+^[[39m\nCI / Test\tUNKNOWN STEP\t2026-05-30T16:59:58.2770263Z ^[[31m+ | Category      | Tools | Description                                                    |^[[39m\nCI / Test\tUNKNOWN STEP\t2026-05-30T16:59:58.2771277Z ^[[31m+ | ------------- | ----- | -------------------------------------------------------------- |^[[39m\nCI / Test\tUNKNOWN STEP\t2026-05-30T16:59:58.2772025Z ^[[31m+ | Telegram      | 80    | Messages, media, chats, polls, stickers, gifts, stars, stories |^[[39m\nCI / Test\tUNKNOWN STEP\t2026-05-30T16:59:58.2772801Z ^[[31m+ | TON & Jettons | 15    | Wallet, send/receive, balances, prices, NFTs, DEX router       |^[[39m\nCI / Test\tUNKNOWN STEP\t2026-05-30T16:59:58.2773562Z ^[[31m+ | STON.fi DEX   | 5     | Swap, quote, search, trending, pools                           |^[[39m\nCI / Test\tUNKNOWN STEP\t2026-05-30T16:59:58.2774408Z ^[[31m+ | DeDust DEX    | 5     | Swap, quote, pools, prices, token analytics                    |^[[39m\nCI / Test\tUNKNOWN STEP\t2026-05-30T16:59:58.2775891Z ^[[31m+ | TON DNS       | 8     | Auctions, bidding, linking, TON Sites, resolution              |^[[39m\nCI / Test\tUNKNOWN STEP\t2026-05-30T16:59:58.2777383Z ^[[31m+ | Deals         | 5     | P2P escrow, on-chain verification, anti double-spend           |^[[39m\nCI / Test\tUNKNOWN STEP\t2026-05-30T16:59:58.2778888Z ^[[31m+ | Journal       | 3     | Trade logging, P&L tracking, natural language queries          |^[[39m\nCI / Test\tUNKNOWN STEP\t2026-05-30T16:59:58.2780416Z ^[[31m+ | Web           | 3     | Search, page extraction (Tavily), binary file download         |^[[39m\nCI / Test\tUNKNOWN STEP\t2026-05-30T16:59:58.2782170Z ^[[31m+ | Workspace     | 6     | Sandboxed file operations, path traversal protection           |^[[39m\nCI / Test\tUNKNOWN STEP\t2026-05-30T16:59:58.2783645Z ^[[31m+ | Exec          | 4     | Shell, files, processes (off by default, admin-only)           |^[[39m\nCI / Test\tUNKNOWN STEP\t2026-05-30T16:59:58.2785089Z ^[[31m+ | Bot           | 1     | Inline bot message sending for plugin interactions             |^[[39m\nCI / Test\tUNKNOWN STEP\t2026-05-30T16:59:58.2785941Z ^[[31m+^[[39m\nCI / Test\tUNKNOWN STEP\t2026-05-30T16:59:58.2786521Z ^[[31m+ ### Advanced Capabilities^[[39m\nCI / Test\tUNKNOWN STEP\t2026-05-30T16:59:58.2786862Z ^[[31m+^[[39m\nCI / Test\tUNKNOWN STEP\t2026-05-30T16:59:58.2787162Z ^[[31m+ | Capability | Description |^[[39m\nCI / Test\tUNKNOWN STEP\t2026-05-30T16:59:58.2787597Z ^[[31m+ | ---------- | ----------- |^[[39m\nCI / Test\tUNKNOWN STEP\t2026-05-30T16:59:58.2788360Z ^[[31m+ | **Multi-Provider LLM** | 16 providers with hot-swap from CLI/WebUI and 100+ model presets in the shared catalog. |^[[39m\nCI / Test\tUNKNOWN STEP\t2026-05-30T16:59:58.2789453Z ^[[31m+ | **RAG + Semantic Memory** | Local SQLite FTS5 + sqlite-vec plus optional Upstash Vector sync and dimension mismatch detection. |^[[39m\nCI / Test\tUNKNOWN STEP\t2026-05-30T16:59:58.2790842Z ^[[31m+ | **Memory Graph + Prioritization** | Entity graph, priority scoring, cleanup candidates, pinning, and retention controls. |^[[39m\nCI / Test\tUNKNOWN STEP\t2026-05-30T16:59:58.2791982Z ^[[31m+ | **Auto-Compaction** | AI summarizes old context, preserves critical identifiers, and writes compaction audit entries. |^[[39m\nCI / Test\tUNKNOWN STEP\t2026-05-30T16:59:58.2793213Z ^[[31m+ | **Observation Masking** | Compresses old tool results while preserving recent tool outputs for reasoning. |^[[39m\nCI / Test\tUNKNOWN STEP\t2026-05-30T16:59:58.2794360Z ^[[31m+ | **Autonomous Mode** | Long-running goals with planning, policy checks, retries, checkpoints, reflection, pause/resume, and escalation. |^[[39m\nCI / Test\tUNKNOWN STEP\t2026-05-30T16:59:58.2795557Z ^[[31m+ | **Workflow Automation** | Cron/event/webhook workflows and DAG pipelines with bounded timeouts and delegated-agent result waiting. |^[[39m\nCI / Test\tUNKNOWN STEP\t2026-05-30T16:59:58.2796750Z ^[[31m+ | **Multi-Agent Network** | Signed Ed25519 messages, trust levels, allowlist/blocklist controls, replay protection, and task delegation. |^[[39m\nCI / Test\tUNKNOWN STEP\t2026-05-30T16:59:58.2797895Z ^[[31m+ | **Managed Agents** | Create, clone, start/stop, authenticate, and monitor personal-account or bot-mode agents from WebUI. |^[[39m\nCI / Test\tUNKNOWN STEP\t2026-05-30T16:59:58.2798952Z ^[[31m+ | **Plugin SDK** | Frozen SDK, isolated DBs, scoped secrets, lifecycle hooks, bot inline callbacks, and custom tools. |^[[39m\nCI / Test\tUNKNOWN STEP\t2026-05-30T16:59:58.2800050Z ^[[31m+ | **MCP Client** | stdio, SSE, and Streamable HTTP servers with namespaced tools and WebUI management. |^[[39m\nCI / Test\tUNKNOWN STEP\t2026-05-30T16:59:58.2801328Z ^[[31m+ | **Smart DEX Router** | Compares STON.fi and DeDust, supports wallet, jettons, NFTs, DNS, and payment verification. |^[[39m\nCI / Test\tUNKNOWN STEP\t2026-05-30T16:59:58.2802443Z ^[[31m+ | **Prediction + Feedback** | Behavior predictions, dashboard suggestions, feedback capture, and adaptive prompting experiments. |^[[39m\nCI / Test\tUNKNOWN STEP\t2026-05-30T16:59:58.2803554Z ^[[31m+ | **Security Center** | Audit trail, approvals, zero-trust execution policy, secrets, auth hardening, and anomaly alerts. |^[[39m\nCI / Test\tUNKNOWN STEP\t2026-05-30T16:59:58.2804584Z ^[[31m+ | **System Execution** | Exec tools are off by default; allowlist and YOLO modes are audited and admin-scoped. |^[[39m\nCI / Test\tUNKNOWN STEP\t2026-05-30T16:59:58.2805690Z ^[[31m+ | **Management API** | HTTPS control plane for remote admin, bootstrap mode, lifecycle control, logs, memory, and reused WebUI routes. |^[[39m\nCI / Test\tUNKNOWN STEP\t2026-05-30T16:59:58.2806803Z ^[[31m+ | **TON Proxy + MTProto Proxy** | .ton HTTP proxy lifecycle plus MTProto/Bot API proxy support for restricted networks. |^[[39m\nCI / Test\tUNKNOWN STEP\t2026-05-30T16:59:58.2807775Z ^[[31m+ | **Heartbeat** | Autonomous periodic wake-up with configurable prompt and safe admin-id handling. |^[[39m\nCI / Test\tUNKNOWN STEP\t2026-05-30T16:59:58.2808292Z ^[[31m+^[[39m\nCI / Test\tUNKNOWN STEP\t2026-05-30T16:59:58.2808520Z ^[[31m+ ---^[[39m\nCI / Test\tUNKNOWN STEP\t2026-05-30T16:59:58.2808755Z ^[[31m+^[[39m\nCI / Test\tUNKNOWN STEP\t2026-05-30T16:59:58.2809014Z ^[[31m+ ## Prerequisites^[[39m\nCI / Test\tUNKNOWN STEP\t2026-05-30T16:59:58.2809285Z ^[[31m+^[[39m\nCI / Test\tUNKNOWN STEP\t2026-05-30T16:59:58.2809695Z ^[[31m+ - **Node.js 20.0.0+** - [Download](https://nodejs.org/)^[[39m\nCI / Test\tUNKNOWN STEP\t2026-05-30T16:59:58.2813230Z ^[[31m+ - **LLM API Key** - One of: [Anthropic](https://console.anthropic.com/) (recommended), [OpenAI](https://platform.openai.com/), [Google](https://aistudio.google.com/), [xAI](https://console.x.ai/), [Groq](https://console.groq.com/), [OpenRouter](https://openrouter.ai/), [Moonshot](https://platform.moonshot.ai/), [Mistral](https://console.mistral.ai/), [Cerebras](https://cloud.cerebras.ai/), [ZAI](https://open.bigmodel.cn/), [MiniMax](https://platform.minimaxi.com/), [Hugging Face](https://huggingface.co/settings/tokens), [NVIDIA NIM](https://build.nvidia.com/) — or keyless: Claude Code (auto-detect), Cocoon (TON), Local (Ollama/vLLM)^[[39m\nCI / Test\tUNKNOWN STEP\t2026-05-30T16:59:58.2817836Z ^[[31m+ - **Telegram Account** - Dedicated account recommended for security^[[39m\nCI / Test\tUNKNOWN STEP\t2026-05-30T16:59:58.2819269Z ^[[31m+ - **Telegram API Credentials** - From [my.telegram.org/apps](https://my.telegram.org/apps)^[[39m\nCI / Test\tUNKNOWN STEP\t2026-05-30T16:59:58.2820920Z ^[[31m+ - **Your Telegram User ID** - Message [@userinfobot](https://t.me/userinfobot)^[[39m\nCI / Test\tUNKNOWN STEP\t2026-05-30T16:59:58.2822458Z ^[[31m+ - **Bot Token** *(optional)* - From [@BotFather](https://t.me/BotFather) for inline bot features (deals)^[[39m\nCI / Test\tUNKNOWN STEP\t2026-05-30T16:59:58.2823365Z ^[[31m+^[[39m\nCI / Test\tUNKNOWN STEP\t2026-05-30T16:59:58.2824193Z ^[[31m+ > **Security Warning**: The agent will have full control over the Telegram account. Use a dedicated account, not your main one.^[[39m\nCI / Test\tUNKNOWN STEP\t2026-05-30T16:59:58.2824812Z ^[[31m+^[[39m\nCI / Test\tUNKNOWN STEP\t2026-05-30T16:59:58.2825043Z ^[[31m+ ---^[[39m\nCI / Test\tUNKNOWN STEP\t2026-05-30T16:59:58.2825270Z ^[[31m+^[[39m\nCI / Test\tUNKNOWN STEP\t2026-05-30T16:59:58.2825706Z ^[[31m+ ## Quick Start^[[39m\nCI / Test\tUNKNOWN STEP\t2026-05-30T16:59:58.2825977Z ^[[31m+^[[39m\nCI / Test\tUNKNOWN STEP\t2026-05-30T16:59:58.2826256Z ^[[31m+ ### 1. Installation^[[39m\nCI / Test\tUNKNOWN STEP\t2026-05-30T16:59:58.2826525Z ^[[31m+^[[39m\nCI / Test\tUNKNOWN STEP\t2026-05-30T16:59:58.2826810Z ^[[31m+ **npm (recommended):**^[[39m\nCI / Test\tUNKNOWN STEP\t2026-05-30T16:59:58.2827109Z ^[[31m+ ```bash^[[39m\nCI / Test\tUNKNOWN STEP\t2026-05-30T16:59:58.2827435Z ^[[31m+ npm install -g teleton@latest^[[39m\nCI / Test\tUNKNOWN STEP\t2026-05-30T16:59:58.2827744Z ^[[31m+ ```^[[39m\nCI / Test\tUNKNOWN STEP\t2026-05-30T16:59:58.2827967Z ^[[31m+^[[39m\nCI / Test\tUNKNOWN STEP\t2026-05-30T16:59:58.2828205Z ^[[31m+ **Docker:**^[[39m\nCI / Test\tUNKNOWN STEP\t2026-05-30T16:59:58.2828469Z ^[[31m+ ```bash^[[39m",
+[2026-05-30T17:19:22.283Z] [INFO]     "stderr": "",
+[2026-05-30T17:19:22.283Z] [INFO]     "interrupted": false,
+[2026-05-30T17:19:22.283Z] [INFO]     "isImage": false,
+[2026-05-30T17:19:22.283Z] [INFO]     "noOutputExpected": false
+[2026-05-30T17:19:22.283Z] [INFO]   }
+[2026-05-30T17:19:22.283Z] [INFO] }
+[2026-05-30T17:19:23.311Z] [INFO] {
+[2026-05-30T17:19:23.311Z] [INFO]   "type": "user",
+[2026-05-30T17:19:23.311Z] [INFO]   "message": {
+[2026-05-30T17:19:23.311Z] [INFO]     "role": "user",
+[2026-05-30T17:19:23.311Z] [INFO]     "content": [
+[2026-05-30T17:19:23.311Z] [INFO]       {
+[2026-05-30T17:19:23.311Z] [INFO]         "tool_use_id": "toolu_01FFYtYzN5VvbvgLVgWcAHUB",
+[2026-05-30T17:19:23.311Z] [INFO]         "type": "tool_result",
+[2026-05-30T17:19:23.311Z] [INFO]         "content": "import { existsSync, readFileSync, readdirSync } from \"node:fs\";\nimport { dirname, join, resolve } from \"node:path\";\nimport { fileURLToPath } from \"node:url\";\n\nimport pkg from \"../../../package.json\" with { type: \"json\" };\n\nconst __dirname = dirname(fileURLToPath(import.meta.url));\nconst repoRoot = resolve(__dirname, \"../../..\");\nconst readmePath = join(repoRoot, \"README.md\");\n\nfunction countWebUiPages(): number {\n  return readdirSync(join(repoRoot, \"web/src/pages\")).filter((file) => file.endsWith(\".tsx\"))\n    .length;\n}\n\nfunction countWebUiApiRouteGroups(): number {\n  return readFileSync(join(repoRoot, \"src/webui/server.ts\"), \"utf8\").match(\n    /this\\.app\\.route\\(\"\\/api\\//g\n  )!.length;\n}\n\nfunction assertLocalLinksResolve(markdownFile: string): void {\n  const body = readFileSync(markdownFile, \"utf8\");\n  const markdownLinkPattern = /!?\\[[^\\]]*]\\((?!https?:|mailto:|#)([^)]+)\\)/g;\n\n  for (const match of body.matchAll(markdownLinkPattern)) {\n    const target = decodeURIComponent(match[1].split(\"#\")[0]);\n    if (!target) continue;\n\n    const resolved = resolve(dirname(markdownFile), target);\n    expect(existsSync(resolved), `${markdownFile} links to missing file ${target}`).toBe(true);\n  }\n}\n\ndescribe(\"root README\", () => {\n  it(\"documents the current fork version and WebUI surface\", () => {\n    const readme = readFileSync(readmePath, \"utf8\");\n\n    expect(readme).toContain(`Current fork version: \\`${pkg.version}\\``);\n    expect(readme).toContain(`${countWebUiPages()} WebUI pages`);\n    expect(readme).toContain(`${countWebUiApiRouteGroups()} authenticated WebUI API route groups`);\n    expect(readme).toContain(\"100+ model presets\");\n    expect(readme).toContain(\"off | allowlist | yolo\");\n    expect(readme).not.toContain(\"70+ models\");\n    expect(readme).not.toContain(\"14 route groups\");\n    expect(readme).not.toContain(\"11 pages\");\n    expect(readme).not.toContain(\"github.com/TONresistor/teleton-agent.git\");\n    expect(readme).not.toContain(\"TONresistor/teleton-agent/issues\");\n  });\n\n  it(\"documents the current MCP tool namespace\", () => {\n    const readme = readFileSync(readmePath, \"utf8\");\n\n    expect(readme).toContain(\"`mcp.<server>.<tool>`\");\n    expect(readme).not.toContain(\"`mcp_<server>_<tool>`\");\n  });\n\n  it(\"does not contain broken local markdown links\", () => {\n    assertLocalLinksResolve(readmePath);\n  });\n});",
+[2026-05-30T17:19:23.311Z] [INFO]         "is_error": false
+[2026-05-30T17:19:23.311Z] [INFO]       }
+[2026-05-30T17:19:23.311Z] [INFO]     ]
+[2026-05-30T17:19:23.311Z] [INFO]   },
+[2026-05-30T17:19:23.311Z] [INFO]   "parent_tool_use_id": null,
+[2026-05-30T17:19:23.311Z] [INFO]   "session_id": "45441128-80e2-48c1-a2ea-f81ede05030b",
+[2026-05-30T17:19:23.311Z] [INFO]   "uuid": "3d3cfd93-324d-4b5d-9bc4-9659636c2a09",
+[2026-05-30T17:19:23.311Z] [INFO]   "timestamp": "2026-05-30T17:19:23.310Z",
+[2026-05-30T17:19:23.311Z] [INFO]   "tool_use_result": {
+[2026-05-30T17:19:23.311Z] [INFO]     "stdout": "import { existsSync, readFileSync, readdirSync } from \"node:fs\";\nimport { dirname, join, resolve } from \"node:path\";\nimport { fileURLToPath } from \"node:url\";\n\nimport pkg from \"../../../package.json\" with { type: \"json\" };\n\nconst __dirname = dirname(fileURLToPath(import.meta.url));\nconst repoRoot = resolve(__dirname, \"../../..\");\nconst readmePath = join(repoRoot, \"README.md\");\n\nfunction countWebUiPages(): number {\n  return readdirSync(join(repoRoot, \"web/src/pages\")).filter((file) => file.endsWith(\".tsx\"))\n    .length;\n}\n\nfunction countWebUiApiRouteGroups(): number {\n  return readFileSync(join(repoRoot, \"src/webui/server.ts\"), \"utf8\").match(\n    /this\\.app\\.route\\(\"\\/api\\//g\n  )!.length;\n}\n\nfunction assertLocalLinksResolve(markdownFile: string): void {\n  const body = readFileSync(markdownFile, \"utf8\");\n  const markdownLinkPattern = /!?\\[[^\\]]*]\\((?!https?:|mailto:|#)([^)]+)\\)/g;\n\n  for (const match of body.matchAll(markdownLinkPattern)) {\n    const target = decodeURIComponent(match[1].split(\"#\")[0]);\n    if (!target) continue;\n\n    const resolved = resolve(dirname(markdownFile), target);\n    expect(existsSync(resolved), `${markdownFile} links to missing file ${target}`).toBe(true);\n  }\n}\n\ndescribe(\"root README\", () => {\n  it(\"documents the current fork version and WebUI surface\", () => {\n    const readme = readFileSync(readmePath, \"utf8\");\n\n    expect(readme).toContain(`Current fork version: \\`${pkg.version}\\``);\n    expect(readme).toContain(`${countWebUiPages()} WebUI pages`);\n    expect(readme).toContain(`${countWebUiApiRouteGroups()} authenticated WebUI API route groups`);\n    expect(readme).toContain(\"100+ model presets\");\n    expect(readme).toContain(\"off | allowlist | yolo\");\n    expect(readme).not.toContain(\"70+ models\");\n    expect(readme).not.toContain(\"14 route groups\");\n    expect(readme).not.toContain(\"11 pages\");\n    expect(readme).not.toContain(\"github.com/TONresistor/teleton-agent.git\");\n    expect(readme).not.toContain(\"TONresistor/teleton-agent/issues\");\n  });\n\n  it(\"documents the current MCP tool namespace\", () => {\n    const readme = readFileSync(readmePath, \"utf8\");\n\n    expect(readme).toContain(\"`mcp.<server>.<tool>`\");\n    expect(readme).not.toContain(\"`mcp_<server>_<tool>`\");\n  });\n\n  it(\"does not contain broken local markdown links\", () => {\n    assertLocalLinksResolve(readmePath);\n  });\n});",
+[2026-05-30T17:19:23.311Z] [INFO]     "stderr": "",
+[2026-05-30T17:19:23.311Z] [INFO]     "interrupted": false,
+[2026-05-30T17:19:23.311Z] [INFO]     "isImage": false,
+[2026-05-30T17:19:23.311Z] [INFO]     "noOutputExpected": false
+[2026-05-30T17:19:23.311Z] [INFO]   }
+[2026-05-30T17:19:23.311Z] [INFO] }
+[2026-05-30T17:19:23.329Z] [INFO] [log_fae96b] sending request {
+[2026-05-30T17:19:23.332Z] [INFO]   method: "post",
+[2026-05-30T17:19:23.333Z] [INFO]   url: "https://api.anthropic.com/v1/messages?beta=true",
+[2026-05-30T17:19:23.333Z] [INFO]   options: {
+[2026-05-30T17:19:23.335Z] [INFO]     method: "post",
+[2026-05-30T17:19:23.335Z] [INFO]     path: "/v1/messages?beta=true",
+[2026-05-30T17:19:23.336Z] [INFO]     body: {
+[2026-05-30T17:19:23.337Z] [INFO]       model: "claude-opus-4-8",
+[2026-05-30T17:19:23.338Z] [INFO]       messages: [
+[2026-05-30T17:19:23.338Z] [INFO]         [Object ...], [Object ...], [Object ...], [Object ...], [Object ...], [Object ...], [Object ...], [Object ...], [Object ...], [Object ...], [Object ...], [Object ...], [Object ...], [Object ...], [Object ...], [Object ...]
+[2026-05-30T17:19:23.338Z] [INFO]       ],
+[2026-05-30T17:19:23.339Z] [INFO]       system: [
+[2026-05-30T17:19:23.339Z] [INFO]         [Object ...], [Object ...], [Object ...], [Object ...]
+[2026-05-30T17:19:23.340Z] [INFO]       ],
+[2026-05-30T17:19:23.340Z] [INFO]       tools: [
+[2026-05-30T17:19:23.341Z] [INFO]         [Object ...], [Object ...], [Object ...], [Object ...], [Object ...], [Object ...], [Object ...], [Object ...], [Object ...], [Object ...]
+[2026-05-30T17:19:23.341Z] [INFO]       ],
+[2026-05-30T17:19:23.341Z] [INFO]       tool_choice: undefined,
+[2026-05-30T17:19:23.342Z] [INFO]       metadata: [Object ...],
+[2026-05-30T17:19:23.342Z] [INFO]       max_tokens: 128000,
+[2026-05-30T17:19:23.342Z] [INFO]       thinking: [Object ...],
+[2026-05-30T17:19:23.343Z] [INFO]       context_management: [Object ...],
+[2026-05-30T17:19:23.343Z] [INFO]       output_config: [Object ...],
+[2026-05-30T17:19:23.344Z] [INFO]       diagnostics: [Object ...],
+[2026-05-30T17:19:23.344Z] [INFO]       stream: true,
+[2026-05-30T17:19:23.344Z] [INFO]     },
+[2026-05-30T17:19:23.345Z] [INFO]     timeout: 600000,
+[2026-05-30T17:19:23.345Z] [INFO]     signal: AbortSignal {
+[2026-05-30T17:19:23.346Z] [INFO]       [Symbol(events.maxEventTargetListeners)]: 50,
+[2026-05-30T17:19:23.346Z] [INFO]       [Symbol(events.maxEventTargetListenersWarned)]: false,
+[2026-05-30T17:19:23.347Z] [INFO]       aborted: false,
+[2026-05-30T17:19:23.347Z] [INFO]       reason: undefined,
+[2026-05-30T17:19:23.347Z] [INFO]       onabort: null,
+[2026-05-30T17:19:23.348Z] [INFO]       throwIfAborted: [Function: throwIfAborted],
+[2026-05-30T17:19:23.348Z] [INFO]       addEventListener: [Function: addEventListener],
+[2026-05-30T17:19:23.349Z] [INFO]       removeEventListener: [Function: removeEventListener],
+[2026-05-30T17:19:23.350Z] [INFO]       dispatchEvent: [Function: dispatchEvent],
+[2026-05-30T17:19:23.352Z] [INFO]     },
+[2026-05-30T17:19:23.353Z] [INFO]     stream: true,
+[2026-05-30T17:19:23.353Z] [INFO]   },
+[2026-05-30T17:19:23.353Z] [INFO]   headers: {
+[2026-05-30T17:19:23.354Z] [INFO]     accept: "application/json",
+[2026-05-30T17:19:23.354Z] [INFO]     "anthropic-beta": "claude-code-20250219,oauth-2025-04-20,interleaved-thinking-2025-05-14,thinking-token-count-2026-05-13,context-management-2025-06-27,prompt-caching-scope-2026-01-05,mid-conversation-system-2026-04-07,advisor-tool-2026-03-01,advanced-tool-use-2025-11-20,effort-2025-11-24,extended-cache-ttl-2025-04-11,cache-diagnosis-2026-04-07",
+[2026-05-30T17:19:23.355Z] [INFO]     "anthropic-dangerous-direct-browser-access": "true",
+[2026-05-30T17:19:23.355Z] [INFO]     "anthropic-version": "2023-06-01",
+[2026-05-30T17:19:23.355Z] [INFO]     authorization: "***",
+[2026-05-30T17:19:23.362Z] [INFO]     "content-type": "application/json",
+[2026-05-30T17:19:23.365Z] [INFO]     "user-agent": "claude-cli/2.1.158 (external, sdk-cli)",
+[2026-05-30T17:19:23.366Z] [INFO]     "x-app": "cli",
+[2026-05-30T17:19:23.368Z] [INFO]     "x-claude-code-session-id": "45441128-80e2-48c1-a2ea-f81ede05030b",
+[2026-05-30T17:19:23.369Z] [INFO]     "x-client-request-id": "cdefbe18-e64c-4581-8162-350e33743461",
+[2026-05-30T17:19:23.369Z] [INFO]     "x-stainless-arch": "x64",
+[2026-05-30T17:19:23.369Z] [INFO]     "x-stainless-lang": "js",
+[2026-05-30T17:19:23.370Z] [INFO]     "x-stainless-os": "Linux",
+[2026-05-30T17:19:23.371Z] [INFO]     "x-stainless-package-version": "0.94.0",
+[2026-05-30T17:19:23.373Z] [INFO]     "x-stainless-retry-count": "0",
+[2026-05-30T17:19:23.375Z] [INFO]     "x-stainless-runtime": "node",
+[2026-05-30T17:19:23.376Z] [INFO]     "x-stainless-runtime-version": "v24.3.0",
+[2026-05-30T17:19:23.377Z] [INFO]     "x-stainless-timeout": "600",
+[2026-05-30T17:19:23.379Z] [INFO]   },
+[2026-05-30T17:19:23.380Z] [INFO] }
+[2026-05-30T17:19:25.845Z] [INFO] [log_fae96b, request-id: "req_011CbZ8qf8TJZupqAMbxEfbi"] post https://api.anthropic.com/v1/messages?beta=true succeeded with status 200 in 2515ms
+[2026-05-30T17:19:25.846Z] [INFO] [log_fae96b] response start {
+[2026-05-30T17:19:25.846Z] [INFO]   url: "https://api.anthropic.com/v1/messages?beta=true",
+[2026-05-30T17:19:25.847Z] [INFO]   status: 200,
+[2026-05-30T17:19:25.848Z] [INFO]   headers: {
+[2026-05-30T17:19:25.848Z] [INFO]     "anthropic-organization-id": "ebc2ac93-f86f-4d15-aff3-de8830d8d789",
+[2026-05-30T17:19:25.848Z] [INFO]     "anthropic-ratelimit-unified-5h-reset": "1780173000",
+[2026-05-30T17:19:25.848Z] [INFO]     "anthropic-ratelimit-unified-5h-status": "allowed",
+[2026-05-30T17:19:25.849Z] [INFO]     "anthropic-ratelimit-unified-5h-utilization": "0.25",
+[2026-05-30T17:19:25.850Z] [INFO]     "anthropic-ratelimit-unified-7d-reset": "1780398000",
+[2026-05-30T17:19:25.851Z] [INFO]     "anthropic-ratelimit-unified-7d-status": "allowed",
+[2026-05-30T17:19:25.853Z] [INFO]     "anthropic-ratelimit-unified-7d-utilization": "0.73",
+[2026-05-30T17:19:25.853Z] [INFO]     "anthropic-ratelimit-unified-fallback-percentage": "0.5",
+[2026-05-30T17:19:25.854Z] [INFO]     "anthropic-ratelimit-unified-overage-disabled-reason": "org_level_disabled",
+[2026-05-30T17:19:25.854Z] [INFO]     "anthropic-ratelimit-unified-overage-status": "rejected",
+[2026-05-30T17:19:25.854Z] [INFO]     "anthropic-ratelimit-unified-representative-claim": "five_hour",
+[2026-05-30T17:19:25.854Z] [INFO]     "anthropic-ratelimit-unified-reset": "1780173000",
+[2026-05-30T17:19:25.855Z] [INFO]     "anthropic-ratelimit-unified-status": "allowed",
+[2026-05-30T17:19:25.855Z] [INFO]     "cache-control": "no-cache",
+[2026-05-30T17:19:25.856Z] [INFO]     "cf-cache-status": "DYNAMIC",
+[2026-05-30T17:19:25.856Z] [INFO]     "cf-ray": "a03f674adc83976a-FRA",
+[2026-05-30T17:19:25.856Z] [INFO]     connection: "keep-alive",
+[2026-05-30T17:19:25.856Z] [INFO]     "content-encoding": "gzip",
+[2026-05-30T17:19:25.857Z] [INFO]     "content-security-policy": "default-src 'none'; frame-ancestors 'none'",
+[2026-05-30T17:19:25.857Z] [INFO]     "content-type": "text/event-stream; charset=utf-8",
+[2026-05-30T17:19:25.858Z] [INFO]     date: "Sat, 30 May 2026 17:19:25 GMT",
+[2026-05-30T17:19:25.858Z] [INFO]     "request-id": "req_011CbZ8qf8TJZupqAMbxEfbi",
+[2026-05-30T17:19:25.860Z] [INFO]     server: "cloudflare",
+[2026-05-30T17:19:25.861Z] [INFO]     "strict-transport-security": "max-age=31536000; includeSubDomains; preload",
+[2026-05-30T17:19:25.862Z] [INFO]     traceresponse: "00-883d509891f5aa216b7c85d8c79d2891-e4f938d0a1581629-01",
+[2026-05-30T17:19:25.862Z] [INFO]     "transfer-encoding": "chunked",
+[2026-05-30T17:19:25.862Z] [INFO]     vary: "Accept-Encoding",
+[2026-05-30T17:19:25.862Z] [INFO]     "x-robots-tag": "none",
+[2026-05-30T17:19:25.863Z] [INFO]     "set-cookie": "***",
+[2026-05-30T17:19:25.863Z] [INFO]   },
+[2026-05-30T17:19:25.864Z] [INFO]   durationMs: 2515,
+[2026-05-30T17:19:25.866Z] [INFO] }
+[2026-05-30T17:19:25.869Z] [INFO] response 200 https://api.anthropic.com/v1/messages?beta=true Headers {
+[2026-05-30T17:19:25.869Z] [INFO]   "date": "Sat, 30 May 2026 17:19:25 GMT",
+[2026-05-30T17:19:25.870Z] [INFO]   "content-type": "text/event-stream; charset=utf-8",
+[2026-05-30T17:19:25.871Z] [INFO]   "transfer-encoding": "chunked",
+[2026-05-30T17:19:25.872Z] [INFO]   "connection": "keep-alive",
+[2026-05-30T17:19:25.873Z] [INFO]   "cache-control": "no-cache",
+[2026-05-30T17:19:25.873Z] [INFO]   "strict-transport-security": "max-age=31536000; includeSubDomains; preload",
+[2026-05-30T17:19:25.874Z] [INFO]   "content-encoding": "gzip",
+[2026-05-30T17:19:25.874Z] [INFO]   "vary": "Accept-Encoding",
+[2026-05-30T17:19:25.875Z] [INFO]   "content-security-policy": "default-src 'none'; frame-ancestors 'none'",
+[2026-05-30T17:19:25.875Z] [INFO]   "set-cookie": [ "_cfuvid=RICtgE3m_gv0z4tIdt1pwUj5ifrNdGLeI_atkx4QovA-1780161563.34116-1.0.1.1-skZB.N8MjJ1lOXf1UKgXlq9T7p07wWxzApH93zQ4ISw; HttpOnly; SameSite=None; Secure; Path=/; Domain=api.anthropic.com" ],
+[2026-05-30T17:19:25.876Z] [INFO]   "anthropic-ratelimit-unified-status": "allowed",
+[2026-05-30T17:19:25.876Z] [INFO]   "anthropic-ratelimit-unified-5h-status": "allowed",
+[2026-05-30T17:19:25.877Z] [INFO]   "anthropic-ratelimit-unified-5h-reset": "1780173000",
+[2026-05-30T17:19:25.877Z] [INFO]   "anthropic-ratelimit-unified-5h-utilization": "0.25",
+[2026-05-30T17:19:25.883Z] [INFO]   "anthropic-ratelimit-unified-7d-status": "allowed",
+[2026-05-30T17:19:25.884Z] [INFO]   "anthropic-ratelimit-unified-7d-reset": "1780398000",
+[2026-05-30T17:19:25.885Z] [INFO]   "anthropic-ratelimit-unified-7d-utilization": "0.73",
+[2026-05-30T17:19:25.889Z] [INFO]   "anthropic-ratelimit-unified-representative-claim": "five_hour",
+[2026-05-30T17:19:25.889Z] [INFO]   "anthropic-ratelimit-unified-fallback-percentage": "0.5",
+[2026-05-30T17:19:25.890Z] [INFO]   "anthropic-ratelimit-unified-reset": "1780173000",
+[2026-05-30T17:19:25.893Z] [INFO]   "anthropic-ratelimit-unified-overage-disabled-reason": "org_level_disabled",
+[2026-05-30T17:19:25.894Z] [INFO]   "anthropic-ratelimit-unified-overage-status": "rejected",
+[2026-05-30T17:19:25.895Z] [INFO]   "request-id": "req_011CbZ8qf8TJZupqAMbxEfbi",
+[2026-05-30T17:19:25.896Z] [INFO]   "anthropic-organization-id": "ebc2ac93-f86f-4d15-aff3-de8830d8d789",
+[2026-05-30T17:19:25.900Z] [INFO]   "traceresponse": "00-883d509891f5aa216b7c85d8c79d2891-e4f938d0a1581629-01",
+[2026-05-30T17:19:25.901Z] [INFO]   "server": "cloudflare",
+[2026-05-30T17:19:25.903Z] [INFO]   "cf-cache-status": "DYNAMIC",
+[2026-05-30T17:19:25.903Z] [INFO]   "x-robots-tag": "none",
+[2026-05-30T17:19:25.904Z] [INFO]   "cf-ray": "a03f674adc83976a-FRA",
+[2026-05-30T17:19:25.904Z] [INFO] } ReadableStream {
+[2026-05-30T17:19:25.905Z] [INFO]   blob: [Function: blob],
+[2026-05-30T17:19:25.905Z] [INFO]   bytes: [Function: bytes],
+[2026-05-30T17:19:25.905Z] [INFO]   cancel: [Function],
+[2026-05-30T17:19:25.906Z] [INFO]   getReader: [Function],
+[2026-05-30T17:19:25.906Z] [INFO]   json: [Function: json],
+[2026-05-30T17:19:25.906Z] [INFO]   locked: [Getter],
+[2026-05-30T17:19:25.907Z] [INFO]   pipeThrough: [Function],
+[2026-05-30T17:19:25.907Z] [INFO]   pipeTo: [Function],
+[2026-05-30T17:19:25.908Z] [INFO]   tee: [Function],
+[2026-05-30T17:19:25.908Z] [INFO]   text: [Function: text],
+[2026-05-30T17:19:25.909Z] [INFO]   values: [Function: values],
+[2026-05-30T17:19:25.909Z] [INFO]   [Symbol(Symbol.asyncIterator)]: [Function: asyncIterator2],
+[2026-05-30T17:19:25.909Z] [INFO] }
+[2026-05-30T17:19:25.910Z] [INFO] [log_fae96b] response parsed {
+[2026-05-30T17:19:25.910Z] [INFO]   url: "https://api.anthropic.com/v1/messages?beta=true",
+[2026-05-30T17:19:25.910Z] [INFO]   status: 200,
+[2026-05-30T17:19:25.911Z] [INFO]   body: bR {
+[2026-05-30T17:19:25.911Z] [INFO]     iterator: [AsyncGeneratorFunction: z],
+[2026-05-30T17:19:25.911Z] [INFO]     controller: AbortController {
+[2026-05-30T17:19:25.912Z] [INFO]       signal: [AbortSignal ...],
+[2026-05-30T17:19:25.912Z] [INFO]       abort: [Function: abort],
+[2026-05-30T17:19:25.912Z] [INFO]     },
+[2026-05-30T17:19:25.913Z] [INFO]     [Symbol(Symbol.asyncIterator)]: [Function],
+[2026-05-30T17:19:25.913Z] [INFO]     tee: [Function: tee],
+[2026-05-30T17:19:25.914Z] [INFO]     toReadableStream: [Function: toReadableStream],
+[2026-05-30T17:19:25.916Z] [INFO]   },
+[2026-05-30T17:19:25.920Z] [INFO]   durationMs: 2515,
+[2026-05-30T17:19:25.920Z] [INFO] }
+[2026-05-30T17:19:27.350Z] [INFO] {
+[2026-05-30T17:19:27.350Z] [INFO]   "type": "system",
+[2026-05-30T17:19:27.350Z] [INFO]   "subtype": "thinking_tokens",
+[2026-05-30T17:19:27.350Z] [INFO]   "estimated_tokens": 50,
+[2026-05-30T17:19:27.350Z] [INFO]   "estimated_tokens_delta": 50,
+[2026-05-30T17:19:27.350Z] [INFO]   "uuid": "efa3839a-3e2d-48e9-b2cf-2b97c2c76dc7",
+[2026-05-30T17:19:27.350Z] [INFO]   "session_id": "45441128-80e2-48c1-a2ea-f81ede05030b"
+[2026-05-30T17:19:27.350Z] [INFO] }
+[2026-05-30T17:19:29.229Z] [INFO] {
+[2026-05-30T17:19:29.229Z] [INFO]   "type": "system",
+[2026-05-30T17:19:29.229Z] [INFO]   "subtype": "thinking_tokens",
+[2026-05-30T17:19:29.229Z] [INFO]   "estimated_tokens": 200,
+[2026-05-30T17:19:29.229Z] [INFO]   "estimated_tokens_delta": 150,
+[2026-05-30T17:19:29.229Z] [INFO]   "uuid": "e1f252f2-9f8f-45df-8f2b-f6e0cc152fad",
+[2026-05-30T17:19:29.229Z] [INFO]   "session_id": "45441128-80e2-48c1-a2ea-f81ede05030b"
+[2026-05-30T17:19:29.229Z] [INFO] }
+[2026-05-30T17:19:30.644Z] [INFO] {
+[2026-05-30T17:19:30.644Z] [INFO]   "type": "system",
+[2026-05-30T17:19:30.644Z] [INFO]   "subtype": "thinking_tokens",
+[2026-05-30T17:19:30.644Z] [INFO]   "estimated_tokens": 300,
+[2026-05-30T17:19:30.644Z] [INFO]   "estimated_tokens_delta": 100,
+[2026-05-30T17:19:30.644Z] [INFO]   "uuid": "d609b790-ff32-48b9-aa13-503a1831432b",
+[2026-05-30T17:19:30.644Z] [INFO]   "session_id": "45441128-80e2-48c1-a2ea-f81ede05030b"
+[2026-05-30T17:19:30.644Z] [INFO] }
+[2026-05-30T17:19:32.059Z] [INFO] {
+[2026-05-30T17:19:32.059Z] [INFO]   "type": "system",
+[2026-05-30T17:19:32.059Z] [INFO]   "subtype": "thinking_tokens",
+[2026-05-30T17:19:32.059Z] [INFO]   "estimated_tokens": 400,
+[2026-05-30T17:19:32.059Z] [INFO]   "estimated_tokens_delta": 100,
+[2026-05-30T17:19:32.059Z] [INFO]   "uuid": "d561c55d-96ae-4e89-aba0-581bc8af6e42",
+[2026-05-30T17:19:32.059Z] [INFO]   "session_id": "45441128-80e2-48c1-a2ea-f81ede05030b"
+[2026-05-30T17:19:32.059Z] [INFO] }
+[2026-05-30T17:19:32.524Z] [INFO] {
+[2026-05-30T17:19:32.524Z] [INFO]   "type": "assistant",
+[2026-05-30T17:19:32.524Z] [INFO]   "message": {
+[2026-05-30T17:19:32.524Z] [INFO]     "model": "claude-opus-4-8",
+[2026-05-30T17:19:32.524Z] [INFO]     "id": "msg_01WwnehpUsrNPmBTU6kxrYQY",
+[2026-05-30T17:19:32.524Z] [INFO]     "type": "message",
+[2026-05-30T17:19:32.524Z] [INFO]     "role": "assistant",
+[2026-05-30T17:19:32.524Z] [INFO]     "content": [
+[2026-05-30T17:19:32.524Z] [INFO]       {
+[2026-05-30T17:19:32.524Z] [INFO]         "type": "thinking",
+[2026-05-30T17:19:32.524Z] [INFO]         "thinking": "",
+[2026-05-30T17:19:32.524Z] [INFO]         "signature": "EoEMCmMIDhgCKkBDR+SqiXSOvNb6jKNSujzT9Lzs/M42KpHWxVp6u5A28FBBW0rrV8q7rl7HBHWDTp8DBq2WLNHGlaHsjFarItVKMg9jbGF1ZGUtb3B1cy00LTg4AEIIdGhpbmtpbmcSDCQQ7O2neNp0h1rQVxoMTpWUXutR4q1H3ZZHIjCVWIQ74NcOLNjhXUyzivz7buhtTfXXELzu44zHKb+pvDMoXO4qlkgTsqjljR56whMqywqJrU9A+KPzAOfKg+3XbSPxKwrIbmYTM5OkGz7xnN6tLzNhQyHZHNBdzrOUoE6IPU6y7fhURVSn6FX9GvndJZ59Xdzk7b7e2W6Xpqrn1PcPjrWt8stpakscD02cq/Ei2/p5uouMKGdYe8mk4UalvyvWC4c93+I1QAWf5xAK/bbRFX4mPId5mo08bZV+li+N/bPIq0HQb9e0sDsLaCR/rlL+8eRj6PS+uAmBLecLx5xNmNsOdmpF4z0/JRU+A//ochzHPJHD5W4IQoIoKOYfrU217DvSKeaD7D9tCSOJYJkTZPvuftOjchsjovxjTqVHB71swyMpT+BLwPWfXRajxZa+2GVDeHndoEh1prBzVJ4SI+4dQ4jYatQznHFSIZolbrha7ufrRSz4bzMlY2YPaVGG3Fv7Pj5/x6DTMlKkKY2fedS9NpolGA4PPVNwIrBFupOUbmNh0qtfL9nedtr4HM2gidNcijD4oq0F35QHsedKYhX0Nreu2gEK1aCnY4DFWx8mY3k9En50yrFGk7VLCNa3H352jr8jzEbyDDMwkjMUJkpJWWYai7XDOjLYga/FELLY0xJ+jiKOK5li14i9yTbBo9y4e8hX65koALvmTBAAbZyavAMNaA+Sms3MGQAcxH8ODSu10g400i1XdCLYus1YV+4gqmvUKr7sYN+p7sexsuKPsSXcV3tArNSXG5kfHGdm9OP/TWxFMeYuukYTC+frcYomkjwh86NcAgvW70qmn72dpO+p5HxIkLod2oGXdhdj89/ioBUO9gYV6xp+NmwB06U15UD8zRukh3UmpJqtZjUyl0cdHOYvqDWpeS+n+cj18SWK+AFrHTNDzg1DAtuIwblmqoZa+RHjQE8HOXw8YkI3JurOOMnoRqTN4TEMKSZcD1u3BJL8xdM3Wiq+NZU4XIC9ZHInqaAFR2BY6J3S0rE5AqfKPAjUPv+VSf6eCMRx5ziViZpNfk5I4ROgq3KbHef/wJjGKtFUYj6QeGXMeaIrpEc4oOU6E22rxDmq1FIer0qHw3hlA+jHp//NqAXPeAQofhEeErXjIKHF/csur0I6A/d1/k4i/y+DlpcI7G85c1P5Cfrf8FvRwwxsQ/Y+fwLxUX1+IdzOVl7/XlLcOJNr3wxkfPm4Q007B43b4I7HwYqq/3pKG5sxk3QA9yF2fiTz9i9qvwGG6qhiMSe557y7CHg2kyiLWK5FkpOZ5uqU+f/8blKDNUQ74S4i51NeXo1RfbRMNUUKIJNzEIgfICqRYIiicKTHui2tYi0B1tNgW5v92uIyQrguD7xDaVfhHKDzrRuaaOmHLsS4svntOpfB7rep576R36RPp+KlVlA2tWj/gnkbNHcG9T6Z4wPW+xX5A3a3ZgO3Bh/19+a0Y421tBSuHwvIXR7QPt/Obcd2d2JO863aTrgRQUP7k4STGNouS8KRaKfu9ayAGU3WmQMyTzsUaxWuvZPX7foI+/KfvmseE4kEcNKeRtpzxfdZjjj5ukmdYdhw9BGAs+b64z2cjAsNruYvuUFN7WQJ4zqlDZkzXueejMalmsmCY3RE3ILY3yP37WwNU/G1mHBhxr4EFX0DBGnLwgFbX539nNDUeaCfYJrkaztenSNZZ4BjA4gWm+K7306J0JAyiEOfBfZ3qEtbF+8N1tiwdoz/ivPC8fSfDlbnu04EGaKX8NL7YXeT8WdlZhqkAa28neIgmsZyYnMQ6UQGmuPeSyKX/8cQef6KWp2TgNYsuNn42wJ1BIqWYVPPg0YMANQ7ZRYM5d3I1JXTbkTlPMc2EQkixmpzQX2VGu6rS/6sIBgB"
+[2026-05-30T17:19:32.524Z] [INFO]       }
+[2026-05-30T17:19:32.524Z] [INFO]     ],
+[2026-05-30T17:19:32.524Z] [INFO]     "stop_reason": null,
+[2026-05-30T17:19:32.524Z] [INFO]     "stop_sequence": null,
+[2026-05-30T17:19:32.524Z] [INFO]     "stop_details": null,
+[2026-05-30T17:19:32.524Z] [INFO]     "usage": {
+[2026-05-30T17:19:32.524Z] [INFO]       "input_tokens": 2,
+[2026-05-30T17:19:32.524Z] [INFO]       "cache_creation_input_tokens": 12756,
+[2026-05-30T17:19:32.524Z] [INFO]       "cache_read_input_tokens": 44576,
+[2026-05-30T17:19:32.524Z] [INFO]       "cache_creation": {
+[2026-05-30T17:19:32.524Z] [INFO]         "ephemeral_5m_input_tokens": 0,
+[2026-05-30T17:19:32.524Z] [INFO]         "ephemeral_1h_input_tokens": 12756
+[2026-05-30T17:19:32.524Z] [INFO]       },
+[2026-05-30T17:19:32.524Z] [INFO]       "output_tokens": 2,
+[2026-05-30T17:19:32.524Z] [INFO]       "service_tier": "standard",
+[2026-05-30T17:19:32.524Z] [INFO]       "inference_geo": "not_available"
+[2026-05-30T17:19:32.524Z] [INFO]     },
+[2026-05-30T17:19:32.524Z] [INFO]     "diagnostics": null,
+[2026-05-30T17:19:32.524Z] [INFO]     "context_management": null
+[2026-05-30T17:19:32.524Z] [INFO]   },
+[2026-05-30T17:19:32.524Z] [INFO]   "parent_tool_use_id": null,
+[2026-05-30T17:19:32.524Z] [INFO]   "session_id": "45441128-80e2-48c1-a2ea-f81ede05030b",
+[2026-05-30T17:19:32.524Z] [INFO]   "uuid": "8f981575-7aeb-4b0a-b1fa-0cd8bb5c3263",
+[2026-05-30T17:19:32.524Z] [INFO]   "request_id": "req_011CbZ8qf8TJZupqAMbxEfbi"
+[2026-05-30T17:19:32.524Z] [INFO] }
+[2026-05-30T17:19:32.997Z] [INFO] {
+[2026-05-30T17:19:32.997Z] [INFO]   "type": "assistant",
+[2026-05-30T17:19:32.997Z] [INFO]   "message": {
+[2026-05-30T17:19:32.997Z] [INFO]     "model": "claude-opus-4-8",
+[2026-05-30T17:19:32.997Z] [INFO]     "id": "msg_01WwnehpUsrNPmBTU6kxrYQY",
+[2026-05-30T17:19:32.997Z] [INFO]     "type": "message",
+[2026-05-30T17:19:32.997Z] [INFO]     "role": "assistant",
+[2026-05-30T17:19:32.997Z] [INFO]     "content": [
+[2026-05-30T17:19:32.997Z] [INFO]       {
+[2026-05-30T17:19:32.997Z] [INFO]         "type": "text",
+[2026-05-30T17:19:32.997Z] [INFO]         "text": "The failing test is a pre-existing README version mismatch unrelated to this issue. Let me verify."
+[2026-05-30T17:19:32.997Z] [INFO]       }
+[2026-05-30T17:19:32.997Z] [INFO]     ],
+[2026-05-30T17:19:32.997Z] [INFO]     "stop_reason": null,
+[2026-05-30T17:19:32.997Z] [INFO]     "stop_sequence": null,
+[2026-05-30T17:19:32.997Z] [INFO]     "stop_details": null,
+[2026-05-30T17:19:32.997Z] [INFO]     "usage": {
+[2026-05-30T17:19:32.997Z] [INFO]       "input_tokens": 2,
+[2026-05-30T17:19:32.997Z] [INFO]       "cache_creation_input_tokens": 12756,
+[2026-05-30T17:19:32.997Z] [INFO]       "cache_read_input_tokens": 44576,
+[2026-05-30T17:19:32.997Z] [INFO]       "cache_creation": {
+[2026-05-30T17:19:32.997Z] [INFO]         "ephemeral_5m_input_tokens": 0,
+[2026-05-30T17:19:32.997Z] [INFO]         "ephemeral_1h_input_tokens": 12756
+[2026-05-30T17:19:32.997Z] [INFO]       },
+[2026-05-30T17:19:32.997Z] [INFO]       "output_tokens": 2,
+[2026-05-30T17:19:32.997Z] [INFO]       "service_tier": "standard",
+[2026-05-30T17:19:32.997Z] [INFO]       "inference_geo": "not_available"
+[2026-05-30T17:19:32.997Z] [INFO]     },
+[2026-05-30T17:19:32.997Z] [INFO]     "diagnostics": null,
+[2026-05-30T17:19:32.997Z] [INFO]     "context_management": null
+[2026-05-30T17:19:32.997Z] [INFO]   },
+[2026-05-30T17:19:32.997Z] [INFO]   "parent_tool_use_id": null,
+[2026-05-30T17:19:32.997Z] [INFO]   "session_id": "45441128-80e2-48c1-a2ea-f81ede05030b",
+[2026-05-30T17:19:32.997Z] [INFO]   "uuid": "be15b037-c841-4292-b353-542327ac4abc",
+[2026-05-30T17:19:32.997Z] [INFO]   "request_id": "req_011CbZ8qf8TJZupqAMbxEfbi"
+[2026-05-30T17:19:32.997Z] [INFO] }
+[2026-05-30T17:19:34.191Z] [INFO] {
+[2026-05-30T17:19:34.191Z] [INFO]   "type": "assistant",
+[2026-05-30T17:19:34.191Z] [INFO]   "message": {
+[2026-05-30T17:19:34.191Z] [INFO]     "model": "claude-opus-4-8",
+[2026-05-30T17:19:34.191Z] [INFO]     "id": "msg_01WwnehpUsrNPmBTU6kxrYQY",
+[2026-05-30T17:19:34.191Z] [INFO]     "type": "message",
+[2026-05-30T17:19:34.191Z] [INFO]     "role": "assistant",
+[2026-05-30T17:19:34.191Z] [INFO]     "content": [
+[2026-05-30T17:19:34.191Z] [INFO]       {
+[2026-05-30T17:19:34.191Z] [INFO]         "type": "tool_use",
+[2026-05-30T17:19:34.191Z] [INFO]         "id": "toolu_01HDSsBtNFNS5mrctGwKcqTJ",
+[2026-05-30T17:19:34.191Z] [INFO]         "name": "Bash",
+[2026-05-30T17:19:34.191Z] [INFO]         "input": {
+[2026-05-30T17:19:34.191Z] [INFO]           "command": "cd /tmp/gh-issue-solver-1780161489554\nnode -p \"require('./package.json').version\"\necho \"--- README version line ---\"\ngrep -n \"Current fork version\" README.md\necho \"--- README WebUI pages line ---\"\ngrep -n \"WebUI pages\\|API route groups\" README.md",
+[2026-05-30T17:19:34.191Z] [INFO]           "description": "Check version mismatch"
+[2026-05-30T17:19:34.191Z] [INFO]         },
+[2026-05-30T17:19:34.191Z] [INFO]         "caller": {
+[2026-05-30T17:19:34.191Z] [INFO]           "type": "direct"
+[2026-05-30T17:19:34.191Z] [INFO]         }
+[2026-05-30T17:19:34.191Z] [INFO]       }
+[2026-05-30T17:19:34.191Z] [INFO]     ],
+[2026-05-30T17:19:34.191Z] [INFO]     "stop_reason": null,
+[2026-05-30T17:19:34.191Z] [INFO]     "stop_sequence": null,
+[2026-05-30T17:19:34.191Z] [INFO]     "stop_details": null,
+[2026-05-30T17:19:34.191Z] [INFO]     "usage": {
+[2026-05-30T17:19:34.191Z] [INFO]       "input_tokens": 2,
+[2026-05-30T17:19:34.191Z] [INFO]       "cache_creation_input_tokens": 12756,
+[2026-05-30T17:19:34.191Z] [INFO]       "cache_read_input_tokens": 44576,
+[2026-05-30T17:19:34.191Z] [INFO]       "cache_creation": {
+[2026-05-30T17:19:34.191Z] [INFO]         "ephemeral_5m_input_tokens": 0,
+[2026-05-30T17:19:34.191Z] [INFO]         "ephemeral_1h_input_tokens": 12756
+[2026-05-30T17:19:34.191Z] [INFO]       },
+[2026-05-30T17:19:34.191Z] [INFO]       "output_tokens": 2,
+[2026-05-30T17:19:34.191Z] [INFO]       "service_tier": "standard",
+[2026-05-30T17:19:34.191Z] [INFO]       "inference_geo": "not_available"
+[2026-05-30T17:19:34.191Z] [INFO]     },
+[2026-05-30T17:19:34.191Z] [INFO]     "diagnostics": null,
+[2026-05-30T17:19:34.191Z] [INFO]     "context_management": null
+[2026-05-30T17:19:34.191Z] [INFO]   },
+[2026-05-30T17:19:34.191Z] [INFO]   "parent_tool_use_id": null,
+[2026-05-30T17:19:34.191Z] [INFO]   "session_id": "45441128-80e2-48c1-a2ea-f81ede05030b",
+[2026-05-30T17:19:34.191Z] [INFO]   "uuid": "ad7baab4-169a-43e2-960f-074c908f29c3",
+[2026-05-30T17:19:34.191Z] [INFO]   "request_id": "req_011CbZ8qf8TJZupqAMbxEfbi"
+[2026-05-30T17:19:34.191Z] [INFO] }
+[2026-05-30T17:19:35.668Z] [INFO] {
+[2026-05-30T17:19:35.668Z] [INFO]   "type": "user",
+[2026-05-30T17:19:35.668Z] [INFO]   "message": {
+[2026-05-30T17:19:35.668Z] [INFO]     "role": "user",
+[2026-05-30T17:19:35.668Z] [INFO]     "content": [
+[2026-05-30T17:19:35.668Z] [INFO]       {
+[2026-05-30T17:19:35.668Z] [INFO]         "tool_use_id": "toolu_01HDSsBtNFNS5mrctGwKcqTJ",
+[2026-05-30T17:19:35.668Z] [INFO]         "type": "tool_result",
+[2026-05-30T17:19:35.668Z] [INFO]         "content": "0.8.22\n--- README version line ---\n45:Current fork version: `0.8.21`.\n--- README WebUI pages line ---\n49:The current WebUI ships with 23 WebUI pages and 42 authenticated WebUI API route groups.\n386:Optional web dashboard, localhost only, token auth. Start with `teleton start --webui` or `teleton setup --ui`. The current build exposes 23 WebUI pages and 42 authenticated WebUI API route groups.\n638:│   └── routes/             # 42 authenticated API route groups\n757:| [WebUI User Guide](docs/user-guide/README.md) | Bilingual guide to the current WebUI pages and workflows |",
+[2026-05-30T17:19:35.668Z] [INFO]         "is_error": false
+[2026-05-30T17:19:35.668Z] [INFO]       }
+[2026-05-30T17:19:35.668Z] [INFO]     ]
+[2026-05-30T17:19:35.668Z] [INFO]   },
+[2026-05-30T17:19:35.668Z] [INFO]   "parent_tool_use_id": null,
+[2026-05-30T17:19:35.668Z] [INFO]   "session_id": "45441128-80e2-48c1-a2ea-f81ede05030b",
+[2026-05-30T17:19:35.668Z] [INFO]   "uuid": "33a645fd-1b5b-4026-bb67-2230b6ea0e35",
+[2026-05-30T17:19:35.668Z] [INFO]   "timestamp": "2026-05-30T17:19:35.667Z",
+[2026-05-30T17:19:35.668Z] [INFO]   "tool_use_result": {
+[2026-05-30T17:19:35.668Z] [INFO]     "stdout": "0.8.22\n--- README version line ---\n45:Current fork version: `0.8.21`.\n--- README WebUI pages line ---\n49:The current WebUI ships with 23 WebUI pages and 42 authenticated WebUI API route groups.\n386:Optional web dashboard, localhost only, token auth. Start with `teleton start --webui` or `teleton setup --ui`. The current build exposes 23 WebUI pages and 42 authenticated WebUI API route groups.\n638:│   └── routes/             # 42 authenticated API route groups\n757:| [WebUI User Guide](docs/user-guide/README.md) | Bilingual guide to the current WebUI pages and workflows |",
+[2026-05-30T17:19:35.668Z] [INFO]     "stderr": "",
+[2026-05-30T17:19:35.668Z] [INFO]     "interrupted": false,
+[2026-05-30T17:19:35.668Z] [INFO]     "isImage": false,
+[2026-05-30T17:19:35.668Z] [INFO]     "noOutputExpected": false
+[2026-05-30T17:19:35.668Z] [INFO]   }
+[2026-05-30T17:19:35.668Z] [INFO] }
+[2026-05-30T17:19:35.685Z] [INFO] [log_3eb895] sending request {
+[2026-05-30T17:19:35.686Z] [INFO]   method: "post",
+[2026-05-30T17:19:35.687Z] [INFO]   url: "https://api.anthropic.com/v1/messages?beta=true",
+[2026-05-30T17:19:35.688Z] [INFO]   options: {
+[2026-05-30T17:19:35.689Z] [INFO]     method: "post",
+[2026-05-30T17:19:35.690Z] [INFO]     path: "/v1/messages?beta=true",
+[2026-05-30T17:19:35.690Z] [INFO]     body: {
+[2026-05-30T17:19:35.690Z] [INFO]       model: "claude-opus-4-8",
+[2026-05-30T17:19:35.691Z] [INFO]       messages: [
+[2026-05-30T17:19:35.691Z] [INFO]         [Object ...], [Object ...], [Object ...], [Object ...], [Object ...], [Object ...], [Object ...], [Object ...], [Object ...], [Object ...], [Object ...], [Object ...], [Object ...], [Object ...], [Object ...], [Object ...], [Object ...], [Object ...]
+[2026-05-30T17:19:35.693Z] [INFO]       ],
+[2026-05-30T17:19:35.694Z] [INFO]       system: [
+[2026-05-30T17:19:35.694Z] [INFO]         [Object ...], [Object ...], [Object ...], [Object ...]
+[2026-05-30T17:19:35.695Z] [INFO]       ],
+[2026-05-30T17:19:35.695Z] [INFO]       tools: [
+[2026-05-30T17:19:35.696Z] [INFO]         [Object ...], [Object ...], [Object ...], [Object ...], [Object ...], [Object ...], [Object ...], [Object ...], [Object ...], [Object ...]
+[2026-05-30T17:19:35.696Z] [INFO]       ],
+[2026-05-30T17:19:35.697Z] [INFO]       tool_choice: undefined,
+[2026-05-30T17:19:35.697Z] [INFO]       metadata: [Object ...],
+[2026-05-30T17:19:35.697Z] [INFO]       max_tokens: 128000,
+[2026-05-30T17:19:35.697Z] [INFO]       thinking: [Object ...],
+[2026-05-30T17:19:35.698Z] [INFO]       context_management: [Object ...],
+[2026-05-30T17:19:35.698Z] [INFO]       output_config: [Object ...],
+[2026-05-30T17:19:35.698Z] [INFO]       diagnostics: [Object ...],
+[2026-05-30T17:19:35.698Z] [INFO]       stream: true,
+[2026-05-30T17:19:35.699Z] [INFO]     },
+[2026-05-30T17:19:35.700Z] [INFO]     timeout: 600000,
+[2026-05-30T17:19:35.701Z] [INFO]     signal: AbortSignal {
+[2026-05-30T17:19:35.704Z] [INFO]       [Symbol(events.maxEventTargetListeners)]: 50,
+[2026-05-30T17:19:35.704Z] [INFO]       [Symbol(events.maxEventTargetListenersWarned)]: false,
+[2026-05-30T17:19:35.706Z] [INFO]       aborted: false,
+[2026-05-30T17:19:35.708Z] [INFO]       reason: undefined,
+[2026-05-30T17:19:35.714Z] [INFO]       onabort: null,
+[2026-05-30T17:19:35.717Z] [INFO]       throwIfAborted: [Function: throwIfAborted],
+[2026-05-30T17:19:35.718Z] [INFO]       addEventListener: [Function: addEventListener],
+[2026-05-30T17:19:35.722Z] [INFO]       removeEventListener: [Function: removeEventListener],
+[2026-05-30T17:19:35.724Z] [INFO]       dispatchEvent: [Function: dispatchEvent],
+[2026-05-30T17:19:35.726Z] [INFO]     },
+[2026-05-30T17:19:35.726Z] [INFO]     stream: true,
+[2026-05-30T17:19:35.727Z] [INFO]   },
+[2026-05-30T17:19:35.727Z] [INFO]   headers: {
+[2026-05-30T17:19:35.728Z] [INFO]     accept: "application/json",
+[2026-05-30T17:19:35.728Z] [INFO]     "anthropic-beta": "claude-code-20250219,oauth-2025-04-20,interleaved-thinking-2025-05-14,thinking-token-count-2026-05-13,context-management-2025-06-27,prompt-caching-scope-2026-01-05,mid-conversation-system-2026-04-07,advisor-tool-2026-03-01,advanced-tool-use-2025-11-20,effort-2025-11-24,extended-cache-ttl-2025-04-11,cache-diagnosis-2026-04-07",
+[2026-05-30T17:19:35.728Z] [INFO]     "anthropic-dangerous-direct-browser-access": "true",
+[2026-05-30T17:19:35.729Z] [INFO]     "anthropic-version": "2023-06-01",
+[2026-05-30T17:19:35.729Z] [INFO]     authorization: "***",
+[2026-05-30T17:19:35.730Z] [INFO]     "content-type": "application/json",
+[2026-05-30T17:19:35.730Z] [INFO]     "user-agent": "claude-cli/2.1.158 (external, sdk-cli)",
+[2026-05-30T17:19:35.730Z] [INFO]     "x-app": "cli",
+[2026-05-30T17:19:35.731Z] [INFO]     "x-claude-code-session-id": "45441128-80e2-48c1-a2ea-f81ede05030b",
+[2026-05-30T17:19:35.731Z] [INFO]     "x-client-request-id": "eeff9daf-b1af-41b9-91cb-bcbdae7f6f63",
+[2026-05-30T17:19:35.734Z] [INFO]     "x-stainless-arch": "x64",
+[2026-05-30T17:19:35.737Z] [INFO]     "x-stainless-lang": "js",
+[2026-05-30T17:19:35.738Z] [INFO]     "x-stainless-os": "Linux",
+[2026-05-30T17:19:35.738Z] [INFO]     "x-stainless-package-version": "0.94.0",
+[2026-05-30T17:19:35.738Z] [INFO]     "x-stainless-retry-count": "0",
+[2026-05-30T17:19:35.740Z] [INFO]     "x-stainless-runtime": "node",
+[2026-05-30T17:19:35.742Z] [INFO]     "x-stainless-runtime-version": "v24.3.0",
+[2026-05-30T17:19:35.743Z] [INFO]     "x-stainless-timeout": "600",
+[2026-05-30T17:19:35.744Z] [INFO]   },
+[2026-05-30T17:19:35.745Z] [INFO] }
+[2026-05-30T17:19:36.930Z] [INFO] [log_3eb895, request-id: "req_011CbZ8rZvhYBmq2ZMkyuPp7"] post https://api.anthropic.com/v1/messages?beta=true succeeded with status 200 in 1245ms
+[2026-05-30T17:19:36.931Z] [INFO] [log_3eb895] response start {
+[2026-05-30T17:19:36.931Z] [INFO]   url: "https://api.anthropic.com/v1/messages?beta=true",
+[2026-05-30T17:19:36.931Z] [INFO]   status: 200,
+[2026-05-30T17:19:36.931Z] [INFO]   headers: {
+[2026-05-30T17:19:36.932Z] [INFO]     "anthropic-organization-id": "ebc2ac93-f86f-4d15-aff3-de8830d8d789",
+[2026-05-30T17:19:36.933Z] [INFO]     "anthropic-ratelimit-unified-5h-reset": "1780173000",
+[2026-05-30T17:19:36.933Z] [INFO]     "anthropic-ratelimit-unified-5h-status": "allowed",
+[2026-05-30T17:19:36.933Z] [INFO]     "anthropic-ratelimit-unified-5h-utilization": "0.25",
+[2026-05-30T17:19:36.934Z] [INFO]     "anthropic-ratelimit-unified-7d-reset": "1780398000",
+[2026-05-30T17:19:36.935Z] [INFO]     "anthropic-ratelimit-unified-7d-status": "allowed",
+[2026-05-30T17:19:36.936Z] [INFO]     "anthropic-ratelimit-unified-7d-utilization": "0.73",
+[2026-05-30T17:19:36.936Z] [INFO]     "anthropic-ratelimit-unified-fallback-percentage": "0.5",
+[2026-05-30T17:19:36.937Z] [INFO]     "anthropic-ratelimit-unified-overage-disabled-reason": "org_level_disabled",
+[2026-05-30T17:19:36.937Z] [INFO]     "anthropic-ratelimit-unified-overage-status": "rejected",
+[2026-05-30T17:19:36.939Z] [INFO]     "anthropic-ratelimit-unified-representative-claim": "five_hour",
+[2026-05-30T17:19:36.940Z] [INFO]     "anthropic-ratelimit-unified-reset": "1780173000",
+[2026-05-30T17:19:36.940Z] [INFO]     "anthropic-ratelimit-unified-status": "allowed",
+[2026-05-30T17:19:36.940Z] [INFO]     "cache-control": "no-cache",
+[2026-05-30T17:19:36.940Z] [INFO]     "cf-cache-status": "DYNAMIC",
+[2026-05-30T17:19:36.941Z] [INFO]     "cf-ray": "a03f679818b7b10b-FRA",
+[2026-05-30T17:19:36.941Z] [INFO]     connection: "keep-alive",
+[2026-05-30T17:19:36.942Z] [INFO]     "content-encoding": "gzip",
+[2026-05-30T17:19:36.942Z] [INFO]     "content-security-policy": "default-src 'none'; frame-ancestors 'none'",
+[2026-05-30T17:19:36.942Z] [INFO]     "content-type": "text/event-stream; charset=utf-8",
+[2026-05-30T17:19:36.942Z] [INFO]     date: "Sat, 30 May 2026 17:19:36 GMT",
+[2026-05-30T17:19:36.943Z] [INFO]     "request-id": "req_011CbZ8rZvhYBmq2ZMkyuPp7",
+[2026-05-30T17:19:36.943Z] [INFO]     server: "cloudflare",
+[2026-05-30T17:19:36.944Z] [INFO]     "strict-transport-security": "max-age=31536000; includeSubDomains; preload",
+[2026-05-30T17:19:36.945Z] [INFO]     traceresponse: "00-f5b55e635104873d1d56b265e9a40b7d-4011a231d78af9ff-01",
+[2026-05-30T17:19:36.946Z] [INFO]     "transfer-encoding": "chunked",
+[2026-05-30T17:19:36.947Z] [INFO]     vary: "Accept-Encoding",
+[2026-05-30T17:19:36.947Z] [INFO]     "x-robots-tag": "none",
+[2026-05-30T17:19:36.948Z] [INFO]     "set-cookie": "***",
+[2026-05-30T17:19:36.949Z] [INFO]   },
+[2026-05-30T17:19:36.950Z] [INFO]   durationMs: 1245,
+[2026-05-30T17:19:36.951Z] [INFO] }
+[2026-05-30T17:19:36.953Z] [INFO] response 200 https://api.anthropic.com/v1/messages?beta=true Headers {
+[2026-05-30T17:19:36.953Z] [INFO]   "date": "Sat, 30 May 2026 17:19:36 GMT",
+[2026-05-30T17:19:36.954Z] [INFO]   "content-type": "text/event-stream; charset=utf-8",
+[2026-05-30T17:19:36.955Z] [INFO]   "transfer-encoding": "chunked",
+[2026-05-30T17:19:36.955Z] [INFO]   "connection": "keep-alive",
+[2026-05-30T17:19:36.955Z] [INFO]   "cache-control": "no-cache",
+[2026-05-30T17:19:36.956Z] [INFO]   "strict-transport-security": "max-age=31536000; includeSubDomains; preload",
+[2026-05-30T17:19:36.956Z] [INFO]   "content-encoding": "gzip",
+[2026-05-30T17:19:36.956Z] [INFO]   "vary": "Accept-Encoding",
+[2026-05-30T17:19:36.956Z] [INFO]   "content-security-policy": "default-src 'none'; frame-ancestors 'none'",
+[2026-05-30T17:19:36.958Z] [INFO]   "set-cookie": [ "_cfuvid=DU35c_.3LkrDs05NjCZ8tUUfoDNQ9sHO5fiSet4YDJ8-1780161575.6954987-1.0.1.1-I.yNKn_rxZLiMtSYjDxDqcavJhiEHaXejhPI1xvQZWs; HttpOnly; SameSite=None; Secure; Path=/; Domain=api.anthropic.com" ],
+[2026-05-30T17:19:36.958Z] [INFO]   "anthropic-ratelimit-unified-status": "allowed",
+[2026-05-30T17:19:36.959Z] [INFO]   "anthropic-ratelimit-unified-5h-status": "allowed",
+[2026-05-30T17:19:36.959Z] [INFO]   "anthropic-ratelimit-unified-5h-reset": "1780173000",
+[2026-05-30T17:19:36.960Z] [INFO]   "anthropic-ratelimit-unified-5h-utilization": "0.25",
+[2026-05-30T17:19:36.961Z] [INFO]   "anthropic-ratelimit-unified-7d-status": "allowed",
+[2026-05-30T17:19:36.961Z] [INFO]   "anthropic-ratelimit-unified-7d-reset": "1780398000",
+[2026-05-30T17:19:36.961Z] [INFO]   "anthropic-ratelimit-unified-7d-utilization": "0.73",
+[2026-05-30T17:19:36.961Z] [INFO]   "anthropic-ratelimit-unified-representative-claim": "five_hour",
+[2026-05-30T17:19:36.962Z] [INFO]   "anthropic-ratelimit-unified-fallback-percentage": "0.5",
+[2026-05-30T17:19:36.962Z] [INFO]   "anthropic-ratelimit-unified-reset": "1780173000",
+[2026-05-30T17:19:36.963Z] [INFO]   "anthropic-ratelimit-unified-overage-disabled-reason": "org_level_disabled",
+[2026-05-30T17:19:36.963Z] [INFO]   "anthropic-ratelimit-unified-overage-status": "rejected",
+[2026-05-30T17:19:36.963Z] [INFO]   "request-id": "req_011CbZ8rZvhYBmq2ZMkyuPp7",
+[2026-05-30T17:19:36.964Z] [INFO]   "anthropic-organization-id": "ebc2ac93-f86f-4d15-aff3-de8830d8d789",
+[2026-05-30T17:19:36.964Z] [INFO]   "traceresponse": "00-f5b55e635104873d1d56b265e9a40b7d-4011a231d78af9ff-01",
+[2026-05-30T17:19:36.964Z] [INFO]   "server": "cloudflare",
+[2026-05-30T17:19:36.964Z] [INFO]   "cf-cache-status": "DYNAMIC",
+[2026-05-30T17:19:36.965Z] [INFO]   "x-robots-tag": "none",
+[2026-05-30T17:19:36.966Z] [INFO]   "cf-ray": "a03f679818b7b10b-FRA",
+[2026-05-30T17:19:36.966Z] [INFO] } ReadableStream {
+[2026-05-30T17:19:36.967Z] [INFO]   blob: [Function: blob],
+[2026-05-30T17:19:36.967Z] [INFO]   bytes: [Function: bytes],
+[2026-05-30T17:19:36.968Z] [INFO]   cancel: [Function],
+[2026-05-30T17:19:36.968Z] [INFO]   getReader: [Function],
+[2026-05-30T17:19:36.969Z] [INFO]   json: [Function: json],
+[2026-05-30T17:19:36.969Z] [INFO]   locked: [Getter],
+[2026-05-30T17:19:36.970Z] [INFO]   pipeThrough: [Function],
+[2026-05-30T17:19:36.970Z] [INFO]   pipeTo: [Function],
+[2026-05-30T17:19:36.971Z] [INFO]   tee: [Function],
+[2026-05-30T17:19:36.971Z] [INFO]   text: [Function: text],
+[2026-05-30T17:19:36.971Z] [INFO]   values: [Function: values],
+[2026-05-30T17:19:36.971Z] [INFO]   [Symbol(Symbol.asyncIterator)]: [Function: asyncIterator2],
+[2026-05-30T17:19:36.972Z] [INFO] }
+[2026-05-30T17:19:36.972Z] [INFO] [log_3eb895] response parsed {
+[2026-05-30T17:19:36.972Z] [INFO]   url: "https://api.anthropic.com/v1/messages?beta=true",
+[2026-05-30T17:19:36.972Z] [INFO]   status: 200,
+[2026-05-30T17:19:36.973Z] [INFO]   body: bR {
+[2026-05-30T17:19:36.973Z] [INFO]     iterator: [AsyncGeneratorFunction: z],
+[2026-05-30T17:19:36.973Z] [INFO]     controller: AbortController {
+[2026-05-30T17:19:36.973Z] [INFO]       signal: [AbortSignal ...],
+[2026-05-30T17:19:36.974Z] [INFO]       abort: [Function: abort],
+[2026-05-30T17:19:36.974Z] [INFO]     },
+[2026-05-30T17:19:36.974Z] [INFO]     [Symbol(Symbol.asyncIterator)]: [Function],
+[2026-05-30T17:19:36.975Z] [INFO]     tee: [Function: tee],
+[2026-05-30T17:19:36.975Z] [INFO]     toReadableStream: [Function: toReadableStream],
+[2026-05-30T17:19:36.975Z] [INFO]   },
+[2026-05-30T17:19:36.976Z] [INFO]   durationMs: 1246,
+[2026-05-30T17:19:36.976Z] [INFO] }
+[2026-05-30T17:19:37.959Z] [INFO] {
+[2026-05-30T17:19:37.959Z] [INFO]   "type": "system",
+[2026-05-30T17:19:37.959Z] [INFO]   "subtype": "thinking_tokens",
+[2026-05-30T17:19:37.959Z] [INFO]   "estimated_tokens": 50,
+[2026-05-30T17:19:37.959Z] [INFO]   "estimated_tokens_delta": 50,
+[2026-05-30T17:19:37.959Z] [INFO]   "uuid": "328b2e9a-4da8-4ecf-bd2f-381066168a05",
+[2026-05-30T17:19:37.959Z] [INFO]   "session_id": "45441128-80e2-48c1-a2ea-f81ede05030b"
+[2026-05-30T17:19:37.959Z] [INFO] }
+[2026-05-30T17:19:39.359Z] [INFO] {
+[2026-05-30T17:19:39.359Z] [INFO]   "type": "system",
+[2026-05-30T17:19:39.359Z] [INFO]   "subtype": "thinking_tokens",
+[2026-05-30T17:19:39.359Z] [INFO]   "estimated_tokens": 150,
+[2026-05-30T17:19:39.359Z] [INFO]   "estimated_tokens_delta": 100,
+[2026-05-30T17:19:39.359Z] [INFO]   "uuid": "f2f9f176-a291-4426-90e1-221582fa6054",
+[2026-05-30T17:19:39.359Z] [INFO]   "session_id": "45441128-80e2-48c1-a2ea-f81ede05030b"
+[2026-05-30T17:19:39.359Z] [INFO] }
+[2026-05-30T17:19:40.767Z] [INFO] {
+[2026-05-30T17:19:40.767Z] [INFO]   "type": "system",
+[2026-05-30T17:19:40.767Z] [INFO]   "subtype": "thinking_tokens",
+[2026-05-30T17:19:40.767Z] [INFO]   "estimated_tokens": 250,
+[2026-05-30T17:19:40.767Z] [INFO]   "estimated_tokens_delta": 100,
+[2026-05-30T17:19:40.767Z] [INFO]   "uuid": "dbe097d8-3b96-43ed-a8a1-fed789886f35",
+[2026-05-30T17:19:40.767Z] [INFO]   "session_id": "45441128-80e2-48c1-a2ea-f81ede05030b"
+[2026-05-30T17:19:40.767Z] [INFO] }
+[2026-05-30T17:19:42.182Z] [INFO] {
+[2026-05-30T17:19:42.182Z] [INFO]   "type": "system",
+[2026-05-30T17:19:42.182Z] [INFO]   "subtype": "thinking_tokens",
+[2026-05-30T17:19:42.182Z] [INFO]   "estimated_tokens": 300,
+[2026-05-30T17:19:42.182Z] [INFO]   "estimated_tokens_delta": 50,
+[2026-05-30T17:19:42.182Z] [INFO]   "uuid": "a43c4c10-7f97-497a-a919-905bb25721b6",
+[2026-05-30T17:19:42.182Z] [INFO]   "session_id": "45441128-80e2-48c1-a2ea-f81ede05030b"
+[2026-05-30T17:19:42.182Z] [INFO] }
+[2026-05-30T17:19:43.703Z] [INFO] {
+[2026-05-30T17:19:43.703Z] [INFO]   "type": "system",
+[2026-05-30T17:19:43.703Z] [INFO]   "subtype": "thinking_tokens",
+[2026-05-30T17:19:43.703Z] [INFO]   "estimated_tokens": 450,
+[2026-05-30T17:19:43.703Z] [INFO]   "estimated_tokens_delta": 150,
+[2026-05-30T17:19:43.703Z] [INFO]   "uuid": "110b0e5c-9af0-4c4f-9e45-39af2995a201",
+[2026-05-30T17:19:43.703Z] [INFO]   "session_id": "45441128-80e2-48c1-a2ea-f81ede05030b"
+[2026-05-30T17:19:43.703Z] [INFO] }
+[2026-05-30T17:19:45.508Z] [INFO] {
+[2026-05-30T17:19:45.508Z] [INFO]   "type": "system",
+[2026-05-30T17:19:45.508Z] [INFO]   "subtype": "thinking_tokens",
+[2026-05-30T17:19:45.508Z] [INFO]   "estimated_tokens": 600,
+[2026-05-30T17:19:45.508Z] [INFO]   "estimated_tokens_delta": 150,
+[2026-05-30T17:19:45.508Z] [INFO]   "uuid": "36d289ba-8570-4892-8418-b3480ba0f44d",
+[2026-05-30T17:19:45.508Z] [INFO]   "session_id": "45441128-80e2-48c1-a2ea-f81ede05030b"
+[2026-05-30T17:19:45.508Z] [INFO] }
+[2026-05-30T17:19:49.496Z] [INFO] {
+[2026-05-30T17:19:49.496Z] [INFO]   "type": "system",
+[2026-05-30T17:19:49.496Z] [INFO]   "subtype": "thinking_tokens",
+[2026-05-30T17:19:49.496Z] [INFO]   "estimated_tokens": 650,
+[2026-05-30T17:19:49.496Z] [INFO]   "estimated_tokens_delta": 50,
+[2026-05-30T17:19:49.496Z] [INFO]   "uuid": "c4befafd-c6c3-475b-8461-56bfd3b24893",
+[2026-05-30T17:19:49.496Z] [INFO]   "session_id": "45441128-80e2-48c1-a2ea-f81ede05030b"
+[2026-05-30T17:19:49.496Z] [INFO] }
+[2026-05-30T17:19:49.608Z] [INFO] {
+[2026-05-30T17:19:49.608Z] [INFO]   "type": "assistant",
+[2026-05-30T17:19:49.608Z] [INFO]   "message": {
+[2026-05-30T17:19:49.608Z] [INFO]     "model": "claude-opus-4-8",
+[2026-05-30T17:19:49.608Z] [INFO]     "id": "msg_01P8NR7qHfVSD58Fk8NZrB5N",
+[2026-05-30T17:19:49.608Z] [INFO]     "type": "message",
+[2026-05-30T17:19:49.608Z] [INFO]     "role": "assistant",
+[2026-05-30T17:19:49.608Z] [INFO]     "content": [
+[2026-05-30T17:19:49.608Z] [INFO]       {
+[2026-05-30T17:19:49.608Z] [INFO]         "type": "thinking",
+[2026-05-30T17:19:49.608Z] [INFO]         "thinking": "",
+[2026-05-30T17:19:49.608Z] [INFO]         "signature": "EpQTCmMIDhgCKkD4C5WKttIo0hv84hzq/LlTK6Tegem/LhEYV4G/vwgs4weE8T36jo/BZLvHZZ4f+z2RnELLKooVwIXozX5gHtofMg9jbGF1ZGUtb3B1cy00LTg4AEIIdGhpbmtpbmcSDGdHA92Sax75Nj0fqhoMADhm/h6y7GNGPKooIjBh8JsgswyYuJEfQKLPIJekrMHcTCdnZm+2xLMIBav7kot7OPO9GZm2DSFhDYEm+Gsq3hHzLASax3I1Dwow5cw6QjfdQeobP8pKKLJSfuiJzIaE8wCLLgIhjssHidTDKWRmB4ykZNA9ae4AFYUbwy5oSRntk1qjd8Qte2BXKSxpbpLniIhAO6p4vc9GkO8XGVkMI7SKPdRJDH1RJ10svBVGxDXKzJaVgYVkm0C7J8Ep1G8ssuLMdiIT+ezd6umbdKdVbG7XxTQ3OjBNK6jmNEEdwDfrnkXMcJlQaKdXnnWh9sZbyuHe8cMeRqCnt38at9Ozaqji7THmcwA9oe/dtnrlv0aGixtX8ASH4Gw0zjfr6O7Z4ng8848cRGhjaAB+tVdmGSvUtNj+ZkjZcjXUlASGIXmgddGxLp+iGJa4SGuzMWColr14rG1QXNm0Ii7CAinO1Zdj1mfWgsLJSkl7cKYTWLgYRNmLZCDUHRFnyVf8WyIG/wfqeuKb/v622ZZC+NlzyUmEeTbQCdFXEEd1EKgtBIWQXbuDYVM57uV9l8VOdjIhSc6zzy6MvfC0RE+xYgiBnRVA0ZpDjw55DTVn7sEEsfGKNKK21mjFdzUwC20j+W61GGqqKWU1CkZ+tClLpLcmedKyBN42wza3E70stgdFC1hQcW7mWrVLzevu4yzLHWOdeUrE0ZOCqHXlYrGRGCjrDkp3nVPzUr2kNuMCLxMMZuWSi2xJeUMVLMzbUR2AnVONVQmPSD2/9ed6E5ez1nYGsJxm0E+fvdaLAvsmqL0XZrUflT29XYOioi3sSMUaAJpKIxpQJPfT31xjXsD7ZRjUD4hbZSSK9v9AloOu57o1/lT/ovA6EyEvTxDmuJJ+59fH7jnFjRDliNKquDCx0Y5cCse5rq1XWBrFXNVd+FWcLzTot+d5KMaQAosedBhQFw/0Nr0RBzQKZAP61/eRUB1YbIMBiq8arNR/cOSWIsOIOELgfmeZ98L8eDnTuKdUWCmCxYQNHjspNmWOOquB5S9nfWT0e54sBiXgPqFIJ3rzx/3helTN8nttaLGVvYQ9nJv5kmGdWr8SYABQFo5wUHmxgMU1eW31kLzaL0b7Q38GXdpE/Cgr3pbyqYqhKD6s0q49KnGx5VlH/bikTD8OQlT1MWUIrcZeETLXXaOHqUn9l/vG3su6txFMBfjK+I7Tc4Tf216GmFKFnlKXHPdtVpN5ghb1T6qMaKwbh5Ovo0obs8XAYIf28PssA3B2ztpcEBZQfc7jzavIqKWm1+V8/GJYFik3HfBepbNLoPxVXOGJ+TGgtAhtmUgqqgzQ7Adpc2EYhVb62TIiukKAvE6+WP0SzL4G8k8eSTRe2skcBKsQPt4Z55fa37zGPS58BRzJ6nIPZ9sP5EGGdGhUJt2oPGIwzzqYN90FvJXgSukS07L/pLuHS3y9cL3Hp7OWDBmQ5ZmUsxNzUu4QGm3NqgYcidfaRDg3H3njU5IcEgzG8T5goNztgnqjulwF2BgsjsZqbqNK2QfTQ37ejU/sheW52qCOD/xPGVMsBVdyj7G4ueYL41p/0fsSsLqoDjqgvbLyq8rwRwL42Xc/ngdSlFZ28cKVy7HC0ldy0P1vOmu4+d2SjTSZRuKqA1NKn/rwznV0K6GkaTeiNNJnBCHlHPKtKyTKl9SL8fxli2hAH1VmaMDbA8750E6fsrwTWjVOTWwNqkBJ4ET2qYTYDMyW5tBjVcggEECSNh8JbPzsd6WTvqMxJrCw+igPTANQqaCAV6XCqplaauDHIsfNlFMFCEX3M0NY7/olZx4XJk7Ks9U+tIpAKDyssmkJmlpOxvQsDBMJbXvmkvrdNGjzoGs+zVkB6YWgns/ALBPppdCY9ncmZnbaDNP6Wj/5MLoyJa3ZnjUtm8KsedV33kEdqA47bWXbqRuPtkQElVqDKoBkgrEoGWyJo+ThqEuKThE39fDBwbX5RSDWagZYEwU8S7EnWd+ajTCaG0shWJn1uPBwpuxeLzEo0wc/rfx0eZp1kU/a/NwWm4IhZc8h94VPhgIkMcuDnNtYTMzDgt/w0ajA8PDWT/ED3bOt6MHAUFc5dmdDark2J++5wZPLAO0FzL7uBqfZL9Va88Mqhmfepx0xZWHNP7zgCJwip0xqNhNBauWXOsoBDbOsoCmeLq74tQwbBgy8VkefVEQOAYv/9cZbOngy6C4LvhwfPCUKkvMb/muozX26V9fS/yI8BLbo0lrj9GJpiceep2KOc+ESX7xI1Q0aBh3Gp5RZjVK75uq6hArFwPMVkvnWxz7QQVuCXBiDorBLw4bO9o8HCtkEjPiw8w63i+hutlbh8ycGxHRRY81IVLKBevKsDEVSrD4LcARY68JWa8F/pwO01gIa4BA57+f6afdrzIuaEJHzSkk9AiQwt0dhIng0BB3CvNsPwFGZt93iecLNNDYtoEztfdt+Fbxx5UT11MvJz2OjSTw9maHnUHzhsFjiuzp/6uFcHiBean77sm96JUSLWozsUA/GuubphBDlLyYcnVejD7Z7R1/TBnnvEX/HXIjPd23qnllNID6ftMzhumVZBoGyi1bk77vTaZjWiqmUAPOPSD231x6WA/k1DkIfOXWsIXN/NSl3KIMkyDnfSNecJtllzDdFTnnKjSXzE7Wk1YAPX6PwyXQDXm/m8pwW+Ic7jEXyAvhNi1JfSdM5UsAascb1xMDODDxaPJRFWTcJTlE0KLVwNLaL4fjMN6hvwLaQ528aS3X168WRoQZMUCNBObIn0fRbYVy0kV7krayWIK3492yhH1K1/NVAg2jjRUzE/Ebs67A69LtZWKtN6sEuKG6Fz0Pwno7mpfSj0ONkaM2qrWQRfV0++bonV/fHAvBhCMuKzp58AnyDt3ydNhAaGB+SzW6kknOYtw/07AptNARwOLOcxtsyKkKdiFzBzBdOZxzFoKcnUriPP2kyX1HvMydVAXntfJD/ET1cgi5SeNQp3X7CTxSIcOhfVsYA+msci1UaSqTa32/3KWbJ9jlp+rB2P7U7pOjU95K7KRrtzMFm5LAMpWEmJWYw/ALoRwremxWCcbw92SrihxsKxw0kaiBDS+6T+ZLhPAK+ihgB"
+[2026-05-30T17:19:49.608Z] [INFO]       }
+[2026-05-30T17:19:49.608Z] [INFO]     ],
+[2026-05-30T17:19:49.608Z] [INFO]     "stop_reason": null,
+[2026-05-30T17:19:49.608Z] [INFO]     "stop_sequence": null,
+[2026-05-30T17:19:49.608Z] [INFO]     "stop_details": null,
+[2026-05-30T17:19:49.608Z] [INFO]     "usage": {
+[2026-05-30T17:19:49.608Z] [INFO]       "input_tokens": 2,
+[2026-05-30T17:19:49.608Z] [INFO]       "cache_creation_input_tokens": 896,
+[2026-05-30T17:19:49.608Z] [INFO]       "cache_read_input_tokens": 57332,
+[2026-05-30T17:19:49.608Z] [INFO]       "cache_creation": {
+[2026-05-30T17:19:49.608Z] [INFO]         "ephemeral_5m_input_tokens": 0,
+[2026-05-30T17:19:49.608Z] [INFO]         "ephemeral_1h_input_tokens": 896
+[2026-05-30T17:19:49.608Z] [INFO]       },
+[2026-05-30T17:19:49.608Z] [INFO]       "output_tokens": 3,
+[2026-05-30T17:19:49.608Z] [INFO]       "service_tier": "standard",
+[2026-05-30T17:19:49.608Z] [INFO]       "inference_geo": "not_available"
+[2026-05-30T17:19:49.608Z] [INFO]     },
+[2026-05-30T17:19:49.608Z] [INFO]     "diagnostics": null,
+[2026-05-30T17:19:49.608Z] [INFO]     "context_management": null
+[2026-05-30T17:19:49.608Z] [INFO]   },
+[2026-05-30T17:19:49.608Z] [INFO]   "parent_tool_use_id": null,
+[2026-05-30T17:19:49.608Z] [INFO]   "session_id": "45441128-80e2-48c1-a2ea-f81ede05030b",
+[2026-05-30T17:19:49.608Z] [INFO]   "uuid": "e92d3042-eea0-474c-96b4-10048fc9eb74",
+[2026-05-30T17:19:49.608Z] [INFO]   "request_id": "req_011CbZ8rZvhYBmq2ZMkyuPp7"
+[2026-05-30T17:19:49.608Z] [INFO] }
+[2026-05-30T17:19:49.694Z] [INFO] {
+[2026-05-30T17:19:49.694Z] [INFO]   "type": "assistant",
+[2026-05-30T17:19:49.694Z] [INFO]   "message": {
+[2026-05-30T17:19:49.694Z] [INFO]     "model": "claude-opus-4-8",
+[2026-05-30T17:19:49.694Z] [INFO]     "id": "msg_01P8NR7qHfVSD58Fk8NZrB5N",
+[2026-05-30T17:19:49.694Z] [INFO]     "type": "message",
+[2026-05-30T17:19:49.694Z] [INFO]     "role": "assistant",
+[2026-05-30T17:19:49.694Z] [INFO]     "content": [
+[2026-05-30T17:19:49.694Z] [INFO]       {
+[2026-05-30T17:19:49.694Z] [INFO]         "type": "text",
+[2026-05-30T17:19:49.694Z] [INFO]         "text": "Confirmed: a pre-existing README version mismatch (package.json is `0.8.22`, README says `0.8.21`). Let me check the contributing guide, look for any tests checking community files, and review recent merged PRs for style."
+[2026-05-30T17:19:49.694Z] [INFO]       }
+[2026-05-30T17:19:49.694Z] [INFO]     ],
+[2026-05-30T17:19:49.694Z] [INFO]     "stop_reason": null,
+[2026-05-30T17:19:49.694Z] [INFO]     "stop_sequence": null,
+[2026-05-30T17:19:49.694Z] [INFO]     "stop_details": null,
+[2026-05-30T17:19:49.694Z] [INFO]     "usage": {
+[2026-05-30T17:19:49.694Z] [INFO]       "input_tokens": 2,
+[2026-05-30T17:19:49.694Z] [INFO]       "cache_creation_input_tokens": 896,
+[2026-05-30T17:19:49.694Z] [INFO]       "cache_read_input_tokens": 57332,
+[2026-05-30T17:19:49.694Z] [INFO]       "cache_creation": {
+[2026-05-30T17:19:49.694Z] [INFO]         "ephemeral_5m_input_tokens": 0,
+[2026-05-30T17:19:49.694Z] [INFO]         "ephemeral_1h_input_tokens": 896
+[2026-05-30T17:19:49.694Z] [INFO]       },
+[2026-05-30T17:19:49.694Z] [INFO]       "output_tokens": 3,
+[2026-05-30T17:19:49.694Z] [INFO]       "service_tier": "standard",
+[2026-05-30T17:19:49.694Z] [INFO]       "inference_geo": "not_available"
+[2026-05-30T17:19:49.694Z] [INFO]     },
+[2026-05-30T17:19:49.694Z] [INFO]     "diagnostics": null,
+[2026-05-30T17:19:49.694Z] [INFO]     "context_management": null
+[2026-05-30T17:19:49.694Z] [INFO]   },
+[2026-05-30T17:19:49.694Z] [INFO]   "parent_tool_use_id": null,
+[2026-05-30T17:19:49.694Z] [INFO]   "session_id": "45441128-80e2-48c1-a2ea-f81ede05030b",
+[2026-05-30T17:19:49.694Z] [INFO]   "uuid": "70c10217-ee90-4ba2-a337-fef0441debdb",
+[2026-05-30T17:19:49.694Z] [INFO]   "request_id": "req_011CbZ8rZvhYBmq2ZMkyuPp7"
+[2026-05-30T17:19:49.694Z] [INFO] }
+[2026-05-30T17:19:50.166Z] [INFO] {
+[2026-05-30T17:19:50.166Z] [INFO]   "type": "assistant",
+[2026-05-30T17:19:50.166Z] [INFO]   "message": {
+[2026-05-30T17:19:50.166Z] [INFO]     "model": "claude-opus-4-8",
+[2026-05-30T17:19:50.166Z] [INFO]     "id": "msg_01P8NR7qHfVSD58Fk8NZrB5N",
+[2026-05-30T17:19:50.166Z] [INFO]     "type": "message",
+[2026-05-30T17:19:50.166Z] [INFO]     "role": "assistant",
+[2026-05-30T17:19:50.166Z] [INFO]     "content": [
+[2026-05-30T17:19:50.166Z] [INFO]       {
+[2026-05-30T17:19:50.166Z] [INFO]         "type": "tool_use",
+[2026-05-30T17:19:50.166Z] [INFO]         "id": "toolu_01Wpn3QiGUN8APFQKYcCc9Yk",
+[2026-05-30T17:19:50.166Z] [INFO]         "name": "Bash",
+[2026-05-30T17:19:50.166Z] [INFO]         "input": {
+[2026-05-30T17:19:50.166Z] [INFO]           "command": "cd /tmp/gh-issue-solver-1780161489554\necho \"=== docs tests dir ===\"; ls src/docs/__tests__/\necho \"=== grep CODE_OF_CONDUCT / GOVERNANCE references ===\"; grep -rniE \"code_of_conduct|code of conduct|governance\" --include=*.md --include=*.ts . | grep -v node_modules | head -30\necho \"=== CONTRIBUTING tail ===\"; tail -30 CONTRIBUTING.md",
+[2026-05-30T17:19:50.166Z] [INFO]           "description": "Check for related tests and references"
+[2026-05-30T17:19:50.166Z] [INFO]         },
+[2026-05-30T17:19:50.166Z] [INFO]         "caller": {
+[2026-05-30T17:19:50.166Z] [INFO]           "type": "direct"
+[2026-05-30T17:19:50.166Z] [INFO]         }
+[2026-05-30T17:19:50.166Z] [INFO]       }
+[2026-05-30T17:19:50.166Z] [INFO]     ],
+[2026-05-30T17:19:50.166Z] [INFO]     "stop_reason": null,
+[2026-05-30T17:19:50.166Z] [INFO]     "stop_sequence": null,
+[2026-05-30T17:19:50.166Z] [INFO]     "stop_details": null,
+[2026-05-30T17:19:50.166Z] [INFO]     "usage": {
+[2026-05-30T17:19:50.166Z] [INFO]       "input_tokens": 2,
+[2026-05-30T17:19:50.166Z] [INFO]       "cache_creation_input_tokens": 896,
+[2026-05-30T17:19:50.166Z] [INFO]       "cache_read_input_tokens": 57332,
+[2026-05-30T17:19:50.166Z] [INFO]       "cache_creation": {
+[2026-05-30T17:19:50.166Z] [INFO]         "ephemeral_5m_input_tokens": 0,
+[2026-05-30T17:19:50.166Z] [INFO]         "ephemeral_1h_input_tokens": 896
+[2026-05-30T17:19:50.166Z] [INFO]       },
+[2026-05-30T17:19:50.166Z] [INFO]       "output_tokens": 3,
+[2026-05-30T17:19:50.166Z] [INFO]       "service_tier": "standard",
+[2026-05-30T17:19:50.166Z] [INFO]       "inference_geo": "not_available"
+[2026-05-30T17:19:50.166Z] [INFO]     },
+[2026-05-30T17:19:50.166Z] [INFO]     "diagnostics": null,
+[2026-05-30T17:19:50.166Z] [INFO]     "context_management": null
+[2026-05-30T17:19:50.166Z] [INFO]   },
+[2026-05-30T17:19:50.166Z] [INFO]   "parent_tool_use_id": null,
+[2026-05-30T17:19:50.166Z] [INFO]   "session_id": "45441128-80e2-48c1-a2ea-f81ede05030b",
+[2026-05-30T17:19:50.166Z] [INFO]   "uuid": "229db326-90fe-4364-8b88-857e14fb3015",
+[2026-05-30T17:19:50.166Z] [INFO]   "request_id": "req_011CbZ8rZvhYBmq2ZMkyuPp7"
+[2026-05-30T17:19:50.166Z] [INFO] }
+[2026-05-30T17:19:50.867Z] [INFO] {
+[2026-05-30T17:19:50.867Z] [INFO]   "type": "user",
+[2026-05-30T17:19:50.867Z] [INFO]   "message": {
+[2026-05-30T17:19:50.867Z] [INFO]     "role": "user",
+[2026-05-30T17:19:50.867Z] [INFO]     "content": [
+[2026-05-30T17:19:50.867Z] [INFO]       {
+[2026-05-30T17:19:50.867Z] [INFO]         "tool_use_id": "toolu_01Wpn3QiGUN8APFQKYcCc9Yk",
+[2026-05-30T17:19:50.867Z] [INFO]         "type": "tool_result",
+[2026-05-30T17:19:50.867Z] [INFO]         "content": "=== docs tests dir ===\nreadme.test.ts\nuser-guide.test.ts\n=== grep CODE_OF_CONDUCT / GOVERNANCE references ===\n./READINESS_ANALYSIS.md:113:| 12 | Community health | 3 | Issue templates + SECURITY.md exist; missing CoC, PR template, issue-chooser config, governance. |\n./CONTRIBUTING.md:19:- [Code of Conduct](#code-of-conduct)\n=== CONTRIBUTING tail ===\n   { \"remoteAgents\": \"{{count}} remote agents\" }\n   ```\n\n   ```tsx\n   t('pages.network.remoteAgents', { count: agents.length })\n   ```\n\n### Adding a new language\n\n1. Create `web/src/locales/<lang>/translation.json` by copying the English file and translating every value.\n2. Register the locale in `web/src/i18n.ts`: import the JSON, add it to `resources`, and add it to `SUPPORTED_LANGUAGES` / `LANGUAGE_LABELS`.\n3. Run `npm run check:i18n` to confirm 100% parity.\n\n### Verifying translations\n\n```bash\ncd web && npm run check:i18n\n```\n\nThis compares each locale against the English reference and **fails** if any locale has missing keys, extra keys, or mismatched interpolation placeholders. The same check runs in CI (the `Check i18n translation parity` step), so a PR that forgets to translate a key will not pass.\n\n## Plugin Development\n\nPlugins extend the agent with custom tools without modifying core code. See the [Plugin SDK documentation](plugins.md) for a complete guide, or refer to the plugin example in the [README](README.md#plugins).\n\nPlugins are loaded from `~/.teleton/plugins/` at startup -- no rebuild required.\n\n---\n\nQuestions? Reach out on Telegram: [@ResistanceForum](https://t.me/ResistanceForum) or open a [discussion](https://github.com/TONresistor/teleton-agent/issues).",
+[2026-05-30T17:19:50.867Z] [INFO]         "is_error": false
+[2026-05-30T17:19:50.867Z] [INFO]       }
+[2026-05-30T17:19:50.867Z] [INFO]     ]
+[2026-05-30T17:19:50.867Z] [INFO]   },
+[2026-05-30T17:19:50.867Z] [INFO]   "parent_tool_use_id": null,
+[2026-05-30T17:19:50.867Z] [INFO]   "session_id": "45441128-80e2-48c1-a2ea-f81ede05030b",
+[2026-05-30T17:19:50.867Z] [INFO]   "uuid": "0ddbee4f-e66a-4b7f-9a8d-2c58a42ad458",
+[2026-05-30T17:19:50.867Z] [INFO]   "timestamp": "2026-05-30T17:19:50.865Z",
+[2026-05-30T17:19:50.867Z] [INFO]   "tool_use_result": {
+[2026-05-30T17:19:50.867Z] [INFO]     "stdout": "=== docs tests dir ===\nreadme.test.ts\nuser-guide.test.ts\n=== grep CODE_OF_CONDUCT / GOVERNANCE references ===\n./READINESS_ANALYSIS.md:113:| 12 | Community health | 3 | Issue templates + SECURITY.md exist; missing CoC, PR template, issue-chooser config, governance. |\n./CONTRIBUTING.md:19:- [Code of Conduct](#code-of-conduct)\n=== CONTRIBUTING tail ===\n   { \"remoteAgents\": \"{{count}} remote agents\" }\n   ```\n\n   ```tsx\n   t('pages.network.remoteAgents', { count: agents.length })\n   ```\n\n### Adding a new language\n\n1. Create `web/src/locales/<lang>/translation.json` by copying the English file and translating every value.\n2. Register the locale in `web/src/i18n.ts`: import the JSON, add it to `resources`, and add it to `SUPPORTED_LANGUAGES` / `LANGUAGE_LABELS`.\n3. Run `npm run check:i18n` to confirm 100% parity.\n\n### Verifying translations\n\n```bash\ncd web && npm run check:i18n\n```\n\nThis compares each locale against the English reference and **fails** if any locale has missing keys, extra keys, or mismatched interpolation placeholders. The same check runs in CI (the `Check i18n translation parity` step), so a PR that forgets to translate a key will not pass.\n\n## Plugin Development\n\nPlugins extend the agent with custom tools without modifying core code. See the [Plugin SDK documentation](plugins.md) for a complete guide, or refer to the plugin example in the [README](README.md#plugins).\n\nPlugins are loaded from `~/.teleton/plugins/` at startup -- no rebuild required.\n\n---\n\nQuestions? Reach out on Telegram: [@ResistanceForum](https://t.me/ResistanceForum) or open a [discussion](https://github.com/TONresistor/teleton-agent/issues).",
+[2026-05-30T17:19:50.867Z] [INFO]     "stderr": "",
+[2026-05-30T17:19:50.867Z] [INFO]     "interrupted": false,
+[2026-05-30T17:19:50.867Z] [INFO]     "isImage": false,
+[2026-05-30T17:19:50.867Z] [INFO]     "noOutputExpected": false
+[2026-05-30T17:19:50.867Z] [INFO]   }
+[2026-05-30T17:19:50.867Z] [INFO] }
+[2026-05-30T17:19:50.875Z] [INFO] [log_ff45c8] sending request {
+[2026-05-30T17:19:50.876Z] [INFO]   method: "post",
+[2026-05-30T17:19:50.877Z] [INFO]   url: "https://api.anthropic.com/v1/messages?beta=true",
+[2026-05-30T17:19:50.878Z] [INFO]   options: {
+[2026-05-30T17:19:50.878Z] [INFO]     method: "post",
+[2026-05-30T17:19:50.878Z] [INFO]     path: "/v1/messages?beta=true",
+[2026-05-30T17:19:50.878Z] [INFO]     body: {
+[2026-05-30T17:19:50.879Z] [INFO]       model: "claude-opus-4-8",
+[2026-05-30T17:19:50.879Z] [INFO]       messages: [
+[2026-05-30T17:19:50.879Z] [INFO]         [Object ...], [Object ...], [Object ...], [Object ...], [Object ...], [Object ...], [Object ...], [Object ...], [Object ...], [Object ...], [Object ...], [Object ...], [Object ...], [Object ...], [Object ...], [Object ...], [Object ...], [Object ...], [Object ...], [Object ...]
+[2026-05-30T17:19:50.879Z] [INFO]       ],
+[2026-05-30T17:19:50.879Z] [INFO]       system: [
+[2026-05-30T17:19:50.879Z] [INFO]         [Object ...], [Object ...], [Object ...], [Object ...]
+[2026-05-30T17:19:50.880Z] [INFO]       ],
+[2026-05-30T17:19:50.880Z] [INFO]       tools: [
+[2026-05-30T17:19:50.880Z] [INFO]         [Object ...], [Object ...], [Object ...], [Object ...], [Object ...], [Object ...], [Object ...], [Object ...], [Object ...], [Object ...]
+[2026-05-30T17:19:50.881Z] [INFO]       ],
+[2026-05-30T17:19:50.881Z] [INFO]       tool_choice: undefined,
+[2026-05-30T17:19:50.881Z] [INFO]       metadata: [Object ...],
+[2026-05-30T17:19:50.881Z] [INFO]       max_tokens: 128000,
+[2026-05-30T17:19:50.881Z] [INFO]       thinking: [Object ...],
+[2026-05-30T17:19:50.881Z] [INFO]       context_management: [Object ...],
+[2026-05-30T17:19:50.882Z] [INFO]       output_config: [Object ...],
+[2026-05-30T17:19:50.882Z] [INFO]       diagnostics: [Object ...],
+[2026-05-30T17:19:50.882Z] [INFO]       stream: true,
+[2026-05-30T17:19:50.882Z] [INFO]     },
+[2026-05-30T17:19:50.882Z] [INFO]     timeout: 600000,
+[2026-05-30T17:19:50.882Z] [INFO]     signal: AbortSignal {
+[2026-05-30T17:19:50.882Z] [INFO]       [Symbol(events.maxEventTargetListeners)]: 50,
+[2026-05-30T17:19:50.883Z] [INFO]       [Symbol(events.maxEventTargetListenersWarned)]: false,
+[2026-05-30T17:19:50.883Z] [INFO]       aborted: false,
+[2026-05-30T17:19:50.883Z] [INFO]       reason: undefined,
+[2026-05-30T17:19:50.883Z] [INFO]       onabort: null,
+[2026-05-30T17:19:50.883Z] [INFO]       throwIfAborted: [Function: throwIfAborted],
+[2026-05-30T17:19:50.883Z] [INFO]       addEventListener: [Function: addEventListener],
+[2026-05-30T17:19:50.883Z] [INFO]       removeEventListener: [Function: removeEventListener],
+[2026-05-30T17:19:50.884Z] [INFO]       dispatchEvent: [Function: dispatchEvent],
+[2026-05-30T17:19:50.884Z] [INFO]     },
+[2026-05-30T17:19:50.884Z] [INFO]     stream: true,
+[2026-05-30T17:19:50.884Z] [INFO]   },
+[2026-05-30T17:19:50.884Z] [INFO]   headers: {
+[2026-05-30T17:19:50.884Z] [INFO]     accept: "application/json",
+[2026-05-30T17:19:50.885Z] [INFO]     "anthropic-beta": "claude-code-20250219,oauth-2025-04-20,interleaved-thinking-2025-05-14,thinking-token-count-2026-05-13,context-management-2025-06-27,prompt-caching-scope-2026-01-05,mid-conversation-system-2026-04-07,advisor-tool-2026-03-01,advanced-tool-use-2025-11-20,effort-2025-11-24,extended-cache-ttl-2025-04-11,cache-diagnosis-2026-04-07",
+[2026-05-30T17:19:50.885Z] [INFO]     "anthropic-dangerous-direct-browser-access": "true",
+[2026-05-30T17:19:50.885Z] [INFO]     "anthropic-version": "2023-06-01",
+[2026-05-30T17:19:50.885Z] [INFO]     authorization: "***",
+[2026-05-30T17:19:50.885Z] [INFO]     "content-type": "application/json",
+[2026-05-30T17:19:50.885Z] [INFO]     "user-agent": "claude-cli/2.1.158 (external, sdk-cli)",
+[2026-05-30T17:19:50.886Z] [INFO]     "x-app": "cli",
+[2026-05-30T17:19:50.886Z] [INFO]     "x-claude-code-session-id": "45441128-80e2-48c1-a2ea-f81ede05030b",
+[2026-05-30T17:19:50.886Z] [INFO]     "x-client-request-id": "69c06c4f-2955-4d77-87b8-c350a2dcccf9",
+[2026-05-30T17:19:50.886Z] [INFO]     "x-stainless-arch": "x64",
+[2026-05-30T17:19:50.886Z] [INFO]     "x-stainless-lang": "js",
+[2026-05-30T17:19:50.886Z] [INFO]     "x-stainless-os": "Linux",
+[2026-05-30T17:19:50.886Z] [INFO]     "x-stainless-package-version": "0.94.0",
+[2026-05-30T17:19:50.887Z] [INFO]     "x-stainless-retry-count": "0",
+[2026-05-30T17:19:50.887Z] [INFO]     "x-stainless-runtime": "node",
+[2026-05-30T17:19:50.887Z] [INFO]     "x-stainless-runtime-version": "v24.3.0",
+[2026-05-30T17:19:50.887Z] [INFO]     "x-stainless-timeout": "600",
+[2026-05-30T17:19:50.887Z] [INFO]   },
+[2026-05-30T17:19:50.887Z] [INFO] }
+[2026-05-30T17:19:52.722Z] [INFO] [log_ff45c8, request-id: "req_011CbZ8sgwQTM95TDkvLin7s"] post https://api.anthropic.com/v1/messages?beta=true succeeded with status 200 in 1846ms
+[2026-05-30T17:19:52.723Z] [INFO] [log_ff45c8] response start {
+[2026-05-30T17:19:52.724Z] [INFO]   url: "https://api.anthropic.com/v1/messages?beta=true",
+[2026-05-30T17:19:52.725Z] [INFO]   status: 200,
+[2026-05-30T17:19:52.725Z] [INFO]   headers: {
+[2026-05-30T17:19:52.725Z] [INFO]     "anthropic-organization-id": "ebc2ac93-f86f-4d15-aff3-de8830d8d789",
+[2026-05-30T17:19:52.725Z] [INFO]     "anthropic-ratelimit-unified-5h-reset": "1780173000",
+[2026-05-30T17:19:52.725Z] [INFO]     "anthropic-ratelimit-unified-5h-status": "allowed",
+[2026-05-30T17:19:52.726Z] [INFO]     "anthropic-ratelimit-unified-5h-utilization": "0.25",
+[2026-05-30T17:19:52.726Z] [INFO]     "anthropic-ratelimit-unified-7d-reset": "1780398000",
+[2026-05-30T17:19:52.726Z] [INFO]     "anthropic-ratelimit-unified-7d-status": "allowed",
+[2026-05-30T17:19:52.726Z] [INFO]     "anthropic-ratelimit-unified-7d-utilization": "0.73",
+[2026-05-30T17:19:52.726Z] [INFO]     "anthropic-ratelimit-unified-fallback-percentage": "0.5",
+[2026-05-30T17:19:52.727Z] [INFO]     "anthropic-ratelimit-unified-overage-disabled-reason": "org_level_disabled",
+[2026-05-30T17:19:52.727Z] [INFO]     "anthropic-ratelimit-unified-overage-status": "rejected",
+[2026-05-30T17:19:52.727Z] [INFO]     "anthropic-ratelimit-unified-representative-claim": "five_hour",
+[2026-05-30T17:19:52.728Z] [INFO]     "anthropic-ratelimit-unified-reset": "1780173000",
+[2026-05-30T17:19:52.728Z] [INFO]     "anthropic-ratelimit-unified-status": "allowed",
+[2026-05-30T17:19:52.729Z] [INFO]     "cache-control": "no-cache",
+[2026-05-30T17:19:52.729Z] [INFO]     "cf-cache-status": "DYNAMIC",
+[2026-05-30T17:19:52.729Z] [INFO]     "cf-ray": "a03f67f718a3976a-FRA",
+[2026-05-30T17:19:52.730Z] [INFO]     connection: "keep-alive",
+[2026-05-30T17:19:52.730Z] [INFO]     "content-encoding": "gzip",
+[2026-05-30T17:19:52.730Z] [INFO]     "content-security-policy": "default-src 'none'; frame-ancestors 'none'",
+[2026-05-30T17:19:52.730Z] [INFO]     "content-type": "text/event-stream; charset=utf-8",
+[2026-05-30T17:19:52.730Z] [INFO]     date: "Sat, 30 May 2026 17:19:52 GMT",
+[2026-05-30T17:19:52.730Z] [INFO]     "request-id": "req_011CbZ8sgwQTM95TDkvLin7s",
+[2026-05-30T17:19:52.731Z] [INFO]     server: "cloudflare",
+[2026-05-30T17:19:52.731Z] [INFO]     "strict-transport-security": "max-age=31536000; includeSubDomains; preload",
+[2026-05-30T17:19:52.731Z] [INFO]     traceresponse: "00-4342c5ffec3d810dda9f172ee488347c-2dd0af18bf372608-01",
+[2026-05-30T17:19:52.732Z] [INFO]     "transfer-encoding": "chunked",
+[2026-05-30T17:19:52.732Z] [INFO]     vary: "Accept-Encoding",
+[2026-05-30T17:19:52.732Z] [INFO]     "x-robots-tag": "none",
+[2026-05-30T17:19:52.732Z] [INFO]     "set-cookie": "***",
+[2026-05-30T17:19:52.732Z] [INFO]   },
+[2026-05-30T17:19:52.733Z] [INFO]   durationMs: 1846,
+[2026-05-30T17:19:52.733Z] [INFO] }
+[2026-05-30T17:19:52.734Z] [INFO] response 200 https://api.anthropic.com/v1/messages?beta=true Headers {
+[2026-05-30T17:19:52.735Z] [INFO]   "date": "Sat, 30 May 2026 17:19:52 GMT",
+[2026-05-30T17:19:52.735Z] [INFO]   "content-type": "text/event-stream; charset=utf-8",
+[2026-05-30T17:19:52.736Z] [INFO]   "transfer-encoding": "chunked",
+[2026-05-30T17:19:52.736Z] [INFO]   "connection": "keep-alive",
+[2026-05-30T17:19:52.737Z] [INFO]   "cache-control": "no-cache",
+[2026-05-30T17:19:52.737Z] [INFO]   "strict-transport-security": "max-age=31536000; includeSubDomains; preload",
+[2026-05-30T17:19:52.738Z] [INFO]   "content-encoding": "gzip",
+[2026-05-30T17:19:52.738Z] [INFO]   "vary": "Accept-Encoding",
+[2026-05-30T17:19:52.739Z] [INFO]   "content-security-policy": "default-src 'none'; frame-ancestors 'none'",
+[2026-05-30T17:19:52.739Z] [INFO]   "set-cookie": [ "_cfuvid=I469JD.gLs7cKj4mYmyKGW53sLfl9orGZRAih0_gdbc-1780161590.8953233-1.0.1.1-lGazCkn2jfZCm0YJbyEJRvNGpEjXIOEDmW3UbFAILyU; HttpOnly; SameSite=None; Secure; Path=/; Domain=api.anthropic.com" ],
+[2026-05-30T17:19:52.740Z] [INFO]   "anthropic-ratelimit-unified-status": "allowed",
+[2026-05-30T17:19:52.741Z] [INFO]   "anthropic-ratelimit-unified-5h-status": "allowed",
+[2026-05-30T17:19:52.741Z] [INFO]   "anthropic-ratelimit-unified-5h-reset": "1780173000",
+[2026-05-30T17:19:52.741Z] [INFO]   "anthropic-ratelimit-unified-5h-utilization": "0.25",
+[2026-05-30T17:19:52.742Z] [INFO]   "anthropic-ratelimit-unified-7d-status": "allowed",
+[2026-05-30T17:19:52.742Z] [INFO]   "anthropic-ratelimit-unified-7d-reset": "1780398000",
+[2026-05-30T17:19:52.742Z] [INFO]   "anthropic-ratelimit-unified-7d-utilization": "0.73",
+[2026-05-30T17:19:52.742Z] [INFO]   "anthropic-ratelimit-unified-representative-claim": "five_hour",
+[2026-05-30T17:19:52.743Z] [INFO]   "anthropic-ratelimit-unified-fallback-percentage": "0.5",
+[2026-05-30T17:19:52.743Z] [INFO]   "anthropic-ratelimit-unified-reset": "1780173000",
+[2026-05-30T17:19:52.743Z] [INFO]   "anthropic-ratelimit-unified-overage-disabled-reason": "org_level_disabled",
+[2026-05-30T17:19:52.743Z] [INFO]   "anthropic-ratelimit-unified-overage-status": "rejected",
+[2026-05-30T17:19:52.743Z] [INFO]   "request-id": "req_011CbZ8sgwQTM95TDkvLin7s",
+[2026-05-30T17:19:52.744Z] [INFO]   "anthropic-organization-id": "ebc2ac93-f86f-4d15-aff3-de8830d8d789",
+[2026-05-30T17:19:52.744Z] [INFO]   "traceresponse": "00-4342c5ffec3d810dda9f172ee488347c-2dd0af18bf372608-01",
+[2026-05-30T17:19:52.744Z] [INFO]   "server": "cloudflare",
+[2026-05-30T17:19:52.744Z] [INFO]   "cf-cache-status": "DYNAMIC",
+[2026-05-30T17:19:52.745Z] [INFO]   "x-robots-tag": "none",
+[2026-05-30T17:19:52.746Z] [INFO]   "cf-ray": "a03f67f718a3976a-FRA",
+[2026-05-30T17:19:52.746Z] [INFO] } ReadableStream {
+[2026-05-30T17:19:52.747Z] [INFO]   blob: [Function: blob],
+[2026-05-30T17:19:52.747Z] [INFO]   bytes: [Function: bytes],
+[2026-05-30T17:19:52.747Z] [INFO]   cancel: [Function],
+[2026-05-30T17:19:52.747Z] [INFO]   getReader: [Function],
+[2026-05-30T17:19:52.747Z] [INFO]   json: [Function: json],
+[2026-05-30T17:19:52.748Z] [INFO]   locked: [Getter],
+[2026-05-30T17:19:52.748Z] [INFO]   pipeThrough: [Function],
+[2026-05-30T17:19:52.748Z] [INFO]   pipeTo: [Function],
+[2026-05-30T17:19:52.749Z] [INFO]   tee: [Function],
+[2026-05-30T17:19:52.750Z] [INFO]   text: [Function: text],
+[2026-05-30T17:19:52.751Z] [INFO]   values: [Function: values],
+[2026-05-30T17:19:52.751Z] [INFO]   [Symbol(Symbol.asyncIterator)]: [Function: asyncIterator2],
+[2026-05-30T17:19:52.751Z] [INFO] }
+[2026-05-30T17:19:52.752Z] [INFO] [log_ff45c8] response parsed {
+[2026-05-30T17:19:52.752Z] [INFO]   url: "https://api.anthropic.com/v1/messages?beta=true",
+[2026-05-30T17:19:52.752Z] [INFO]   status: 200,
+[2026-05-30T17:19:52.752Z] [INFO]   body: bR {
+[2026-05-30T17:19:52.752Z] [INFO]     iterator: [AsyncGeneratorFunction: z],
+[2026-05-30T17:19:52.753Z] [INFO]     controller: AbortController {
+[2026-05-30T17:19:52.753Z] [INFO]       signal: [AbortSignal ...],
+[2026-05-30T17:19:52.753Z] [INFO]       abort: [Function: abort],
+[2026-05-30T17:19:52.753Z] [INFO]     },
+[2026-05-30T17:19:52.754Z] [INFO]     [Symbol(Symbol.asyncIterator)]: [Function],
+[2026-05-30T17:19:52.754Z] [INFO]     tee: [Function: tee],
+[2026-05-30T17:19:52.754Z] [INFO]     toReadableStream: [Function: toReadableStream],
+[2026-05-30T17:19:52.755Z] [INFO]   },
+[2026-05-30T17:19:52.755Z] [INFO]   durationMs: 1847,
+[2026-05-30T17:19:52.755Z] [INFO] }
+[2026-05-30T17:19:53.816Z] [INFO] {
+[2026-05-30T17:19:53.816Z] [INFO]   "type": "system",
+[2026-05-30T17:19:53.816Z] [INFO]   "subtype": "thinking_tokens",
+[2026-05-30T17:19:53.816Z] [INFO]   "estimated_tokens": 50,
+[2026-05-30T17:19:53.816Z] [INFO]   "estimated_tokens_delta": 50,
+[2026-05-30T17:19:53.816Z] [INFO]   "uuid": "02ffb093-d31f-4c2b-925a-784cd46435b3",
+[2026-05-30T17:19:53.816Z] [INFO]   "session_id": "45441128-80e2-48c1-a2ea-f81ede05030b"
+[2026-05-30T17:19:53.816Z] [INFO] }
+[2026-05-30T17:19:53.817Z] [INFO] {
+[2026-05-30T17:19:53.817Z] [INFO]   "type": "assistant",
+[2026-05-30T17:19:53.817Z] [INFO]   "message": {
+[2026-05-30T17:19:53.817Z] [INFO]     "model": "claude-opus-4-8",
+[2026-05-30T17:19:53.817Z] [INFO]     "id": "msg_01VF9KZMUkD1SLwUu27PqXNg",
+[2026-05-30T17:19:53.817Z] [INFO]     "type": "message",
+[2026-05-30T17:19:53.817Z] [INFO]     "role": "assistant",
+[2026-05-30T17:19:53.817Z] [INFO]     "content": [
+[2026-05-30T17:19:53.817Z] [INFO]       {
+[2026-05-30T17:19:53.817Z] [INFO]         "type": "thinking",
+[2026-05-30T17:19:53.817Z] [INFO]         "thinking": "",
+[2026-05-30T17:19:53.817Z] [INFO]         "signature": "EskCCmMIDhgCKkBtlFO+Tt/eThcJG+jLfoGvg8x91vB+OFxHImoLte7HQ4Mi7izHM59Lv7PxFIhiT48qQ2yWSfNwqh9mKPuNcNArMg9jbGF1ZGUtb3B1cy00LTg4AEIIdGhpbmtpbmcSDOtQ4m0YhUuribCm4xoMCgH5MFcWGOPfNpOIIjA56mxDwyzOX06iLc6h3TKcMfktSFTirS0Pf4QzNQihHZzii5ma1hFkXiUUy6cn7GQqkwHXvvQXivkZZJXKYSmKrl8h7WRAlRhRiP2kCK/4S96TJPwgGND+bbleDijpumElyPPodxMfBqnU8JykJ5avYQccrwhRcT81pk7twZjcOwG4Yn4XUEA9rMHN2Vlo09jIZglK2xvNGBQP1mLTsoeTMoSvosThES8eLVcy5pCrEDf3XeVSIEoGwQOdyqh3HhisXP1kFlgYAQ=="
+[2026-05-30T17:19:53.817Z] [INFO]       }
+[2026-05-30T17:19:53.817Z] [INFO]     ],
+[2026-05-30T17:19:53.817Z] [INFO]     "stop_reason": null,
+[2026-05-30T17:19:53.817Z] [INFO]     "stop_sequence": null,
+[2026-05-30T17:19:53.817Z] [INFO]     "stop_details": null,
+[2026-05-30T17:19:53.817Z] [INFO]     "usage": {
+[2026-05-30T17:19:53.817Z] [INFO]       "input_tokens": 2,
+[2026-05-30T17:19:53.817Z] [INFO]       "cache_creation_input_tokens": 1774,
+[2026-05-30T17:19:53.817Z] [INFO]       "cache_read_input_tokens": 58228,
+[2026-05-30T17:19:53.817Z] [INFO]       "cache_creation": {
+[2026-05-30T17:19:53.817Z] [INFO]         "ephemeral_5m_input_tokens": 0,
+[2026-05-30T17:19:53.817Z] [INFO]         "ephemeral_1h_input_tokens": 1774
+[2026-05-30T17:19:53.817Z] [INFO]       },
+[2026-05-30T17:19:53.817Z] [INFO]       "output_tokens": 2,
+[2026-05-30T17:19:53.817Z] [INFO]       "service_tier": "standard",
+[2026-05-30T17:19:53.817Z] [INFO]       "inference_geo": "not_available"
+[2026-05-30T17:19:53.817Z] [INFO]     },
+[2026-05-30T17:19:53.817Z] [INFO]     "diagnostics": null,
+[2026-05-30T17:19:53.817Z] [INFO]     "context_management": null
+[2026-05-30T17:19:53.817Z] [INFO]   },
+[2026-05-30T17:19:53.817Z] [INFO]   "parent_tool_use_id": null,
+[2026-05-30T17:19:53.817Z] [INFO]   "session_id": "45441128-80e2-48c1-a2ea-f81ede05030b",
+[2026-05-30T17:19:53.817Z] [INFO]   "uuid": "62a16a91-058f-4b3c-8491-98a56baaf0d2",
+[2026-05-30T17:19:53.817Z] [INFO]   "request_id": "req_011CbZ8sgwQTM95TDkvLin7s"
+[2026-05-30T17:19:53.817Z] [INFO] }
+[2026-05-30T17:19:54.288Z] [INFO] {
+[2026-05-30T17:19:54.288Z] [INFO]   "type": "assistant",
+[2026-05-30T17:19:54.288Z] [INFO]   "message": {
+[2026-05-30T17:19:54.288Z] [INFO]     "model": "claude-opus-4-8",
+[2026-05-30T17:19:54.288Z] [INFO]     "id": "msg_01VF9KZMUkD1SLwUu27PqXNg",
+[2026-05-30T17:19:54.288Z] [INFO]     "type": "message",
+[2026-05-30T17:19:54.288Z] [INFO]     "role": "assistant",
+[2026-05-30T17:19:54.288Z] [INFO]     "content": [
+[2026-05-30T17:19:54.288Z] [INFO]       {
+[2026-05-30T17:19:54.288Z] [INFO]         "type": "text",
+[2026-05-30T17:19:54.288Z] [INFO]         "text": "CONTRIBUTING.md already references a Code of Conduct in its TOC. Let me look at that section and the README structure."
+[2026-05-30T17:19:54.288Z] [INFO]       }
+[2026-05-30T17:19:54.288Z] [INFO]     ],
+[2026-05-30T17:19:54.288Z] [INFO]     "stop_reason": null,
+[2026-05-30T17:19:54.288Z] [INFO]     "stop_sequence": null,
+[2026-05-30T17:19:54.288Z] [INFO]     "stop_details": null,
+[2026-05-30T17:19:54.288Z] [INFO]     "usage": {
+[2026-05-30T17:19:54.288Z] [INFO]       "input_tokens": 2,
+[2026-05-30T17:19:54.288Z] [INFO]       "cache_creation_input_tokens": 1774,
+[2026-05-30T17:19:54.288Z] [INFO]       "cache_read_input_tokens": 58228,
+[2026-05-30T17:19:54.288Z] [INFO]       "cache_creation": {
+[2026-05-30T17:19:54.288Z] [INFO]         "ephemeral_5m_input_tokens": 0,
+[2026-05-30T17:19:54.288Z] [INFO]         "ephemeral_1h_input_tokens": 1774
+[2026-05-30T17:19:54.288Z] [INFO]       },
+[2026-05-30T17:19:54.288Z] [INFO]       "output_tokens": 2,
+[2026-05-30T17:19:54.288Z] [INFO]       "service_tier": "standard",
+[2026-05-30T17:19:54.288Z] [INFO]       "inference_geo": "not_available"
+[2026-05-30T17:19:54.288Z] [INFO]     },
+[2026-05-30T17:19:54.288Z] [INFO]     "diagnostics": null,
+[2026-05-30T17:19:54.288Z] [INFO]     "context_management": null
+[2026-05-30T17:19:54.288Z] [INFO]   },
+[2026-05-30T17:19:54.288Z] [INFO]   "parent_tool_use_id": null,
+[2026-05-30T17:19:54.288Z] [INFO]   "session_id": "45441128-80e2-48c1-a2ea-f81ede05030b",
+[2026-05-30T17:19:54.288Z] [INFO]   "uuid": "e304654e-6016-4ac1-90a5-f8abaf2b3353",
+[2026-05-30T17:19:54.288Z] [INFO]   "request_id": "req_011CbZ8sgwQTM95TDkvLin7s"
+[2026-05-30T17:19:54.288Z] [INFO] }
+[2026-05-30T17:19:55.947Z] [INFO] {
+[2026-05-30T17:19:55.947Z] [INFO]   "type": "assistant",
+[2026-05-30T17:19:55.947Z] [INFO]   "message": {
+[2026-05-30T17:19:55.947Z] [INFO]     "model": "claude-opus-4-8",
+[2026-05-30T17:19:55.947Z] [INFO]     "id": "msg_01VF9KZMUkD1SLwUu27PqXNg",
+[2026-05-30T17:19:55.947Z] [INFO]     "type": "message",
+[2026-05-30T17:19:55.947Z] [INFO]     "role": "assistant",
+[2026-05-30T17:19:55.947Z] [INFO]     "content": [
+[2026-05-30T17:19:55.947Z] [INFO]       {
+[2026-05-30T17:19:55.947Z] [INFO]         "type": "tool_use",
+[2026-05-30T17:19:55.947Z] [INFO]         "id": "toolu_01SKa2WPgMBEMKVbVpg5qsFp",
+[2026-05-30T17:19:55.947Z] [INFO]         "name": "Bash",
+[2026-05-30T17:19:55.947Z] [INFO]         "input": {
+[2026-05-30T17:19:55.947Z] [INFO]           "command": "cd /tmp/gh-issue-solver-1780161489554\necho \"=== CONTRIBUTING TOC + CoC section ===\"; sed -n '1,60p' CONTRIBUTING.md\necho \"=== grep 'code-of-conduct' / 'Code of Conduct' in CONTRIBUTING ===\"; grep -n -iE \"code.of.conduct\" CONTRIBUTING.md",
+[2026-05-30T17:19:55.947Z] [INFO]           "description": "Read CONTRIBUTING top section"
+[2026-05-30T17:19:55.947Z] [INFO]         },
+[2026-05-30T17:19:55.947Z] [INFO]         "caller": {
+[2026-05-30T17:19:55.947Z] [INFO]           "type": "direct"
+[2026-05-30T17:19:55.947Z] [INFO]         }
+[2026-05-30T17:19:55.947Z] [INFO]       }
+[2026-05-30T17:19:55.947Z] [INFO]     ],
+[2026-05-30T17:19:55.947Z] [INFO]     "stop_reason": null,
+[2026-05-30T17:19:55.947Z] [INFO]     "stop_sequence": null,
+[2026-05-30T17:19:55.947Z] [INFO]     "stop_details": null,
+[2026-05-30T17:19:55.947Z] [INFO]     "usage": {
+[2026-05-30T17:19:55.947Z] [INFO]       "input_tokens": 2,
+[2026-05-30T17:19:55.947Z] [INFO]       "cache_creation_input_tokens": 1774,
+[2026-05-30T17:19:55.947Z] [INFO]       "cache_read_input_tokens": 58228,
+[2026-05-30T17:19:55.947Z] [INFO]       "cache_creation": {
+[2026-05-30T17:19:55.947Z] [INFO]         "ephemeral_5m_input_tokens": 0,
+[2026-05-30T17:19:55.947Z] [INFO]         "ephemeral_1h_input_tokens": 1774
+[2026-05-30T17:19:55.947Z] [INFO]       },
+[2026-05-30T17:19:55.947Z] [INFO]       "output_tokens": 2,
+[2026-05-30T17:19:55.947Z] [INFO]       "service_tier": "standard",
+[2026-05-30T17:19:55.947Z] [INFO]       "inference_geo": "not_available"
+[2026-05-30T17:19:55.947Z] [INFO]     },
+[2026-05-30T17:19:55.947Z] [INFO]     "diagnostics": null,
+[2026-05-30T17:19:55.947Z] [INFO]     "context_management": null
+[2026-05-30T17:19:55.947Z] [INFO]   },
+[2026-05-30T17:19:55.947Z] [INFO]   "parent_tool_use_id": null,
+[2026-05-30T17:19:55.947Z] [INFO]   "session_id": "45441128-80e2-48c1-a2ea-f81ede05030b",
+[2026-05-30T17:19:55.947Z] [INFO]   "uuid": "0bfe41bc-eb27-454a-8f49-d80294533569",
+[2026-05-30T17:19:55.947Z] [INFO]   "request_id": "req_011CbZ8sgwQTM95TDkvLin7s"
+[2026-05-30T17:19:55.947Z] [INFO] }
+[2026-05-30T17:19:56.663Z] [INFO] {
+[2026-05-30T17:19:56.663Z] [INFO]   "type": "user",
+[2026-05-30T17:19:56.663Z] [INFO]   "message": {
+[2026-05-30T17:19:56.663Z] [INFO]     "role": "user",
+[2026-05-30T17:19:56.663Z] [INFO]     "content": [
+[2026-05-30T17:19:56.663Z] [INFO]       {
+[2026-05-30T17:19:56.663Z] [INFO]         "tool_use_id": "toolu_01SKa2WPgMBEMKVbVpg5qsFp",
+[2026-05-30T17:19:56.663Z] [INFO]         "type": "tool_result",
+[2026-05-30T17:19:56.663Z] [INFO]         "content": "=== CONTRIBUTING TOC + CoC section ===\n# Contributing to Teleton Agent\n\nThank you for your interest in contributing to Teleton Agent. This guide covers everything you need to get started.\n\n## Table of Contents\n\n- [Reporting Bugs](#reporting-bugs)\n- [Suggesting Features](#suggesting-features)\n- [Development Setup](#development-setup)\n- [Branch Strategy](#branch-strategy)\n- [Commit Conventions](#commit-conventions)\n- [Versioning Policy (SemVer)](#versioning-policy-semver)\n- [Releases](#releases)\n- [Making Changes](#making-changes)\n- [Pull Request Process](#pull-request-process)\n- [Code Style](#code-style)\n- [WebUI Internationalization (i18n)](#webui-internationalization-i18n)\n- [Plugin Development](#plugin-development)\n- [Code of Conduct](#code-of-conduct)\n\n## Reporting Bugs\n\nOpen a [GitHub Issue](https://github.com/TONresistor/teleton-agent/issues/new?template=bug_report.md) using the bug report template. Include:\n\n- A clear description of the problem\n- Steps to reproduce\n- Expected vs. actual behavior\n- Environment details (OS, Node.js version, teleton version, LLM provider)\n\nSearch [existing issues](https://github.com/TONresistor/teleton-agent/issues) first to avoid duplicates.\n\n## Suggesting Features\n\nOpen a [GitHub Issue](https://github.com/TONresistor/teleton-agent/issues/new?template=feature_request.md) using the feature request template. Describe the use case, your proposed solution, and any alternatives you considered.\n\n## Development Setup\n\n```bash\ngit clone https://github.com/TONresistor/teleton-agent.git\ncd teleton-agent\nnpm install\nnpm run dev\n```\n\nThis starts the agent in watch mode with automatic restarts on file changes.\n\n### Prerequisites\n\n- **Node.js 20.0.0+** ([download](https://nodejs.org/))\n- **npm 9+** (ships with Node.js)\n- An LLM API key from any [supported provider](README.md#supported-providers) (Anthropic, OpenAI, Google, xAI, Groq, OpenRouter, Mistral, and more)\n- Telegram API credentials from [my.telegram.org/apps](https://my.telegram.org/apps)\n\n### Useful Commands\n\n| Command | Description |\n|---------|-------------|\n| `npm run dev` | Start in watch mode (tsx) |\n| `npm run build` | Build backend (tsup) + frontend (vite) |\n| `npm run typecheck` | Type checking (`tsc --noEmit`) |\n=== grep 'code-of-conduct' / 'Code of Conduct' in CONTRIBUTING ===\n19:- [Code of Conduct](#code-of-conduct)",
+[2026-05-30T17:19:56.663Z] [INFO]         "is_error": false
+[2026-05-30T17:19:56.663Z] [INFO]       }
+[2026-05-30T17:19:56.663Z] [INFO]     ]
+[2026-05-30T17:19:56.663Z] [INFO]   },
+[2026-05-30T17:19:56.663Z] [INFO]   "parent_tool_use_id": null,
+[2026-05-30T17:19:56.663Z] [INFO]   "session_id": "45441128-80e2-48c1-a2ea-f81ede05030b",
+[2026-05-30T17:19:56.663Z] [INFO]   "uuid": "0f0f8db6-0036-4ce6-beb8-69249822e0dd",
+[2026-05-30T17:19:56.663Z] [INFO]   "timestamp": "2026-05-30T17:19:56.661Z",
+[2026-05-30T17:19:56.663Z] [INFO]   "tool_use_result": {
+[2026-05-30T17:19:56.663Z] [INFO]     "stdout": "=== CONTRIBUTING TOC + CoC section ===\n# Contributing to Teleton Agent\n\nThank you for your interest in contributing to Teleton Agent. This guide covers everything you need to get started.\n\n## Table of Contents\n\n- [Reporting Bugs](#reporting-bugs)\n- [Suggesting Features](#suggesting-features)\n- [Development Setup](#development-setup)\n- [Branch Strategy](#branch-strategy)\n- [Commit Conventions](#commit-conventions)\n- [Versioning Policy (SemVer)](#versioning-policy-semver)\n- [Releases](#releases)\n- [Making Changes](#making-changes)\n- [Pull Request Process](#pull-request-process)\n- [Code Style](#code-style)\n- [WebUI Internationalization (i18n)](#webui-internationalization-i18n)\n- [Plugin Development](#plugin-development)\n- [Code of Conduct](#code-of-conduct)\n\n## Reporting Bugs\n\nOpen a [GitHub Issue](https://github.com/TONresistor/teleton-agent/issues/new?template=bug_report.md) using the bug report template. Include:\n\n- A clear description of the problem\n- Steps to reproduce\n- Expected vs. actual behavior\n- Environment details (OS, Node.js version, teleton version, LLM provider)\n\nSearch [existing issues](https://github.com/TONresistor/teleton-agent/issues) first to avoid duplicates.\n\n## Suggesting Features\n\nOpen a [GitHub Issue](https://github.com/TONresistor/teleton-agent/issues/new?template=feature_request.md) using the feature request template. Describe the use case, your proposed solution, and any alternatives you considered.\n\n## Development Setup\n\n```bash\ngit clone https://github.com/TONresistor/teleton-agent.git\ncd teleton-agent\nnpm install\nnpm run dev\n```\n\nThis starts the agent in watch mode with automatic restarts on file changes.\n\n### Prerequisites\n\n- **Node.js 20.0.0+** ([download](https://nodejs.org/))\n- **npm 9+** (ships with Node.js)\n- An LLM API key from any [supported provider](README.md#supported-providers) (Anthropic, OpenAI, Google, xAI, Groq, OpenRouter, Mistral, and more)\n- Telegram API credentials from [my.telegram.org/apps](https://my.telegram.org/apps)\n\n### Useful Commands\n\n| Command | Description |\n|---------|-------------|\n| `npm run dev` | Start in watch mode (tsx) |\n| `npm run build` | Build backend (tsup) + frontend (vite) |\n| `npm run typecheck` | Type checking (`tsc --noEmit`) |\n=== grep 'code-of-conduct' / 'Code of Conduct' in CONTRIBUTING ===\n19:- [Code of Conduct](#code-of-conduct)",
+[2026-05-30T17:19:56.663Z] [INFO]     "stderr": "",
+[2026-05-30T17:19:56.663Z] [INFO]     "interrupted": false,
+[2026-05-30T17:19:56.663Z] [INFO]     "isImage": false,
+[2026-05-30T17:19:56.663Z] [INFO]     "noOutputExpected": false
+[2026-05-30T17:19:56.663Z] [INFO]   }
+[2026-05-30T17:19:56.663Z] [INFO] }
+[2026-05-30T17:19:56.676Z] [INFO] [log_16ebc5] sending request {
+[2026-05-30T17:19:56.677Z] [INFO]   method: "post",
+[2026-05-30T17:19:56.677Z] [INFO]   url: "https://api.anthropic.com/v1/messages?beta=true",
+[2026-05-30T17:19:56.678Z] [INFO]   options: {
+[2026-05-30T17:19:56.678Z] [INFO]     method: "post",
+[2026-05-30T17:19:56.678Z] [INFO]     path: "/v1/messages?beta=true",
+[2026-05-30T17:19:56.679Z] [INFO]     body: {
+[2026-05-30T17:19:56.679Z] [INFO]       model: "claude-opus-4-8",
+[2026-05-30T17:19:56.680Z] [INFO]       messages: [
+[2026-05-30T17:19:56.681Z] [INFO]         [Object ...], [Object ...], [Object ...], [Object ...], [Object ...], [Object ...], [Object ...], [Object ...], [Object ...], [Object ...], [Object ...], [Object ...], [Object ...], [Object ...], [Object ...], [Object ...], [Object ...], [Object ...], [Object ...], [Object ...], [Object ...], [Object ...]
+[2026-05-30T17:19:56.682Z] [INFO]       ],
+[2026-05-30T17:19:56.683Z] [INFO]       system: [
+[2026-05-30T17:19:56.683Z] [INFO]         [Object ...], [Object ...], [Object ...], [Object ...]
+[2026-05-30T17:19:56.684Z] [INFO]       ],
+[2026-05-30T17:19:56.685Z] [INFO]       tools: [
+[2026-05-30T17:19:56.685Z] [INFO]         [Object ...], [Object ...], [Object ...], [Object ...], [Object ...], [Object ...], [Object ...], [Object ...], [Object ...], [Object ...]
+[2026-05-30T17:19:56.685Z] [INFO]       ],
+[2026-05-30T17:19:56.686Z] [INFO]       tool_choice: undefined,
+[2026-05-30T17:19:56.687Z] [INFO]       metadata: [Object ...],
+[2026-05-30T17:19:56.687Z] [INFO]       max_tokens: 128000,
+[2026-05-30T17:19:56.687Z] [INFO]       thinking: [Object ...],
+[2026-05-30T17:19:56.687Z] [INFO]       context_management: [Object ...],
+[2026-05-30T17:19:56.688Z] [INFO]       output_config: [Object ...],
+[2026-05-30T17:19:56.688Z] [INFO]       diagnostics: [Object ...],
+[2026-05-30T17:19:56.689Z] [INFO]       stream: true,
+[2026-05-30T17:19:56.689Z] [INFO]     },
+[2026-05-30T17:19:56.690Z] [INFO]     timeout: 600000,
+[2026-05-30T17:19:56.692Z] [INFO]     signal: AbortSignal {
+[2026-05-30T17:19:56.695Z] [INFO]       [Symbol(events.maxEventTargetListeners)]: 50,
+[2026-05-30T17:19:56.699Z] [INFO]       [Symbol(events.maxEventTargetListenersWarned)]: false,
+[2026-05-30T17:19:56.700Z] [INFO]       aborted: false,
+[2026-05-30T17:19:56.701Z] [INFO]       reason: undefined,
+[2026-05-30T17:19:56.701Z] [INFO]       onabort: null,
+[2026-05-30T17:19:56.702Z] [INFO]       throwIfAborted: [Function: throwIfAborted],
+[2026-05-30T17:19:56.703Z] [INFO]       addEventListener: [Function: addEventListener],
+[2026-05-30T17:19:56.706Z] [INFO]       removeEventListener: [Function: removeEventListener],
+[2026-05-30T17:19:56.707Z] [INFO]       dispatchEvent: [Function: dispatchEvent],
+[2026-05-30T17:19:56.708Z] [INFO]     },
+[2026-05-30T17:19:56.710Z] [INFO]     stream: true,
+[2026-05-30T17:19:56.712Z] [INFO]   },
+[2026-05-30T17:19:56.715Z] [INFO]   headers: {
+[2026-05-30T17:19:56.721Z] [INFO]     accept: "application/json",
+[2026-05-30T17:19:56.725Z] [INFO]     "anthropic-beta": "claude-code-20250219,oauth-2025-04-20,interleaved-thinking-2025-05-14,thinking-token-count-2026-05-13,context-management-2025-06-27,prompt-caching-scope-2026-01-05,mid-conversation-system-2026-04-07,advisor-tool-2026-03-01,advanced-tool-use-2025-11-20,effort-2025-11-24,extended-cache-ttl-2025-04-11,cache-diagnosis-2026-04-07",
+[2026-05-30T17:19:56.725Z] [INFO]     "anthropic-dangerous-direct-browser-access": "true",
+[2026-05-30T17:19:56.726Z] [INFO]     "anthropic-version": "2023-06-01",
+[2026-05-30T17:19:56.727Z] [INFO]     authorization: "***",
+[2026-05-30T17:19:56.728Z] [INFO]     "content-type": "application/json",
+[2026-05-30T17:19:56.728Z] [INFO]     "user-agent": "claude-cli/2.1.158 (external, sdk-cli)",
+[2026-05-30T17:19:56.728Z] [INFO]     "x-app": "cli",
+[2026-05-30T17:19:56.729Z] [INFO]     "x-claude-code-session-id": "45441128-80e2-48c1-a2ea-f81ede05030b",
+[2026-05-30T17:19:56.730Z] [INFO]     "x-client-request-id": "ec771522-b68b-4515-a7b8-18a46cf1e5d0",
+[2026-05-30T17:19:56.731Z] [INFO]     "x-stainless-arch": "x64",
+[2026-05-30T17:19:56.731Z] [INFO]     "x-stainless-lang": "js",
+[2026-05-30T17:19:56.732Z] [INFO]     "x-stainless-os": "Linux",
+[2026-05-30T17:19:56.732Z] [INFO]     "x-stainless-package-version": "0.94.0",
+[2026-05-30T17:19:56.733Z] [INFO]     "x-stainless-retry-count": "0",
+[2026-05-30T17:19:56.733Z] [INFO]     "x-stainless-runtime": "node",
+[2026-05-30T17:19:56.734Z] [INFO]     "x-stainless-runtime-version": "v24.3.0",
+[2026-05-30T17:19:56.735Z] [INFO]     "x-stainless-timeout": "600",
+[2026-05-30T17:19:56.735Z] [INFO]   },
+[2026-05-30T17:19:56.736Z] [INFO] }
+[2026-05-30T17:19:58.705Z] [INFO] [log_16ebc5, request-id: "req_011CbZ8t7iAuQQS1z7kxRsqA"] post https://api.anthropic.com/v1/messages?beta=true succeeded with status 200 in 2030ms
+[2026-05-30T17:19:58.706Z] [INFO] [log_16ebc5] response start {
+[2026-05-30T17:19:58.708Z] [INFO]   url: "https://api.anthropic.com/v1/messages?beta=true",
+[2026-05-30T17:19:58.709Z] [INFO]   status: 200,
+[2026-05-30T17:19:58.709Z] [INFO]   headers: {
+[2026-05-30T17:19:58.710Z] [INFO]     "anthropic-organization-id": "ebc2ac93-f86f-4d15-aff3-de8830d8d789",
+[2026-05-30T17:19:58.710Z] [INFO]     "anthropic-ratelimit-unified-5h-reset": "1780173000",
+[2026-05-30T17:19:58.711Z] [INFO]     "anthropic-ratelimit-unified-5h-status": "allowed",
+[2026-05-30T17:19:58.711Z] [INFO]     "anthropic-ratelimit-unified-5h-utilization": "0.25",
+[2026-05-30T17:19:58.711Z] [INFO]     "anthropic-ratelimit-unified-7d-reset": "1780398000",
+[2026-05-30T17:19:58.711Z] [INFO]     "anthropic-ratelimit-unified-7d-status": "allowed",
+[2026-05-30T17:19:58.712Z] [INFO]     "anthropic-ratelimit-unified-7d-utilization": "0.73",
+[2026-05-30T17:19:58.712Z] [INFO]     "anthropic-ratelimit-unified-fallback-percentage": "0.5",
+[2026-05-30T17:19:58.712Z] [INFO]     "anthropic-ratelimit-unified-overage-disabled-reason": "org_level_disabled",
+[2026-05-30T17:19:58.712Z] [INFO]     "anthropic-ratelimit-unified-overage-status": "rejected",
+[2026-05-30T17:19:58.712Z] [INFO]     "anthropic-ratelimit-unified-representative-claim": "five_hour",
+[2026-05-30T17:19:58.713Z] [INFO]     "anthropic-ratelimit-unified-reset": "1780173000",
+[2026-05-30T17:19:58.713Z] [INFO]     "anthropic-ratelimit-unified-status": "allowed",
+[2026-05-30T17:19:58.713Z] [INFO]     "cache-control": "no-cache",
+[2026-05-30T17:19:58.713Z] [INFO]     "cf-cache-status": "DYNAMIC",
+[2026-05-30T17:19:58.713Z] [INFO]     "cf-ray": "a03f681b5e4c976a-FRA",
+[2026-05-30T17:19:58.713Z] [INFO]     connection: "keep-alive",
+[2026-05-30T17:19:58.713Z] [INFO]     "content-encoding": "gzip",
+[2026-05-30T17:19:58.714Z] [INFO]     "content-security-policy": "default-src 'none'; frame-ancestors 'none'",
+[2026-05-30T17:19:58.714Z] [INFO]     "content-type": "text/event-stream; charset=utf-8",
+[2026-05-30T17:19:58.714Z] [INFO]     date: "Sat, 30 May 2026 17:19:58 GMT",
+[2026-05-30T17:19:58.714Z] [INFO]     "request-id": "req_011CbZ8t7iAuQQS1z7kxRsqA",
+[2026-05-30T17:19:58.714Z] [INFO]     server: "cloudflare",
+[2026-05-30T17:19:58.714Z] [INFO]     "strict-transport-security": "max-age=31536000; includeSubDomains; preload",
+[2026-05-30T17:19:58.714Z] [INFO]     traceresponse: "00-beccb8da13621ea8c17941ae920a9af3-295928ca07c944db-01",
+[2026-05-30T17:19:58.714Z] [INFO]     "transfer-encoding": "chunked",
+[2026-05-30T17:19:58.715Z] [INFO]     vary: "Accept-Encoding",
+[2026-05-30T17:19:58.715Z] [INFO]     "x-robots-tag": "none",
+[2026-05-30T17:19:58.716Z] [INFO]     "set-cookie": "***",
+[2026-05-30T17:19:58.716Z] [INFO]   },
+[2026-05-30T17:19:58.716Z] [INFO]   durationMs: 2030,
+[2026-05-30T17:19:58.716Z] [INFO] }
+[2026-05-30T17:19:58.717Z] [INFO] response 200 https://api.anthropic.com/v1/messages?beta=true Headers {
+[2026-05-30T17:19:58.717Z] [INFO]   "date": "Sat, 30 May 2026 17:19:58 GMT",
+[2026-05-30T17:19:58.717Z] [INFO]   "content-type": "text/event-stream; charset=utf-8",
+[2026-05-30T17:19:58.717Z] [INFO]   "transfer-encoding": "chunked",
+[2026-05-30T17:19:58.718Z] [INFO]   "connection": "keep-alive",
+[2026-05-30T17:19:58.718Z] [INFO]   "cache-control": "no-cache",
+[2026-05-30T17:19:58.718Z] [INFO]   "strict-transport-security": "max-age=31536000; includeSubDomains; preload",
+[2026-05-30T17:19:58.719Z] [INFO]   "content-encoding": "gzip",
+[2026-05-30T17:19:58.720Z] [INFO]   "vary": "Accept-Encoding",
+[2026-05-30T17:19:58.720Z] [INFO]   "content-security-policy": "default-src 'none'; frame-ancestors 'none'",
+[2026-05-30T17:19:58.721Z] [INFO]   "set-cookie": [ "_cfuvid=RZn4pc1uWZRTQoPSFdXabAo11Ek6IcwWkkMR574On8Q-1780161596.6927516-1.0.1.1-FFK.rpV6GgJW7g3tlRdzZj3SBwyUKxRql4Xkf8YutJ4; HttpOnly; SameSite=None; Secure; Path=/; Domain=api.anthropic.com" ],
+[2026-05-30T17:19:58.721Z] [INFO]   "anthropic-ratelimit-unified-status": "allowed",
+[2026-05-30T17:19:58.721Z] [INFO]   "anthropic-ratelimit-unified-5h-status": "allowed",
+[2026-05-30T17:19:58.722Z] [INFO]   "anthropic-ratelimit-unified-5h-reset": "1780173000",
+[2026-05-30T17:19:58.723Z] [INFO]   "anthropic-ratelimit-unified-5h-utilization": "0.25",
+[2026-05-30T17:19:58.724Z] [INFO]   "anthropic-ratelimit-unified-7d-status": "allowed",
+[2026-05-30T17:19:58.724Z] [INFO]   "anthropic-ratelimit-unified-7d-reset": "1780398000",
+[2026-05-30T17:19:58.724Z] [INFO]   "anthropic-ratelimit-unified-7d-utilization": "0.73",
+[2026-05-30T17:19:58.725Z] [INFO]   "anthropic-ratelimit-unified-representative-claim": "five_hour",
+[2026-05-30T17:19:58.725Z] [INFO]   "anthropic-ratelimit-unified-fallback-percentage": "0.5",
+[2026-05-30T17:19:58.725Z] [INFO]   "anthropic-ratelimit-unified-reset": "1780173000",
+[2026-05-30T17:19:58.726Z] [INFO]   "anthropic-ratelimit-unified-overage-disabled-reason": "org_level_disabled",
+[2026-05-30T17:19:58.726Z] [INFO]   "anthropic-ratelimit-unified-overage-status": "rejected",
+[2026-05-30T17:19:58.726Z] [INFO]   "request-id": "req_011CbZ8t7iAuQQS1z7kxRsqA",
+[2026-05-30T17:19:58.726Z] [INFO]   "anthropic-organization-id": "ebc2ac93-f86f-4d15-aff3-de8830d8d789",
+[2026-05-30T17:19:58.726Z] [INFO]   "traceresponse": "00-beccb8da13621ea8c17941ae920a9af3-295928ca07c944db-01",
+[2026-05-30T17:19:58.726Z] [INFO]   "server": "cloudflare",
+[2026-05-30T17:19:58.727Z] [INFO]   "cf-cache-status": "DYNAMIC",
+[2026-05-30T17:19:58.727Z] [INFO]   "x-robots-tag": "none",
+[2026-05-30T17:19:58.727Z] [INFO]   "cf-ray": "a03f681b5e4c976a-FRA",
+[2026-05-30T17:19:58.727Z] [INFO] } ReadableStream {
+[2026-05-30T17:19:58.727Z] [INFO]   blob: [Function: blob],
+[2026-05-30T17:19:58.727Z] [INFO]   bytes: [Function: bytes],
+[2026-05-30T17:19:58.727Z] [INFO]   cancel: [Function],
+[2026-05-30T17:19:58.727Z] [INFO]   getReader: [Function],
+[2026-05-30T17:19:58.728Z] [INFO]   json: [Function: json],
+[2026-05-30T17:19:58.728Z] [INFO]   locked: [Getter],
+[2026-05-30T17:19:58.728Z] [INFO]   pipeThrough: [Function],
+[2026-05-30T17:19:58.728Z] [INFO]   pipeTo: [Function],
+[2026-05-30T17:19:58.729Z] [INFO]   tee: [Function],
+[2026-05-30T17:19:58.729Z] [INFO]   text: [Function: text],
+[2026-05-30T17:19:58.729Z] [INFO]   values: [Function: values],
+[2026-05-30T17:19:58.730Z] [INFO]   [Symbol(Symbol.asyncIterator)]: [Function: asyncIterator2],
+[2026-05-30T17:19:58.730Z] [INFO] }
+[2026-05-30T17:19:58.730Z] [INFO] [log_16ebc5] response parsed {
+[2026-05-30T17:19:58.730Z] [INFO]   url: "https://api.anthropic.com/v1/messages?beta=true",
+[2026-05-30T17:19:58.731Z] [INFO]   status: 200,
+[2026-05-30T17:19:58.731Z] [INFO]   body: bR {
+[2026-05-30T17:19:58.731Z] [INFO]     iterator: [AsyncGeneratorFunction: z],
+[2026-05-30T17:19:58.731Z] [INFO]     controller: AbortController {
+[2026-05-30T17:19:58.731Z] [INFO]       signal: [AbortSignal ...],
+[2026-05-30T17:19:58.732Z] [INFO]       abort: [Function: abort],
+[2026-05-30T17:19:58.732Z] [INFO]     },
+[2026-05-30T17:19:58.732Z] [INFO]     [Symbol(Symbol.asyncIterator)]: [Function],
+[2026-05-30T17:19:58.732Z] [INFO]     tee: [Function: tee],
+[2026-05-30T17:19:58.733Z] [INFO]     toReadableStream: [Function: toReadableStream],
+[2026-05-30T17:19:58.733Z] [INFO]   },
+[2026-05-30T17:19:58.733Z] [INFO]   durationMs: 2030,
+[2026-05-30T17:19:58.733Z] [INFO] }
+[2026-05-30T17:20:00.299Z] [INFO] {
+[2026-05-30T17:20:00.299Z] [INFO]   "type": "assistant",
+[2026-05-30T17:20:00.299Z] [INFO]   "message": {
+[2026-05-30T17:20:00.299Z] [INFO]     "model": "claude-opus-4-8",
+[2026-05-30T17:20:00.299Z] [INFO]     "id": "msg_01K2BKtH48F1hoQq9mHA5Vww",
+[2026-05-30T17:20:00.299Z] [INFO]     "type": "message",
+[2026-05-30T17:20:00.299Z] [INFO]     "role": "assistant",
+[2026-05-30T17:20:00.299Z] [INFO]     "content": [
+[2026-05-30T17:20:00.299Z] [INFO]       {
+[2026-05-30T17:20:00.299Z] [INFO]         "type": "tool_use",
+[2026-05-30T17:20:00.299Z] [INFO]         "id": "toolu_01BvEz3P8oxhyNx2Zhb1C5Gb",
+[2026-05-30T17:20:00.299Z] [INFO]         "name": "Bash",
+[2026-05-30T17:20:00.299Z] [INFO]         "input": {
+[2026-05-30T17:20:00.299Z] [INFO]           "command": "cd /tmp/gh-issue-solver-1780161489554\ngrep -n -iE \"code of conduct|## Pull Request Process|^## \" CONTRIBUTING.md | tail -20\necho \"=== tail end of contributing where CoC TOC points ===\"\ngrep -n \"Code of Conduct\" CONTRIBUTING.md",
+[2026-05-30T17:20:00.299Z] [INFO]           "description": "Find Code of Conduct section in CONTRIBUTING"
+[2026-05-30T17:20:00.299Z] [INFO]         },
+[2026-05-30T17:20:00.299Z] [INFO]         "caller": {
+[2026-05-30T17:20:00.299Z] [INFO]           "type": "direct"
+[2026-05-30T17:20:00.299Z] [INFO]         }
+[2026-05-30T17:20:00.299Z] [INFO]       }
+[2026-05-30T17:20:00.299Z] [INFO]     ],
+[2026-05-30T17:20:00.299Z] [INFO]     "stop_reason": null,
+[2026-05-30T17:20:00.299Z] [INFO]     "stop_sequence": null,
+[2026-05-30T17:20:00.299Z] [INFO]     "stop_details": null,
+[2026-05-30T17:20:00.299Z] [INFO]     "usage": {
+[2026-05-30T17:20:00.299Z] [INFO]       "input_tokens": 2,
+[2026-05-30T17:20:00.299Z] [INFO]       "cache_creation_input_tokens": 1309,
+[2026-05-30T17:20:00.299Z] [INFO]       "cache_read_input_tokens": 60002,
+[2026-05-30T17:20:00.299Z] [INFO]       "cache_creation": {
+[2026-05-30T17:20:00.299Z] [INFO]         "ephemeral_5m_input_tokens": 0,
+[2026-05-30T17:20:00.299Z] [INFO]         "ephemeral_1h_input_tokens": 1309
+[2026-05-30T17:20:00.299Z] [INFO]       },
+[2026-05-30T17:20:00.299Z] [INFO]       "output_tokens": 55,
+[2026-05-30T17:20:00.299Z] [INFO]       "service_tier": "standard",
+[2026-05-30T17:20:00.299Z] [INFO]       "inference_geo": "not_available"
+[2026-05-30T17:20:00.299Z] [INFO]     },
+[2026-05-30T17:20:00.299Z] [INFO]     "diagnostics": null,
+[2026-05-30T17:20:00.299Z] [INFO]     "context_management": null
+[2026-05-30T17:20:00.299Z] [INFO]   },
+[2026-05-30T17:20:00.299Z] [INFO]   "parent_tool_use_id": null,
+[2026-05-30T17:20:00.299Z] [INFO]   "session_id": "45441128-80e2-48c1-a2ea-f81ede05030b",
+[2026-05-30T17:20:00.299Z] [INFO]   "uuid": "76b8dbfc-f397-453e-bbd0-932dc973408b",
+[2026-05-30T17:20:00.299Z] [INFO]   "request_id": "req_011CbZ8t7iAuQQS1z7kxRsqA"
+[2026-05-30T17:20:00.299Z] [INFO] }
+[2026-05-30T17:20:01.073Z] [INFO] {
+[2026-05-30T17:20:01.073Z] [INFO]   "type": "user",
+[2026-05-30T17:20:01.073Z] [INFO]   "message": {
+[2026-05-30T17:20:01.073Z] [INFO]     "role": "user",
+[2026-05-30T17:20:01.073Z] [INFO]     "content": [
+[2026-05-30T17:20:01.073Z] [INFO]       {
+[2026-05-30T17:20:01.073Z] [INFO]         "tool_use_id": "toolu_01BvEz3P8oxhyNx2Zhb1C5Gb",
+[2026-05-30T17:20:01.073Z] [INFO]         "type": "tool_result",
+[2026-05-30T17:20:01.073Z] [INFO]         "content": "5:## Table of Contents\n19:- [Code of Conduct](#code-of-conduct)\n21:## Reporting Bugs\n32:## Suggesting Features\n36:## Development Setup\n68:## Branch Strategy\n76:## Commit Conventions\n116:## Versioning Policy (SemVer)\n136:## Releases\n163:## Making Changes\n186:## Pull Request Process\n202:## Code Style\n219:## WebUI Internationalization (i18n)\n269:## Plugin Development\n=== tail end of contributing where CoC TOC points ===\n19:- [Code of Conduct](#code-of-conduct)",
+[2026-05-30T17:20:01.073Z] [INFO]         "is_error": false
+[2026-05-30T17:20:01.073Z] [INFO]       }
+[2026-05-30T17:20:01.073Z] [INFO]     ]
+[2026-05-30T17:20:01.073Z] [INFO]   },
+[2026-05-30T17:20:01.073Z] [INFO]   "parent_tool_use_id": null,
+[2026-05-30T17:20:01.073Z] [INFO]   "session_id": "45441128-80e2-48c1-a2ea-f81ede05030b",
+[2026-05-30T17:20:01.073Z] [INFO]   "uuid": "5096ccdf-36ba-4919-b532-443dc8562831",
+[2026-05-30T17:20:01.073Z] [INFO]   "timestamp": "2026-05-30T17:20:01.072Z",
+[2026-05-30T17:20:01.073Z] [INFO]   "tool_use_result": {
+[2026-05-30T17:20:01.073Z] [INFO]     "stdout": "5:## Table of Contents\n19:- [Code of Conduct](#code-of-conduct)\n21:## Reporting Bugs\n32:## Suggesting Features\n36:## Development Setup\n68:## Branch Strategy\n76:## Commit Conventions\n116:## Versioning Policy (SemVer)\n136:## Releases\n163:## Making Changes\n186:## Pull Request Process\n202:## Code Style\n219:## WebUI Internationalization (i18n)\n269:## Plugin Development\n=== tail end of contributing where CoC TOC points ===\n19:- [Code of Conduct](#code-of-conduct)",
+[2026-05-30T17:20:01.073Z] [INFO]     "stderr": "",
+[2026-05-30T17:20:01.073Z] [INFO]     "interrupted": false,
+[2026-05-30T17:20:01.073Z] [INFO]     "isImage": false,
+[2026-05-30T17:20:01.073Z] [INFO]     "noOutputExpected": false
+[2026-05-30T17:20:01.073Z] [INFO]   }
+[2026-05-30T17:20:01.073Z] [INFO] }
+[2026-05-30T17:20:01.082Z] [INFO] [log_13ab9e] sending request {
+[2026-05-30T17:20:01.084Z] [INFO]   method: "post",
+[2026-05-30T17:20:01.084Z] [INFO]   url: "https://api.anthropic.com/v1/messages?beta=true",
+[2026-05-30T17:20:01.085Z] [INFO]   options: {
+[2026-05-30T17:20:01.085Z] [INFO]     method: "post",
+[2026-05-30T17:20:01.086Z] [INFO]     path: "/v1/messages?beta=true",
+[2026-05-30T17:20:01.087Z] [INFO]     body: {
+[2026-05-30T17:20:01.087Z] [INFO]       model: "claude-opus-4-8",
+[2026-05-30T17:20:01.088Z] [INFO]       messages: [
+[2026-05-30T17:20:01.088Z] [INFO]         [Object ...], [Object ...], [Object ...], [Object ...], [Object ...], [Object ...], [Object ...], [Object ...], [Object ...], [Object ...], [Object ...], [Object ...], [Object ...], [Object ...], [Object ...], [Object ...], [Object ...], [Object ...], [Object ...], [Object ...], [Object ...], [Object ...], [Object ...], [Object ...], [Object ...]
+[2026-05-30T17:20:01.088Z] [INFO]       ],
+[2026-05-30T17:20:01.089Z] [INFO]       system: [
+[2026-05-30T17:20:01.090Z] [INFO]         [Object ...], [Object ...], [Object ...], [Object ...]
+[2026-05-30T17:20:01.090Z] [INFO]       ],
+[2026-05-30T17:20:01.091Z] [INFO]       tools: [
+[2026-05-30T17:20:01.092Z] [INFO]         [Object ...], [Object ...], [Object ...], [Object ...], [Object ...], [Object ...], [Object ...], [Object ...], [Object ...], [Object ...]
+[2026-05-30T17:20:01.092Z] [INFO]       ],
+[2026-05-30T17:20:01.092Z] [INFO]       tool_choice: undefined,
+[2026-05-30T17:20:01.093Z] [INFO]       metadata: [Object ...],
+[2026-05-30T17:20:01.093Z] [INFO]       max_tokens: 128000,
+[2026-05-30T17:20:01.093Z] [INFO]       thinking: [Object ...],
+[2026-05-30T17:20:01.094Z] [INFO]       context_management: [Object ...],
+[2026-05-30T17:20:01.094Z] [INFO]       output_config: [Object ...],
+[2026-05-30T17:20:01.096Z] [INFO]       diagnostics: [Object ...],
+[2026-05-30T17:20:01.096Z] [INFO]       stream: true,
+[2026-05-30T17:20:01.097Z] [INFO]     },
+[2026-05-30T17:20:01.098Z] [INFO]     timeout: 600000,
+[2026-05-30T17:20:01.101Z] [INFO]     signal: AbortSignal {
+[2026-05-30T17:20:01.101Z] [INFO]       [Symbol(events.maxEventTargetListeners)]: 50,
+[2026-05-30T17:20:01.102Z] [INFO]       [Symbol(events.maxEventTargetListenersWarned)]: false,
+[2026-05-30T17:20:01.102Z] [INFO]       aborted: false,
+[2026-05-30T17:20:01.103Z] [INFO]       reason: undefined,
+[2026-05-30T17:20:01.103Z] [INFO]       onabort: null,
+[2026-05-30T17:20:01.103Z] [INFO]       throwIfAborted: [Function: throwIfAborted],
+[2026-05-30T17:20:01.104Z] [INFO]       addEventListener: [Function: addEventListener],
+[2026-05-30T17:20:01.104Z] [INFO]       removeEventListener: [Function: removeEventListener],
+[2026-05-30T17:20:01.106Z] [INFO]       dispatchEvent: [Function: dispatchEvent],
+[2026-05-30T17:20:01.106Z] [INFO]     },
+[2026-05-30T17:20:01.107Z] [INFO]     stream: true,
+[2026-05-30T17:20:01.107Z] [INFO]   },
+[2026-05-30T17:20:01.107Z] [INFO]   headers: {
+[2026-05-30T17:20:01.108Z] [INFO]     accept: "application/json",
+[2026-05-30T17:20:01.109Z] [INFO]     "anthropic-beta": "claude-code-20250219,oauth-2025-04-20,interleaved-thinking-2025-05-14,thinking-token-count-2026-05-13,context-management-2025-06-27,prompt-caching-scope-2026-01-05,mid-conversation-system-2026-04-07,advisor-tool-2026-03-01,advanced-tool-use-2025-11-20,effort-2025-11-24,extended-cache-ttl-2025-04-11,cache-diagnosis-2026-04-07",
+[2026-05-30T17:20:01.109Z] [INFO]     "anthropic-dangerous-direct-browser-access": "true",
+[2026-05-30T17:20:01.109Z] [INFO]     "anthropic-version": "2023-06-01",
+[2026-05-30T17:20:01.110Z] [INFO]     authorization: "***",
+[2026-05-30T17:20:01.110Z] [INFO]     "content-type": "application/json",
+[2026-05-30T17:20:01.111Z] [INFO]     "user-agent": "claude-cli/2.1.158 (external, sdk-cli)",
+[2026-05-30T17:20:01.111Z] [INFO]     "x-app": "cli",
+[2026-05-30T17:20:01.111Z] [INFO]     "x-claude-code-session-id": "45441128-80e2-48c1-a2ea-f81ede05030b",
+[2026-05-30T17:20:01.112Z] [INFO]     "x-client-request-id": "89ac3f63-36db-49a8-8400-bf4a7b9caf65",
+[2026-05-30T17:20:01.112Z] [INFO]     "x-stainless-arch": "x64",
+[2026-05-30T17:20:01.112Z] [INFO]     "x-stainless-lang": "js",
+[2026-05-30T17:20:01.112Z] [INFO]     "x-stainless-os": "Linux",
+[2026-05-30T17:20:01.112Z] [INFO]     "x-stainless-package-version": "0.94.0",
+[2026-05-30T17:20:01.113Z] [INFO]     "x-stainless-retry-count": "0",
+[2026-05-30T17:20:01.113Z] [INFO]     "x-stainless-runtime": "node",
+[2026-05-30T17:20:01.113Z] [INFO]     "x-stainless-runtime-version": "v24.3.0",
+[2026-05-30T17:20:01.114Z] [INFO]     "x-stainless-timeout": "600",
+[2026-05-30T17:20:01.114Z] [INFO]   },
+[2026-05-30T17:20:01.114Z] [INFO] }
+[2026-05-30T17:20:02.435Z] [INFO] [log_13ab9e, request-id: "req_011CbZ8tSXG8EaPGef95nwXN"] post https://api.anthropic.com/v1/messages?beta=true succeeded with status 200 in 1352ms
+[2026-05-30T17:20:02.440Z] [INFO] [log_13ab9e] response start {
+[2026-05-30T17:20:02.441Z] [INFO]   url: "https://api.anthropic.com/v1/messages?beta=true",
+[2026-05-30T17:20:02.441Z] [INFO]   status: 200,
+[2026-05-30T17:20:02.441Z] [INFO]   headers: {
+[2026-05-30T17:20:02.442Z] [INFO]     "anthropic-organization-id": "ebc2ac93-f86f-4d15-aff3-de8830d8d789",
+[2026-05-30T17:20:02.442Z] [INFO]     "anthropic-ratelimit-unified-5h-reset": "1780173000",
+[2026-05-30T17:20:02.443Z] [INFO]     "anthropic-ratelimit-unified-5h-status": "allowed",
+[2026-05-30T17:20:02.445Z] [INFO]     "anthropic-ratelimit-unified-5h-utilization": "0.25",
+[2026-05-30T17:20:02.445Z] [INFO]     "anthropic-ratelimit-unified-7d-reset": "1780398000",
+[2026-05-30T17:20:02.446Z] [INFO]     "anthropic-ratelimit-unified-7d-status": "allowed",
+[2026-05-30T17:20:02.448Z] [INFO]     "anthropic-ratelimit-unified-7d-utilization": "0.73",
+[2026-05-30T17:20:02.448Z] [INFO]     "anthropic-ratelimit-unified-fallback-percentage": "0.5",
+[2026-05-30T17:20:02.449Z] [INFO]     "anthropic-ratelimit-unified-overage-disabled-reason": "org_level_disabled",
+[2026-05-30T17:20:02.451Z] [INFO]     "anthropic-ratelimit-unified-overage-status": "rejected",
+[2026-05-30T17:20:02.451Z] [INFO]     "anthropic-ratelimit-unified-representative-claim": "five_hour",
+[2026-05-30T17:20:02.452Z] [INFO]     "anthropic-ratelimit-unified-reset": "1780173000",
+[2026-05-30T17:20:02.452Z] [INFO]     "anthropic-ratelimit-unified-status": "allowed",
+[2026-05-30T17:20:02.452Z] [INFO]     "cache-control": "no-cache",
+[2026-05-30T17:20:02.453Z] [INFO]     "cf-cache-status": "DYNAMIC",
+[2026-05-30T17:20:02.453Z] [INFO]     "cf-ray": "a03f6836dc58b10b-FRA",
+[2026-05-30T17:20:02.454Z] [INFO]     connection: "keep-alive",
+[2026-05-30T17:20:02.454Z] [INFO]     "content-encoding": "gzip",
+[2026-05-30T17:20:02.454Z] [INFO]     "content-security-policy": "default-src 'none'; frame-ancestors 'none'",
+[2026-05-30T17:20:02.455Z] [INFO]     "content-type": "text/event-stream; charset=utf-8",
+[2026-05-30T17:20:02.455Z] [INFO]     date: "Sat, 30 May 2026 17:20:02 GMT",
+[2026-05-30T17:20:02.457Z] [INFO]     "request-id": "req_011CbZ8tSXG8EaPGef95nwXN",
+[2026-05-30T17:20:02.457Z] [INFO]     server: "cloudflare",
+[2026-05-30T17:20:02.457Z] [INFO]     "strict-transport-security": "max-age=31536000; includeSubDomains; preload",
+[2026-05-30T17:20:02.457Z] [INFO]     traceresponse: "00-ae97f2a5cd5514ba78acbd43c0eb9aad-6dd08b7a3a761498-01",
+[2026-05-30T17:20:02.457Z] [INFO]     "transfer-encoding": "chunked",
+[2026-05-30T17:20:02.458Z] [INFO]     vary: "Accept-Encoding",
+[2026-05-30T17:20:02.458Z] [INFO]     "x-robots-tag": "none",
+[2026-05-30T17:20:02.458Z] [INFO]     "set-cookie": "***",
+[2026-05-30T17:20:02.459Z] [INFO]   },
+[2026-05-30T17:20:02.459Z] [INFO]   durationMs: 1352,
+[2026-05-30T17:20:02.459Z] [INFO] }
+[2026-05-30T17:20:02.459Z] [INFO] response 200 https://api.anthropic.com/v1/messages?beta=true Headers {
+[2026-05-30T17:20:02.460Z] [INFO]   "date": "Sat, 30 May 2026 17:20:02 GMT",
+[2026-05-30T17:20:02.460Z] [INFO]   "content-type": "text/event-stream; charset=utf-8",
+[2026-05-30T17:20:02.460Z] [INFO]   "transfer-encoding": "chunked",
+[2026-05-30T17:20:02.461Z] [INFO]   "connection": "keep-alive",
+[2026-05-30T17:20:02.461Z] [INFO]   "cache-control": "no-cache",
+[2026-05-30T17:20:02.461Z] [INFO]   "strict-transport-security": "max-age=31536000; includeSubDomains; preload",
+[2026-05-30T17:20:02.461Z] [INFO]   "content-encoding": "gzip",
+[2026-05-30T17:20:02.461Z] [INFO]   "vary": "Accept-Encoding",
+[2026-05-30T17:20:02.462Z] [INFO]   "content-security-policy": "default-src 'none'; frame-ancestors 'none'",
+[2026-05-30T17:20:02.462Z] [INFO]   "set-cookie": [ "_cfuvid=9UKWIyTefk0Q0NbEJvpNhj_s.Zsq8CyisC1TXOiPHRk-1780161601.0935118-1.0.1.1-vW544ghWjPKkVsVlrpUgCCWxLEVCra3BA5kx1gRQU9M; HttpOnly; SameSite=None; Secure; Path=/; Domain=api.anthropic.com" ],
+[2026-05-30T17:20:02.463Z] [INFO]   "anthropic-ratelimit-unified-status": "allowed",
+[2026-05-30T17:20:02.463Z] [INFO]   "anthropic-ratelimit-unified-5h-status": "allowed",
+[2026-05-30T17:20:02.463Z] [INFO]   "anthropic-ratelimit-unified-5h-reset": "1780173000",
+[2026-05-30T17:20:02.463Z] [INFO]   "anthropic-ratelimit-unified-5h-utilization": "0.25",
+[2026-05-30T17:20:02.464Z] [INFO]   "anthropic-ratelimit-unified-7d-status": "allowed",
+[2026-05-30T17:20:02.464Z] [INFO]   "anthropic-ratelimit-unified-7d-reset": "1780398000",
+[2026-05-30T17:20:02.464Z] [INFO]   "anthropic-ratelimit-unified-7d-utilization": "0.73",
+[2026-05-30T17:20:02.464Z] [INFO]   "anthropic-ratelimit-unified-representative-claim": "five_hour",
+[2026-05-30T17:20:02.464Z] [INFO]   "anthropic-ratelimit-unified-fallback-percentage": "0.5",
+[2026-05-30T17:20:02.465Z] [INFO]   "anthropic-ratelimit-unified-reset": "1780173000",
+[2026-05-30T17:20:02.465Z] [INFO]   "anthropic-ratelimit-unified-overage-disabled-reason": "org_level_disabled",
+[2026-05-30T17:20:02.465Z] [INFO]   "anthropic-ratelimit-unified-overage-status": "rejected",
+[2026-05-30T17:20:02.465Z] [INFO]   "request-id": "req_011CbZ8tSXG8EaPGef95nwXN",
+[2026-05-30T17:20:02.465Z] [INFO]   "anthropic-organization-id": "ebc2ac93-f86f-4d15-aff3-de8830d8d789",
+[2026-05-30T17:20:02.466Z] [INFO]   "traceresponse": "00-ae97f2a5cd5514ba78acbd43c0eb9aad-6dd08b7a3a761498-01",
+[2026-05-30T17:20:02.466Z] [INFO]   "server": "cloudflare",
+[2026-05-30T17:20:02.467Z] [INFO]   "cf-cache-status": "DYNAMIC",
+[2026-05-30T17:20:02.468Z] [INFO]   "x-robots-tag": "none",
+[2026-05-30T17:20:02.469Z] [INFO]   "cf-ray": "a03f6836dc58b10b-FRA",
+[2026-05-30T17:20:02.470Z] [INFO] } ReadableStream {
+[2026-05-30T17:20:02.470Z] [INFO]   blob: [Function: blob],
+[2026-05-30T17:20:02.470Z] [INFO]   bytes: [Function: bytes],
+[2026-05-30T17:20:02.472Z] [INFO]   cancel: [Function],
+[2026-05-30T17:20:02.474Z] [INFO]   getReader: [Function],
+[2026-05-30T17:20:02.475Z] [INFO]   json: [Function: json],
+[2026-05-30T17:20:02.477Z] [INFO]   locked: [Getter],
+[2026-05-30T17:20:02.479Z] [INFO]   pipeThrough: [Function],
+[2026-05-30T17:20:02.481Z] [INFO]   pipeTo: [Function],
+[2026-05-30T17:20:02.481Z] [INFO]   tee: [Function],
+[2026-05-30T17:20:02.482Z] [INFO]   text: [Function: text],
+[2026-05-30T17:20:02.482Z] [INFO]   values: [Function: values],
+[2026-05-30T17:20:02.483Z] [INFO]   [Symbol(Symbol.asyncIterator)]: [Function: asyncIterator2],
+[2026-05-30T17:20:02.483Z] [INFO] }
+[2026-05-30T17:20:02.486Z] [INFO] [log_13ab9e] response parsed {
+[2026-05-30T17:20:02.489Z] [INFO]   url: "https://api.anthropic.com/v1/messages?beta=true",
+[2026-05-30T17:20:02.497Z] [INFO]   status: 200,
+[2026-05-30T17:20:02.498Z] [INFO]   body: bR {
+[2026-05-30T17:20:02.506Z] [INFO]     iterator: [AsyncGeneratorFunction: z],
+[2026-05-30T17:20:02.508Z] [INFO]     controller: AbortController {
+[2026-05-30T17:20:02.511Z] [INFO]       signal: [AbortSignal ...],
+[2026-05-30T17:20:02.517Z] [INFO]       abort: [Function: abort],
+[2026-05-30T17:20:02.518Z] [INFO]     },
+[2026-05-30T17:20:02.522Z] [INFO]     [Symbol(Symbol.asyncIterator)]: [Function],
+[2026-05-30T17:20:02.524Z] [INFO]     tee: [Function: tee],
+[2026-05-30T17:20:02.529Z] [INFO]     toReadableStream: [Function: toReadableStream],
+[2026-05-30T17:20:02.529Z] [INFO]   },
+[2026-05-30T17:20:02.529Z] [INFO]   durationMs: 1352,
+[2026-05-30T17:20:02.529Z] [INFO] }
+[2026-05-30T17:20:03.908Z] [INFO] {
+[2026-05-30T17:20:03.908Z] [INFO]   "type": "system",
+[2026-05-30T17:20:03.908Z] [INFO]   "subtype": "thinking_tokens",
+[2026-05-30T17:20:03.908Z] [INFO]   "estimated_tokens": 50,
+[2026-05-30T17:20:03.908Z] [INFO]   "estimated_tokens_delta": 50,
+[2026-05-30T17:20:03.908Z] [INFO]   "uuid": "adaaad6c-53b3-46c8-9a32-0d33de4405a3",
+[2026-05-30T17:20:03.908Z] [INFO]   "session_id": "45441128-80e2-48c1-a2ea-f81ede05030b"
+[2026-05-30T17:20:03.908Z] [INFO] }
+[2026-05-30T17:20:05.326Z] [INFO] {
+[2026-05-30T17:20:05.326Z] [INFO]   "type": "system",
+[2026-05-30T17:20:05.326Z] [INFO]   "subtype": "thinking_tokens",
+[2026-05-30T17:20:05.326Z] [INFO]   "estimated_tokens": 200,
+[2026-05-30T17:20:05.326Z] [INFO]   "estimated_tokens_delta": 150,
+[2026-05-30T17:20:05.326Z] [INFO]   "uuid": "2ef3d08b-7d74-4045-bffe-0a6c81703b3e",
+[2026-05-30T17:20:05.326Z] [INFO]   "session_id": "45441128-80e2-48c1-a2ea-f81ede05030b"
+[2026-05-30T17:20:05.326Z] [INFO] }
+[2026-05-30T17:20:06.853Z] [INFO] {
+[2026-05-30T17:20:06.853Z] [INFO]   "type": "system",
+[2026-05-30T17:20:06.853Z] [INFO]   "subtype": "thinking_tokens",
+[2026-05-30T17:20:06.853Z] [INFO]   "estimated_tokens": 300,
+[2026-05-30T17:20:06.853Z] [INFO]   "estimated_tokens_delta": 100,
+[2026-05-30T17:20:06.853Z] [INFO]   "uuid": "7f6d9c82-131a-4dea-9225-dee37b35407d",
+[2026-05-30T17:20:06.853Z] [INFO]   "session_id": "45441128-80e2-48c1-a2ea-f81ede05030b"
+[2026-05-30T17:20:06.853Z] [INFO] }
+[2026-05-30T17:20:06.855Z] [INFO] {
+[2026-05-30T17:20:06.855Z] [INFO]   "type": "assistant",
+[2026-05-30T17:20:06.855Z] [INFO]   "message": {
+[2026-05-30T17:20:06.855Z] [INFO]     "model": "claude-opus-4-8",
+[2026-05-30T17:20:06.855Z] [INFO]     "id": "msg_0113ZRwZaNuoqz4ZB7RAqznM",
+[2026-05-30T17:20:06.855Z] [INFO]     "type": "message",
+[2026-05-30T17:20:06.855Z] [INFO]     "role": "assistant",
+[2026-05-30T17:20:06.855Z] [INFO]     "content": [
+[2026-05-30T17:20:06.855Z] [INFO]       {
+[2026-05-30T17:20:06.855Z] [INFO]         "type": "thinking",
+[2026-05-30T17:20:06.855Z] [INFO]         "thinking": "",
+[2026-05-30T17:20:06.855Z] [INFO]         "signature": "EowICmMIDhgCKkBuO4WeMVxn9gmrmeAhivuCh3S1/LKzJAc5J7hoxq1Z0rc8gMntt5WmtTBEnB3zslLCGpZppkqImKWCMAHey9NpMg9jbGF1ZGUtb3B1cy00LTg4AEIIdGhpbmtpbmcSDBhLO9KO0yevUTGp0BoMItRAG+AfNLUylU/7IjC/UhynMECbM9GQajPelCdiTVJoghlzxATWNwe8TNolBtgVA9gZURgNxPbOqN2pZ1oq1gbAvoPIboGVRvKB6lXCCTZ4GZ7x5pRj/UTxPp1RGjpYorBUoK7y4aeERJ8JMo1qRJm+mAe4GER2s5ql8XduF6m1xh62CJo+L/0U9M6ZAuXSrsn3d5aDU/3Kptq3IumJA5HwMSWsDI+tMY1VnUPdKyZbe84knX75Ta3Zj4E3vYlRDg3MmcOwEx3vzqqdiLIkMJdtMUF85I2vSyYv8Kh+MAqE0KfGDIfvGS34jdPqeU2teqJn1OKTX04VMD/G0SnQi8KHBqdQUxtbuzYzuOweZnOQvbv+/3WdQFsKD5Yj6YgizUOlZGN4Xs451vgD3n6tTsGQh+dlB6T8TXb/U1bVa4c3ohYTidOVvEOoDgFECnU902mjpOY/X+N6YlebmWqByY8/GsocaUC8YJWVc0aIIk/ysZNBo5+aU3H9XLIrhbQi/wzq1NUQUhInecnmzIRkBRcS7a5pj5PP1LqUuUdnB3zbm4lbe1/LltxwVELHMrPMHDZwFkYpG2axYh4PdL5L4xg/XBFCv2EQXMQetEApJxQoh8JKbZ6/0EkIrv8A/W3V0wN7xc3N+rQOYisq/LnJTlxUUI8FQz0HKuU4QVqXVxsgVxMBWFL2mnWfGPidLTtcUaSwpzJpk0kbu/TFkftGVnhDK5o/UcEtXIvaoklymbPA0YrP4KnXHD6WZOsnpU1r7r6x1jo8DXZeSQHB6hhIXFZ9pWfCZo36mliBVn4QvnyOzXrkQq1/V56pKh3A7wHOKsNpei+kPzc18G89pCVb2Ypvnbci3yyw4IyVjCk9sj3vgTL9g9uvS0lqNCrnhCWR3LWYfO8LNIJrNDY4whtoApJ5f/57BsLrkZ6bWB0/k/jkJzYeTiPkS33mxwydKWwUgeb+XvJifKDvUvL3B4tWurZQ0oyTH8XOLnS9vDsT3/VOaCPNFQulnrT3fNTypgmptly/86mR/0hIv8s2NIvwMfWR0RhX8fBkhLH2yrnM1HMerd8qMaer/1CYdlzYYIsTr36FCUnTF9j4PwOSrsSdKD7Y2bbMqb5tUQlDT73Tf16SxvqHC7Pj7jOXKMpvE7Z6nDZhDFwUdZMtxnRlwpewHm4Rat8aJSM8qkLpBrNjsbxurcy6kIZt8Cx5UZcWs7gzaQ7LCKjbqhgB"
+[2026-05-30T17:20:06.855Z] [INFO]       }
+[2026-05-30T17:20:06.855Z] [INFO]     ],
+[2026-05-30T17:20:06.855Z] [INFO]     "stop_reason": null,
+[2026-05-30T17:20:06.855Z] [INFO]     "stop_sequence": null,
+[2026-05-30T17:20:06.855Z] [INFO]     "stop_details": null,
+[2026-05-30T17:20:06.855Z] [INFO]     "usage": {
+[2026-05-30T17:20:06.855Z] [INFO]       "input_tokens": 131,
+[2026-05-30T17:20:06.855Z] [INFO]       "cache_creation_input_tokens": 411,
+[2026-05-30T17:20:06.855Z] [INFO]       "cache_read_input_tokens": 61311,
+[2026-05-30T17:20:06.855Z] [INFO]       "cache_creation": {
+[2026-05-30T17:20:06.855Z] [INFO]         "ephemeral_5m_input_tokens": 0,
+[2026-05-30T17:20:06.855Z] [INFO]         "ephemeral_1h_input_tokens": 411
+[2026-05-30T17:20:06.855Z] [INFO]       },
+[2026-05-30T17:20:06.855Z] [INFO]       "output_tokens": 3,
+[2026-05-30T17:20:06.855Z] [INFO]       "service_tier": "standard",
+[2026-05-30T17:20:06.855Z] [INFO]       "inference_geo": "not_available"
+[2026-05-30T17:20:06.855Z] [INFO]     },
+[2026-05-30T17:20:06.855Z] [INFO]     "diagnostics": null,
+[2026-05-30T17:20:06.855Z] [INFO]     "context_management": null
+[2026-05-30T17:20:06.855Z] [INFO]   },
+[2026-05-30T17:20:06.855Z] [INFO]   "parent_tool_use_id": null,
+[2026-05-30T17:20:06.855Z] [INFO]   "session_id": "45441128-80e2-48c1-a2ea-f81ede05030b",
+[2026-05-30T17:20:06.855Z] [INFO]   "uuid": "48ee7dc2-765c-454a-90bd-bca84be17f58",
+[2026-05-30T17:20:06.855Z] [INFO]   "request_id": "req_011CbZ8tSXG8EaPGef95nwXN"
+[2026-05-30T17:20:06.855Z] [INFO] }
+[2026-05-30T17:20:10.738Z] [INFO] {
+[2026-05-30T17:20:10.738Z] [INFO]   "type": "assistant",
+[2026-05-30T17:20:10.738Z] [INFO]   "message": {
+[2026-05-30T17:20:10.738Z] [INFO]     "model": "claude-opus-4-8",
+[2026-05-30T17:20:10.738Z] [INFO]     "id": "msg_0113ZRwZaNuoqz4ZB7RAqznM",
+[2026-05-30T17:20:10.738Z] [INFO]     "type": "message",
+[2026-05-30T17:20:10.738Z] [INFO]     "role": "assistant",
+[2026-05-30T17:20:10.738Z] [INFO]     "content": [
+[2026-05-30T17:20:10.738Z] [INFO]       {
+[2026-05-30T17:20:10.738Z] [INFO]         "type": "tool_use",
+[2026-05-30T17:20:10.738Z] [INFO]         "id": "toolu_01LarLuSNFihin5356zdQPd9",
+[2026-05-30T17:20:10.738Z] [INFO]         "name": "Bash",
+[2026-05-30T17:20:10.738Z] [INFO]         "input": {
+[2026-05-30T17:20:10.738Z] [INFO]           "command": "cd /tmp/gh-issue-solver-1780161489554\necho \"=== SECURITY.md ===\"; cat SECURITY.md\necho \"=== README links section / footer for contributing references ===\"; grep -n -iE \"contributing|security\\.md|community|t\\.me/|@Resistance\" README.md | head",
+[2026-05-30T17:20:10.738Z] [INFO]           "description": "Read SECURITY.md and README contact refs"
+[2026-05-30T17:20:10.738Z] [INFO]         },
+[2026-05-30T17:20:10.738Z] [INFO]         "caller": {
+[2026-05-30T17:20:10.738Z] [INFO]           "type": "direct"
+[2026-05-30T17:20:10.738Z] [INFO]         }
+[2026-05-30T17:20:10.738Z] [INFO]       }
+[2026-05-30T17:20:10.738Z] [INFO]     ],
+[2026-05-30T17:20:10.738Z] [INFO]     "stop_reason": null,
+[2026-05-30T17:20:10.738Z] [INFO]     "stop_sequence": null,
+[2026-05-30T17:20:10.738Z] [INFO]     "stop_details": null,
+[2026-05-30T17:20:10.738Z] [INFO]     "usage": {
+[2026-05-30T17:20:10.738Z] [INFO]       "input_tokens": 131,
+[2026-05-30T17:20:10.738Z] [INFO]       "cache_creation_input_tokens": 411,
+[2026-05-30T17:20:10.738Z] [INFO]       "cache_read_input_tokens": 61311,
+[2026-05-30T17:20:10.738Z] [INFO]       "cache_creation": {
+[2026-05-30T17:20:10.738Z] [INFO]         "ephemeral_5m_input_tokens": 0,
+[2026-05-30T17:20:10.738Z] [INFO]         "ephemeral_1h_input_tokens": 411
+[2026-05-30T17:20:10.738Z] [INFO]       },
+[2026-05-30T17:20:10.738Z] [INFO]       "output_tokens": 3,
+[2026-05-30T17:20:10.738Z] [INFO]       "service_tier": "standard",
+[2026-05-30T17:20:10.738Z] [INFO]       "inference_geo": "not_available"
+[2026-05-30T17:20:10.738Z] [INFO]     },
+[2026-05-30T17:20:10.738Z] [INFO]     "diagnostics": null,
+[2026-05-30T17:20:10.738Z] [INFO]     "context_management": null
+[2026-05-30T17:20:10.738Z] [INFO]   },
+[2026-05-30T17:20:10.738Z] [INFO]   "parent_tool_use_id": null,
+[2026-05-30T17:20:10.738Z] [INFO]   "session_id": "45441128-80e2-48c1-a2ea-f81ede05030b",
+[2026-05-30T17:20:10.738Z] [INFO]   "uuid": "a8e0ded6-5d55-4b6f-abe5-d404db3dac79",
+[2026-05-30T17:20:10.738Z] [INFO]   "request_id": "req_011CbZ8tSXG8EaPGef95nwXN"
+[2026-05-30T17:20:10.738Z] [INFO] }
+[2026-05-30T17:20:11.583Z] [INFO] {
+[2026-05-30T17:20:11.583Z] [INFO]   "type": "user",
+[2026-05-30T17:20:11.583Z] [INFO]   "message": {
+[2026-05-30T17:20:11.583Z] [INFO]     "role": "user",
+[2026-05-30T17:20:11.583Z] [INFO]     "content": [
+[2026-05-30T17:20:11.583Z] [INFO]       {
+[2026-05-30T17:20:11.583Z] [INFO]         "tool_use_id": "toolu_01LarLuSNFihin5356zdQPd9",
+[2026-05-30T17:20:11.583Z] [INFO]         "type": "tool_result",
+[2026-05-30T17:20:11.583Z] [INFO]         "content": "=== SECURITY.md ===\n# Security Policy\n\n## Supported Versions\n\n| Version | Supported |\n|---------|-----------|\n| 0.5.x   | Yes       |\n| < 0.5   | No        |\n\nOnly the latest minor release receives security patches. We recommend always running the latest version.\n\n## Reporting a Vulnerability\n\n**Do not open a public GitHub issue for security vulnerabilities.**\n\nInstead, please report vulnerabilities through one of these channels:\n\n- **GitHub Security Advisories**: [Report a vulnerability](https://github.com/TONresistor/teleton-agent/security/advisories/new)\n- **Telegram**: dm t.me/zkproof\n\n### What to Expect\n\n- **Acknowledgment** within 72 hours of your report\n- **Assessment** within 7 days with severity classification\n- **Fix timeline** based on severity:\n  - Critical: patch release within 7 days\n  - High: patch release within 14 days\n  - Medium/Low: included in the next scheduled release\n- **Coordinated disclosure** after 90 days or when a fix is available, whichever comes first\n\n### What to Include\n\n- Description of the vulnerability\n- Steps to reproduce\n- Potential impact assessment\n- Suggested fix (if any)\n\n## Security Architecture\n\nTeleton Agent implements multiple layers of defense:\n\n### Prompt Injection Defense\n\n- `sanitizeForPrompt()` strips control characters, invisible Unicode, markdown headers, and HTML/XML tags from user-controlled fields\n- `sanitizeForContext()` provides lighter sanitization for RAG results and knowledge chunks\n- User messages are wrapped in tagged envelopes to prevent role confusion\n\n### Plugin Isolation\n\n- Plugin SDK objects are frozen (immutable) at creation\n- Plugins receive sanitized configuration (no API keys or sensitive fields)\n- Each plugin gets an isolated SQLite database\n- Manifest validation enforces SDK version compatibility\n- Tool definitions are validated before registration\n\n### Wallet Security\n\n- Wallet files are stored with `0600` permissions (owner read/write only)\n- Key derivation (PBKDF2) results are cached to avoid repeated computation\n- Financial tools (`ton_send`, `jetton_send`, `stonfi_swap`) are restricted to DM-only scope\n\n### Exec Allowlist Mode\n\nWhen `exec.mode` is set to `allowlist`, the agent only runs commands whose **program name** (first token) matches an entry in `exec.command_allowlist`.\n\nKey restrictions in this mode:\n\n- **No shell metacharacters**: commands containing `;`, `&`, `|`, `` ` ``, `$`, `<`, `>`, `\\`, or newlines are rejected outright, preventing shell injection via chaining or substitution.\n- **No shell interpreter**: allowed commands are executed via `spawn(program, args)` directly — no `bash -c` — so the OS never interprets shell syntax.\n- **First-token matching**: `allowlist: [\"git\"]` permits `git status`, `git diff`, etc., but rejects `gitconfig` (different binary) and `git status && id` (contains `&`).\n- **No pipes or redirects**: pipeline-based operations are not supported in allowlist mode; use `yolo` mode if you need them and understand the risks.\n\nExample safe configuration:\n\n```yaml\nexec:\n  mode: allowlist\n  command_allowlist:\n    - git\n    - ls\n    - df\n```\n\n### Workspace Sandboxing\n\n- `validateReadPath()` and `validateWritePath()` prevent path traversal attacks\n- File operations are restricted to `~/.teleton/workspace/`\n- Allowed file extensions are explicitly whitelisted\n- File size limits are enforced per media type\n\n### URL Sanitization\n\n- Blocks `javascript:`, `data:`, `vbscript:`, and `file:` protocol URLs in tool outputs\n\n### Network Security\n\n- WebUI binds to `localhost` by default\n- Bearer token authentication for all WebUI API endpoints\n- CORS restricted to configured origins\n- Telegram flood wait handling respects server-provided backoff timers\n\n## Responsible Use\n\nTeleton Agent operates as a Telegram userbot. Users are responsible for:\n\n- Complying with [Telegram's Terms of Service](https://telegram.org/tos)\n- Securing their API credentials and wallet mnemonics\n- Configuring appropriate access policies (admin IDs, DM/group policies)\n- Monitoring agent behavior in group chats\n=== README links section / footer for contributing references ===\n113:- **Your Telegram User ID** - Message [@userinfobot](https://t.me/userinfobot)\n114:- **Bot Token** *(optional)* - From [@BotFather](https://t.me/BotFather) for inline bot features (deals)\n406:By default, the agent has a **sandboxed workspace** at `~/.teleton/workspace/` with 6 file tools (read, write, delete, rename, list, info). Path traversal protection, symlink detection, and 500 MB quota. Core files (`SOUL.md`, `STRATEGY.md`, `SECURITY.md`) are immutable. Write operations are DM-only.\n663:| **Immutable config** | SOUL.md, STRATEGY.md, SECURITY.md cannot be modified by the agent |\n678:Do not open public issues for security vulnerabilities. Contact maintainers (t.me/zkproof) directly or use GitHub's private security advisory feature.\n687:6. Review `SECURITY.md` and customize for your use case\n764:## Contributing\n766:See [CONTRIBUTING.md](CONTRIBUTING.md) for the full guide.\n812:- **Channel**: [@teletonagents](https://t.me/teletonagents)\n813:- **Group Chat**: [@teletonagentHQ](https://t.me/teletonagentHQ)",
+[2026-05-30T17:20:11.583Z] [INFO]         "is_error": false
+[2026-05-30T17:20:11.583Z] [INFO]       }
+[2026-05-30T17:20:11.583Z] [INFO]     ]
+[2026-05-30T17:20:11.583Z] [INFO]   },
+[2026-05-30T17:20:11.583Z] [INFO]   "parent_tool_use_id": null,
+[2026-05-30T17:20:11.583Z] [INFO]   "session_id": "45441128-80e2-48c1-a2ea-f81ede05030b",
+[2026-05-30T17:20:11.583Z] [INFO]   "uuid": "96de3720-ab5c-4ae9-a4f3-b5f5f0c8681c",
+[2026-05-30T17:20:11.583Z] [INFO]   "timestamp": "2026-05-30T17:20:11.578Z",
+[2026-05-30T17:20:11.583Z] [INFO]   "tool_use_result": {
+[2026-05-30T17:20:11.583Z] [INFO]     "stdout": "=== SECURITY.md ===\n# Security Policy\n\n## Supported Versions\n\n| Version | Supported |\n|---------|-----------|\n| 0.5.x   | Yes       |\n| < 0.5   | No        |\n\nOnly the latest minor release receives security patches. We recommend always running the latest version.\n\n## Reporting a Vulnerability\n\n**Do not open a public GitHub issue for security vulnerabilities.**\n\nInstead, please report vulnerabilities through one of these channels:\n\n- **GitHub Security Advisories**: [Report a vulnerability](https://github.com/TONresistor/teleton-agent/security/advisories/new)\n- **Telegram**: dm t.me/zkproof\n\n### What to Expect\n\n- **Acknowledgment** within 72 hours of your report\n- **Assessment** within 7 days with severity classification\n- **Fix timeline** based on severity:\n  - Critical: patch release within 7 days\n  - High: patch release within 14 days\n  - Medium/Low: included in the next scheduled release\n- **Coordinated disclosure** after 90 days or when a fix is available, whichever comes first\n\n### What to Include\n\n- Description of the vulnerability\n- Steps to reproduce\n- Potential impact assessment\n- Suggested fix (if any)\n\n## Security Architecture\n\nTeleton Agent implements multiple layers of defense:\n\n### Prompt Injection Defense\n\n- `sanitizeForPrompt()` strips control characters, invisible Unicode, markdown headers, and HTML/XML tags from user-controlled fields\n- `sanitizeForContext()` provides lighter sanitization for RAG results and knowledge chunks\n- User messages are wrapped in tagged envelopes to prevent role confusion\n\n### Plugin Isolation\n\n- Plugin SDK objects are frozen (immutable) at creation\n- Plugins receive sanitized configuration (no API keys or sensitive fields)\n- Each plugin gets an isolated SQLite database\n- Manifest validation enforces SDK version compatibility\n- Tool definitions are validated before registration\n\n### Wallet Security\n\n- Wallet files are stored with `0600` permissions (owner read/write only)\n- Key derivation (PBKDF2) results are cached to avoid repeated computation\n- Financial tools (`ton_send`, `jetton_send`, `stonfi_swap`) are restricted to DM-only scope\n\n### Exec Allowlist Mode\n\nWhen `exec.mode` is set to `allowlist`, the agent only runs commands whose **program name** (first token) matches an entry in `exec.command_allowlist`.\n\nKey restrictions in this mode:\n\n- **No shell metacharacters**: commands containing `;`, `&`, `|`, `` ` ``, `$`, `<`, `>`, `\\`, or newlines are rejected outright, preventing shell injection via chaining or substitution.\n- **No shell interpreter**: allowed commands are executed via `spawn(program, args)` directly — no `bash -c` — so the OS never interprets shell syntax.\n- **First-token matching**: `allowlist: [\"git\"]` permits `git status`, `git diff`, etc., but rejects `gitconfig` (different binary) and `git status && id` (contains `&`).\n- **No pipes or redirects**: pipeline-based operations are not supported in allowlist mode; use `yolo` mode if you need them and understand the risks.\n\nExample safe configuration:\n\n```yaml\nexec:\n  mode: allowlist\n  command_allowlist:\n    - git\n    - ls\n    - df\n```\n\n### Workspace Sandboxing\n\n- `validateReadPath()` and `validateWritePath()` prevent path traversal attacks\n- File operations are restricted to `~/.teleton/workspace/`\n- Allowed file extensions are explicitly whitelisted\n- File size limits are enforced per media type\n\n### URL Sanitization\n\n- Blocks `javascript:`, `data:`, `vbscript:`, and `file:` protocol URLs in tool outputs\n\n### Network Security\n\n- WebUI binds to `localhost` by default\n- Bearer token authentication for all WebUI API endpoints\n- CORS restricted to configured origins\n- Telegram flood wait handling respects server-provided backoff timers\n\n## Responsible Use\n\nTeleton Agent operates as a Telegram userbot. Users are responsible for:\n\n- Complying with [Telegram's Terms of Service](https://telegram.org/tos)\n- Securing their API credentials and wallet mnemonics\n- Configuring appropriate access policies (admin IDs, DM/group policies)\n- Monitoring agent behavior in group chats\n=== README links section / footer for contributing references ===\n113:- **Your Telegram User ID** - Message [@userinfobot](https://t.me/userinfobot)\n114:- **Bot Token** *(optional)* - From [@BotFather](https://t.me/BotFather) for inline bot features (deals)\n406:By default, the agent has a **sandboxed workspace** at `~/.teleton/workspace/` with 6 file tools (read, write, delete, rename, list, info). Path traversal protection, symlink detection, and 500 MB quota. Core files (`SOUL.md`, `STRATEGY.md`, `SECURITY.md`) are immutable. Write operations are DM-only.\n663:| **Immutable config** | SOUL.md, STRATEGY.md, SECURITY.md cannot be modified by the agent |\n678:Do not open public issues for security vulnerabilities. Contact maintainers (t.me/zkproof) directly or use GitHub's private security advisory feature.\n687:6. Review `SECURITY.md` and customize for your use case\n764:## Contributing\n766:See [CONTRIBUTING.md](CONTRIBUTING.md) for the full guide.\n812:- **Channel**: [@teletonagents](https://t.me/teletonagents)\n813:- **Group Chat**: [@teletonagentHQ](https://t.me/teletonagentHQ)",
+[2026-05-30T17:20:11.583Z] [INFO]     "stderr": "",
+[2026-05-30T17:20:11.583Z] [INFO]     "interrupted": false,
+[2026-05-30T17:20:11.583Z] [INFO]     "isImage": false,
+[2026-05-30T17:20:11.583Z] [INFO]     "noOutputExpected": false
+[2026-05-30T17:20:11.583Z] [INFO]   }
+[2026-05-30T17:20:11.583Z] [INFO] }
+[2026-05-30T17:20:11.597Z] [INFO] [log_025c8d] sending request {
+[2026-05-30T17:20:11.597Z] [INFO]   method: "post",
+[2026-05-30T17:20:11.598Z] [INFO]   url: "https://api.anthropic.com/v1/messages?beta=true",
+[2026-05-30T17:20:11.598Z] [INFO]   options: {
+[2026-05-30T17:20:11.598Z] [INFO]     method: "post",
+[2026-05-30T17:20:11.599Z] [INFO]     path: "/v1/messages?beta=true",
+[2026-05-30T17:20:11.599Z] [INFO]     body: {
+[2026-05-30T17:20:11.599Z] [INFO]       model: "claude-opus-4-8",
+[2026-05-30T17:20:11.600Z] [INFO]       messages: [
+[2026-05-30T17:20:11.601Z] [INFO]         [Object ...], [Object ...], [Object ...], [Object ...], [Object ...], [Object ...], [Object ...], [Object ...], [Object ...], [Object ...], [Object ...], [Object ...], [Object ...], [Object ...], [Object ...], [Object ...], [Object ...], [Object ...], [Object ...], [Object ...], [Object ...], [Object ...], [Object ...], [Object ...], [Object ...], [Object ...], [Object ...]
+[2026-05-30T17:20:11.601Z] [INFO]       ],
+[2026-05-30T17:20:11.602Z] [INFO]       system: [
+[2026-05-30T17:20:11.602Z] [INFO]         [Object ...], [Object ...], [Object ...], [Object ...]
+[2026-05-30T17:20:11.603Z] [INFO]       ],
+[2026-05-30T17:20:11.603Z] [INFO]       tools: [
+[2026-05-30T17:20:11.604Z] [INFO]         [Object ...], [Object ...], [Object ...], [Object ...], [Object ...], [Object ...], [Object ...], [Object ...], [Object ...], [Object ...]
+[2026-05-30T17:20:11.604Z] [INFO]       ],
+[2026-05-30T17:20:11.605Z] [INFO]       tool_choice: undefined,
+[2026-05-30T17:20:11.605Z] [INFO]       metadata: [Object ...],
+[2026-05-30T17:20:11.605Z] [INFO]       max_tokens: 128000,
+[2026-05-30T17:20:11.606Z] [INFO]       thinking: [Object ...],
+[2026-05-30T17:20:11.607Z] [INFO]       context_management: [Object ...],
+[2026-05-30T17:20:11.607Z] [INFO]       output_config: [Object ...],
+[2026-05-30T17:20:11.607Z] [INFO]       diagnostics: [Object ...],
+[2026-05-30T17:20:11.608Z] [INFO]       stream: true,
+[2026-05-30T17:20:11.610Z] [INFO]     },
+[2026-05-30T17:20:11.610Z] [INFO]     timeout: 600000,
+[2026-05-30T17:20:11.611Z] [INFO]     signal: AbortSignal {
+[2026-05-30T17:20:11.611Z] [INFO]       [Symbol(events.maxEventTargetListeners)]: 50,
+[2026-05-30T17:20:11.612Z] [INFO]       [Symbol(events.maxEventTargetListenersWarned)]: false,
+[2026-05-30T17:20:11.612Z] [INFO]       aborted: false,
+[2026-05-30T17:20:11.613Z] [INFO]       reason: undefined,
+[2026-05-30T17:20:11.614Z] [INFO]       onabort: null,
+[2026-05-30T17:20:11.614Z] [INFO]       throwIfAborted: [Function: throwIfAborted],
+[2026-05-30T17:20:11.615Z] [INFO]       addEventListener: [Function: addEventListener],
+[2026-05-30T17:20:11.615Z] [INFO]       removeEventListener: [Function: removeEventListener],
+[2026-05-30T17:20:11.616Z] [INFO]       dispatchEvent: [Function: dispatchEvent],
+[2026-05-30T17:20:11.617Z] [INFO]     },
+[2026-05-30T17:20:11.620Z] [INFO]     stream: true,
+[2026-05-30T17:20:11.620Z] [INFO]   },
+[2026-05-30T17:20:11.621Z] [INFO]   headers: {
+[2026-05-30T17:20:11.621Z] [INFO]     accept: "application/json",
+[2026-05-30T17:20:11.621Z] [INFO]     "anthropic-beta": "claude-code-20250219,oauth-2025-04-20,interleaved-thinking-2025-05-14,thinking-token-count-2026-05-13,context-management-2025-06-27,prompt-caching-scope-2026-01-05,mid-conversation-system-2026-04-07,advisor-tool-2026-03-01,advanced-tool-use-2025-11-20,effort-2025-11-24,extended-cache-ttl-2025-04-11,cache-diagnosis-2026-04-07",
+[2026-05-30T17:20:11.622Z] [INFO]     "anthropic-dangerous-direct-browser-access": "true",
+[2026-05-30T17:20:11.622Z] [INFO]     "anthropic-version": "2023-06-01",
+[2026-05-30T17:20:11.622Z] [INFO]     authorization: "***",
+[2026-05-30T17:20:11.622Z] [INFO]     "content-type": "application/json",
+[2026-05-30T17:20:11.622Z] [INFO]     "user-agent": "claude-cli/2.1.158 (external, sdk-cli)",
+[2026-05-30T17:20:11.622Z] [INFO]     "x-app": "cli",
+[2026-05-30T17:20:11.622Z] [INFO]     "x-claude-code-session-id": "45441128-80e2-48c1-a2ea-f81ede05030b",
+[2026-05-30T17:20:11.623Z] [INFO]     "x-client-request-id": "570de76c-fd54-48ce-a111-a2ddbd600b59",
+[2026-05-30T17:20:11.623Z] [INFO]     "x-stainless-arch": "x64",
+[2026-05-30T17:20:11.623Z] [INFO]     "x-stainless-lang": "js",
+[2026-05-30T17:20:11.624Z] [INFO]     "x-stainless-os": "Linux",
+[2026-05-30T17:20:11.624Z] [INFO]     "x-stainless-package-version": "0.94.0",
+[2026-05-30T17:20:11.625Z] [INFO]     "x-stainless-retry-count": "0",
+[2026-05-30T17:20:11.625Z] [INFO]     "x-stainless-runtime": "node",
+[2026-05-30T17:20:11.625Z] [INFO]     "x-stainless-runtime-version": "v24.3.0",
+[2026-05-30T17:20:11.626Z] [INFO]     "x-stainless-timeout": "600",
+[2026-05-30T17:20:11.627Z] [INFO]   },
+[2026-05-30T17:20:11.627Z] [INFO] }
+[2026-05-30T17:20:13.131Z] [INFO] [log_025c8d, request-id: "req_011CbZ8uDbAGhm8hDvtUcqhU"] post https://api.anthropic.com/v1/messages?beta=true succeeded with status 200 in 1534ms
+[2026-05-30T17:20:13.131Z] [INFO] [log_025c8d] response start {
+[2026-05-30T17:20:13.132Z] [INFO]   url: "https://api.anthropic.com/v1/messages?beta=true",
+[2026-05-30T17:20:13.132Z] [INFO]   status: 200,
+[2026-05-30T17:20:13.132Z] [INFO]   headers: {
+[2026-05-30T17:20:13.133Z] [INFO]     "anthropic-organization-id": "ebc2ac93-f86f-4d15-aff3-de8830d8d789",
+[2026-05-30T17:20:13.133Z] [INFO]     "anthropic-ratelimit-unified-5h-reset": "1780173000",
+[2026-05-30T17:20:13.133Z] [INFO]     "anthropic-ratelimit-unified-5h-status": "allowed",
+[2026-05-30T17:20:13.133Z] [INFO]     "anthropic-ratelimit-unified-5h-utilization": "0.26",
+[2026-05-30T17:20:13.133Z] [INFO]     "anthropic-ratelimit-unified-7d-reset": "1780398000",
+[2026-05-30T17:20:13.134Z] [INFO]     "anthropic-ratelimit-unified-7d-status": "allowed",
+[2026-05-30T17:20:13.134Z] [INFO]     "anthropic-ratelimit-unified-7d-utilization": "0.73",
+[2026-05-30T17:20:13.134Z] [INFO]     "anthropic-ratelimit-unified-fallback-percentage": "0.5",
+[2026-05-30T17:20:13.134Z] [INFO]     "anthropic-ratelimit-unified-overage-disabled-reason": "org_level_disabled",
+[2026-05-30T17:20:13.134Z] [INFO]     "anthropic-ratelimit-unified-overage-status": "rejected",
+[2026-05-30T17:20:13.135Z] [INFO]     "anthropic-ratelimit-unified-representative-claim": "five_hour",
+[2026-05-30T17:20:13.135Z] [INFO]     "anthropic-ratelimit-unified-reset": "1780173000",
+[2026-05-30T17:20:13.135Z] [INFO]     "anthropic-ratelimit-unified-status": "allowed",
+[2026-05-30T17:20:13.136Z] [INFO]     "cache-control": "no-cache",
+[2026-05-30T17:20:13.136Z] [INFO]     "cf-cache-status": "DYNAMIC",
+[2026-05-30T17:20:13.136Z] [INFO]     "cf-ray": "a03f68788da1976a-FRA",
+[2026-05-30T17:20:13.136Z] [INFO]     connection: "keep-alive",
+[2026-05-30T17:20:13.136Z] [INFO]     "content-encoding": "gzip",
+[2026-05-30T17:20:13.136Z] [INFO]     "content-security-policy": "default-src 'none'; frame-ancestors 'none'",
+[2026-05-30T17:20:13.136Z] [INFO]     "content-type": "text/event-stream; charset=utf-8",
+[2026-05-30T17:20:13.137Z] [INFO]     date: "Sat, 30 May 2026 17:20:13 GMT",
+[2026-05-30T17:20:13.137Z] [INFO]     "request-id": "req_011CbZ8uDbAGhm8hDvtUcqhU",
+[2026-05-30T17:20:13.137Z] [INFO]     server: "cloudflare",
+[2026-05-30T17:20:13.137Z] [INFO]     "strict-transport-security": "max-age=31536000; includeSubDomains; preload",
+[2026-05-30T17:20:13.137Z] [INFO]     traceresponse: "00-d7e68cdebd5a4134fa0a85f437b4ca96-a5277a49953d0d49-01",
+[2026-05-30T17:20:13.138Z] [INFO]     "transfer-encoding": "chunked",
+[2026-05-30T17:20:13.138Z] [INFO]     vary: "Accept-Encoding",
+[2026-05-30T17:20:13.138Z] [INFO]     "x-robots-tag": "none",
+[2026-05-30T17:20:13.138Z] [INFO]     "set-cookie": "***",
+[2026-05-30T17:20:13.138Z] [INFO]   },
+[2026-05-30T17:20:13.139Z] [INFO]   durationMs: 1534,
+[2026-05-30T17:20:13.139Z] [INFO] }
+[2026-05-30T17:20:13.140Z] [INFO] response 200 https://api.anthropic.com/v1/messages?beta=true Headers {
+[2026-05-30T17:20:13.140Z] [INFO]   "date": "Sat, 30 May 2026 17:20:13 GMT",
+[2026-05-30T17:20:13.140Z] [INFO]   "content-type": "text/event-stream; charset=utf-8",
+[2026-05-30T17:20:13.140Z] [INFO]   "transfer-encoding": "chunked",
+[2026-05-30T17:20:13.141Z] [INFO]   "connection": "keep-alive",
+[2026-05-30T17:20:13.141Z] [INFO]   "cache-control": "no-cache",
+[2026-05-30T17:20:13.142Z] [INFO]   "strict-transport-security": "max-age=31536000; includeSubDomains; preload",
+[2026-05-30T17:20:13.142Z] [INFO]   "content-encoding": "gzip",
+[2026-05-30T17:20:13.142Z] [INFO]   "vary": "Accept-Encoding",
+[2026-05-30T17:20:13.142Z] [INFO]   "content-security-policy": "default-src 'none'; frame-ancestors 'none'",
+[2026-05-30T17:20:13.143Z] [INFO]   "set-cookie": [ "_cfuvid=2mDGj5G1xHHoQc2MfrV_Z9c5k3Ux8RQE4S1vV11zLXg-1780161611.6075017-1.0.1.1-M4WIRAh561MY3A16rC7JeDYew9DFfZkK24pGBkeWDaQ; HttpOnly; SameSite=None; Secure; Path=/; Domain=api.anthropic.com" ],
+[2026-05-30T17:20:13.143Z] [INFO]   "anthropic-ratelimit-unified-status": "allowed",
+[2026-05-30T17:20:13.143Z] [INFO]   "anthropic-ratelimit-unified-5h-status": "allowed",
+[2026-05-30T17:20:13.143Z] [INFO]   "anthropic-ratelimit-unified-5h-reset": "1780173000",
+[2026-05-30T17:20:13.143Z] [INFO]   "anthropic-ratelimit-unified-5h-utilization": "0.26",
+[2026-05-30T17:20:13.143Z] [INFO]   "anthropic-ratelimit-unified-7d-status": "allowed",
+[2026-05-30T17:20:13.144Z] [INFO]   "anthropic-ratelimit-unified-7d-reset": "1780398000",
+[2026-05-30T17:20:13.144Z] [INFO]   "anthropic-ratelimit-unified-7d-utilization": "0.73",
+[2026-05-30T17:20:13.144Z] [INFO]   "anthropic-ratelimit-unified-representative-claim": "five_hour",
+[2026-05-30T17:20:13.144Z] [INFO]   "anthropic-ratelimit-unified-fallback-percentage": "0.5",
+[2026-05-30T17:20:13.145Z] [INFO]   "anthropic-ratelimit-unified-reset": "1780173000",
+[2026-05-30T17:20:13.145Z] [INFO]   "anthropic-ratelimit-unified-overage-disabled-reason": "org_level_disabled",
+[2026-05-30T17:20:13.145Z] [INFO]   "anthropic-ratelimit-unified-overage-status": "rejected",
+[2026-05-30T17:20:13.145Z] [INFO]   "request-id": "req_011CbZ8uDbAGhm8hDvtUcqhU",
+[2026-05-30T17:20:13.145Z] [INFO]   "anthropic-organization-id": "ebc2ac93-f86f-4d15-aff3-de8830d8d789",
+[2026-05-30T17:20:13.145Z] [INFO]   "traceresponse": "00-d7e68cdebd5a4134fa0a85f437b4ca96-a5277a49953d0d49-01",
+[2026-05-30T17:20:13.146Z] [INFO]   "server": "cloudflare",
+[2026-05-30T17:20:13.146Z] [INFO]   "cf-cache-status": "DYNAMIC",
+[2026-05-30T17:20:13.146Z] [INFO]   "x-robots-tag": "none",
+[2026-05-30T17:20:13.146Z] [INFO]   "cf-ray": "a03f68788da1976a-FRA",
+[2026-05-30T17:20:13.146Z] [INFO] } ReadableStream {
+[2026-05-30T17:20:13.146Z] [INFO]   blob: [Function: blob],
+[2026-05-30T17:20:13.147Z] [INFO]   bytes: [Function: bytes],
+[2026-05-30T17:20:13.147Z] [INFO]   cancel: [Function],
+[2026-05-30T17:20:13.148Z] [INFO]   getReader: [Function],
+[2026-05-30T17:20:13.148Z] [INFO]   json: [Function: json],
+[2026-05-30T17:20:13.148Z] [INFO]   locked: [Getter],
+[2026-05-30T17:20:13.149Z] [INFO]   pipeThrough: [Function],
+[2026-05-30T17:20:13.149Z] [INFO]   pipeTo: [Function],
+[2026-05-30T17:20:13.149Z] [INFO]   tee: [Function],
+[2026-05-30T17:20:13.149Z] [INFO]   text: [Function: text],
+[2026-05-30T17:20:13.150Z] [INFO]   values: [Function: values],
+[2026-05-30T17:20:13.150Z] [INFO]   [Symbol(Symbol.asyncIterator)]: [Function: asyncIterator2],
+[2026-05-30T17:20:13.150Z] [INFO] }
+[2026-05-30T17:20:13.150Z] [INFO] [log_025c8d] response parsed {
+[2026-05-30T17:20:13.150Z] [INFO]   url: "https://api.anthropic.com/v1/messages?beta=true",
+[2026-05-30T17:20:13.151Z] [INFO]   status: 200,
+[2026-05-30T17:20:13.151Z] [INFO]   body: bR {
+[2026-05-30T17:20:13.151Z] [INFO]     iterator: [AsyncGeneratorFunction: z],
+[2026-05-30T17:20:13.151Z] [INFO]     controller: AbortController {
+[2026-05-30T17:20:13.151Z] [INFO]       signal: [AbortSignal ...],
+[2026-05-30T17:20:13.151Z] [INFO]       abort: [Function: abort],
+[2026-05-30T17:20:13.152Z] [INFO]     },
+[2026-05-30T17:20:13.152Z] [INFO]     [Symbol(Symbol.asyncIterator)]: [Function],
+[2026-05-30T17:20:13.152Z] [INFO]     tee: [Function: tee],
+[2026-05-30T17:20:13.152Z] [INFO]     toReadableStream: [Function: toReadableStream],
+[2026-05-30T17:20:13.152Z] [INFO]   },
+[2026-05-30T17:20:13.152Z] [INFO]   durationMs: 1534,
+[2026-05-30T17:20:13.152Z] [INFO] }
+[2026-05-30T17:20:14.204Z] [INFO] {
+[2026-05-30T17:20:14.204Z] [INFO]   "type": "assistant",
+[2026-05-30T17:20:14.204Z] [INFO]   "message": {
+[2026-05-30T17:20:14.204Z] [INFO]     "model": "claude-opus-4-8",
+[2026-05-30T17:20:14.204Z] [INFO]     "id": "msg_01SjjMnJr1i2tBGKeSV4ooAF",
+[2026-05-30T17:20:14.204Z] [INFO]     "type": "message",
+[2026-05-30T17:20:14.204Z] [INFO]     "role": "assistant",
+[2026-05-30T17:20:14.204Z] [INFO]     "content": [
+[2026-05-30T17:20:14.204Z] [INFO]       {
+[2026-05-30T17:20:14.204Z] [INFO]         "type": "thinking",
+[2026-05-30T17:20:14.204Z] [INFO]         "thinking": "",
+[2026-05-30T17:20:14.204Z] [INFO]         "signature": "Er8CCmMIDhgCKkDOl8ekXwdY8+fpseKQYNqDZiRJ8ZmPqy/99G/63JPIN8w9XUFv6VHyD5iYkh47gOw8No0u9hBiuGMYEXe2bNueMg9jbGF1ZGUtb3B1cy00LTg4AEIIdGhpbmtpbmcSDKWs9IgjBfeG0oU4dRoMb64q7V5FtVK+MglMIjCQ6lGZp3ZPixESPjk05sEl8rZrBNxSIXmryx3wS/buAizuvrdnTkR9K4E+lcUSRbUqiQFZ1n3mHSJ/nnn3bwutmk6u5BvKVA4jfVOK7rSwAmqF7SCd0iLt2QWi57Z9VTS4ZecGJSTSAGQlyXOp7bObf6B16t/1456vt8qJYS2+9DWBQ0eJg/U8XI+AjIZiMjbP37lOhMZUr1eTBa7KDCHTECz89Dq2jt4ftz1rlQ8tuE2ll4zuItGnY7TtfhgB"
+[2026-05-30T17:20:14.204Z] [INFO]       }
+[2026-05-30T17:20:14.204Z] [INFO]     ],
+[2026-05-30T17:20:14.204Z] [INFO]     "stop_reason": null,
+[2026-05-30T17:20:14.204Z] [INFO]     "stop_sequence": null,
+[2026-05-30T17:20:14.204Z] [INFO]     "stop_details": null,
+[2026-05-30T17:20:14.204Z] [INFO]     "usage": {
+[2026-05-30T17:20:14.204Z] [INFO]       "input_tokens": 2,
+[2026-05-30T17:20:14.204Z] [INFO]       "cache_creation_input_tokens": 2637,
+[2026-05-30T17:20:14.204Z] [INFO]       "cache_read_input_tokens": 61722,
+[2026-05-30T17:20:14.204Z] [INFO]       "cache_creation": {
+[2026-05-30T17:20:14.204Z] [INFO]         "ephemeral_5m_input_tokens": 0,
+[2026-05-30T17:20:14.204Z] [INFO]         "ephemeral_1h_input_tokens": 2637
+[2026-05-30T17:20:14.204Z] [INFO]       },
+[2026-05-30T17:20:14.204Z] [INFO]       "output_tokens": 3,
+[2026-05-30T17:20:14.204Z] [INFO]       "service_tier": "standard",
+[2026-05-30T17:20:14.204Z] [INFO]       "inference_geo": "not_available"
+[2026-05-30T17:20:14.204Z] [INFO]     },
+[2026-05-30T17:20:14.204Z] [INFO]     "diagnostics": null,
+[2026-05-30T17:20:14.204Z] [INFO]     "context_management": null
+[2026-05-30T17:20:14.204Z] [INFO]   },
+[2026-05-30T17:20:14.204Z] [INFO]   "parent_tool_use_id": null,
+[2026-05-30T17:20:14.204Z] [INFO]   "session_id": "45441128-80e2-48c1-a2ea-f81ede05030b",
+[2026-05-30T17:20:14.204Z] [INFO]   "uuid": "2a6c8095-ba6e-49a1-94be-5dc7d3edde70",
+[2026-05-30T17:20:14.204Z] [INFO]   "request_id": "req_011CbZ8uDbAGhm8hDvtUcqhU"
+[2026-05-30T17:20:14.204Z] [INFO] }
+[2026-05-30T17:20:15.385Z] [INFO] {
+[2026-05-30T17:20:15.385Z] [INFO]   "type": "assistant",
+[2026-05-30T17:20:15.385Z] [INFO]   "message": {
+[2026-05-30T17:20:15.385Z] [INFO]     "model": "claude-opus-4-8",
+[2026-05-30T17:20:15.385Z] [INFO]     "id": "msg_01SjjMnJr1i2tBGKeSV4ooAF",
+[2026-05-30T17:20:15.385Z] [INFO]     "type": "message",
+[2026-05-30T17:20:15.385Z] [INFO]     "role": "assistant",
+[2026-05-30T17:20:15.385Z] [INFO]     "content": [
+[2026-05-30T17:20:15.385Z] [INFO]       {
+[2026-05-30T17:20:15.385Z] [INFO]         "type": "tool_use",
+[2026-05-30T17:20:15.385Z] [INFO]         "id": "toolu_017Kgf9yV5cE9vAoZKEzuwoP",
+[2026-05-30T17:20:15.385Z] [INFO]         "name": "Bash",
+[2026-05-30T17:20:15.385Z] [INFO]         "input": {
+[2026-05-30T17:20:15.385Z] [INFO]           "command": "cd /tmp/gh-issue-solver-1780161489554\nsed -n '760,825p' README.md",
+[2026-05-30T17:20:15.385Z] [INFO]           "description": "Read README contributing/community footer"
+[2026-05-30T17:20:15.385Z] [INFO]         },
+[2026-05-30T17:20:15.385Z] [INFO]         "caller": {
+[2026-05-30T17:20:15.385Z] [INFO]           "type": "direct"
+[2026-05-30T17:20:15.385Z] [INFO]         }
+[2026-05-30T17:20:15.385Z] [INFO]       }
+[2026-05-30T17:20:15.385Z] [INFO]     ],
+[2026-05-30T17:20:15.385Z] [INFO]     "stop_reason": null,
+[2026-05-30T17:20:15.385Z] [INFO]     "stop_sequence": null,
+[2026-05-30T17:20:15.385Z] [INFO]     "stop_details": null,
+[2026-05-30T17:20:15.385Z] [INFO]     "usage": {
+[2026-05-30T17:20:15.385Z] [INFO]       "input_tokens": 2,
+[2026-05-30T17:20:15.385Z] [INFO]       "cache_creation_input_tokens": 2637,
+[2026-05-30T17:20:15.385Z] [INFO]       "cache_read_input_tokens": 61722,
+[2026-05-30T17:20:15.385Z] [INFO]       "cache_creation": {
+[2026-05-30T17:20:15.385Z] [INFO]         "ephemeral_5m_input_tokens": 0,
+[2026-05-30T17:20:15.385Z] [INFO]         "ephemeral_1h_input_tokens": 2637
+[2026-05-30T17:20:15.385Z] [INFO]       },
+[2026-05-30T17:20:15.385Z] [INFO]       "output_tokens": 3,
+[2026-05-30T17:20:15.385Z] [INFO]       "service_tier": "standard",
+[2026-05-30T17:20:15.385Z] [INFO]       "inference_geo": "not_available"
+[2026-05-30T17:20:15.385Z] [INFO]     },
+[2026-05-30T17:20:15.385Z] [INFO]     "diagnostics": null,
+[2026-05-30T17:20:15.385Z] [INFO]     "context_management": null
+[2026-05-30T17:20:15.385Z] [INFO]   },
+[2026-05-30T17:20:15.385Z] [INFO]   "parent_tool_use_id": null,
+[2026-05-30T17:20:15.385Z] [INFO]   "session_id": "45441128-80e2-48c1-a2ea-f81ede05030b",
+[2026-05-30T17:20:15.385Z] [INFO]   "uuid": "f64cfdd1-2b6b-4d15-bf7f-a6269885457c",
+[2026-05-30T17:20:15.385Z] [INFO]   "request_id": "req_011CbZ8uDbAGhm8hDvtUcqhU"
+[2026-05-30T17:20:15.385Z] [INFO] }
+[2026-05-30T17:20:16.151Z] [INFO] {
+[2026-05-30T17:20:16.151Z] [INFO]   "type": "user",
+[2026-05-30T17:20:16.151Z] [INFO]   "message": {
+[2026-05-30T17:20:16.151Z] [INFO]     "role": "user",
+[2026-05-30T17:20:16.151Z] [INFO]     "content": [
+[2026-05-30T17:20:16.151Z] [INFO]       {
+[2026-05-30T17:20:16.151Z] [INFO]         "tool_use_id": "toolu_017Kgf9yV5cE9vAoZKEzuwoP",
+[2026-05-30T17:20:16.151Z] [INFO]         "type": "tool_result",
+[2026-05-30T17:20:16.151Z] [INFO]         "content": "| [Upstash Vector Setup](docs/upstash-vector-setup.md) | Step-by-step: provision index with matching dimension, connect Teleton, recover from mismatches |\n\n---\n\n## Contributing\n\nSee [CONTRIBUTING.md](CONTRIBUTING.md) for the full guide.\n\n1. Fork the repository\n2. Create a feature branch from `main`\n3. Make your changes\n4. Verify: `npm run typecheck && npm run lint && npm test`\n5. Open a Pull Request against `main`\n\n---\n\n## Contributors\n\n<a href=\"https://github.com/xlabtg/teleton-agent/graphs/contributors\">\n  <img src=\"https://contrib.rocks/image?repo=xlabtg/teleton-agent\" />\n</a>\n\n---\n\n## License\n\nMIT License - see [LICENSE](LICENSE) for details. This fork keeps the original MIT license notice intact; keep the notice with redistributions and derivative work.\n\n---\n\n## Credits\n\n### Built With\n\n- Fork maintenance: [xlabtg/teleton-agent](https://github.com/xlabtg/teleton-agent)\n- Original upstream: [TONresistor/teleton-agent](https://github.com/TONresistor/teleton-agent)\n- [pi-ai](https://github.com/mariozechner/pi-ai) - Multi-provider LLM SDK\n- [GramJS](https://gram.js.org/) - Telegram MTProto library\n- [Grammy](https://grammy.dev/) - Telegram Bot API framework\n- [TON SDK](https://github.com/ton-org/ton) - TON blockchain client\n- [STON.fi SDK](https://www.npmjs.com/package/@ston-fi/sdk) - DEX integration\n- [DeDust SDK](https://www.npmjs.com/package/@dedust/sdk) - DEX integration\n- [MCP SDK](https://github.com/modelcontextprotocol/typescript-sdk) - Model Context Protocol client\n- [sqlite-vec](https://github.com/asg017/sqlite-vec) - Vector search for SQLite\n- [Hono](https://hono.dev/) - Lightweight web framework\n- [Tonutils-Proxy](https://github.com/xssnick/Tonutils-Proxy) - TON Proxy for .ton sites\n\n---\n\n## Support\n\n- **Issues**: [GitHub Issues](https://github.com/xlabtg/teleton-agent/issues)\n- **Channel**: [@teletonagents](https://t.me/teletonagents)\n- **Group Chat**: [@teletonagentHQ](https://t.me/teletonagentHQ)\n- **Contact**: [@zkproof](https://t.me/zkproof)",
+[2026-05-30T17:20:16.151Z] [INFO]         "is_error": false
+[2026-05-30T17:20:16.151Z] [INFO]       }
+[2026-05-30T17:20:16.151Z] [INFO]     ]
+[2026-05-30T17:20:16.151Z] [INFO]   },
+[2026-05-30T17:20:16.151Z] [INFO]   "parent_tool_use_id": null,
+[2026-05-30T17:20:16.151Z] [INFO]   "session_id": "45441128-80e2-48c1-a2ea-f81ede05030b",
+[2026-05-30T17:20:16.151Z] [INFO]   "uuid": "9356e919-3e64-4551-af1b-343b87da42fd",
+[2026-05-30T17:20:16.151Z] [INFO]   "timestamp": "2026-05-30T17:20:16.149Z",
+[2026-05-30T17:20:16.151Z] [INFO]   "tool_use_result": {
+[2026-05-30T17:20:16.151Z] [INFO]     "stdout": "| [Upstash Vector Setup](docs/upstash-vector-setup.md) | Step-by-step: provision index with matching dimension, connect Teleton, recover from mismatches |\n\n---\n\n## Contributing\n\nSee [CONTRIBUTING.md](CONTRIBUTING.md) for the full guide.\n\n1. Fork the repository\n2. Create a feature branch from `main`\n3. Make your changes\n4. Verify: `npm run typecheck && npm run lint && npm test`\n5. Open a Pull Request against `main`\n\n---\n\n## Contributors\n\n<a href=\"https://github.com/xlabtg/teleton-agent/graphs/contributors\">\n  <img src=\"https://contrib.rocks/image?repo=xlabtg/teleton-agent\" />\n</a>\n\n---\n\n## License\n\nMIT License - see [LICENSE](LICENSE) for details. This fork keeps the original MIT license notice intact; keep the notice with redistributions and derivative work.\n\n---\n\n## Credits\n\n### Built With\n\n- Fork maintenance: [xlabtg/teleton-agent](https://github.com/xlabtg/teleton-agent)\n- Original upstream: [TONresistor/teleton-agent](https://github.com/TONresistor/teleton-agent)\n- [pi-ai](https://github.com/mariozechner/pi-ai) - Multi-provider LLM SDK\n- [GramJS](https://gram.js.org/) - Telegram MTProto library\n- [Grammy](https://grammy.dev/) - Telegram Bot API framework\n- [TON SDK](https://github.com/ton-org/ton) - TON blockchain client\n- [STON.fi SDK](https://www.npmjs.com/package/@ston-fi/sdk) - DEX integration\n- [DeDust SDK](https://www.npmjs.com/package/@dedust/sdk) - DEX integration\n- [MCP SDK](https://github.com/modelcontextprotocol/typescript-sdk) - Model Context Protocol client\n- [sqlite-vec](https://github.com/asg017/sqlite-vec) - Vector search for SQLite\n- [Hono](https://hono.dev/) - Lightweight web framework\n- [Tonutils-Proxy](https://github.com/xssnick/Tonutils-Proxy) - TON Proxy for .ton sites\n\n---\n\n## Support\n\n- **Issues**: [GitHub Issues](https://github.com/xlabtg/teleton-agent/issues)\n- **Channel**: [@teletonagents](https://t.me/teletonagents)\n- **Group Chat**: [@teletonagentHQ](https://t.me/teletonagentHQ)\n- **Contact**: [@zkproof](https://t.me/zkproof)",
+[2026-05-30T17:20:16.151Z] [INFO]     "stderr": "",
+[2026-05-30T17:20:16.151Z] [INFO]     "interrupted": false,
+[2026-05-30T17:20:16.151Z] [INFO]     "isImage": false,
+[2026-05-30T17:20:16.151Z] [INFO]     "noOutputExpected": false
+[2026-05-30T17:20:16.151Z] [INFO]   }
+[2026-05-30T17:20:16.151Z] [INFO] }
+[2026-05-30T17:20:16.162Z] [INFO] [log_6ff26c] sending request {
+[2026-05-30T17:20:16.163Z] [INFO]   method: "post",
+[2026-05-30T17:20:16.163Z] [INFO]   url: "https://api.anthropic.com/v1/messages?beta=true",
+[2026-05-30T17:20:16.165Z] [INFO]   options: {
+[2026-05-30T17:20:16.166Z] [INFO]     method: "post",
+[2026-05-30T17:20:16.167Z] [INFO]     path: "/v1/messages?beta=true",
+[2026-05-30T17:20:16.167Z] [INFO]     body: {
+[2026-05-30T17:20:16.169Z] [INFO]       model: "claude-opus-4-8",
+[2026-05-30T17:20:16.170Z] [INFO]       messages: [
+[2026-05-30T17:20:16.173Z] [INFO]         [Object ...], [Object ...], [Object ...], [Object ...], [Object ...], [Object ...], [Object ...], [Object ...], [Object ...], [Object ...], [Object ...], [Object ...], [Object ...], [Object ...], [Object ...], [Object ...], [Object ...], [Object ...], [Object ...], [Object ...], [Object ...], [Object ...], [Object ...], [Object ...], [Object ...], [Object ...], [Object ...], [Object ...], [Object ...]
+[2026-05-30T17:20:16.177Z] [INFO]       ],
+[2026-05-30T17:20:16.179Z] [INFO]       system: [
+[2026-05-30T17:20:16.180Z] [INFO]         [Object ...], [Object ...], [Object ...], [Object ...]
+[2026-05-30T17:20:16.182Z] [INFO]       ],
+[2026-05-30T17:20:16.186Z] [INFO]       tools: [
+[2026-05-30T17:20:16.187Z] [INFO]         [Object ...], [Object ...], [Object ...], [Object ...], [Object ...], [Object ...], [Object ...], [Object ...], [Object ...], [Object ...]
+[2026-05-30T17:20:16.188Z] [INFO]       ],
+[2026-05-30T17:20:16.188Z] [INFO]       tool_choice: undefined,
+[2026-05-30T17:20:16.189Z] [INFO]       metadata: [Object ...],
+[2026-05-30T17:20:16.190Z] [INFO]       max_tokens: 128000,
+[2026-05-30T17:20:16.191Z] [INFO]       thinking: [Object ...],
+[2026-05-30T17:20:16.192Z] [INFO]       context_management: [Object ...],
+[2026-05-30T17:20:16.193Z] [INFO]       output_config: [Object ...],
+[2026-05-30T17:20:16.193Z] [INFO]       diagnostics: [Object ...],
+[2026-05-30T17:20:16.193Z] [INFO]       stream: true,
+[2026-05-30T17:20:16.194Z] [INFO]     },
+[2026-05-30T17:20:16.194Z] [INFO]     timeout: 600000,
+[2026-05-30T17:20:16.196Z] [INFO]     signal: AbortSignal {
+[2026-05-30T17:20:16.196Z] [INFO]       [Symbol(events.maxEventTargetListeners)]: 50,
+[2026-05-30T17:20:16.197Z] [INFO]       [Symbol(events.maxEventTargetListenersWarned)]: false,
+[2026-05-30T17:20:16.198Z] [INFO]       aborted: false,
+[2026-05-30T17:20:16.199Z] [INFO]       reason: undefined,
+[2026-05-30T17:20:16.199Z] [INFO]       onabort: null,
+[2026-05-30T17:20:16.200Z] [INFO]       throwIfAborted: [Function: throwIfAborted],
+[2026-05-30T17:20:16.200Z] [INFO]       addEventListener: [Function: addEventListener],
+[2026-05-30T17:20:16.200Z] [INFO]       removeEventListener: [Function: removeEventListener],
+[2026-05-30T17:20:16.200Z] [INFO]       dispatchEvent: [Function: dispatchEvent],
+[2026-05-30T17:20:16.201Z] [INFO]     },
+[2026-05-30T17:20:16.201Z] [INFO]     stream: true,
+[2026-05-30T17:20:16.202Z] [INFO]   },
+[2026-05-30T17:20:16.202Z] [INFO]   headers: {
+[2026-05-30T17:20:16.203Z] [INFO]     accept: "application/json",
+[2026-05-30T17:20:16.204Z] [INFO]     "anthropic-beta": "claude-code-20250219,oauth-2025-04-20,interleaved-thinking-2025-05-14,thinking-token-count-2026-05-13,context-management-2025-06-27,prompt-caching-scope-2026-01-05,mid-conversation-system-2026-04-07,advisor-tool-2026-03-01,advanced-tool-use-2025-11-20,effort-2025-11-24,extended-cache-ttl-2025-04-11,cache-diagnosis-2026-04-07",
+[2026-05-30T17:20:16.204Z] [INFO]     "anthropic-dangerous-direct-browser-access": "true",
+[2026-05-30T17:20:16.205Z] [INFO]     "anthropic-version": "2023-06-01",
+[2026-05-30T17:20:16.206Z] [INFO]     authorization: "***",
+[2026-05-30T17:20:16.206Z] [INFO]     "content-type": "application/json",
+[2026-05-30T17:20:16.207Z] [INFO]     "user-agent": "claude-cli/2.1.158 (external, sdk-cli)",
+[2026-05-30T17:20:16.207Z] [INFO]     "x-app": "cli",
+[2026-05-30T17:20:16.207Z] [INFO]     "x-claude-code-session-id": "45441128-80e2-48c1-a2ea-f81ede05030b",
+[2026-05-30T17:20:16.208Z] [INFO]     "x-client-request-id": "242613f9-a03f-452b-bb6b-3802cb9ea174",
+[2026-05-30T17:20:16.208Z] [INFO]     "x-stainless-arch": "x64",
+[2026-05-30T17:20:16.208Z] [INFO]     "x-stainless-lang": "js",
+[2026-05-30T17:20:16.208Z] [INFO]     "x-stainless-os": "Linux",
+[2026-05-30T17:20:16.208Z] [INFO]     "x-stainless-package-version": "0.94.0",
+[2026-05-30T17:20:16.209Z] [INFO]     "x-stainless-retry-count": "0",
+[2026-05-30T17:20:16.209Z] [INFO]     "x-stainless-runtime": "node",
+[2026-05-30T17:20:16.209Z] [INFO]     "x-stainless-runtime-version": "v24.3.0",
+[2026-05-30T17:20:16.210Z] [INFO]     "x-stainless-timeout": "600",
+[2026-05-30T17:20:16.211Z] [INFO]   },
+[2026-05-30T17:20:16.211Z] [INFO] }
+[2026-05-30T17:20:17.517Z] [INFO] [log_6ff26c, request-id: "req_011CbZ8uZ2hytcC9CfF2bkRP"] post https://api.anthropic.com/v1/messages?beta=true succeeded with status 200 in 1355ms
+[2026-05-30T17:20:17.517Z] [INFO] [log_6ff26c] response start {
+[2026-05-30T17:20:17.519Z] [INFO]   url: "https://api.anthropic.com/v1/messages?beta=true",
+[2026-05-30T17:20:17.520Z] [INFO]   status: 200,
+[2026-05-30T17:20:17.520Z] [INFO]   headers: {
+[2026-05-30T17:20:17.520Z] [INFO]     "anthropic-organization-id": "ebc2ac93-f86f-4d15-aff3-de8830d8d789",
+[2026-05-30T17:20:17.521Z] [INFO]     "anthropic-ratelimit-unified-5h-reset": "1780173000",
+[2026-05-30T17:20:17.522Z] [INFO]     "anthropic-ratelimit-unified-5h-status": "allowed",
+[2026-05-30T17:20:17.523Z] [INFO]     "anthropic-ratelimit-unified-5h-utilization": "0.26",
+[2026-05-30T17:20:17.525Z] [INFO]     "anthropic-ratelimit-unified-7d-reset": "1780398000",
+[2026-05-30T17:20:17.526Z] [INFO]     "anthropic-ratelimit-unified-7d-status": "allowed",
+[2026-05-30T17:20:17.527Z] [INFO]     "anthropic-ratelimit-unified-7d-utilization": "0.73",
+[2026-05-30T17:20:17.527Z] [INFO]     "anthropic-ratelimit-unified-fallback-percentage": "0.5",
+[2026-05-30T17:20:17.528Z] [INFO]     "anthropic-ratelimit-unified-overage-disabled-reason": "org_level_disabled",
+[2026-05-30T17:20:17.528Z] [INFO]     "anthropic-ratelimit-unified-overage-status": "rejected",
+[2026-05-30T17:20:17.529Z] [INFO]     "anthropic-ratelimit-unified-representative-claim": "five_hour",
+[2026-05-30T17:20:17.530Z] [INFO]     "anthropic-ratelimit-unified-reset": "1780173000",
+[2026-05-30T17:20:17.530Z] [INFO]     "anthropic-ratelimit-unified-status": "allowed",
+[2026-05-30T17:20:17.530Z] [INFO]     "cache-control": "no-cache",
+[2026-05-30T17:20:17.531Z] [INFO]     "cf-cache-status": "DYNAMIC",
+[2026-05-30T17:20:17.531Z] [INFO]     "cf-ray": "a03f68951c0b976a-FRA",
+[2026-05-30T17:20:17.531Z] [INFO]     connection: "keep-alive",
+[2026-05-30T17:20:17.532Z] [INFO]     "content-encoding": "gzip",
+[2026-05-30T17:20:17.532Z] [INFO]     "content-security-policy": "default-src 'none'; frame-ancestors 'none'",
+[2026-05-30T17:20:17.533Z] [INFO]     "content-type": "text/event-stream; charset=utf-8",
+[2026-05-30T17:20:17.533Z] [INFO]     date: "Sat, 30 May 2026 17:20:17 GMT",
+[2026-05-30T17:20:17.533Z] [INFO]     "request-id": "req_011CbZ8uZ2hytcC9CfF2bkRP",
+[2026-05-30T17:20:17.533Z] [INFO]     server: "cloudflare",
+[2026-05-30T17:20:17.533Z] [INFO]     "strict-transport-security": "max-age=31536000; includeSubDomains; preload",
+[2026-05-30T17:20:17.534Z] [INFO]     traceresponse: "00-d271954425d80487b44a80c47eb8006c-34304b77fcffb3ed-01",
+[2026-05-30T17:20:17.534Z] [INFO]     "transfer-encoding": "chunked",
+[2026-05-30T17:20:17.534Z] [INFO]     vary: "Accept-Encoding",
+[2026-05-30T17:20:17.534Z] [INFO]     "x-robots-tag": "none",
+[2026-05-30T17:20:17.535Z] [INFO]     "set-cookie": "***",
+[2026-05-30T17:20:17.535Z] [INFO]   },
+[2026-05-30T17:20:17.535Z] [INFO]   durationMs: 1355,
+[2026-05-30T17:20:17.537Z] [INFO] }
+[2026-05-30T17:20:17.537Z] [INFO] response 200 https://api.anthropic.com/v1/messages?beta=true Headers {
+[2026-05-30T17:20:17.537Z] [INFO]   "date": "Sat, 30 May 2026 17:20:17 GMT",
+[2026-05-30T17:20:17.538Z] [INFO]   "content-type": "text/event-stream; charset=utf-8",
+[2026-05-30T17:20:17.538Z] [INFO]   "transfer-encoding": "chunked",
+[2026-05-30T17:20:17.538Z] [INFO]   "connection": "keep-alive",
+[2026-05-30T17:20:17.538Z] [INFO]   "cache-control": "no-cache",
+[2026-05-30T17:20:17.539Z] [INFO]   "strict-transport-security": "max-age=31536000; includeSubDomains; preload",
+[2026-05-30T17:20:17.540Z] [INFO]   "content-encoding": "gzip",
+[2026-05-30T17:20:17.540Z] [INFO]   "vary": "Accept-Encoding",
+[2026-05-30T17:20:17.541Z] [INFO]   "content-security-policy": "default-src 'none'; frame-ancestors 'none'",
+[2026-05-30T17:20:17.542Z] [INFO]   "set-cookie": [ "_cfuvid=LNQQsJPlx2eFZwW.HDrHSBup3U.EyVeG9o0eizoYv7c-1780161616.1757076-1.0.1.1-BGkzQOwFcybCsrq4cyZ4rgpbICI5Vkhw_wXNi4RiBMc; HttpOnly; SameSite=None; Secure; Path=/; Domain=api.anthropic.com" ],
+[2026-05-30T17:20:17.542Z] [INFO]   "anthropic-ratelimit-unified-status": "allowed",
+[2026-05-30T17:20:17.543Z] [INFO]   "anthropic-ratelimit-unified-5h-status": "allowed",
+[2026-05-30T17:20:17.544Z] [INFO]   "anthropic-ratelimit-unified-5h-reset": "1780173000",
+[2026-05-30T17:20:17.544Z] [INFO]   "anthropic-ratelimit-unified-5h-utilization": "0.26",
+[2026-05-30T17:20:17.544Z] [INFO]   "anthropic-ratelimit-unified-7d-status": "allowed",
+[2026-05-30T17:20:17.545Z] [INFO]   "anthropic-ratelimit-unified-7d-reset": "1780398000",
+[2026-05-30T17:20:17.545Z] [INFO]   "anthropic-ratelimit-unified-7d-utilization": "0.73",
+[2026-05-30T17:20:17.545Z] [INFO]   "anthropic-ratelimit-unified-representative-claim": "five_hour",
+[2026-05-30T17:20:17.546Z] [INFO]   "anthropic-ratelimit-unified-fallback-percentage": "0.5",
+[2026-05-30T17:20:17.546Z] [INFO]   "anthropic-ratelimit-unified-reset": "1780173000",
+[2026-05-30T17:20:17.546Z] [INFO]   "anthropic-ratelimit-unified-overage-disabled-reason": "org_level_disabled",
+[2026-05-30T17:20:17.547Z] [INFO]   "anthropic-ratelimit-unified-overage-status": "rejected",
+[2026-05-30T17:20:17.547Z] [INFO]   "request-id": "req_011CbZ8uZ2hytcC9CfF2bkRP",
+[2026-05-30T17:20:17.547Z] [INFO]   "anthropic-organization-id": "ebc2ac93-f86f-4d15-aff3-de8830d8d789",
+[2026-05-30T17:20:17.548Z] [INFO]   "traceresponse": "00-d271954425d80487b44a80c47eb8006c-34304b77fcffb3ed-01",
+[2026-05-30T17:20:17.548Z] [INFO]   "server": "cloudflare",
+[2026-05-30T17:20:17.549Z] [INFO]   "cf-cache-status": "DYNAMIC",
+[2026-05-30T17:20:17.549Z] [INFO]   "x-robots-tag": "none",
+[2026-05-30T17:20:17.549Z] [INFO]   "cf-ray": "a03f68951c0b976a-FRA",
+[2026-05-30T17:20:17.550Z] [INFO] } ReadableStream {
+[2026-05-30T17:20:17.550Z] [INFO]   blob: [Function: blob],
+[2026-05-30T17:20:17.551Z] [INFO]   bytes: [Function: bytes],
+[2026-05-30T17:20:17.551Z] [INFO]   cancel: [Function],
+[2026-05-30T17:20:17.552Z] [INFO]   getReader: [Function],
+[2026-05-30T17:20:17.552Z] [INFO]   json: [Function: json],
+[2026-05-30T17:20:17.553Z] [INFO]   locked: [Getter],
+[2026-05-30T17:20:17.554Z] [INFO]   pipeThrough: [Function],
+[2026-05-30T17:20:17.554Z] [INFO]   pipeTo: [Function],
+[2026-05-30T17:20:17.554Z] [INFO]   tee: [Function],
+[2026-05-30T17:20:17.556Z] [INFO]   text: [Function: text],
+[2026-05-30T17:20:17.556Z] [INFO]   values: [Function: values],
+[2026-05-30T17:20:17.557Z] [INFO]   [Symbol(Symbol.asyncIterator)]: [Function: asyncIterator2],
+[2026-05-30T17:20:17.557Z] [INFO] }
+[2026-05-30T17:20:17.557Z] [INFO] [log_6ff26c] response parsed {
+[2026-05-30T17:20:17.557Z] [INFO]   url: "https://api.anthropic.com/v1/messages?beta=true",
+[2026-05-30T17:20:17.557Z] [INFO]   status: 200,
+[2026-05-30T17:20:17.558Z] [INFO]   body: bR {
+[2026-05-30T17:20:17.558Z] [INFO]     iterator: [AsyncGeneratorFunction: z],
+[2026-05-30T17:20:17.558Z] [INFO]     controller: AbortController {
+[2026-05-30T17:20:17.558Z] [INFO]       signal: [AbortSignal ...],
+[2026-05-30T17:20:17.558Z] [INFO]       abort: [Function: abort],
+[2026-05-30T17:20:17.558Z] [INFO]     },
+[2026-05-30T17:20:17.559Z] [INFO]     [Symbol(Symbol.asyncIterator)]: [Function],
+[2026-05-30T17:20:17.562Z] [INFO]     tee: [Function: tee],
+[2026-05-30T17:20:17.562Z] [INFO]     toReadableStream: [Function: toReadableStream],
+[2026-05-30T17:20:17.563Z] [INFO]   },
+[2026-05-30T17:20:17.563Z] [INFO]   durationMs: 1355,
+[2026-05-30T17:20:17.563Z] [INFO] }
+[2026-05-30T17:20:18.488Z] [INFO] {
+[2026-05-30T17:20:18.488Z] [INFO]   "type": "system",
+[2026-05-30T17:20:18.488Z] [INFO]   "subtype": "thinking_tokens",
+[2026-05-30T17:20:18.488Z] [INFO]   "estimated_tokens": 50,
+[2026-05-30T17:20:18.488Z] [INFO]   "estimated_tokens_delta": 50,
+[2026-05-30T17:20:18.488Z] [INFO]   "uuid": "d68b4801-7bb6-46bd-9d1f-ae0942e46e3f",
+[2026-05-30T17:20:18.488Z] [INFO]   "session_id": "45441128-80e2-48c1-a2ea-f81ede05030b"
+[2026-05-30T17:20:18.488Z] [INFO] }
+[2026-05-30T17:20:19.779Z] [INFO] {
+[2026-05-30T17:20:19.779Z] [INFO]   "type": "system",
+[2026-05-30T17:20:19.779Z] [INFO]   "subtype": "thinking_tokens",
+[2026-05-30T17:20:19.779Z] [INFO]   "estimated_tokens": 100,
+[2026-05-30T17:20:19.779Z] [INFO]   "estimated_tokens_delta": 50,
+[2026-05-30T17:20:19.779Z] [INFO]   "uuid": "f0c73c88-50eb-4b94-8b7b-54159b7450e8",
+[2026-05-30T17:20:19.779Z] [INFO]   "session_id": "45441128-80e2-48c1-a2ea-f81ede05030b"
+[2026-05-30T17:20:19.779Z] [INFO] }
+[2026-05-30T17:20:21.491Z] [INFO] {
+[2026-05-30T17:20:21.491Z] [INFO]   "type": "system",
+[2026-05-30T17:20:21.491Z] [INFO]   "subtype": "thinking_tokens",
+[2026-05-30T17:20:21.491Z] [INFO]   "estimated_tokens": 300,
+[2026-05-30T17:20:21.491Z] [INFO]   "estimated_tokens_delta": 200,
+[2026-05-30T17:20:21.491Z] [INFO]   "uuid": "71e5b8f9-681b-4199-95f0-d07539c9e775",
+[2026-05-30T17:20:21.491Z] [INFO]   "session_id": "45441128-80e2-48c1-a2ea-f81ede05030b"
+[2026-05-30T17:20:21.491Z] [INFO] }
+[2026-05-30T17:20:22.895Z] [INFO] {
+[2026-05-30T17:20:22.895Z] [INFO]   "type": "system",
+[2026-05-30T17:20:22.895Z] [INFO]   "subtype": "thinking_tokens",
+[2026-05-30T17:20:22.895Z] [INFO]   "estimated_tokens": 400,
+[2026-05-30T17:20:22.895Z] [INFO]   "estimated_tokens_delta": 100,
+[2026-05-30T17:20:22.895Z] [INFO]   "uuid": "03fc8730-0a11-4a08-b6cb-a4de8808ef4b",
+[2026-05-30T17:20:22.895Z] [INFO]   "session_id": "45441128-80e2-48c1-a2ea-f81ede05030b"
+[2026-05-30T17:20:22.895Z] [INFO] }
+[2026-05-30T17:20:24.300Z] [INFO] {
+[2026-05-30T17:20:24.300Z] [INFO]   "type": "system",
+[2026-05-30T17:20:24.300Z] [INFO]   "subtype": "thinking_tokens",
+[2026-05-30T17:20:24.300Z] [INFO]   "estimated_tokens": 500,
+[2026-05-30T17:20:24.300Z] [INFO]   "estimated_tokens_delta": 100,
+[2026-05-30T17:20:24.300Z] [INFO]   "uuid": "0a4816b8-6dea-4017-a9c8-378ce0668de1",
+[2026-05-30T17:20:24.300Z] [INFO]   "session_id": "45441128-80e2-48c1-a2ea-f81ede05030b"
+[2026-05-30T17:20:24.300Z] [INFO] }
+[2026-05-30T17:20:26.137Z] [INFO] {
+[2026-05-30T17:20:26.137Z] [INFO]   "type": "system",
+[2026-05-30T17:20:26.137Z] [INFO]   "subtype": "thinking_tokens",
+[2026-05-30T17:20:26.137Z] [INFO]   "estimated_tokens": 650,
+[2026-05-30T17:20:26.137Z] [INFO]   "estimated_tokens_delta": 150,
+[2026-05-30T17:20:26.137Z] [INFO]   "uuid": "4982496a-31a3-40be-b58b-0976c4c846f7",
+[2026-05-30T17:20:26.137Z] [INFO]   "session_id": "45441128-80e2-48c1-a2ea-f81ede05030b"
+[2026-05-30T17:20:26.137Z] [INFO] }
+[2026-05-30T17:20:27.655Z] [INFO] {
+[2026-05-30T17:20:27.655Z] [INFO]   "type": "system",
+[2026-05-30T17:20:27.655Z] [INFO]   "subtype": "thinking_tokens",
+[2026-05-30T17:20:27.655Z] [INFO]   "estimated_tokens": 800,
+[2026-05-30T17:20:27.655Z] [INFO]   "estimated_tokens_delta": 150,
+[2026-05-30T17:20:27.655Z] [INFO]   "uuid": "3a40a56e-697a-488a-ad5f-e7cf8052d479",
+[2026-05-30T17:20:27.655Z] [INFO]   "session_id": "45441128-80e2-48c1-a2ea-f81ede05030b"
+[2026-05-30T17:20:27.655Z] [INFO] }
+[2026-05-30T17:20:29.024Z] [INFO] {
+[2026-05-30T17:20:29.024Z] [INFO]   "type": "assistant",
+[2026-05-30T17:20:29.024Z] [INFO]   "message": {
+[2026-05-30T17:20:29.024Z] [INFO]     "model": "claude-opus-4-8",
+[2026-05-30T17:20:29.024Z] [INFO]     "id": "msg_01MdB2AHvnkC4bvY5K2VbT27",
+[2026-05-30T17:20:29.024Z] [INFO]     "type": "message",
+[2026-05-30T17:20:29.024Z] [INFO]     "role": "assistant",
+[2026-05-30T17:20:29.024Z] [INFO]     "content": [
+[2026-05-30T17:20:29.024Z] [INFO]       {
+[2026-05-30T17:20:29.024Z] [INFO]         "type": "thinking",
+[2026-05-30T17:20:29.024Z] [INFO]         "thinking": "",
+[2026-05-30T17:20:29.024Z] [INFO]         "signature": "EqESCmMIDhgCKkCb+2ALQFrezU/P4LyENEjYeGkfnTBbg+SzOCcncRMqcMdDQuT/Q82jZQxOilwyRrvjc8E5zxENFMfkhqts6ulhMg9jbGF1ZGUtb3B1cy00LTg4AEIIdGhpbmtpbmcSDKPHU2VCTeQzehvo1xoMWmo2aIEtP2v0B0VvIjDMGrh22QyFDq2nLh1Y2FZ1zrdejzZcIsh1ysbY551aeR1Z7qYnM8kwbrMKYc/aXRcq6xC/Kayu8duHArpYpX6uC1a0gv+YPXvKwfqAVnuyIg/WPDGPb2t8x8a08Rmyg3Y/DWHUAsI78NMrpgAEz14GQDaeopWr3idaX3r8h9eilFAnM8DIcuINlfVkCmW0aRqpM1g4BtPnWtKsI7vsFE1pNoa40Yhco/9cCRyP8SYodBYfV4+aA02fOQC5Jo5rf8CbdSWAUmVohbPAiqdT8uoY3TMf71zWvg3/YWvCUe4swWr5NbHSORmygOxyAZ+Lcf+crTBUFoIZ9cMqF/ge+H0EQmdHidzvYDvUYl/+lpxxZLmrfy1rzoXW0pQhdzq1pUUIt3KFtJI2WQypP11Dn6kZadID/pqdfIXTm1TyEyH/ig5YhoYO9kJivVw+LlJdIACbnBDhDDYyKpV00rvmoqD2kV3byG5p0KRbGYpHO1S57jSg/lK6HnyZ6ILPVXKR88KTAaR9TZhIuLwG4B1IUyCYm9ZsS++BjEmwfleJ3lxhQFSJ7x3EoyKNaTnaJuNcIDLF1lymby5spz3oBVF9mLEyJA73GrXapBV9TBHQIl0MPnMZ9794Go4oRfBf0jpHhoNhkrRtvmcGH2DjyTUX/Q4c4fObaM0Kcjorc2qnegMwuHxZliGkBGKgH35a2ci/Mi55MnTinPesE9a67dWRM8JuzAaC0Q/8hCP2uSXFE+FHEnENosIFXor/jS8BnMCKFW4sS/b2GhHpP+GnsWzi4zU3MFj5lo2W/V/nT+T8eZATKkNqsteKZfhpm0q+R/RD3acWNZKdWhTGBLO8iFde/x7i34dmeLpHobcOhKzY6+GdoDFGhwryJo0zaiTeETGqpPjOzIUKz8OL7LF1qYPU4joD5C908Gi4L/Vkvm3FxY+k8QQKZPrmFzUe2pEgmAr35rQ/2MwZPI0OgEoynBVLxipUkWHASJI7gj5v8lJmRUf5EU2Y4r7WoBKXLM3PbUw8g2ZeafwDFu75R0OhVAcGA9X91XGj43lKPv5zp4Ytdy4mCmpVJ93Z7EmF/q2Ur1m5rBJHtHN1LSRgCghNVgcJ6vq2PHwr/3pyJzjuGPRx9n4aGmKluA9pF+lnd/MZ6MDhUXpv+FsFL/atu9o3KuGE6WFZp6LIgdRbmH/hRDlvO3HDfP038zamWEv7+qyeueDE5yD7meFulq8Yx/IXjet1gwrxfs4G7TGujrXFZv0pmEkGxJK3SjxgVI/JJ/odGJ5gnjJ6VieDeMqyhcptSTwlTeJZeAjutOkCqZsM5ewPIHUfsbW+8vfVDOOlciXA/k52kD9hNYTRo1R/WpIwnzVufUGiQ4WfNRF/lsTQjB3+uz51oCjCfWcy5d0idAE4UkkrOYF3jenr9OYT5VoT05/BbbSPDDNt50s3AzFtOyajotn0PNWWBLHv7MTHYcdxzMEKFyg7GxaBf6iZ8uBwVpB2pjcMLhR2lPzlX7BdZmxHHWUjvYRqd136JhnrUgxmH8M1TLoaTn/clJwbdyFLIzyhDi4v2AV8mZpM+AsofxgUVUwAEuG5g0Ud5cc/6ZrA1M/3EoXfUv0BayodFSb5VTayjTm7+hMBDvMEhk9/qyFkxiJhBGxIeWu//vKxqOGj2Q8QAWdq+aGVjR7FxBC4ovaAVEVp3I87Es49zXJDhaOmy24XiYt9XfSzJLHKSwHhool5BLrydUcisUF+ecR5vgAfw2QMjwkDtnaWGPv29HeDn4G3UxX5hJy3AQEMYW0Xlt2KBre4wBbyjFem+Jpw6sACU2h+bXR7LBJdv0D502VAMbkdSKf9kJ5+fWIIud1KyJ1qJVlbTLMHo0Z7g54zR72k3Amq2d7KFsCqjoVyZmqbyj7FN1txYQfSmDwfHchURGXiQnMm0knxJ5U1XTMMNfOCmGEy4OCBeABEQZSMuJnmSD7bP+0ldkhY9j9wM6ZiDuzOnX8NNn/a9M69fu1S/zlGCajkOYxxua/dsXG6bJ2wrkLwsj17iDzvSql1Ing1txJTtW2CdF6iWiJ/ZgDqswAUaJfmUPrb6HpCPNs1rhYGdxgKunWW723b7Al/MIKJH7A0PXpWNWv0aXsS5rXKvbJ7YrG+UnBjxQb2M+6aylcud2KTtjPGCHw5CXHeJG2iie1QKvr1UO/2q4DsG7RhWpWcI+sAwZQmtBr4a0DvNm2Z1XAGe5uLy1FoXc6lWJuS/+8t0lWxXyUCL3Zw6UOUV+IIpXJPyr+GTUpNhGLRAFgLLVkWu8H1uQM3FZXG2o0vcghDr3WEh/PTG8p+dUJEs504ELCwCbSO8XsM12vBEGKdQ/SBtu/I0U4+2aV7fjIbSyWn7EeSuCpm6V3FnnVdAzr3n3TBUxNn0HYgj8qo5c7AU3y88h+GY7W4yue4sAsw78NXQaNPX0LPLU1vrRUsnpffU7UiUiH9PvcraZOf1tKSbme7mwz0oI3CDdjFhvVKURe1iGZ87QXpVlFQN4ZCmXRxOkEnn/F63H31M43oe2aYcTbMyPxq0ZKLiS2/zGKCN7YM+nCVKQUom5Nu+7bom8T5sg8nudL1mo45RsaBu7nkBFmQScJ9Exh/8X3EOfD4wHj1jMY4ulB4ZIWZFJktoIUcHki49nI10QG8iK5swm0KDKNRPCtcpqE/SadW/KOt5ShC21XMjgeGwivKdCrIRRSuX4mHGCOxvmjfxOtCCX2HFfgmzcc9KYqM+065nx3LxVJ05+oLfHYHd0Dzzul0xgA6hbJnuTcvVtBRz4R6RPbH/nFSR5Aw4RTkL00im3XX0L/U2O/dSX2ysLfyWYpSLzxyK3xjQwxYppOszsjXDJoYUgBKBOkGw7Mb3cJhcWMgioNai28Mf7LHJa54K4CAiRWxAau1wRiFkA8aHnBEcTYOFLQKkfYQ/U8E7O/RJTvtp4NWGAE="
+[2026-05-30T17:20:29.024Z] [INFO]       }
+[2026-05-30T17:20:29.024Z] [INFO]     ],
+[2026-05-30T17:20:29.024Z] [INFO]     "stop_reason": null,
+[2026-05-30T17:20:29.024Z] [INFO]     "stop_sequence": null,
+[2026-05-30T17:20:29.024Z] [INFO]     "stop_details": null,
+[2026-05-30T17:20:29.024Z] [INFO]     "usage": {
+[2026-05-30T17:20:29.024Z] [INFO]       "input_tokens": 2,
+[2026-05-30T17:20:29.024Z] [INFO]       "cache_creation_input_tokens": 1067,
+[2026-05-30T17:20:29.024Z] [INFO]       "cache_read_input_tokens": 64359,
+[2026-05-30T17:20:29.024Z] [INFO]       "cache_creation": {
+[2026-05-30T17:20:29.024Z] [INFO]         "ephemeral_5m_input_tokens": 0,
+[2026-05-30T17:20:29.024Z] [INFO]         "ephemeral_1h_input_tokens": 1067
+[2026-05-30T17:20:29.024Z] [INFO]       },
+[2026-05-30T17:20:29.024Z] [INFO]       "output_tokens": 7,
+[2026-05-30T17:20:29.024Z] [INFO]       "service_tier": "standard",
+[2026-05-30T17:20:29.024Z] [INFO]       "inference_geo": "not_available"
+[2026-05-30T17:20:29.024Z] [INFO]     },
+[2026-05-30T17:20:29.024Z] [INFO]     "diagnostics": null,
+[2026-05-30T17:20:29.024Z] [INFO]     "context_management": null
+[2026-05-30T17:20:29.024Z] [INFO]   },
+[2026-05-30T17:20:29.024Z] [INFO]   "parent_tool_use_id": null,
+[2026-05-30T17:20:29.024Z] [INFO]   "session_id": "45441128-80e2-48c1-a2ea-f81ede05030b",
+[2026-05-30T17:20:29.024Z] [INFO]   "uuid": "0d5e625a-de90-4559-9682-b8d8420ab860",
+[2026-05-30T17:20:29.024Z] [INFO]   "request_id": "req_011CbZ8uZ2hytcC9CfF2bkRP"
+[2026-05-30T17:20:29.024Z] [INFO] }
+[2026-05-30T17:20:29.025Z] [INFO] {
+[2026-05-30T17:20:29.025Z] [INFO]   "type": "assistant",
+[2026-05-30T17:20:29.025Z] [INFO]   "message": {
+[2026-05-30T17:20:29.025Z] [INFO]     "model": "claude-opus-4-8",
+[2026-05-30T17:20:29.025Z] [INFO]     "id": "msg_01MdB2AHvnkC4bvY5K2VbT27",
+[2026-05-30T17:20:29.025Z] [INFO]     "type": "message",
+[2026-05-30T17:20:29.025Z] [INFO]     "role": "assistant",
+[2026-05-30T17:20:29.025Z] [INFO]     "content": [
+[2026-05-30T17:20:29.025Z] [INFO]       {
+[2026-05-30T17:20:29.025Z] [INFO]         "type": "text",
+[2026-05-30T17:20:29.025Z] [INFO]         "text": "I have a clear picture now. Let me set up tasks and start implementing."
+[2026-05-30T17:20:29.025Z] [INFO]       }
+[2026-05-30T17:20:29.025Z] [INFO]     ],
+[2026-05-30T17:20:29.025Z] [INFO]     "stop_reason": null,
+[2026-05-30T17:20:29.025Z] [INFO]     "stop_sequence": null,
+[2026-05-30T17:20:29.025Z] [INFO]     "stop_details": null,
+[2026-05-30T17:20:29.025Z] [INFO]     "usage": {
+[2026-05-30T17:20:29.025Z] [INFO]       "input_tokens": 2,
+[2026-05-30T17:20:29.025Z] [INFO]       "cache_creation_input_tokens": 1067,
+[2026-05-30T17:20:29.025Z] [INFO]       "cache_read_input_tokens": 64359,
+[2026-05-30T17:20:29.025Z] [INFO]       "cache_creation": {
+[2026-05-30T17:20:29.025Z] [INFO]         "ephemeral_5m_input_tokens": 0,
+[2026-05-30T17:20:29.025Z] [INFO]         "ephemeral_1h_input_tokens": 1067
+[2026-05-30T17:20:29.025Z] [INFO]       },
+[2026-05-30T17:20:29.025Z] [INFO]       "output_tokens": 7,
+[2026-05-30T17:20:29.025Z] [INFO]       "service_tier": "standard",
+[2026-05-30T17:20:29.025Z] [INFO]       "inference_geo": "not_available"
+[2026-05-30T17:20:29.025Z] [INFO]     },
+[2026-05-30T17:20:29.025Z] [INFO]     "diagnostics": null,
+[2026-05-30T17:20:29.025Z] [INFO]     "context_management": null
+[2026-05-30T17:20:29.025Z] [INFO]   },
+[2026-05-30T17:20:29.025Z] [INFO]   "parent_tool_use_id": null,
+[2026-05-30T17:20:29.025Z] [INFO]   "session_id": "45441128-80e2-48c1-a2ea-f81ede05030b",
+[2026-05-30T17:20:29.025Z] [INFO]   "uuid": "1e0c1f69-7702-49d1-ba49-82b2ae97580a",
+[2026-05-30T17:20:29.025Z] [INFO]   "request_id": "req_011CbZ8uZ2hytcC9CfF2bkRP"
+[2026-05-30T17:20:29.025Z] [INFO] }
+[2026-05-30T17:20:29.464Z] [INFO] {
+[2026-05-30T17:20:29.464Z] [INFO]   "type": "assistant",
+[2026-05-30T17:20:29.464Z] [INFO]   "message": {
+[2026-05-30T17:20:29.464Z] [INFO]     "model": "claude-opus-4-8",
+[2026-05-30T17:20:29.464Z] [INFO]     "id": "msg_01MdB2AHvnkC4bvY5K2VbT27",
+[2026-05-30T17:20:29.464Z] [INFO]     "type": "message",
+[2026-05-30T17:20:29.464Z] [INFO]     "role": "assistant",
+[2026-05-30T17:20:29.464Z] [INFO]     "content": [
+[2026-05-30T17:20:29.464Z] [INFO]       {
+[2026-05-30T17:20:29.464Z] [INFO]         "type": "tool_use",
+[2026-05-30T17:20:29.464Z] [INFO]         "id": "toolu_0165zKQbCndpkHdBSRM3RSL1",
+[2026-05-30T17:20:29.464Z] [INFO]         "name": "ToolSearch",
+[2026-05-30T17:20:29.464Z] [INFO]         "input": {
+[2026-05-30T17:20:29.464Z] [INFO]           "query": "select:TaskCreate",
+[2026-05-30T17:20:29.464Z] [INFO]           "max_results": 1
+[2026-05-30T17:20:29.464Z] [INFO]         },
+[2026-05-30T17:20:29.464Z] [INFO]         "caller": {
+[2026-05-30T17:20:29.464Z] [INFO]           "type": "direct"
+[2026-05-30T17:20:29.464Z] [INFO]         }
+[2026-05-30T17:20:29.464Z] [INFO]       }
+[2026-05-30T17:20:29.464Z] [INFO]     ],
+[2026-05-30T17:20:29.464Z] [INFO]     "stop_reason": null,
+[2026-05-30T17:20:29.464Z] [INFO]     "stop_sequence": null,
+[2026-05-30T17:20:29.464Z] [INFO]     "stop_details": null,
+[2026-05-30T17:20:29.464Z] [INFO]     "usage": {
+[2026-05-30T17:20:29.464Z] [INFO]       "input_tokens": 2,
+[2026-05-30T17:20:29.464Z] [INFO]       "cache_creation_input_tokens": 1067,
+[2026-05-30T17:20:29.464Z] [INFO]       "cache_read_input_tokens": 64359,
+[2026-05-30T17:20:29.464Z] [INFO]       "cache_creation": {
+[2026-05-30T17:20:29.464Z] [INFO]         "ephemeral_5m_input_tokens": 0,
+[2026-05-30T17:20:29.464Z] [INFO]         "ephemeral_1h_input_tokens": 1067
+[2026-05-30T17:20:29.464Z] [INFO]       },
+[2026-05-30T17:20:29.464Z] [INFO]       "output_tokens": 7,
+[2026-05-30T17:20:29.464Z] [INFO]       "service_tier": "standard",
+[2026-05-30T17:20:29.464Z] [INFO]       "inference_geo": "not_available"
+[2026-05-30T17:20:29.464Z] [INFO]     },
+[2026-05-30T17:20:29.464Z] [INFO]     "diagnostics": null,
+[2026-05-30T17:20:29.464Z] [INFO]     "context_management": null
+[2026-05-30T17:20:29.464Z] [INFO]   },
+[2026-05-30T17:20:29.464Z] [INFO]   "parent_tool_use_id": null,
+[2026-05-30T17:20:29.464Z] [INFO]   "session_id": "45441128-80e2-48c1-a2ea-f81ede05030b",
+[2026-05-30T17:20:29.464Z] [INFO]   "uuid": "2554ace5-5db6-45d9-a127-c7bf2ae306e3",
+[2026-05-30T17:20:29.464Z] [INFO]   "request_id": "req_011CbZ8uZ2hytcC9CfF2bkRP"
+[2026-05-30T17:20:29.464Z] [INFO] }
+[2026-05-30T17:20:29.469Z] [INFO] {
+[2026-05-30T17:20:29.469Z] [INFO]   "type": "user",
+[2026-05-30T17:20:29.469Z] [INFO]   "message": {
+[2026-05-30T17:20:29.469Z] [INFO]     "role": "user",
+[2026-05-30T17:20:29.469Z] [INFO]     "content": [
+[2026-05-30T17:20:29.469Z] [INFO]       {
+[2026-05-30T17:20:29.469Z] [INFO]         "type": "tool_result",
+[2026-05-30T17:20:29.469Z] [INFO]         "tool_use_id": "toolu_0165zKQbCndpkHdBSRM3RSL1",
+[2026-05-30T17:20:29.469Z] [INFO]         "content": [
+[2026-05-30T17:20:29.469Z] [INFO]           {
+[2026-05-30T17:20:29.469Z] [INFO]             "type": "tool_reference",
+[2026-05-30T17:20:29.469Z] [INFO]             "tool_name": "TaskCreate"
+[2026-05-30T17:20:29.469Z] [INFO]           }
+[2026-05-30T17:20:29.469Z] [INFO]         ]
+[2026-05-30T17:20:29.469Z] [INFO]       }
+[2026-05-30T17:20:29.469Z] [INFO]     ]
+[2026-05-30T17:20:29.469Z] [INFO]   },
+[2026-05-30T17:20:29.469Z] [INFO]   "parent_tool_use_id": null,
+[2026-05-30T17:20:29.469Z] [INFO]   "session_id": "45441128-80e2-48c1-a2ea-f81ede05030b",
+[2026-05-30T17:20:29.469Z] [INFO]   "uuid": "c6ef222e-b948-4400-a7e0-ca637caa195f",
+[2026-05-30T17:20:29.469Z] [INFO]   "timestamp": "2026-05-30T17:20:29.468Z",
+[2026-05-30T17:20:29.469Z] [INFO]   "tool_use_result": {
+[2026-05-30T17:20:29.469Z] [INFO]     "matches": [
+[2026-05-30T17:20:29.469Z] [INFO]       "TaskCreate"
+[2026-05-30T17:20:29.469Z] [INFO]     ],
+[2026-05-30T17:20:29.469Z] [INFO]     "query": "select:TaskCreate",
+[2026-05-30T17:20:29.469Z] [INFO]     "total_deferred_tools": 31
+[2026-05-30T17:20:29.469Z] [INFO]   }
+[2026-05-30T17:20:29.469Z] [INFO] }
+[2026-05-30T17:20:29.539Z] [INFO] [log_46fe37] sending request {
+[2026-05-30T17:20:29.539Z] [INFO]   method: "post",
+[2026-05-30T17:20:29.540Z] [INFO]   url: "https://api.anthropic.com/v1/messages?beta=true",
+[2026-05-30T17:20:29.541Z] [INFO]   options: {
+[2026-05-30T17:20:29.541Z] [INFO]     method: "post",
+[2026-05-30T17:20:29.542Z] [INFO]     path: "/v1/messages?beta=true",
+[2026-05-30T17:20:29.542Z] [INFO]     body: {
+[2026-05-30T17:20:29.543Z] [INFO]       model: "claude-opus-4-8",
+[2026-05-30T17:20:29.543Z] [INFO]       messages: [
+[2026-05-30T17:20:29.543Z] [INFO]         [Object ...], [Object ...], [Object ...], [Object ...], [Object ...], [Object ...], [Object ...], [Object ...], [Object ...], [Object ...], [Object ...], [Object ...], [Object ...], [Object ...], [Object ...], [Object ...], [Object ...], [Object ...], [Object ...], [Object ...], [Object ...], [Object ...], [Object ...], [Object ...], [Object ...], [Object ...], [Object ...], [Object ...], [Object ...], [Object ...], [Object ...]
+[2026-05-30T17:20:29.543Z] [INFO]       ],
+[2026-05-30T17:20:29.543Z] [INFO]       system: [
+[2026-05-30T17:20:29.544Z] [INFO]         [Object ...], [Object ...], [Object ...], [Object ...]
+[2026-05-30T17:20:29.544Z] [INFO]       ],
+[2026-05-30T17:20:29.546Z] [INFO]       tools: [
+[2026-05-30T17:20:29.546Z] [INFO]         [Object ...], [Object ...], [Object ...], [Object ...], [Object ...], [Object ...], [Object ...], [Object ...], [Object ...], [Object ...], [Object ...]
+[2026-05-30T17:20:29.546Z] [INFO]       ],
+[2026-05-30T17:20:29.546Z] [INFO]       tool_choice: undefined,
+[2026-05-30T17:20:29.547Z] [INFO]       metadata: [Object ...],
+[2026-05-30T17:20:29.547Z] [INFO]       max_tokens: 128000,
+[2026-05-30T17:20:29.547Z] [INFO]       thinking: [Object ...],
+[2026-05-30T17:20:29.547Z] [INFO]       context_management: [Object ...],
+[2026-05-30T17:20:29.548Z] [INFO]       output_config: [Object ...],
+[2026-05-30T17:20:29.548Z] [INFO]       diagnostics: [Object ...],
+[2026-05-30T17:20:29.548Z] [INFO]       stream: true,
+[2026-05-30T17:20:29.548Z] [INFO]     },
+[2026-05-30T17:20:29.549Z] [INFO]     timeout: 600000,
+[2026-05-30T17:20:29.549Z] [INFO]     signal: AbortSignal {
+[2026-05-30T17:20:29.549Z] [INFO]       [Symbol(events.maxEventTargetListeners)]: 50,
+[2026-05-30T17:20:29.549Z] [INFO]       [Symbol(events.maxEventTargetListenersWarned)]: false,
+[2026-05-30T17:20:29.550Z] [INFO]       aborted: false,
+[2026-05-30T17:20:29.550Z] [INFO]       reason: undefined,
+[2026-05-30T17:20:29.550Z] [INFO]       onabort: null,
+[2026-05-30T17:20:29.550Z] [INFO]       throwIfAborted: [Function: throwIfAborted],
+[2026-05-30T17:20:29.550Z] [INFO]       addEventListener: [Function: addEventListener],
+[2026-05-30T17:20:29.551Z] [INFO]       removeEventListener: [Function: removeEventListener],
+[2026-05-30T17:20:29.551Z] [INFO]       dispatchEvent: [Function: dispatchEvent],
+[2026-05-30T17:20:29.551Z] [INFO]     },
+[2026-05-30T17:20:29.551Z] [INFO]     stream: true,
+[2026-05-30T17:20:29.552Z] [INFO]   },
+[2026-05-30T17:20:29.552Z] [INFO]   headers: {
+[2026-05-30T17:20:29.552Z] [INFO]     accept: "application/json",
+[2026-05-30T17:20:29.552Z] [INFO]     "anthropic-beta": "claude-code-20250219,oauth-2025-04-20,interleaved-thinking-2025-05-14,thinking-token-count-2026-05-13,context-management-2025-06-27,prompt-caching-scope-2026-01-05,mid-conversation-system-2026-04-07,advisor-tool-2026-03-01,advanced-tool-use-2025-11-20,effort-2025-11-24,extended-cache-ttl-2025-04-11,cache-diagnosis-2026-04-07",
+[2026-05-30T17:20:29.552Z] [INFO]     "anthropic-dangerous-direct-browser-access": "true",
+[2026-05-30T17:20:29.553Z] [INFO]     "anthropic-version": "2023-06-01",
+[2026-05-30T17:20:29.553Z] [INFO]     authorization: "***",
+[2026-05-30T17:20:29.553Z] [INFO]     "content-type": "application/json",
+[2026-05-30T17:20:29.553Z] [INFO]     "user-agent": "claude-cli/2.1.158 (external, sdk-cli)",
+[2026-05-30T17:20:29.554Z] [INFO]     "x-app": "cli",
+[2026-05-30T17:20:29.554Z] [INFO]     "x-claude-code-session-id": "45441128-80e2-48c1-a2ea-f81ede05030b",
+[2026-05-30T17:20:29.555Z] [INFO]     "x-client-request-id": "f4231d7b-ce21-437a-ab22-18ff099b822c",
+[2026-05-30T17:20:29.555Z] [INFO]     "x-stainless-arch": "x64",
+[2026-05-30T17:20:29.555Z] [INFO]     "x-stainless-lang": "js",
+[2026-05-30T17:20:29.555Z] [INFO]     "x-stainless-os": "Linux",
+[2026-05-30T17:20:29.556Z] [INFO]     "x-stainless-package-version": "0.94.0",
+[2026-05-30T17:20:29.556Z] [INFO]     "x-stainless-retry-count": "0",
+[2026-05-30T17:20:29.557Z] [INFO]     "x-stainless-runtime": "node",
+[2026-05-30T17:20:29.557Z] [INFO]     "x-stainless-runtime-version": "v24.3.0",
+[2026-05-30T17:20:29.557Z] [INFO]     "x-stainless-timeout": "600",
+[2026-05-30T17:20:29.558Z] [INFO]   },
+[2026-05-30T17:20:29.558Z] [INFO] }
+[2026-05-30T17:20:31.424Z] [INFO] [log_46fe37, request-id: "req_011CbZ8vYF6wGZ4DxyBXv55N"] post https://api.anthropic.com/v1/messages?beta=true succeeded with status 200 in 1885ms
+[2026-05-30T17:20:31.425Z] [INFO] [log_46fe37] response start {
+[2026-05-30T17:20:31.426Z] [INFO]   url: "https://api.anthropic.com/v1/messages?beta=true",
+[2026-05-30T17:20:31.426Z] [INFO]   status: 200,
+[2026-05-30T17:20:31.427Z] [INFO]   headers: {
+[2026-05-30T17:20:31.427Z] [INFO]     "anthropic-organization-id": "ebc2ac93-f86f-4d15-aff3-de8830d8d789",
+[2026-05-30T17:20:31.427Z] [INFO]     "anthropic-ratelimit-unified-5h-reset": "1780173000",
+[2026-05-30T17:20:31.428Z] [INFO]     "anthropic-ratelimit-unified-5h-status": "allowed",
+[2026-05-30T17:20:31.428Z] [INFO]     "anthropic-ratelimit-unified-5h-utilization": "0.26",
+[2026-05-30T17:20:31.428Z] [INFO]     "anthropic-ratelimit-unified-7d-reset": "1780398000",
+[2026-05-30T17:20:31.429Z] [INFO]     "anthropic-ratelimit-unified-7d-status": "allowed",
+[2026-05-30T17:20:31.430Z] [INFO]     "anthropic-ratelimit-unified-7d-utilization": "0.73",
+[2026-05-30T17:20:31.430Z] [INFO]     "anthropic-ratelimit-unified-fallback-percentage": "0.5",
+[2026-05-30T17:20:31.431Z] [INFO]     "anthropic-ratelimit-unified-overage-disabled-reason": "org_level_disabled",
+[2026-05-30T17:20:31.431Z] [INFO]     "anthropic-ratelimit-unified-overage-status": "rejected",
+[2026-05-30T17:20:31.432Z] [INFO]     "anthropic-ratelimit-unified-representative-claim": "five_hour",
+[2026-05-30T17:20:31.432Z] [INFO]     "anthropic-ratelimit-unified-reset": "1780173000",
+[2026-05-30T17:20:31.432Z] [INFO]     "anthropic-ratelimit-unified-status": "allowed",
+[2026-05-30T17:20:31.433Z] [INFO]     "cache-control": "no-cache",
+[2026-05-30T17:20:31.433Z] [INFO]     "cf-cache-status": "DYNAMIC",
+[2026-05-30T17:20:31.434Z] [INFO]     "cf-ray": "a03f68e8ab19b10b-FRA",
+[2026-05-30T17:20:31.435Z] [INFO]     connection: "keep-alive",
+[2026-05-30T17:20:31.435Z] [INFO]     "content-encoding": "gzip",
+[2026-05-30T17:20:31.435Z] [INFO]     "content-security-policy": "default-src 'none'; frame-ancestors 'none'",
+[2026-05-30T17:20:31.436Z] [INFO]     "content-type": "text/event-stream; charset=utf-8",
+[2026-05-30T17:20:31.437Z] [INFO]     date: "Sat, 30 May 2026 17:20:31 GMT",
+[2026-05-30T17:20:31.437Z] [INFO]     "request-id": "req_011CbZ8vYF6wGZ4DxyBXv55N",
+[2026-05-30T17:20:31.437Z] [INFO]     server: "cloudflare",
+[2026-05-30T17:20:31.437Z] [INFO]     "strict-transport-security": "max-age=31536000; includeSubDomains; preload",
+[2026-05-30T17:20:31.438Z] [INFO]     traceresponse: "00-69b7333d469eb0b48025dde2a6047aee-c17b258a942ae35e-01",
+[2026-05-30T17:20:31.438Z] [INFO]     "transfer-encoding": "chunked",
+[2026-05-30T17:20:31.438Z] [INFO]     vary: "Accept-Encoding",
+[2026-05-30T17:20:31.438Z] [INFO]     "x-robots-tag": "none",
+[2026-05-30T17:20:31.438Z] [INFO]     "set-cookie": "***",
+[2026-05-30T17:20:31.438Z] [INFO]   },
+[2026-05-30T17:20:31.439Z] [INFO]   durationMs: 1885,
+[2026-05-30T17:20:31.439Z] [INFO] }
+[2026-05-30T17:20:31.439Z] [INFO] response 200 https://api.anthropic.com/v1/messages?beta=true Headers {
+[2026-05-30T17:20:31.439Z] [INFO]   "date": "Sat, 30 May 2026 17:20:31 GMT",
+[2026-05-30T17:20:31.439Z] [INFO]   "content-type": "text/event-stream; charset=utf-8",
+[2026-05-30T17:20:31.440Z] [INFO]   "transfer-encoding": "chunked",
+[2026-05-30T17:20:31.440Z] [INFO]   "connection": "keep-alive",
+[2026-05-30T17:20:31.440Z] [INFO]   "cache-control": "no-cache",
+[2026-05-30T17:20:31.440Z] [INFO]   "strict-transport-security": "max-age=31536000; includeSubDomains; preload",
+[2026-05-30T17:20:31.441Z] [INFO]   "content-encoding": "gzip",
+[2026-05-30T17:20:31.441Z] [INFO]   "vary": "Accept-Encoding",
+[2026-05-30T17:20:31.441Z] [INFO]   "content-security-policy": "default-src 'none'; frame-ancestors 'none'",
+[2026-05-30T17:20:31.441Z] [INFO]   "set-cookie": [ "_cfuvid=rGu7QITgKLKylyi0fcgy4J2ysGVSEMfwXb1QC5w_eCU-1780161629.5517695-1.0.1.1-tS6fMpENkfNn2Ax5bXIrGdDIbEZQ.FGJsDCrVVEG2Eg; HttpOnly; SameSite=None; Secure; Path=/; Domain=api.anthropic.com" ],
+[2026-05-30T17:20:31.442Z] [INFO]   "anthropic-ratelimit-unified-status": "allowed",
+[2026-05-30T17:20:31.442Z] [INFO]   "anthropic-ratelimit-unified-5h-status": "allowed",
+[2026-05-30T17:20:31.442Z] [INFO]   "anthropic-ratelimit-unified-5h-reset": "1780173000",
+[2026-05-30T17:20:31.443Z] [INFO]   "anthropic-ratelimit-unified-5h-utilization": "0.26",
+[2026-05-30T17:20:31.443Z] [INFO]   "anthropic-ratelimit-unified-7d-status": "allowed",
+[2026-05-30T17:20:31.444Z] [INFO]   "anthropic-ratelimit-unified-7d-reset": "1780398000",
+[2026-05-30T17:20:31.444Z] [INFO]   "anthropic-ratelimit-unified-7d-utilization": "0.73",
+[2026-05-30T17:20:31.444Z] [INFO]   "anthropic-ratelimit-unified-representative-claim": "five_hour",
+[2026-05-30T17:20:31.444Z] [INFO]   "anthropic-ratelimit-unified-fallback-percentage": "0.5",
+[2026-05-30T17:20:31.444Z] [INFO]   "anthropic-ratelimit-unified-reset": "1780173000",
+[2026-05-30T17:20:31.445Z] [INFO]   "anthropic-ratelimit-unified-overage-disabled-reason": "org_level_disabled",
+[2026-05-30T17:20:31.445Z] [INFO]   "anthropic-ratelimit-unified-overage-status": "rejected",
+[2026-05-30T17:20:31.446Z] [INFO]   "request-id": "req_011CbZ8vYF6wGZ4DxyBXv55N",
+[2026-05-30T17:20:31.446Z] [INFO]   "anthropic-organization-id": "ebc2ac93-f86f-4d15-aff3-de8830d8d789",
+[2026-05-30T17:20:31.446Z] [INFO]   "traceresponse": "00-69b7333d469eb0b48025dde2a6047aee-c17b258a942ae35e-01",
+[2026-05-30T17:20:31.446Z] [INFO]   "server": "cloudflare",
+[2026-05-30T17:20:31.447Z] [INFO]   "cf-cache-status": "DYNAMIC",
+[2026-05-30T17:20:31.447Z] [INFO]   "x-robots-tag": "none",
+[2026-05-30T17:20:31.447Z] [INFO]   "cf-ray": "a03f68e8ab19b10b-FRA",
+[2026-05-30T17:20:31.447Z] [INFO] } ReadableStream {
+[2026-05-30T17:20:31.448Z] [INFO]   blob: [Function: blob],
+[2026-05-30T17:20:31.448Z] [INFO]   bytes: [Function: bytes],
+[2026-05-30T17:20:31.449Z] [INFO]   cancel: [Function],
+[2026-05-30T17:20:31.449Z] [INFO]   getReader: [Function],
+[2026-05-30T17:20:31.449Z] [INFO]   json: [Function: json],
+[2026-05-30T17:20:31.450Z] [INFO]   locked: [Getter],
+[2026-05-30T17:20:31.450Z] [INFO]   pipeThrough: [Function],
+[2026-05-30T17:20:31.450Z] [INFO]   pipeTo: [Function],
+[2026-05-30T17:20:31.450Z] [INFO]   tee: [Function],
+[2026-05-30T17:20:31.451Z] [INFO]   text: [Function: text],
+[2026-05-30T17:20:31.451Z] [INFO]   values: [Function: values],
+[2026-05-30T17:20:31.451Z] [INFO]   [Symbol(Symbol.asyncIterator)]: [Function: asyncIterator2],
+[2026-05-30T17:20:31.451Z] [INFO] }
+[2026-05-30T17:20:31.452Z] [INFO] [log_46fe37] response parsed {
+[2026-05-30T17:20:31.453Z] [INFO]   url: "https://api.anthropic.com/v1/messages?beta=true",
+[2026-05-30T17:20:31.453Z] [INFO]   status: 200,
+[2026-05-30T17:20:31.453Z] [INFO]   body: bR {
+[2026-05-30T17:20:31.453Z] [INFO]     iterator: [AsyncGeneratorFunction: z],
+[2026-05-30T17:20:31.454Z] [INFO]     controller: AbortController {
+[2026-05-30T17:20:31.454Z] [INFO]       signal: [AbortSignal ...],
+[2026-05-30T17:20:31.454Z] [INFO]       abort: [Function: abort],
+[2026-05-30T17:20:31.454Z] [INFO]     },
+[2026-05-30T17:20:31.454Z] [INFO]     [Symbol(Symbol.asyncIterator)]: [Function],
+[2026-05-30T17:20:31.455Z] [INFO]     tee: [Function: tee],
+[2026-05-30T17:20:31.455Z] [INFO]     toReadableStream: [Function: toReadableStream],
+[2026-05-30T17:20:31.455Z] [INFO]   },
+[2026-05-30T17:20:31.455Z] [INFO]   durationMs: 1886,
+[2026-05-30T17:20:31.456Z] [INFO] }
+[2026-05-30T17:20:32.960Z] [INFO] {
+[2026-05-30T17:20:32.960Z] [INFO]   "type": "system",
+[2026-05-30T17:20:32.960Z] [INFO]   "subtype": "thinking_tokens",
+[2026-05-30T17:20:32.960Z] [INFO]   "estimated_tokens": 50,
+[2026-05-30T17:20:32.960Z] [INFO]   "estimated_tokens_delta": 50,
+[2026-05-30T17:20:32.960Z] [INFO]   "uuid": "bbd4fe6c-6662-477d-a45c-24b915f4b3ca",
+[2026-05-30T17:20:32.960Z] [INFO]   "session_id": "45441128-80e2-48c1-a2ea-f81ede05030b"
+[2026-05-30T17:20:32.960Z] [INFO] }
+[2026-05-30T17:20:32.964Z] [INFO] {
+[2026-05-30T17:20:32.964Z] [INFO]   "type": "assistant",
+[2026-05-30T17:20:32.964Z] [INFO]   "message": {
+[2026-05-30T17:20:32.964Z] [INFO]     "model": "claude-opus-4-8",
+[2026-05-30T17:20:32.964Z] [INFO]     "id": "msg_015oa7Yh91xTHPn14S72KvN6",
+[2026-05-30T17:20:32.964Z] [INFO]     "type": "message",
+[2026-05-30T17:20:32.964Z] [INFO]     "role": "assistant",
+[2026-05-30T17:20:32.964Z] [INFO]     "content": [
+[2026-05-30T17:20:32.964Z] [INFO]       {
+[2026-05-30T17:20:32.964Z] [INFO]         "type": "thinking",
+[2026-05-30T17:20:32.964Z] [INFO]         "thinking": "",
+[2026-05-30T17:20:32.964Z] [INFO]         "signature": "EtQDCmMIDhgCKkBFd3kGLcxTf6nvtUZ4b4ejgqeGsoln4Rvo9z8ggLGHt4b+41sBfk04+f2MCwez6vzbQmesKGRyygweUxsaS9/TMg9jbGF1ZGUtb3B1cy00LTg4AEIIdGhpbmtpbmcSDDouH9VLfoiysza6BBoMivS75dY5eFWDqUAbIjAObZvdTzWNDSLIInoJQsaTRmqKc3eCWIylymEVXgY1/08vgD5RQYi+i2nK37s25Z0qngL/cdiuzMHQnhEbwlEVSEdJOABRsOtglVSzbzL32rvQ+B8AOW7nMcnazIIktS+FqaYFwRZDZXXQPNqwQLA03DV6W6icBfj0ivV986i7WtQ6Sxbxi1MAqtXLumXIZuGMVY8z4fI71en9iHwcuX5WylCm/h6wKfZQPceveSVr57RTOAIkFSOXs+D0kpqO49rWToe9Mr5FXOzPwZ1Bxvfk1VmQgyscZquCsSodxVEDEWTOgiCYVULXIg7YgrG0Iw8s/U/srJlp6g5WRfG/Dt6K17Kv/S6wDupOqE0jMU7DvmYOvyawLQw/LLKMR0ssvSaDnujsDvc8D6NRUmxDKXFkMXXLE76wMr4Lh/qtjE3UxKFLb4FjCX7VRtC5P90gI83OGAE="
+[2026-05-30T17:20:32.964Z] [INFO]       }
+[2026-05-30T17:20:32.964Z] [INFO]     ],
+[2026-05-30T17:20:32.964Z] [INFO]     "stop_reason": null,
+[2026-05-30T17:20:32.964Z] [INFO]     "stop_sequence": null,
+[2026-05-30T17:20:32.964Z] [INFO]     "stop_details": null,
+[2026-05-30T17:20:32.964Z] [INFO]     "usage": {
+[2026-05-30T17:20:32.964Z] [INFO]       "input_tokens": 2,
+[2026-05-30T17:20:32.964Z] [INFO]       "cache_creation_input_tokens": 53145,
+[2026-05-30T17:20:32.964Z] [INFO]       "cache_read_input_tokens": 14447,
+[2026-05-30T17:20:32.964Z] [INFO]       "cache_creation": {
+[2026-05-30T17:20:32.964Z] [INFO]         "ephemeral_5m_input_tokens": 0,
+[2026-05-30T17:20:32.964Z] [INFO]         "ephemeral_1h_input_tokens": 53145
+[2026-05-30T17:20:32.964Z] [INFO]       },
+[2026-05-30T17:20:32.964Z] [INFO]       "output_tokens": 6,
+[2026-05-30T17:20:32.964Z] [INFO]       "service_tier": "standard",
+[2026-05-30T17:20:32.964Z] [INFO]       "inference_geo": "not_available"
+[2026-05-30T17:20:32.964Z] [INFO]     },
+[2026-05-30T17:20:32.964Z] [INFO]     "diagnostics": {
+[2026-05-30T17:20:32.964Z] [INFO]       "cache_miss_reason": {
+[2026-05-30T17:20:32.964Z] [INFO]         "type": "tools_changed",
+[2026-05-30T17:20:32.964Z] [INFO]         "cache_missed_input_tokens": 50239
+[2026-05-30T17:20:32.964Z] [INFO]       }
+[2026-05-30T17:20:32.964Z] [INFO]     },
+[2026-05-30T17:20:32.964Z] [INFO]     "context_management": null
+[2026-05-30T17:20:32.964Z] [INFO]   },
+[2026-05-30T17:20:32.964Z] [INFO]   "parent_tool_use_id": null,
+[2026-05-30T17:20:32.964Z] [INFO]   "session_id": "45441128-80e2-48c1-a2ea-f81ede05030b",
+[2026-05-30T17:20:32.964Z] [INFO]   "uuid": "0a5fb7a0-3d67-4cb4-a88a-41a0f3d14b3e",
+[2026-05-30T17:20:32.964Z] [INFO]   "request_id": "req_011CbZ8vYF6wGZ4DxyBXv55N"
+[2026-05-30T17:20:32.964Z] [INFO] }
+[2026-05-30T17:20:33.354Z] [INFO] {
+[2026-05-30T17:20:33.354Z] [INFO]   "type": "assistant",
+[2026-05-30T17:20:33.354Z] [INFO]   "message": {
+[2026-05-30T17:20:33.354Z] [INFO]     "model": "claude-opus-4-8",
+[2026-05-30T17:20:33.354Z] [INFO]     "id": "msg_015oa7Yh91xTHPn14S72KvN6",
+[2026-05-30T17:20:33.354Z] [INFO]     "type": "message",
+[2026-05-30T17:20:33.354Z] [INFO]     "role": "assistant",
+[2026-05-30T17:20:33.354Z] [INFO]     "content": [
+[2026-05-30T17:20:33.354Z] [INFO]       {
+[2026-05-30T17:20:33.354Z] [INFO]         "type": "text",
+[2026-05-30T17:20:33.354Z] [INFO]         "text": "I'll proceed directly with the implementation. Let me create the Code of Conduct first."
+[2026-05-30T17:20:33.354Z] [INFO]       }
+[2026-05-30T17:20:33.354Z] [INFO]     ],
+[2026-05-30T17:20:33.354Z] [INFO]     "stop_reason": null,
+[2026-05-30T17:20:33.354Z] [INFO]     "stop_sequence": null,
+[2026-05-30T17:20:33.354Z] [INFO]     "stop_details": null,
+[2026-05-30T17:20:33.354Z] [INFO]     "usage": {
+[2026-05-30T17:20:33.354Z] [INFO]       "input_tokens": 2,
+[2026-05-30T17:20:33.354Z] [INFO]       "cache_creation_input_tokens": 53145,
+[2026-05-30T17:20:33.354Z] [INFO]       "cache_read_input_tokens": 14447,
+[2026-05-30T17:20:33.354Z] [INFO]       "cache_creation": {
+[2026-05-30T17:20:33.354Z] [INFO]         "ephemeral_5m_input_tokens": 0,
+[2026-05-30T17:20:33.354Z] [INFO]         "ephemeral_1h_input_tokens": 53145
+[2026-05-30T17:20:33.354Z] [INFO]       },
+[2026-05-30T17:20:33.354Z] [INFO]       "output_tokens": 6,
+[2026-05-30T17:20:33.354Z] [INFO]       "service_tier": "standard",
+[2026-05-30T17:20:33.354Z] [INFO]       "inference_geo": "not_available"
+[2026-05-30T17:20:33.354Z] [INFO]     },
+[2026-05-30T17:20:33.354Z] [INFO]     "diagnostics": {
+[2026-05-30T17:20:33.354Z] [INFO]       "cache_miss_reason": {
+[2026-05-30T17:20:33.354Z] [INFO]         "type": "tools_changed",
+[2026-05-30T17:20:33.354Z] [INFO]         "cache_missed_input_tokens": 50239
+[2026-05-30T17:20:33.354Z] [INFO]       }
+[2026-05-30T17:20:33.354Z] [INFO]     },
+[2026-05-30T17:20:33.354Z] [INFO]     "context_management": null
+[2026-05-30T17:20:33.354Z] [INFO]   },
+[2026-05-30T17:20:33.354Z] [INFO]   "parent_tool_use_id": null,
+[2026-05-30T17:20:33.354Z] [INFO]   "session_id": "45441128-80e2-48c1-a2ea-f81ede05030b",
+[2026-05-30T17:20:33.354Z] [INFO]   "uuid": "8da109ce-80ba-47d1-8ed0-32453ce5a6da",
+[2026-05-30T17:20:33.354Z] [INFO]   "request_id": "req_011CbZ8vYF6wGZ4DxyBXv55N"
+[2026-05-30T17:20:33.354Z] [INFO] }
+[2026-05-30T17:20:40.898Z] [INFO] {
+[2026-05-30T17:20:40.898Z] [INFO]   "type": "assistant",
+[2026-05-30T17:20:40.898Z] [INFO]   "message": {
+[2026-05-30T17:20:40.898Z] [INFO]     "id": "1edeae9b-abe5-450e-ac7b-22107ba02ff4",
+[2026-05-30T17:20:40.898Z] [INFO]     "container": null,
+[2026-05-30T17:20:40.898Z] [INFO]     "model": "<synthetic>",
+[2026-05-30T17:20:40.898Z] [INFO]     "role": "assistant",
+[2026-05-30T17:20:40.898Z] [INFO]     "stop_details": null,
+[2026-05-30T17:20:40.898Z] [INFO]     "stop_reason": "stop_sequence",
+[2026-05-30T17:20:40.898Z] [INFO]     "stop_sequence": "",
+[2026-05-30T17:20:40.898Z] [INFO]     "type": "message",
+[2026-05-30T17:20:40.898Z] [INFO]     "usage": {
+[2026-05-30T17:20:40.898Z] [INFO]       "input_tokens": 0,
+[2026-05-30T17:20:40.898Z] [INFO]       "output_tokens": 0,
+[2026-05-30T17:20:40.898Z] [INFO]       "cache_creation_input_tokens": 0,
+[2026-05-30T17:20:40.898Z] [INFO]       "cache_read_input_tokens": 0,
+[2026-05-30T17:20:40.898Z] [INFO]       "server_tool_use": {
+[2026-05-30T17:20:40.898Z] [INFO]         "web_search_requests": 0,
+[2026-05-30T17:20:40.898Z] [INFO]         "web_fetch_requests": 0
+[2026-05-30T17:20:40.898Z] [INFO]       },
+[2026-05-30T17:20:40.898Z] [INFO]       "service_tier": null,
+[2026-05-30T17:20:40.898Z] [INFO]       "cache_creation": {
+[2026-05-30T17:20:40.898Z] [INFO]         "ephemeral_1h_input_tokens": 0,
+[2026-05-30T17:20:40.898Z] [INFO]         "ephemeral_5m_input_tokens": 0
+[2026-05-30T17:20:40.898Z] [INFO]       },
+[2026-05-30T17:20:40.898Z] [INFO]       "inference_geo": null,
+[2026-05-30T17:20:40.898Z] [INFO]       "iterations": null,
+[2026-05-30T17:20:40.898Z] [INFO]       "speed": null
+[2026-05-30T17:20:40.898Z] [INFO]     },
+[2026-05-30T17:20:40.898Z] [INFO]     "content": [
+[2026-05-30T17:20:40.898Z] [INFO]       {
+[2026-05-30T17:20:40.898Z] [INFO]         "type": "text",
+[2026-05-30T17:20:40.898Z] [INFO]         "text": "API Error: Output blocked by content filtering policy"
+[2026-05-30T17:20:40.898Z] [INFO]       }
+[2026-05-30T17:20:40.898Z] [INFO]     ],
+[2026-05-30T17:20:40.898Z] [INFO]     "context_management": null
+[2026-05-30T17:20:40.898Z] [INFO]   },
+[2026-05-30T17:20:40.898Z] [INFO]   "parent_tool_use_id": null,
+[2026-05-30T17:20:40.898Z] [INFO]   "session_id": "45441128-80e2-48c1-a2ea-f81ede05030b",
+[2026-05-30T17:20:40.898Z] [INFO]   "uuid": "abb5c358-4b5d-4b4d-a575-450ad8300358",
+[2026-05-30T17:20:40.898Z] [INFO]   "error": "unknown",
+[2026-05-30T17:20:40.898Z] [INFO]   "request_id": "req_011CbZ8vYF6wGZ4DxyBXv55N"
+[2026-05-30T17:20:40.898Z] [INFO] }
+[2026-05-30T17:20:40.901Z] [INFO] {
+[2026-05-30T17:20:40.901Z] [INFO]   "type": "result",
+[2026-05-30T17:20:40.901Z] [INFO]   "subtype": "success",
+[2026-05-30T17:20:40.901Z] [INFO]   "is_error": true,
+[2026-05-30T17:20:40.901Z] [INFO]   "api_error_status": null,
+[2026-05-30T17:20:40.901Z] [INFO]   "duration_ms": 128511,
+[2026-05-30T17:20:40.901Z] [INFO]   "duration_api_ms": 97971,
+[2026-05-30T17:20:40.901Z] [INFO]   "num_turns": 18,
+[2026-05-30T17:20:40.901Z] [INFO]   "result": "API Error: Output blocked by content filtering policy",
+[2026-05-30T17:20:40.901Z] [INFO]   "stop_reason": "stop_sequence",
+[2026-05-30T17:20:40.901Z] [INFO]   "session_id": "45441128-80e2-48c1-a2ea-f81ede05030b",
+[2026-05-30T17:20:40.901Z] [INFO]   "total_cost_usd": 0.7784734999999999,
+[2026-05-30T17:20:40.901Z] [INFO]   "usage": {
+[2026-05-30T17:20:40.901Z] [INFO]     "input_tokens": 2468,
+[2026-05-30T17:20:40.901Z] [INFO]     "cache_creation_input_tokens": 51072,
+[2026-05-30T17:20:40.901Z] [INFO]     "cache_read_input_tokens": 578517,
+[2026-05-30T17:20:40.901Z] [INFO]     "output_tokens": 6307,
+[2026-05-30T17:20:40.901Z] [INFO]     "server_tool_use": {
+[2026-05-30T17:20:40.901Z] [INFO]       "web_search_requests": 0,
+[2026-05-30T17:20:40.901Z] [INFO]       "web_fetch_requests": 0
+[2026-05-30T17:20:40.901Z] [INFO]     },
+[2026-05-30T17:20:40.901Z] [INFO]     "service_tier": "standard",
+[2026-05-30T17:20:40.901Z] [INFO]     "cache_creation": {
+[2026-05-30T17:20:40.901Z] [INFO]       "ephemeral_1h_input_tokens": 51072,
+[2026-05-30T17:20:40.901Z] [INFO]       "ephemeral_5m_input_tokens": 0
+[2026-05-30T17:20:40.901Z] [INFO]     },
+[2026-05-30T17:20:40.901Z] [INFO]     "inference_geo": "not_available",
+[2026-05-30T17:20:40.901Z] [INFO]     "iterations": [
+[2026-05-30T17:20:40.901Z] [INFO]       {
+[2026-05-30T17:20:40.901Z] [INFO]         "input_tokens": 2,
+[2026-05-30T17:20:40.901Z] [INFO]         "output_tokens": 1050,
+[2026-05-30T17:20:40.901Z] [INFO]         "cache_read_input_tokens": 64359,
+[2026-05-30T17:20:40.901Z] [INFO]         "cache_creation_input_tokens": 1067,
+[2026-05-30T17:20:40.901Z] [INFO]         "cache_creation": {
+[2026-05-30T17:20:40.901Z] [INFO]           "ephemeral_5m_input_tokens": 0,
+[2026-05-30T17:20:40.901Z] [INFO]           "ephemeral_1h_input_tokens": 1067
+[2026-05-30T17:20:40.901Z] [INFO]         },
+[2026-05-30T17:20:40.901Z] [INFO]         "type": "message"
+[2026-05-30T17:20:40.901Z] [INFO]       }
+[2026-05-30T17:20:40.901Z] [INFO]     ],
+[2026-05-30T17:20:40.901Z] [INFO]     "speed": "standard"
+[2026-05-30T17:20:40.901Z] [INFO]   },
+[2026-05-30T17:20:40.901Z] [INFO]   "modelUsage": {
+[2026-05-30T17:20:40.901Z] [INFO]     "claude-opus-4-8": {
+[2026-05-30T17:20:40.901Z] [INFO]       "inputTokens": 2468,
+[2026-05-30T17:20:40.901Z] [INFO]       "outputTokens": 6307,
+[2026-05-30T17:20:40.901Z] [INFO]       "cacheReadInputTokens": 578517,
+[2026-05-30T17:20:40.901Z] [INFO]       "cacheCreationInputTokens": 51072,
+[2026-05-30T17:20:40.901Z] [INFO]       "webSearchRequests": 0,
+[2026-05-30T17:20:40.901Z] [INFO]       "costUSD": 0.7784734999999999,
+[2026-05-30T17:20:40.901Z] [INFO]       "contextWindow": 200000,
+[2026-05-30T17:20:40.901Z] [INFO]       "maxOutputTokens": 64000
+[2026-05-30T17:20:40.901Z] [INFO]     }
+[2026-05-30T17:20:40.901Z] [INFO]   },
+[2026-05-30T17:20:40.901Z] [INFO]   "permission_denials": [],
+[2026-05-30T17:20:40.901Z] [INFO]   "terminal_reason": "completed",
+[2026-05-30T17:20:40.901Z] [INFO]   "fast_mode_state": "off",
+[2026-05-30T17:20:40.901Z] [INFO]   "uuid": "6e3f3fda-c6e9-4225-bcd1-e86ee91fd857"
+[2026-05-30T17:20:40.901Z] [INFO] }
+[2026-05-30T17:20:40.901Z] [INFO] 📌 Result event received, starting 30s stream close timeout (Issue #1280)
+[2026-05-30T17:20:40.902Z] [INFO] 💰 Anthropic official cost captured from success result: $0.778473
+[2026-05-30T17:20:40.902Z] [INFO] 📝 Captured result summary from Claude output
+[2026-05-30T17:20:40.902Z] [INFO] 📊 Session num_turns: 18
+[2026-05-30T17:20:40.903Z] [INFO] ⚠️ Detected error from Claude CLI (subtype: success)
+[2026-05-30T17:20:41.279Z] [INFO] ✅ Stream closed normally after result event
+[2026-05-30T17:20:41.280Z] [INFO] ⚠️ Updated exit code from command result: 1
+[2026-05-30T17:20:41.281Z] [ERROR] 
+[2026-05-30T17:20:41.281Z] [ERROR] 
+[2026-05-30T17:20:41.281Z] [ERROR] ❌ Claude command failed with exit code 1
+[2026-05-30T17:20:41.282Z] [INFO] 📌 Session ID: 45441128-80e2-48c1-a2ea-f81ede05030b
+[2026-05-30T17:20:41.282Z] [INFO] 
+[2026-05-30T17:20:41.282Z] [INFO] 💡 To continue this session:
+[2026-05-30T17:20:41.282Z] [INFO] 
+[2026-05-30T17:20:41.283Z] [INFO]    Interactive mode:    (cd "/tmp/gh-issue-solver-1780161489554" && claude --resume 45441128-80e2-48c1-a2ea-f81ede05030b --model opus)
+[2026-05-30T17:20:41.283Z] [INFO] 
+[2026-05-30T17:20:41.283Z] [INFO]    Autonomous mode:     (cd "/tmp/gh-issue-solver-1780161489554" && claude --resume 45441128-80e2-48c1-a2ea-f81ede05030b --output-format stream-json --dangerously-skip-permissions --model opus -p "Continue.")
+[2026-05-30T17:20:41.283Z] [INFO] 
+[2026-05-30T17:20:41.301Z] [INFO] 
+[2026-05-30T17:20:41.301Z] [INFO] 📈 System resources after execution:
+[2026-05-30T17:20:41.302Z] [INFO]    Memory: MemFree:         7587144 kB
+[2026-05-30T17:20:41.302Z] [INFO]    Load: 2.94 2.93 2.17 6/438 1331521
+[2026-05-30T17:20:41.303Z] [INFO] 
+[2026-05-30T17:20:41.303Z] [INFO] 💡 To continue this session:
+[2026-05-30T17:20:41.303Z] [INFO] 
+[2026-05-30T17:20:41.303Z] [INFO]    Interactive mode:    (cd "/tmp/gh-issue-solver-1780161489554" && claude --resume 45441128-80e2-48c1-a2ea-f81ede05030b --model opus)
+[2026-05-30T17:20:41.303Z] [INFO] 
+[2026-05-30T17:20:41.303Z] [INFO]    Autonomous mode:     (cd "/tmp/gh-issue-solver-1780161489554" && claude --resume 45441128-80e2-48c1-a2ea-f81ede05030b --output-format stream-json --dangerously-skip-permissions --model opus -p "Continue.")
+[2026-05-30T17:20:41.303Z] [INFO] 
+[2026-05-30T17:20:41.305Z] [INFO] 
+[2026-05-30T17:20:41.305Z] [INFO] 💡 To continue this session:
+[2026-05-30T17:20:41.305Z] [INFO]    Interactive mode:    (cd "/tmp/gh-issue-solver-1780161489554" && claude --resume 45441128-80e2-48c1-a2ea-f81ede05030b --model opus)
+[2026-05-30T17:20:41.306Z] [INFO]    Autonomous mode:     (cd "/tmp/gh-issue-solver-1780161489554" && claude --resume 45441128-80e2-48c1-a2ea-f81ede05030b --output-format stream-json --dangerously-skip-permissions --model opus -p "Continue.")
+[2026-05-30T17:20:41.306Z] [INFO] 
+[2026-05-30T17:20:41.306Z] [INFO] 
+[2026-05-30T17:20:41.306Z] [INFO] 📄 Attaching failure logs to Pull Request...

--- a/src/claude.lib.mjs
+++ b/src/claude.lib.mjs
@@ -1191,6 +1191,8 @@ export const executeClaudeCommand = async params => {
             is503Error,
             anthropicTotalCostUSD,
             resultSummary,
+            // Issue #1845: surface the actual error so callers can show it to users
+            errorInfo: { message: lastMessage || 'API explicitly marked error as not retryable', exitCode },
             queuedFeedback, // Issue #817: Bidirectional mode feedback
           };
         }
@@ -1235,6 +1237,8 @@ export const executeClaudeCommand = async params => {
             is503Error, // preserve for callers that check this
             anthropicTotalCostUSD, // Issue #1104: Include cost even on failure
             resultSummary, // Issue #1263: Include result summary
+            // Issue #1845: surface the actual error so callers can show it to users
+            errorInfo: { message: lastMessage || `Transient API error persisted after ${maxRetries} retries`, exitCode },
             queuedFeedback, // Issue #817: Bidirectional mode feedback
           };
         }
@@ -1294,6 +1298,9 @@ export const executeClaudeCommand = async params => {
           errorDuringExecution,
           anthropicTotalCostUSD, // Issue #1104: Include cost even on failure
           resultSummary, // Issue #1263: Include result summary
+          // Issue #1845: surface the core error (e.g. "API Error: Output blocked by content
+          // filtering policy") so users see what actually went wrong, not just a generic message.
+          errorInfo: { message: lastMessage || `Claude command failed with exit code ${exitCode}`, exitCode },
           queuedFeedback, // Issue #817: Bidirectional mode feedback
         };
       }
@@ -1374,6 +1381,8 @@ export const executeClaudeCommand = async params => {
         toolUseCount,
         anthropicTotalCostUSD, // Issue #1104: Include cost even on failure
         resultSummary, // Issue #1263: Include result summary
+        // Issue #1845: surface the actual exception message so callers can show it to users
+        errorInfo: { message: error.message || error.toString() },
         queuedFeedback, // Issue #817: Bidirectional mode feedback
       };
     }

--- a/src/gemini.lib.mjs
+++ b/src/gemini.lib.mjs
@@ -575,6 +575,8 @@ export const executeGeminiCommand = async params => {
           pricingInfo: { modelId: mappedModel, modelName: mappedModel, provider: 'Google', totalCostUSD: null },
           publicPricingEstimate: null,
           resultSummary: geminiJsonState.resultSummary || null,
+          // Issue #1845: surface the actual error so callers can show it to users
+          errorInfo: { message: errorText || `Gemini command failed with exit code ${exitCode}`, exitCode },
         };
       }
 
@@ -616,6 +618,8 @@ export const executeGeminiCommand = async params => {
         pricingInfo: null,
         publicPricingEstimate: null,
         resultSummary: null,
+        // Issue #1845: surface the actual exception message so callers can show it to users
+        errorInfo: { message: error.message || error.toString() },
       };
     }
   };

--- a/src/lib.mjs
+++ b/src/lib.mjs
@@ -665,6 +665,48 @@ export const cleanErrorMessage = error => {
 };
 
 /**
+ * Build a user-facing tool execution failure message that includes the core
+ * error reported by the underlying tool (Issue #1845).
+ *
+ * Previously users only saw the generic "<TOOL> execution failed" and had to
+ * dig through the full failure log to discover what actually went wrong (for
+ * example "API Error: Output blocked by content filtering policy"). When the
+ * tool runner surfaces a specific error via `toolResult.errorInfo.message`
+ * (or related fields) this appends it so the failure is self-explanatory:
+ *
+ *   "CLAUDE execution failed with API Error: Output blocked by content filtering policy"
+ *
+ * Falls back to the generic phrase when no specific error is available.
+ *
+ * @param {Object} options
+ * @param {string} [options.tool] - Tool name (e.g. 'claude'); defaults to 'claude'
+ * @param {Object} [options.toolResult] - Result object returned by the tool runner
+ * @param {number} [options.maxLength=300] - Max length of the appended core error
+ * @returns {string} The formatted failure message
+ */
+export const formatToolExecutionFailure = ({ tool, toolResult, maxLength = 300 } = {}) => {
+  const base = `${(tool || 'claude').toUpperCase()} execution failed`;
+
+  // Prefer the structured error message surfaced by the tool runner. We do NOT
+  // fall back to resultSummary here, because that holds the agent's normal
+  // work summary on success and would be misleading when used as an error.
+  const errorInfo = toolResult?.errorInfo;
+  const rawCore = errorInfo?.message || errorInfo?.errorMatch || (typeof errorInfo === 'string' ? errorInfo : null) || toolResult?.result || null;
+
+  if (!rawCore || typeof rawCore !== 'string') return base;
+
+  // Collapse to a single clean line and strip noise.
+  let core = rawCore.replace(/\s+/g, ' ').trim();
+  if (!core) return base;
+
+  // Avoid duplicating the base phrase if the core error already contains it.
+  if (core.toLowerCase().includes('execution failed')) return base;
+
+  if (core.length > maxLength) core = `${core.slice(0, maxLength - 1)}…`;
+  return `${base} with ${core}`;
+};
+
+/**
  * Format aligned console output
  * @param {string} icon - Icon to display
  * @param {string} label - Label text

--- a/src/lib.mjs
+++ b/src/lib.mjs
@@ -665,14 +665,42 @@ export const cleanErrorMessage = error => {
 };
 
 /**
+ * Extract the core/root error string from a tool runner result (Issue #1845).
+ *
+ * Applies a single precedence everywhere so every failure surface shows the
+ * same root cause: `errorInfo.message` → `errorInfo.errorMatch` → string
+ * `errorInfo` → `result`. Returns a collapsed single line, or null when no
+ * usable error string is available. Shared by `formatToolExecutionFailure`
+ * (GitHub comments / exit message) and the terminal "Error details:" lines in
+ * watch / auto-merge so they never diverge.
+ *
+ * @param {Object} options
+ * @param {Object} [options.toolResult] - Result object returned by the tool runner
+ * @returns {string|null} The core error string, or null when none is available
+ */
+export const extractToolErrorCore = ({ toolResult } = {}) => {
+  // Prefer the structured error message surfaced by the tool runner. We do NOT
+  // fall back to resultSummary here, because that holds the agent's normal
+  // work summary on success and would be misleading when used as an error.
+  const errorInfo = toolResult?.errorInfo;
+  const rawCore = errorInfo?.message || errorInfo?.errorMatch || (typeof errorInfo === 'string' ? errorInfo : null) || toolResult?.result || null;
+
+  if (!rawCore || typeof rawCore !== 'string') return null;
+
+  // Collapse to a single clean line and strip noise.
+  const core = rawCore.replace(/\s+/g, ' ').trim();
+  return core || null;
+};
+
+/**
  * Build a user-facing tool execution failure message that includes the core
  * error reported by the underlying tool (Issue #1845).
  *
  * Previously users only saw the generic "<TOOL> execution failed" and had to
  * dig through the full failure log to discover what actually went wrong (for
  * example "API Error: Output blocked by content filtering policy"). When the
- * tool runner surfaces a specific error via `toolResult.errorInfo.message`
- * (or related fields) this appends it so the failure is self-explanatory:
+ * tool runner surfaces a specific error this appends it so the failure is
+ * self-explanatory:
  *
  *   "CLAUDE execution failed with API Error: Output blocked by content filtering policy"
  *
@@ -687,16 +715,7 @@ export const cleanErrorMessage = error => {
 export const formatToolExecutionFailure = ({ tool, toolResult, maxLength = 300 } = {}) => {
   const base = `${(tool || 'claude').toUpperCase()} execution failed`;
 
-  // Prefer the structured error message surfaced by the tool runner. We do NOT
-  // fall back to resultSummary here, because that holds the agent's normal
-  // work summary on success and would be misleading when used as an error.
-  const errorInfo = toolResult?.errorInfo;
-  const rawCore = errorInfo?.message || errorInfo?.errorMatch || (typeof errorInfo === 'string' ? errorInfo : null) || toolResult?.result || null;
-
-  if (!rawCore || typeof rawCore !== 'string') return base;
-
-  // Collapse to a single clean line and strip noise.
-  let core = rawCore.replace(/\s+/g, ' ').trim();
+  let core = extractToolErrorCore({ toolResult });
   if (!core) return base;
 
   // Avoid duplicating the base phrase if the core error already contains it.

--- a/src/opencode.lib.mjs
+++ b/src/opencode.lib.mjs
@@ -466,6 +466,8 @@ export const executeOpenCodeCommand = async params => {
           permissionPromptDetected: true,
           ...pricingResult,
           resultSummary: lastTextContent || null, // Issue #1263: Use last text content from JSON output stream
+          // Issue #1845: surface the actual error so callers can show it to users
+          errorInfo: { message: 'OpenCode requested an interactive permission prompt (non-interactive run cannot continue)' },
         };
       }
 
@@ -528,6 +530,8 @@ export const executeOpenCodeCommand = async params => {
           limitResetTime,
           ...pricingResult,
           resultSummary: lastTextContent || null, // Issue #1263: Use last text content from JSON output stream
+          // Issue #1845: surface the actual error so callers can show it to users
+          errorInfo: { message: lastMessage || allOutput || `OpenCode command failed with exit code ${exitCode}`, exitCode },
         };
       }
 
@@ -593,6 +597,8 @@ export const executeOpenCodeCommand = async params => {
         pricingInfo: null,
         publicPricingEstimate: null,
         resultSummary: null, // Issue #1263: No result summary available on error
+        // Issue #1845: surface the actual exception message so callers can show it to users
+        errorInfo: { message: error.message || error.toString() },
       };
     }
   };

--- a/src/qwen.lib.mjs
+++ b/src/qwen.lib.mjs
@@ -632,6 +632,8 @@ export const executeQwenCommand = async params => {
           limitResetTime: null,
           ...usageResult,
           resultSummary,
+          // Issue #1845: surface the actual error so callers can show it to users
+          errorInfo: { message: combinedErrorText || errorMessage || `Qwen Code command failed${exitCode !== 0 ? ` with exit code ${exitCode}` : ''}`, exitCode },
         };
       }
 
@@ -665,6 +667,8 @@ export const executeQwenCommand = async params => {
         publicPricingEstimate: null,
         tokenUsage: null,
         resultSummary: null,
+        // Issue #1845: surface the actual exception message so callers can show it to users
+        errorInfo: { message: error.message || error.toString() },
       };
     }
   };

--- a/src/review.mjs
+++ b/src/review.mjs
@@ -43,7 +43,7 @@ const path = (await use('path')).default;
 const fs = (await use('fs')).promises;
 
 // Import shared functions from lib.mjs to follow DRY principle
-import { log, setLogFile, getLogFile, formatAligned } from './lib.mjs';
+import { log, setLogFile, getLogFile, formatAligned, extractToolErrorCore } from './lib.mjs';
 import { parseCliArgumentsWithLino } from './cli-arguments.lib.mjs';
 import { reportError } from './sentry.lib.mjs';
 import * as memoryCheck from './memory-check.mjs';
@@ -398,7 +398,9 @@ Review this pull request thoroughly.`;
 
   // Handle command failure
   if (!commandSuccess) {
-    await log('\n❌ Command execution failed. Check the log file for details.');
+    // Issue #1845: surface the core error (e.g. "API Error: ...") instead of just a generic message.
+    const reviewErrorCore = extractToolErrorCore({ toolResult: result });
+    await log(`\n❌ Command execution failed${reviewErrorCore ? ` with ${reviewErrorCore}` : '. Check the log file for details.'}`);
     await log(`📁 Log file: ${getLogFile()}`);
     process.exit(1);
   }

--- a/src/solve.auto-merge.lib.mjs
+++ b/src/solve.auto-merge.lib.mjs
@@ -22,7 +22,7 @@ const { wrapDollarWithGhRetry } = await import('./github-rate-limit.lib.mjs');
 const $ = wrapDollarWithGhRetry(__rawDollar$);
 // Import shared library functions
 const lib = await import('./lib.mjs');
-const { log, cleanErrorMessage, formatAligned, formatToolExecutionFailure, getLogFile } = lib;
+const { log, cleanErrorMessage, formatAligned, formatToolExecutionFailure, extractToolErrorCore, getLogFile } = lib;
 
 // Note: We don't use detectAndCountFeedback from solve.feedback.lib.mjs
 // because we have our own non-bot comment detection logic that's more
@@ -805,6 +805,8 @@ No further AI sessions will be started automatically for this run. Please review
                 // Resume failed for a non-limit reason — stop the loop
                 await log('');
                 await log(formatAligned('❌', `${argv.tool.toUpperCase()} RESUME FAILED`, ''));
+                // Issue #1845: surface the core error in the terminal, not just in the GitHub log.
+                await log(formatAligned('', 'Error details:', extractToolErrorCore({ toolResult: resumeResult }) || 'Unknown error', 2));
                 await log(formatAligned('', 'Action:', 'Stopping auto-restart — tool execution failed after limit reset', 2));
                 // Issue #1439: Attach failure log before stopping, so user can see what happened
                 const shouldAttachLogsOnResumeFail = argv.attachLogs || argv['attach-logs'];
@@ -855,6 +857,8 @@ No further AI sessions will be started automatically for this run. Please review
           // Per reviewer feedback: non-limit failures should fail and stop attempts
           await log('');
           await log(formatAligned('❌', `${argv.tool.toUpperCase()} EXECUTION FAILED`, ''));
+          // Issue #1845: surface the core error in the terminal, not just in the GitHub log.
+          await log(formatAligned('', 'Error details:', extractToolErrorCore({ toolResult }) || 'Unknown error', 2));
           await log(formatAligned('', 'Action:', 'Stopping auto-restart — tool execution failed', 2));
           // Issue #1439: Attach failure log before stopping, so user can see what happened
           const shouldAttachLogsOnFail = argv.attachLogs || argv['attach-logs'];

--- a/src/solve.auto-merge.lib.mjs
+++ b/src/solve.auto-merge.lib.mjs
@@ -22,7 +22,7 @@ const { wrapDollarWithGhRetry } = await import('./github-rate-limit.lib.mjs');
 const $ = wrapDollarWithGhRetry(__rawDollar$);
 // Import shared library functions
 const lib = await import('./lib.mjs');
-const { log, cleanErrorMessage, formatAligned, getLogFile } = lib;
+const { log, cleanErrorMessage, formatAligned, formatToolExecutionFailure, getLogFile } = lib;
 
 // Note: We don't use detectAndCountFeedback from solve.feedback.lib.mjs
 // because we have our own non-bot comment detection logic that's more
@@ -822,7 +822,7 @@ No further AI sessions will be started automatically for this run. Please review
                         log,
                         sanitizeLogContent,
                         verbose: argv.verbose,
-                        errorMessage: `${argv.tool.toUpperCase()} execution failed after limit reset`,
+                        errorMessage: `${formatToolExecutionFailure({ tool: argv.tool, toolResult: resumeResult })} after limit reset`,
                         sessionId: latestSessionId,
                         tempDir,
                         requestedModel: argv.originalModel || argv.model,
@@ -872,7 +872,7 @@ No further AI sessions will be started automatically for this run. Please review
                   log,
                   sanitizeLogContent,
                   verbose: argv.verbose,
-                  errorMessage: `${argv.tool.toUpperCase()} execution failed`,
+                  errorMessage: formatToolExecutionFailure({ tool: argv.tool, toolResult }),
                   sessionId: latestSessionId,
                   tempDir,
                   requestedModel: argv.originalModel || argv.model,

--- a/src/solve.error-handlers.lib.mjs
+++ b/src/solve.error-handlers.lib.mjs
@@ -18,8 +18,29 @@ export const isErrorIssueAutoCreationDisabled = argv => !!(argv?.disableReportIs
  * Handles log attachment and PR closing on failure
  */
 export const handleFailure = async options => {
-  const { error, errorType, shouldAttachLogs, argv, global, owner, repo, log, getLogFile, attachLogToGitHub, cleanErrorMessage, sanitizeLogContent, $ } = options;
+  const { error, errorType, shouldAttachLogs, argv, global, owner, repo, log, getLogFile, attachLogToGitHub, cleanErrorMessage, sanitizeLogContent, cleanupContext, $ } = options;
   const disableIssueCreation = isErrorIssueAutoCreationDisabled(argv);
+
+  // Issue #1845 / #1834: "On all failures we automatically commit uncommitted changes by default."
+  // Exceptions, unhandled rejections and main-execution errors exit here WITHOUT passing through the
+  // tool-failure auto-commit chokepoint in solve.mjs, so preserve (commit + push) any work the agent
+  // left on disk first. Gated by config (default on; HIVE_MIND_AUTO_COMMIT_ON_CRITICAL_ERROR=false).
+  // Best-effort: never let a commit failure mask the original error.
+  try {
+    const { criticalErrorRecovery } = await import('./config.lib.mjs');
+    if (criticalErrorRecovery.autoCommitUncommittedChanges && cleanupContext?.tempDir) {
+      const { commitUncommittedChangesOnCriticalError } = await import('./critical-error-commit.lib.mjs');
+      await commitUncommittedChangesOnCriticalError({
+        tempDir: cleanupContext.tempDir,
+        branchName: cleanupContext.branchName,
+        $,
+        log,
+        reason: `${errorType || 'execution'} error`,
+      });
+    }
+  } catch (preserveError) {
+    await log(`  ⚠️  Could not auto-commit changes before failure exit: ${preserveError.message}`, { verbose: true });
+  }
 
   // Offer to create GitHub issue for the error
   try {
@@ -117,7 +138,7 @@ export const handleFailure = async options => {
  * Creates an uncaught exception handler
  */
 export const createUncaughtExceptionHandler = options => {
-  const { log, cleanErrorMessage, absoluteLogPath, shouldAttachLogs, argv, global, owner, repo, getLogFile, attachLogToGitHub, sanitizeLogContent, $ } = options;
+  const { log, cleanErrorMessage, absoluteLogPath, shouldAttachLogs, argv, global, owner, repo, getLogFile, attachLogToGitHub, sanitizeLogContent, cleanupContext, $ } = options;
 
   return async error => {
     await log(`\n❌ Uncaught Exception: ${cleanErrorMessage(error)}`, { level: 'error' });
@@ -136,6 +157,7 @@ export const createUncaughtExceptionHandler = options => {
       attachLogToGitHub,
       cleanErrorMessage,
       sanitizeLogContent,
+      cleanupContext,
       $,
     });
 
@@ -147,7 +169,7 @@ export const createUncaughtExceptionHandler = options => {
  * Creates an unhandled rejection handler
  */
 export const createUnhandledRejectionHandler = options => {
-  const { log, cleanErrorMessage, absoluteLogPath, shouldAttachLogs, argv, global, owner, repo, getLogFile, attachLogToGitHub, sanitizeLogContent, $ } = options;
+  const { log, cleanErrorMessage, absoluteLogPath, shouldAttachLogs, argv, global, owner, repo, getLogFile, attachLogToGitHub, sanitizeLogContent, cleanupContext, $ } = options;
 
   return async reason => {
     await log(`\n❌ Unhandled Rejection: ${cleanErrorMessage(reason)}`, { level: 'error' });
@@ -166,6 +188,7 @@ export const createUnhandledRejectionHandler = options => {
       attachLogToGitHub,
       cleanErrorMessage,
       sanitizeLogContent,
+      cleanupContext,
       $,
     });
 
@@ -219,7 +242,7 @@ export const handleNoPrAvailableError = async ({ isContinueMode, tempDir, issueN
  * Handles execution errors in the main catch block
  */
 export const handleMainExecutionError = async options => {
-  const { error, log, cleanErrorMessage, absoluteLogPath, shouldAttachLogs, argv, global, owner, repo, getLogFile, attachLogToGitHub, sanitizeLogContent, $ } = options;
+  const { error, log, cleanErrorMessage, absoluteLogPath, shouldAttachLogs, argv, global, owner, repo, getLogFile, attachLogToGitHub, sanitizeLogContent, cleanupContext, $ } = options;
 
   // Special handling for authentication errors
   if (error.isAuthError) {
@@ -256,6 +279,7 @@ export const handleMainExecutionError = async options => {
     attachLogToGitHub,
     cleanErrorMessage,
     sanitizeLogContent,
+    cleanupContext,
     $,
   });
 

--- a/src/solve.mjs
+++ b/src/solve.mjs
@@ -21,7 +21,7 @@ const fs = (await use('fs')).promises;
 const crypto = (await use('crypto')).default;
 const memoryCheck = await import('./memory-check.mjs');
 const lib = await import('./lib.mjs');
-const { log, setLogFile, getLogFile, getAbsoluteLogPath, cleanErrorMessage, formatAligned, getVersionInfo, setupVerboseLogInterceptor, setupStdioLogInterceptor } = lib;
+const { log, setLogFile, getLogFile, getAbsoluteLogPath, cleanErrorMessage, formatAligned, formatToolExecutionFailure, getVersionInfo, setupVerboseLogInterceptor, setupStdioLogInterceptor } = lib;
 const githubLib = await import('./github.lib.mjs');
 const { sanitizeLogContent, attachLogToGitHub, getToolDisplayName } = githubLib;
 const validation = await import('./solve.validation.lib.mjs');
@@ -1072,6 +1072,10 @@ try {
     //   2. Autonomous claude   - one-shot claude --resume w/ --dangerously-skip-permissions -p (claude only)
     //   3. Solve resume        - re-enters solve.mjs with --resume, preserving tool/model/dir
     const toolForFailure = argv.tool || 'claude';
+    // Issue #1845: include the core error (e.g. "API Error: Output blocked by content filtering
+    // policy") instead of just "<TOOL> execution failed", so users immediately understand what
+    // went wrong both in the terminal and in the failure comment posted to GitHub.
+    const toolFailureMessage = formatToolExecutionFailure({ tool: toolForFailure, toolResult });
     if (sessionId) {
       await log('');
       await log('💡 To continue this session:');
@@ -1116,7 +1120,7 @@ try {
           // Include sessionId so the PR comment can present it
           sessionId,
           // If not a usage limit case, fall back to generic failure format
-          errorMessage: limitReached ? undefined : `${argv.tool.toUpperCase()} execution failed`,
+          errorMessage: limitReached ? undefined : toolFailureMessage,
           requestedModel: argv.originalModel || argv.model,
           tool: argv.tool || 'claude',
           // Issue #1454: Pass resultModelUsage for accurate multi-model display
@@ -1144,13 +1148,13 @@ try {
       const { criticalErrorRecovery } = await import('./config.lib.mjs');
       if (criticalErrorRecovery.autoCommitUncommittedChanges) {
         const { commitUncommittedChangesOnCriticalError } = await import('./critical-error-commit.lib.mjs');
-        await commitUncommittedChangesOnCriticalError({ tempDir, branchName, $, log, reason: `${argv.tool || 'claude'} execution failed` });
+        await commitUncommittedChangesOnCriticalError({ tempDir, branchName, $, log, reason: toolFailureMessage });
       }
     } catch (preserveError) {
       await log(`  ⚠️  Could not auto-commit before failure exit: ${preserveError.message}`, { verbose: true });
     }
 
-    await safeExit(1, `${argv.tool.toUpperCase()} execution failed`);
+    await safeExit(1, toolFailureMessage);
   }
 
   // Clean up .playwright-mcp/ to prevent browser artifacts from triggering auto-restart (Issue #1124)

--- a/src/solve.mjs
+++ b/src/solve.mjs
@@ -181,9 +181,8 @@ const { isIssueUrl, isPrUrl, normalizedUrl, owner, repo, number: urlNumber } = u
 issueUrl = normalizedUrl || issueUrl;
 global.owner = owner;
 global.repo = repo;
-// Issue #1752: failures before PR creation can happen during checks that run
-// before the normal issue-mode setup below. Record the source issue as soon as
-// the URL is validated so the pre-exit notifier can still comment on it.
+// Issue #1752: record the source issue as soon as the URL is validated so the pre-exit
+// notifier can still comment on it if a check fails before normal issue-mode setup below.
 if (isIssueUrl) {
   global.issueNumber = urlNumber;
 }
@@ -193,8 +192,7 @@ if (argv.autoLanguage) {
   const { applyAutoLanguageToArgv } = await import('./auto-language.lib.mjs');
   await applyAutoLanguageToArgv({ argv, githubLib, owner, repo, number: urlNumber, isIssueUrl, isPrUrl, log });
 }
-// Initialize i18n based on --language / --ui-language / --work-language
-// (or detected system locale). --auto-language may set only the work track.
+// Initialize i18n from --language / --ui-language / --work-language (or system locale).
 const { initI18n } = await import('./i18n.lib.mjs');
 await initI18n({
   language: argv.language,
@@ -209,6 +207,7 @@ const errorHandlerOptions = {
   shouldAttachLogs,
   argv,
   global,
+  cleanupContext, // #1845: mutated in place; lets exception handlers auto-commit uncommitted work
   owner: null, // Will be set later when parsed
   repo: null, // Will be set later when parsed
   getLogFile,
@@ -1464,6 +1463,7 @@ try {
   }
   await handleMainExecutionError({
     error,
+    cleanupContext, // #1845: enable auto-commit of uncommitted work before the failure exit
     log,
     cleanErrorMessage,
     absoluteLogPath,

--- a/src/solve.mjs
+++ b/src/solve.mjs
@@ -1072,9 +1072,7 @@ try {
     //   2. Autonomous claude   - one-shot claude --resume w/ --dangerously-skip-permissions -p (claude only)
     //   3. Solve resume        - re-enters solve.mjs with --resume, preserving tool/model/dir
     const toolForFailure = argv.tool || 'claude';
-    // Issue #1845: include the core error (e.g. "API Error: Output blocked by content filtering
-    // policy") instead of just "<TOOL> execution failed", so users immediately understand what
-    // went wrong both in the terminal and in the failure comment posted to GitHub.
+    // Issue #1845: surface the core error instead of just "<TOOL> execution failed" (terminal + comment).
     const toolFailureMessage = formatToolExecutionFailure({ tool: toolForFailure, toolResult });
     if (sessionId) {
       await log('');
@@ -1140,10 +1138,9 @@ try {
       }
     }
 
-    // Issue #1834 (PR #1835 feedback): "on all critical errors we auto commit uncommitted changes
-    // by default." A failed session is a critical error and exits here before the normal
-    // auto-commit chokepoint below, so preserve (commit + push) any work the agent left on disk
-    // first. On by default; disable via HIVE_MIND_AUTO_COMMIT_ON_CRITICAL_ERROR=false. Never throws.
+    // Issue #1834 (PR #1835 feedback): "on all critical errors we auto commit uncommitted changes by
+    // default." A failed session exits here before the normal auto-commit chokepoint below, so commit
+    // + push any work first. On by default; disable via HIVE_MIND_AUTO_COMMIT_ON_CRITICAL_ERROR=false.
     try {
       const { criticalErrorRecovery } = await import('./config.lib.mjs');
       if (criticalErrorRecovery.autoCommitUncommittedChanges) {

--- a/src/solve.restart-shared.lib.mjs
+++ b/src/solve.restart-shared.lib.mjs
@@ -29,7 +29,7 @@ const fs = (await use('fs')).promises;
 
 // Import shared library functions
 const lib = await import('./lib.mjs');
-const { log, formatAligned } = lib;
+const { log, formatAligned, extractToolErrorCore } = lib;
 
 // Import Sentry integration
 const sentryLib = await import('./sentry.lib.mjs');
@@ -507,11 +507,20 @@ export const buildUncommittedChangesFeedback = (changes, restartCount = 0, maxIt
  * @returns {boolean}
  */
 export const isApiError = toolResult => {
-  if (!toolResult || !toolResult.result) return false;
+  if (!toolResult) return false;
+
+  // Issue #1845: runners report failures via `errorInfo` (e.g. claude sets
+  // `errorInfo.message` but NOT `result`). Use the shared core-error extractor so an
+  // "API Error:" is classified correctly regardless of which field the runner populated —
+  // otherwise the MAX_API_ERROR_RETRIES guard never trips for claude and watch mode can
+  // retry a hard API error indefinitely. `extractToolErrorCore` still falls back to
+  // `result`, preserving the original behavior for runners that set it.
+  const errorText = extractToolErrorCore({ toolResult });
+  if (!errorText) return false;
 
   const errorPatterns = ['API Error:', 'not_found_error', 'authentication_error', 'invalid_request_error'];
 
-  return errorPatterns.some(pattern => toolResult.result.includes(pattern));
+  return errorPatterns.some(pattern => errorText.includes(pattern));
 };
 
 /**

--- a/src/solve.watch.lib.mjs
+++ b/src/solve.watch.lib.mjs
@@ -20,7 +20,7 @@ const { wrapDollarWithGhRetry } = await import('./github-rate-limit.lib.mjs');
 const $ = wrapDollarWithGhRetry(__rawDollar$);
 // Import shared library functions
 const lib = await import('./lib.mjs');
-const { log, cleanErrorMessage, formatAligned, formatToolExecutionFailure, getLogFile } = lib;
+const { log, cleanErrorMessage, formatAligned, formatToolExecutionFailure, extractToolErrorCore, getLogFile } = lib;
 
 // Import feedback detection functions
 const feedbackLib = await import('./solve.feedback.lib.mjs');
@@ -373,7 +373,9 @@ export const watchForFeedback = async params => {
             if (consecutiveApiErrors >= MAX_API_ERROR_RETRIES) {
               await log('');
               await log(formatAligned('❌', 'MAXIMUM API ERROR RETRIES REACHED', ''));
-              await log(formatAligned('', 'Error details:', toolResult.result || 'Unknown API error', 2));
+              // Issue #1845: surface the core error (e.g. "API Error: Output blocked by content
+              // filtering policy"); toolResult.result is often unset on failure, so prefer errorInfo.
+              await log(formatAligned('', 'Error details:', extractToolErrorCore({ toolResult }) || 'Unknown API error', 2));
               await log(formatAligned('', 'Consecutive failures:', `${consecutiveApiErrors}`, 2));
               await log(formatAligned('', 'Action:', 'Exiting watch mode to prevent infinite loop', 2));
               await log('');

--- a/src/solve.watch.lib.mjs
+++ b/src/solve.watch.lib.mjs
@@ -20,7 +20,7 @@ const { wrapDollarWithGhRetry } = await import('./github-rate-limit.lib.mjs');
 const $ = wrapDollarWithGhRetry(__rawDollar$);
 // Import shared library functions
 const lib = await import('./lib.mjs');
-const { log, cleanErrorMessage, formatAligned, getLogFile } = lib;
+const { log, cleanErrorMessage, formatAligned, formatToolExecutionFailure, getLogFile } = lib;
 
 // Import feedback detection functions
 const feedbackLib = await import('./solve.feedback.lib.mjs');
@@ -421,7 +421,7 @@ export const watchForFeedback = async params => {
                   sessionId: toolResult.sessionId || latestSessionId,
                   tempDir,
                   // Include error information in the log upload
-                  errorMessage: toolResult.errorInfo?.message || toolResult.result || `${argv.tool.toUpperCase()} execution failed`,
+                  errorMessage: formatToolExecutionFailure({ tool: argv.tool, toolResult }),
                   // Include pricing data if available from failed attempt
                   publicPricingEstimate: toolResult.publicPricingEstimate,
                   pricingInfo: toolResult.pricingInfo,

--- a/tests/format-tool-execution-failure-1845.test.mjs
+++ b/tests/format-tool-execution-failure-1845.test.mjs
@@ -1,0 +1,233 @@
+#!/usr/bin/env node
+/**
+ * Tool Execution Failure Message Unit Tests (Issue #1845)
+ *
+ * Verifies that the shared `formatToolExecutionFailure` helper surfaces the
+ * core error reported by the underlying tool runner, instead of only the
+ * generic "<TOOL> execution failed".
+ *
+ * Reproduces the bug from issue #1845: a Claude run that ended with
+ * "API Error: Output blocked by content filtering policy" previously showed
+ * only "CLAUDE execution failed". The desired output is:
+ *
+ *   "CLAUDE execution failed with API Error: Output blocked by content filtering policy"
+ *
+ * Run with: node tests/format-tool-execution-failure-1845.test.mjs
+ *
+ * @see https://github.com/link-assistant/hive-mind/issues/1845
+ */
+
+import assert from 'node:assert/strict';
+import { formatToolExecutionFailure } from '../src/lib.mjs';
+import { getCodexErrorEventSummary } from '../src/codex.lib.mjs';
+
+let testsPassed = 0;
+let testsFailed = 0;
+
+function test(name, fn) {
+  try {
+    fn();
+    console.log(`✅ ${name}`);
+    testsPassed++;
+  } catch (error) {
+    console.log(`❌ ${name}`);
+    console.log(`   Error: ${error.message}`);
+    testsFailed++;
+  }
+}
+
+console.log('\n📋 formatToolExecutionFailure Tests\n');
+
+// ---------------------------------------------------------------------------
+// Core requirement from the issue
+// ---------------------------------------------------------------------------
+
+test('appends the core error from errorInfo.message (the issue example)', () => {
+  const result = formatToolExecutionFailure({
+    tool: 'claude',
+    toolResult: {
+      success: false,
+      errorInfo: { message: 'API Error: Output blocked by content filtering policy' },
+    },
+  });
+  assert.equal(result, 'CLAUDE execution failed with API Error: Output blocked by content filtering policy');
+});
+
+test('uppercases the tool name', () => {
+  const result = formatToolExecutionFailure({
+    tool: 'gemini',
+    toolResult: { errorInfo: { message: 'boom' } },
+  });
+  assert.equal(result, 'GEMINI execution failed with boom');
+});
+
+test('defaults the tool name to claude when not provided', () => {
+  const result = formatToolExecutionFailure({
+    toolResult: { errorInfo: { message: 'boom' } },
+  });
+  assert.equal(result, 'CLAUDE execution failed with boom');
+});
+
+// ---------------------------------------------------------------------------
+// Fallback behaviour (no specific error available)
+// ---------------------------------------------------------------------------
+
+test('falls back to generic message when there is no errorInfo', () => {
+  const result = formatToolExecutionFailure({ tool: 'claude', toolResult: { success: false } });
+  assert.equal(result, 'CLAUDE execution failed');
+});
+
+test('falls back to generic message when toolResult is missing', () => {
+  const result = formatToolExecutionFailure({ tool: 'codex' });
+  assert.equal(result, 'CODEX execution failed');
+});
+
+test('falls back to generic message when called with no arguments', () => {
+  assert.equal(formatToolExecutionFailure(), 'CLAUDE execution failed');
+});
+
+test('does NOT use resultSummary as the error (would be misleading)', () => {
+  const result = formatToolExecutionFailure({
+    tool: 'claude',
+    toolResult: { success: false, resultSummary: 'Implemented the feature and committed it.' },
+  });
+  assert.equal(result, 'CLAUDE execution failed');
+});
+
+// ---------------------------------------------------------------------------
+// Alternate error fields
+// ---------------------------------------------------------------------------
+
+test('uses errorInfo.errorMatch when message is absent', () => {
+  const result = formatToolExecutionFailure({
+    tool: 'qwen',
+    toolResult: { errorInfo: { errorMatch: 'rate limited' } },
+  });
+  assert.equal(result, 'QWEN execution failed with rate limited');
+});
+
+test('supports errorInfo provided as a plain string', () => {
+  const result = formatToolExecutionFailure({
+    tool: 'opencode',
+    toolResult: { errorInfo: 'permission denied' },
+  });
+  assert.equal(result, 'OPENCODE execution failed with permission denied');
+});
+
+test('uses toolResult.result as a last resort', () => {
+  const result = formatToolExecutionFailure({
+    tool: 'claude',
+    toolResult: { result: 'something specific went wrong' },
+  });
+  assert.equal(result, 'CLAUDE execution failed with something specific went wrong');
+});
+
+// ---------------------------------------------------------------------------
+// Normalisation / edge cases
+// ---------------------------------------------------------------------------
+
+test('collapses multiline / whitespace-heavy errors into a single line', () => {
+  const result = formatToolExecutionFailure({
+    tool: 'claude',
+    toolResult: { errorInfo: { message: 'API Error:\n   Output blocked\tby   policy\n' } },
+  });
+  assert.equal(result, 'CLAUDE execution failed with API Error: Output blocked by policy');
+});
+
+test('does not duplicate the base phrase when the core already says "execution failed"', () => {
+  const result = formatToolExecutionFailure({
+    tool: 'claude',
+    toolResult: { errorInfo: { message: 'CLAUDE execution failed with exit code 1' } },
+  });
+  assert.equal(result, 'CLAUDE execution failed');
+});
+
+test('truncates very long core errors with an ellipsis', () => {
+  const long = 'x'.repeat(500);
+  const result = formatToolExecutionFailure({
+    tool: 'claude',
+    toolResult: { errorInfo: { message: long } },
+    maxLength: 50,
+  });
+  assert.ok(result.startsWith('CLAUDE execution failed with '), `Unexpected prefix: ${result}`);
+  assert.ok(result.endsWith('…'), `Expected ellipsis suffix but got: ${result}`);
+  // base + " with " + 50-char core (49 chars + ellipsis)
+  assert.ok(result.length <= 'CLAUDE execution failed with '.length + 50, `Too long: ${result.length}`);
+});
+
+test('falls back to generic message when errorInfo.message is empty/whitespace', () => {
+  const result = formatToolExecutionFailure({
+    tool: 'claude',
+    toolResult: { errorInfo: { message: '   \n\t ' } },
+  });
+  assert.equal(result, 'CLAUDE execution failed');
+});
+
+test('ignores non-string error values', () => {
+  const result = formatToolExecutionFailure({
+    tool: 'claude',
+    toolResult: { errorInfo: { message: 12345 } },
+  });
+  assert.equal(result, 'CLAUDE execution failed');
+});
+
+// ---------------------------------------------------------------------------
+// Cross-tool result shapes — each runner surfaces errorInfo with a usable
+// `.message`, so the same helper produces a self-explanatory failure for all
+// of them (issue #1845 asked for the fix to be applied across the codebase).
+// ---------------------------------------------------------------------------
+
+console.log('\n📋 Cross-tool result shape Tests\n');
+
+test('claude.lib failure shape -> includes the API error', () => {
+  // Shape returned by claude.lib.mjs main commandFailed return.
+  const toolResult = {
+    success: false,
+    sessionId: 'abc',
+    limitReached: false,
+    errorInfo: { message: 'API Error: Output blocked by content filtering policy', exitCode: 1 },
+  };
+  assert.equal(formatToolExecutionFailure({ tool: 'claude', toolResult }), 'CLAUDE execution failed with API Error: Output blocked by content filtering policy');
+});
+
+test('codex.lib failure shape (getCodexErrorEventSummary) -> includes the event message', () => {
+  // Shape returned by codex.lib.mjs commandFailed return.
+  const summary = getCodexErrorEventSummary({
+    itemErrors: [],
+    turnFailures: [{ message: 'context length exceeded' }],
+    streamErrors: [],
+  });
+  assert.equal(summary.message, 'context length exceeded');
+  assert.equal(formatToolExecutionFailure({ tool: 'codex', toolResult: { success: false, errorInfo: summary } }), 'CODEX execution failed with context length exceeded');
+});
+
+test('gemini.lib failure shape -> includes the error text', () => {
+  const toolResult = { success: false, errorInfo: { message: 'Gemini command failed with exit code 1', exitCode: 1 } };
+  assert.equal(formatToolExecutionFailure({ tool: 'gemini', toolResult }), 'GEMINI execution failed with Gemini command failed with exit code 1');
+});
+
+test('opencode.lib failure shape -> includes the captured error', () => {
+  const toolResult = { success: false, errorInfo: { message: 'permission prompt was not accepted' } };
+  assert.equal(formatToolExecutionFailure({ tool: 'opencode', toolResult }), 'OPENCODE execution failed with permission prompt was not accepted');
+});
+
+test('qwen.lib failure shape -> includes the combined error text', () => {
+  const toolResult = { success: false, errorInfo: { message: 'authentication failed', exitCode: 1 } };
+  assert.equal(formatToolExecutionFailure({ tool: 'qwen', toolResult }), 'QWEN execution failed with authentication failed');
+});
+
+test('agent.lib failure shape -> includes the agent error message', () => {
+  const toolResult = { success: false, errorInfo: { message: 'Agent reported error: rate limit', errorType: 'UsageLimit' } };
+  assert.equal(formatToolExecutionFailure({ tool: 'agent', toolResult }), 'AGENT execution failed with Agent reported error: rate limit');
+});
+
+// ============================================================================
+// Summary
+// ============================================================================
+
+console.log('\n' + '='.repeat(60));
+console.log(`\n📊 Results: ${testsPassed} passed, ${testsFailed} failed, ${testsPassed + testsFailed} total\n`);
+
+if (testsFailed > 0) {
+  process.exit(1);
+}

--- a/tests/format-tool-execution-failure-1845.test.mjs
+++ b/tests/format-tool-execution-failure-1845.test.mjs
@@ -18,7 +18,7 @@
  */
 
 import assert from 'node:assert/strict';
-import { formatToolExecutionFailure } from '../src/lib.mjs';
+import { formatToolExecutionFailure, extractToolErrorCore } from '../src/lib.mjs';
 import { getCodexErrorEventSummary } from '../src/codex.lib.mjs';
 
 let testsPassed = 0;
@@ -219,6 +219,46 @@ test('qwen.lib failure shape -> includes the combined error text', () => {
 test('agent.lib failure shape -> includes the agent error message', () => {
   const toolResult = { success: false, errorInfo: { message: 'Agent reported error: rate limit', errorType: 'UsageLimit' } };
   assert.equal(formatToolExecutionFailure({ tool: 'agent', toolResult }), 'AGENT execution failed with Agent reported error: rate limit');
+});
+
+// ---------------------------------------------------------------------------
+// extractToolErrorCore — the shared root-cause extractor reused by the terminal
+// "Error details:" lines (watch / auto-merge / review) so they show the same
+// core error as the GitHub comment, without the "<TOOL> execution failed with"
+// prefix (issue #1845: apply the fix across the codebase).
+// ---------------------------------------------------------------------------
+
+console.log('\n📋 extractToolErrorCore Tests\n');
+
+test('extractToolErrorCore returns just the core error from errorInfo.message', () => {
+  assert.equal(extractToolErrorCore({ toolResult: { errorInfo: { message: 'API Error: blocked' } } }), 'API Error: blocked');
+});
+
+test('extractToolErrorCore precedence: message > errorMatch > string > result', () => {
+  assert.equal(extractToolErrorCore({ toolResult: { errorInfo: { message: 'm', errorMatch: 'e' }, result: 'r' } }), 'm');
+  assert.equal(extractToolErrorCore({ toolResult: { errorInfo: { errorMatch: 'e' }, result: 'r' } }), 'e');
+  assert.equal(extractToolErrorCore({ toolResult: { errorInfo: 'str', result: 'r' } }), 'str');
+  assert.equal(extractToolErrorCore({ toolResult: { result: 'r' } }), 'r');
+});
+
+test('extractToolErrorCore collapses whitespace into a single line', () => {
+  assert.equal(extractToolErrorCore({ toolResult: { errorInfo: { message: 'API Error:\n  blocked\tby   policy\n' } } }), 'API Error: blocked by policy');
+});
+
+test('extractToolErrorCore returns null when no usable error is present', () => {
+  assert.equal(extractToolErrorCore({ toolResult: { success: false } }), null);
+  assert.equal(extractToolErrorCore({ toolResult: {} }), null);
+  assert.equal(extractToolErrorCore({}), null);
+  assert.equal(extractToolErrorCore(), null);
+});
+
+test('extractToolErrorCore returns null for empty/whitespace and non-string messages', () => {
+  assert.equal(extractToolErrorCore({ toolResult: { errorInfo: { message: '   \n\t ' } } }), null);
+  assert.equal(extractToolErrorCore({ toolResult: { errorInfo: { message: 12345 } } }), null);
+});
+
+test('extractToolErrorCore does NOT use resultSummary (success summary, not an error)', () => {
+  assert.equal(extractToolErrorCore({ toolResult: { resultSummary: 'Implemented the feature.' } }), null);
 });
 
 // ============================================================================

--- a/tests/test-auto-restart-usage-limit-1356.mjs
+++ b/tests/test-auto-restart-usage-limit-1356.mjs
@@ -128,6 +128,58 @@ test('generic failure is neither API error nor usage limit', () => {
   assert(isUsageLimitReached(toolResult) === false, 'Generic failure should not be usage limit');
 });
 
+// ===== Test: isApiError reads errorInfo, not just `result` (Issue #1845) =====
+// Claude (and gemini/opencode/qwen after #1845) report failures via `errorInfo`, NOT a
+// top-level `result` field. The previous isApiError keyed off `toolResult.result` only, so a
+// real Claude "API Error:" failure was misclassified as non-API — watch mode then reset its
+// consecutive-API-error counter and could retry the hard error indefinitely, defeating the
+// MAX_API_ERROR_RETRIES guard. These tests lock in the errorInfo-aware classification.
+console.log('\n📋 isApiError errorInfo-shape Tests (Issue #1845)\n');
+
+test('detects API error from claude errorInfo.message (no `result` field)', () => {
+  // Exact shape returned by claude.lib.mjs commandFailed return.
+  const toolResult = {
+    success: false,
+    sessionId: 'abc',
+    limitReached: false,
+    errorInfo: { message: 'API Error: Output blocked by content filtering policy', exitCode: 1 },
+  };
+  assert(isApiError(toolResult) === true, 'Claude errorInfo API error should be detected');
+  assert(isUsageLimitReached(toolResult) === false, 'Should not be misread as a usage limit');
+});
+
+test('detects not_found_error / authentication_error / invalid_request_error in errorInfo.message', () => {
+  for (const pattern of ['not_found_error', 'authentication_error', 'invalid_request_error']) {
+    const toolResult = { success: false, errorInfo: { message: `API Error: ${pattern}` } };
+    assert(isApiError(toolResult) === true, `Should detect ${pattern} from errorInfo`);
+  }
+});
+
+test('detects API error from errorInfo provided as a plain string', () => {
+  const toolResult = { success: false, errorInfo: 'API Error: overloaded_error' };
+  assert(isApiError(toolResult) === true, 'String errorInfo with API Error should be detected');
+});
+
+test('detects API error from errorInfo.errorMatch when message is absent', () => {
+  const toolResult = { success: false, errorInfo: { errorMatch: 'authentication_error' } };
+  assert(isApiError(toolResult) === true, 'errorMatch API error should be detected');
+});
+
+test('non-API errorInfo failure is NOT an API error', () => {
+  const toolResult = { success: false, errorInfo: { message: 'Claude command failed with exit code 1' } };
+  assert(isApiError(toolResult) === false, 'Generic errorInfo should not be an API error');
+});
+
+test('still detects API error from legacy top-level `result` field (back-compat)', () => {
+  const toolResult = { success: false, result: 'API Error: not_found_error' };
+  assert(isApiError(toolResult) === true, 'Legacy result-based detection must still work');
+});
+
+test('does NOT use resultSummary (success summary) to classify an API error', () => {
+  const toolResult = { success: false, resultSummary: 'Implemented the API Error handler and committed.' };
+  assert(isApiError(toolResult) === false, 'resultSummary must never drive API-error classification');
+});
+
 // ===== Test: Loop behavior simulation =====
 console.log('\n📋 Auto-restart Loop Behavior Simulation Tests\n');
 

--- a/tests/test-issue-1845-failure-auto-commit.mjs
+++ b/tests/test-issue-1845-failure-auto-commit.mjs
@@ -1,0 +1,148 @@
+#!/usr/bin/env node
+// Test file for issue #1845 (requirement R2): "On all failures we automatically commit
+// uncommitted changes by default."
+//
+// The tool-failure chokepoint in solve.mjs already auto-commits, but the EXCEPTION paths
+// (uncaught exception, unhandled rejection, and the top-level catch via
+// handleMainExecutionError) used to exit WITHOUT preserving the work the agent left on disk.
+// handleFailure() in solve.error-handlers.lib.mjs now performs the same guarded auto-commit
+// at the start, gated by criticalErrorRecovery.autoCommitUncommittedChanges and the presence
+// of cleanupContext.tempDir.
+//
+// These tests drive handleFailure() with a scriptable command-stream `$` double (no real git
+// or network) and assert the commit happens exactly when it should — and never throws.
+//
+// Run with: node tests/test-issue-1845-failure-auto-commit.mjs
+// @see https://github.com/link-assistant/hive-mind/issues/1845
+
+import assert from 'assert';
+
+const { handleFailure } = await import('../src/solve.error-handlers.lib.mjs');
+const { criticalErrorRecovery } = await import('../src/config.lib.mjs');
+
+console.log('Testing failure-path auto-commit (Issue #1845, R2)\n');
+
+let passed = 0;
+let failed = 0;
+
+const testAsync = async (name, fn) => {
+  try {
+    await fn();
+    console.log(`  ✅ ${name}`);
+    passed++;
+  } catch (error) {
+    console.log(`  ❌ ${name}`);
+    console.log(`     Error: ${error.message}`);
+    failed++;
+  }
+};
+
+const noopLog = async () => {};
+
+// Scriptable command-stream `$` double: records every command and returns a dirty/clean
+// `git status --porcelain` as configured. Mirrors the pattern used in the #1834 test.
+const makeFake$ = (statusOutput = '') => {
+  const calls = [];
+  const fake = () => async strings => {
+    const cmd = strings.join(' ');
+    calls.push(cmd);
+    if (cmd.includes('git status')) return { code: 0, stdout: statusOutput, stderr: '' };
+    return { code: 0, stdout: '', stderr: '' };
+  };
+  fake.calls = calls;
+  return fake;
+};
+
+// Base options that make handleFailure a no-op apart from the auto-commit step:
+//  - disableReportIssue → handleErrorWithIssueCreation returns early (no network)
+//  - shouldAttachLogs false → no log upload
+//  - global without createdPR / autoClosePullRequestOnFail → no PR close
+const baseOptions = (fake$, cleanupContext) => ({
+  error: new Error('boom: API Error: Output blocked by content filtering policy'),
+  errorType: 'execution',
+  shouldAttachLogs: false,
+  argv: { disableReportIssue: true, noIssueCreation: true },
+  global: {},
+  owner: null,
+  repo: null,
+  log: noopLog,
+  getLogFile: () => null,
+  attachLogToGitHub: async () => false,
+  cleanErrorMessage: e => (e && e.message) || String(e),
+  sanitizeLogContent: x => x,
+  cleanupContext,
+  $: fake$,
+});
+
+console.log('=== Config sanity ===');
+await testAsync('autoCommitUncommittedChanges defaults to true (preserve work on failures)', async () => {
+  assert.strictEqual(criticalErrorRecovery.autoCommitUncommittedChanges, true, 'Auto-commit must be ON by default');
+});
+
+console.log('\n=== handleFailure auto-commit behaviour ===');
+
+await testAsync('Commits and pushes uncommitted work when cleanupContext.tempDir is set and tree is dirty', async () => {
+  const fake$ = makeFake$(' M src/foo.mjs');
+  await handleFailure(baseOptions(fake$, { tempDir: '/tmp/none', branchName: 'issue-1845' }));
+  assert(
+    fake$.calls.some(c => c.includes('git status')),
+    'Should inspect the working tree'
+  );
+  assert(
+    fake$.calls.some(c => c.includes('git add')),
+    'Should stage the uncommitted changes'
+  );
+  assert(
+    fake$.calls.some(c => c.includes('git commit')),
+    'Should commit the preserved work'
+  );
+  assert(
+    fake$.calls.some(c => c.includes('git push')),
+    'Should push the preserved work to the branch'
+  );
+});
+
+await testAsync('Does NOT commit when the working tree is clean', async () => {
+  const fake$ = makeFake$('');
+  await handleFailure(baseOptions(fake$, { tempDir: '/tmp/none', branchName: 'issue-1845' }));
+  assert(
+    fake$.calls.some(c => c.includes('git status')),
+    'Should still inspect the working tree'
+  );
+  assert(!fake$.calls.some(c => c.includes('git commit')), 'Must not commit on a clean tree');
+});
+
+await testAsync('Skips the auto-commit entirely when cleanupContext is absent', async () => {
+  const fake$ = makeFake$(' M src/foo.mjs');
+  await handleFailure(baseOptions(fake$, undefined));
+  assert(!fake$.calls.some(c => c.includes('git status')), 'No cleanupContext → no git inspection at all');
+});
+
+await testAsync('Skips the auto-commit when cleanupContext has no tempDir (nothing checked out yet)', async () => {
+  const fake$ = makeFake$(' M src/foo.mjs');
+  await handleFailure(baseOptions(fake$, { tempDir: null, branchName: null }));
+  assert(!fake$.calls.some(c => c.includes('git status')), 'No tempDir → no git inspection');
+});
+
+await testAsync('Never throws even if git commands fail (auto-commit must not mask the original error)', async () => {
+  const throwing$ = () => async () => {
+    throw new Error('git exploded');
+  };
+  // Should resolve (not reject) — handleFailure must swallow auto-commit failures.
+  await handleFailure(baseOptions(throwing$, { tempDir: '/tmp/none', branchName: 'b' }));
+});
+
+// ============================================================
+// Summary
+// ============================================================
+console.log('\n' + '='.repeat(50));
+console.log(`Test Results: ${passed} passed, ${failed} failed`);
+console.log('='.repeat(50));
+
+if (failed > 0) {
+  console.log('\nSome tests failed!');
+  process.exit(1);
+} else {
+  console.log('\nAll tests passed!');
+  process.exit(0);
+}


### PR DESCRIPTION
## Summary

Fixes #1845. When an AI tool run failed, both the terminal and the posted GitHub `🚨 Solution Draft Failed` comment showed only the generic **`CLAUDE execution failed`**, even though the underlying tool had reported a specific cause (e.g. `API Error: Output blocked by content filtering policy`). The real message was captured inside the tool runner but **dropped at the failure-return boundary**, so no downstream consumer could display it.

Now the user sees the self-explanatory message everywhere a failure is shown:

```
CLAUDE execution failed with API Error: Output blocked by content filtering policy
```

## Root cause

In `src/claude.lib.mjs` the streamed `result` event correctly captured the error into `lastMessage`, but the `success: false` return objects did **not** carry it. `src/solve.mjs` then built the user-facing message from a hardcoded `${tool.toUpperCase()} execution failed` template and passed that same string to the GitHub failure comment. The same gap existed in `gemini`, `opencode`, and `qwen` runners (`codex`/`agent` already returned structured error info).

See the full reconstruction in [`docs/case-studies/issue-1845/README.md`](docs/case-studies/issue-1845/README.md), built from the actual failure log in [`docs/case-studies/issue-1845/raw-data/`](docs/case-studies/issue-1845/raw-data/).

## Changes

**Producers — every tool runner now surfaces `errorInfo: { message, exitCode? }`:**
- `src/claude.lib.mjs` — all 4 failure returns
- `src/gemini.lib.mjs` — command-failed + exception
- `src/opencode.lib.mjs` — permission-prompt, command-failed, exception
- `src/qwen.lib.mjs` — command-failed + exception
- `codex`/`agent` already returned structured error info (left as-is, compatible)

**Shared extractor + formatter (single source of truth) in `src/lib.mjs`:**
- `extractToolErrorCore({ toolResult })` — returns just the core error string (no prefix), or `null`. One precedence used everywhere: `errorInfo.message` → `errorInfo.errorMatch` → string `errorInfo` → `result`. Never falls back to the agent's success summary; collapses whitespace.
- `formatToolExecutionFailure({ tool, toolResult })` — reuses the extractor to build `"<TOOL> execution failed with <core>"`; caps at 300 chars and avoids duplicating the base phrase.

**Consumers — every failure display / exit / log site now shows the core error:**
- `src/solve.mjs` — terminal exit, GitHub failure comment, and the critical-error auto-commit reason (via `formatToolExecutionFailure`)
- `src/solve.auto-merge.lib.mjs` — `RESUME FAILED` + `EXECUTION FAILED`: GitHub `errorMessage` via the formatter **and** a new terminal `Error details:` line via `extractToolErrorCore`
- `src/solve.watch.lib.mjs` — watch-mode failure GitHub message via the formatter; the `MAXIMUM API ERROR RETRIES REACHED` terminal `Error details:` line now uses `extractToolErrorCore` (it previously read `toolResult.result`, which is usually unset on Claude failures, so it printed "Unknown API error")
- `src/review.mjs` — the generic `Command execution failed` message now appends the core error when available
- `src/solve.restart-shared.lib.mjs` — **`isApiError()` now classifies via `extractToolErrorCore`** instead of reading `toolResult.result` directly. The same dropped-field root cause meant a Claude `API Error:` (reported through `errorInfo`, never `result`) was misclassified as **non-API**, so watch mode reset its consecutive-API-error counter and could retry a hard API error indefinitely — defeating the `MAX_API_ERROR_RETRIES` guard. Detection still falls back to `result` for back-compat.

## Auto-commit on all failures (issue requirement R2)

The existing critical-error auto-commit (#1834, `commitUncommittedChangesOnCriticalError`, default on via `HIVE_MIND_AUTO_COMMIT_ON_CRITICAL_ERROR`) already runs on the graceful tool-failure path **before** `safeExit(1)`, and is now labeled with the real failure cause.

**Gap closed:** three other exits bypassed that chokepoint and could leave the agent's work uncommitted — `uncaughtException`, `unhandledRejection`, and the top-level `catch` (`handleMainExecutionError`). All three funnel through `handleFailure()` in `src/solve.error-handlers.lib.mjs`, so this PR adds the same guarded auto-commit at the start of `handleFailure()` (before issue creation / log attach / PR close), gated by the same config flag and `cleanupContext.tempDir`. `solve.mjs` threads the in-place-mutated `cleanupContext` into the error handlers. Best-effort: a commit/push failure is swallowed so it can never mask the original error.

## Tests

- `tests/format-tool-execution-failure-1845.test.mjs` — **27 assertions**: the exact issue example, fallback behavior, whitespace/truncation handling, **cross-tool result-shape tests** for claude / codex / gemini / opencode / qwen / agent, and dedicated `extractToolErrorCore` precedence/null/no-`resultSummary` tests.
- `tests/test-issue-1845-failure-auto-commit.mjs` — **6 assertions** driving `handleFailure()` with a scriptable `$` command-stream double: commit+push on a dirty tree, no-commit on a clean tree, skip when `cleanupContext` is absent / has no `tempDir`, never-throws when git fails, and the config default being `true`.
- `tests/test-auto-restart-usage-limit-1356.mjs` — **+7 assertions** for the `isApiError()` fix: an `API Error:` reported via `errorInfo.message` (the Claude shape with no `result`), via `errorInfo` as a plain string, and via `errorInfo.errorMatch` are all detected; legacy `result`-based detection still works; a generic `errorInfo` failure is not an API error; and `resultSummary` never drives classification.

Local checks:
- ✅ `npm run format:check` (prettier, incl. markdown) passes
- ✅ `npm run lint` (eslint) passes
- ✅ `npm run check:duplication` (jscpd) passes
- ✅ `bash scripts/check-file-line-limits.sh` passes (`solve.mjs` stays at the 1500-line limit)

## How to reproduce the original bug

A Claude run that ends with a content-filtering response emits a `result` event with `is_error: true`, `subtype: success`, `result: "API Error: Output blocked by content filtering policy"`. Before this PR the failure comment showed only `CLAUDE execution failed`; after, it includes the core error — in the terminal, the GitHub comment, the watch/auto-merge `Error details:` lines, and the review-command failure message.
