### PR TITLE
Add cleanup process diagnostics for agent PIDs

### DIFF
--- a/.changeset/issue-1851-process-debug.md
+++ b/.changeset/issue-1851-process-debug.md
@@ -1,0 +1,5 @@
+---
+'@link-assistant/hive-mind': patch
+---
+
+Add cleanup process diagnostics for mapping agent PIDs to task sessions and stopping orphaned terminal-session agents.

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,1 +1,0 @@
-# .gitkeep file auto-generated at 2026-06-04T19:53:21.436Z for PR creation at branch issue-1851-e32e0e6d591c for issue https://github.com/link-assistant/hive-mind/issues/1851

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,0 +1,1 @@
+# .gitkeep file auto-generated at 2026-06-04T19:53:21.436Z for PR creation at branch issue-1851-e32e0e6d591c for issue https://github.com/link-assistant/hive-mind/issues/1851

--- a/README.hi.md
+++ b/README.hi.md
@@ -746,12 +746,25 @@ cleanup --force-start-command
 # Ubuntu / सिस्टम क्लीनअप (apt कैश, journald लॉग, npm कैश)
 cleanup --system --sudo
 
+# लाइव/अटके हुए agent PID को hive/start-command कार्य सत्रों से मिलाएँ
+cleanup --processes
+
+# किसी खास non-agent PID को ट्रेस करें, जैसे browser child या shell
+cleanup --pid 94445
+
+# रोके जा सकने वाले orphaned agents का पूर्वावलोकन करें
+cleanup --kill-orphaned-agents --dry-run
+
+# पूर्वावलोकन जाँचने के बाद orphaned agent process trees रोकें
+cleanup --kill-orphaned-agents --force
+
 # सक्रिय-कार्य पहचान अक्षम करें (केवल सुरक्षित पथ रखे जाते हैं)
 cleanup --no-keep-active-tasks-folders --dry-run
 ```
 
 विकल्पों की पूरी सूची के लिए `cleanup --help` चलाएँ। यह कमांड dry-run के अनुकूल है और
-हर रन के लिए टाइमस्टैम्प वाला `cleanup-*.log` लिखता है।
+हर रन के लिए टाइमस्टैम्प वाला `cleanup-*.log` लिखता है। प्रक्रिया डायग्नोस्टिक आउटपुट
+कमांड लाइन प्रिंट करने से पहले सामान्य token आकारों को छिपाता है।
 
 ## 🔍 निगरानी और लॉगिंग
 
@@ -802,7 +815,22 @@ find docs/ -name "*.md" -exec wc -l {} + | awk '$1 > 1000 {print "ERROR: " $2 " 
 
 ## सर्वर डायग्नोस्टिक्स
 
-उन स्क्रीन की पहचान करें जो संसाधन खपत करने वाली प्रक्रियाओं के पैरेंट हैं
+किसी व्यस्त `claude`, `codex`, `gemini`, `qwen`, या `opencode` PID को उसे शुरू करने
+वाले hive कार्य से जोड़ने के लिए पहले built-in process diagnostic command उपयोग करें:
+
+```bash
+# agent PID, start-command session ID, GitHub task URL, workspace, match reasons और संभावित orphaned agents दिखाएँ।
+cleanup --processes
+
+# उसी report में कोई भी PID शामिल करें।
+cleanup --pid 62220
+
+# केवल terminal task वाले orphaned agents रोकें।
+cleanup --kill-orphaned-agents --dry-run
+cleanup --kill-orphaned-agents --force
+```
+
+Manual fallback: उन स्क्रीन की पहचान करें जो संसाधन खपत करने वाली प्रक्रियाओं के पैरेंट हैं।
 
 ```bash
 TARGETS="62220 65988 63094 66606 1028071 4127023"

--- a/README.md
+++ b/README.md
@@ -767,12 +767,25 @@ cleanup --force-start-command
 # Ubuntu / system cleanup (apt caches, journald logs, npm cache)
 cleanup --system --sudo
 
+# Map live/stuck agent PIDs back to hive/start-command task sessions
+cleanup --processes
+
+# Trace a specific non-agent PID, for example a browser child or shell
+cleanup --pid 94445
+
+# Preview orphaned terminal-session agents that can be stopped
+cleanup --kill-orphaned-agents --dry-run
+
+# Stop orphaned agent process trees after reviewing the preview
+cleanup --kill-orphaned-agents --force
+
 # Disable active-task detection (only protected paths are kept)
 cleanup --no-keep-active-tasks-folders --dry-run
 ```
 
 Run `cleanup --help` for the full list of options. The command is dry-run
-friendly and writes a timestamped `cleanup-*.log` for every run.
+friendly and writes a timestamped `cleanup-*.log` for every run. Process
+diagnostic output redacts common token shapes before printing command lines.
 
 ## 🔍 Monitoring & Logging
 
@@ -823,7 +836,25 @@ find docs/ -name "*.md" -exec wc -l {} + | awk '$1 > 1000 {print "ERROR: " $2 " 
 
 ## Server diagnostics
 
-Identify screens that are parents of processes that eating the resources
+Prefer the built-in process diagnostic command when connecting a busy
+`claude`, `codex`, `gemini`, `qwen`, or `opencode` PID back to the hive task
+that launched it:
+
+```bash
+# Show agent PIDs, start-command session IDs, GitHub task URLs, workspaces,
+# match reasons, and possible orphaned terminal-session agents.
+cleanup --processes
+
+# Include an arbitrary PID in the same report.
+cleanup --pid 62220
+
+# Kill only agents whose matched start-command task is already terminal.
+cleanup --kill-orphaned-agents --dry-run
+cleanup --kill-orphaned-agents --force
+```
+
+Manual fallback: identify screens that are parents of processes that are eating
+the resources.
 
 ```bash
 TARGETS="62220 65988 63094 66606 1028071 4127023"

--- a/README.ru.md
+++ b/README.ru.md
@@ -749,12 +749,26 @@ cleanup --force-start-command
 # Очистка Ubuntu / системы (кэши apt, логи journald, кэш npm)
 cleanup --system --sudo
 
+# Сопоставить живые/зависшие agent PID с задачами hive/start-command
+cleanup --processes
+
+# Отследить конкретный не-agent PID, например дочерний процесс браузера или shell
+cleanup --pid 94445
+
+# Предпросмотр orphaned agents, которые можно остановить
+cleanup --kill-orphaned-agents --dry-run
+
+# Остановить деревья orphaned agent процессов после просмотра предпросмотра
+cleanup --kill-orphaned-agents --force
+
 # Отключить обнаружение активных задач (сохраняются только защищённые пути)
 cleanup --no-keep-active-tasks-folders --dry-run
 ```
 
 Запустите `cleanup --help`, чтобы увидеть полный список опций. Команда удобна для
 режима dry-run и записывает лог `cleanup-*.log` с меткой времени при каждом запуске.
+Диагностический вывод процессов скрывает распространённые формы token перед печатью
+командных строк.
 
 ## 🔍 Мониторинг и логирование
 
@@ -805,7 +819,24 @@ find docs/ -name "*.md" -exec wc -l {} + | awk '$1 > 1000 {print "ERROR: " $2 " 
 
 ## Диагностика сервера
 
-Определите screen-сессии, являющиеся родительскими для процессов, потребляющих ресурсы
+Чтобы связать загруженный `claude`, `codex`, `gemini`, `qwen` или `opencode` PID с
+запустившей его задачей hive, сначала используйте встроенную диагностику процессов:
+
+```bash
+# Показать agent PID, start-command session ID, GitHub task URL, workspace,
+# причины совпадения и возможные orphaned agents.
+cleanup --processes
+
+# Включить произвольный PID в тот же отчёт.
+cleanup --pid 62220
+
+# Остановить только orphaned agents, чья задача уже завершена.
+cleanup --kill-orphaned-agents --dry-run
+cleanup --kill-orphaned-agents --force
+```
+
+Ручной fallback: определите screen-сессии, являющиеся родительскими для процессов,
+потребляющих ресурсы.
 
 ```bash
 TARGETS="62220 65988 63094 66606 1028071 4127023"

--- a/README.zh.md
+++ b/README.zh.md
@@ -741,12 +741,25 @@ cleanup --force-start-command
 # Ubuntu / 系统清理（apt 缓存、journald 日志、npm 缓存）
 cleanup --system --sudo
 
+# 将实时/卡住的 agent PID 映射回 hive/start-command 任务会话
+cleanup --processes
+
+# 跟踪指定的非 agent PID，例如浏览器子进程或 shell
+cleanup --pid 94445
+
+# 预览可以停止的孤立 agent
+cleanup --kill-orphaned-agents --dry-run
+
+# 审查预览后停止孤立 agent 进程树
+cleanup --kill-orphaned-agents --force
+
 # 禁用活动任务检测（仅保留受保护的路径）
 cleanup --no-keep-active-tasks-folders --dry-run
 ```
 
 运行 `cleanup --help` 查看完整的选项列表。该命令对 dry-run 友好，并为每次运行写入
-带时间戳的 `cleanup-*.log` 日志。
+带时间戳的 `cleanup-*.log` 日志。进程诊断输出会在打印命令行前遮蔽常见 token
+格式。
 
 ## 🔍 监控与日志
 
@@ -797,7 +810,22 @@ find docs/ -name "*.md" -exec wc -l {} + | awk '$1 > 1000 {print "ERROR: " $2 " 
 
 ## 服务器诊断
 
-识别消耗资源的进程所属的 Screen 会话：
+将繁忙的 `claude`、`codex`、`gemini`、`qwen` 或 `opencode` PID 关联回启动它的
+hive 任务时，优先使用内置进程诊断命令：
+
+```bash
+# 显示 agent PID、start-command 会话 ID、GitHub 任务 URL、工作区、匹配原因和可能的孤立 agent。
+cleanup --processes
+
+# 在同一报告中包含任意 PID。
+cleanup --pid 62220
+
+# 只停止已完成任务中的孤立 agent。
+cleanup --kill-orphaned-agents --dry-run
+cleanup --kill-orphaned-agents --force
+```
+
+手动兜底：识别消耗资源的进程所属的 Screen 会话。
 
 ```bash
 TARGETS="62220 65988 63094 66606 1028071 4127023"

--- a/docs/case-studies/issue-1851/README.md
+++ b/docs/case-studies/issue-1851/README.md
@@ -1,0 +1,71 @@
+# Case Study - Issue #1851: Debug agent processes
+
+> **Issue:** [Add command to debug claude/codex and other processes](https://github.com/link-assistant/hive-mind/issues/1851)
+> **Branch:** `issue-1851-e32e0e6d591c` - **PR:** [#1852](https://github.com/link-assistant/hive-mind/pull/1852)
+
+This case study records the process-debugging failure mode from issue #1851.
+The raw issue body included command lines and credentials from a production-like
+server. Those values are intentionally not stored here; the data file in this
+folder contains only redacted, structural observations.
+
+## Problem
+
+Long-running servers can accumulate AI-agent processes that are no longer
+attached to a useful hive/start-command task. The operator symptom is usually a
+high-CPU `claude` or `codex` process where `top -c` shows a PID, but the
+maintainer still has to answer:
+
+- which hive task launched this PID,
+- which start-command session and log file own it,
+- which temporary workspace it is using,
+- whether the task is still live or has already reached a terminal state,
+- whether it is safe to stop the process tree without killing active work.
+
+The manual fallback used `/proc/<pid>`, `screen -ls`, `STY` environment values,
+working directories, and start-command logs. That worked, but it was slow and
+easy to get wrong when an agent had been reparented to PID 1.
+
+## Requirements
+
+| #   | Requirement                                                                      | Implementation                                                                                                                |
+| --- | -------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------- |
+| R1  | Add a command to map `claude`, `codex`, and related agent PIDs to hive tasks.    | `cleanup --processes`                                                                                                         |
+| R2  | Support arbitrary high-CPU PIDs, not only recognized agent names.                | `cleanup --pid <pid[,pid...]>`                                                                                                |
+| R3  | Link processes to start-command session IDs, logs, task URLs, and workspaces.    | `src/process-debug.lib.mjs` correlation plus `/proc`, screen, and log collection in `src/cleanup.os.lib.mjs`                  |
+| R4  | Detect orphaned agents for terminal sessions, including PID-1-reparented agents. | `correlateProcesses()` marks matched terminal-session agents as orphaned when no live session remains and the parent is PID 1 |
+| R5  | Make termination explicit and reviewable.                                        | `cleanup --kill-orphaned-agents` is a dry-run unless `--force` is also passed                                                 |
+| R6  | Avoid leaking credentials in diagnostics.                                        | `redactProcessText()` masks common token shapes before reports print command lines                                            |
+| R7  | Add a reproducible test for the observed bug.                                    | `tests/test-issue-1851-process-debug.mjs`                                                                                     |
+
+## Chosen approach
+
+The implementation keeps matching logic pure and testable:
+
+- `process-debug.lib.mjs` parses log metadata, redacts command text, correlates
+  supplied process/session records, and formats reports.
+- `cleanup.os.lib.mjs` performs Linux-specific collection from `/proc`, GNU
+  screen, start-command logs, and optional `$ --status` lookups.
+- `cleanup.mjs` exposes the operator commands and requires `--force` before
+  any orphaned process is signalled.
+
+This keeps normal disk cleanup behavior unchanged while giving operators a
+single command for the manual investigation previously documented in README.
+
+## Operator workflow
+
+```bash
+# Show linked agent processes and possible orphans.
+cleanup --processes
+
+# Trace one arbitrary PID from top/ps.
+cleanup --pid 94445
+
+# Preview terminal-session orphan cleanup.
+cleanup --kill-orphaned-agents --dry-run
+
+# Stop the orphaned agent process trees after reviewing the preview.
+cleanup --kill-orphaned-agents --force
+```
+
+See [`data/redacted-observations.md`](./data/redacted-observations.md) for the
+sanitized observations used to shape the test.

--- a/docs/case-studies/issue-1851/data/redacted-observations.md
+++ b/docs/case-studies/issue-1851/data/redacted-observations.md
@@ -1,0 +1,59 @@
+# Redacted observations for issue #1851
+
+The source issue contained real process tables, start-command task metadata,
+and command lines with credentials. This file preserves only the facts needed to
+understand the bug and verify the fix.
+
+## Observed process shape
+
+- A high-CPU AI-agent process was visible in `top -c`.
+- The agent command line referenced an issue-solving prompt and a temporary
+  worktree under `/tmp/gh-issue-solver-<timestamp>`.
+- At least one stuck agent had `PPID=1`, which indicates the original parent
+  exited and the agent was reparented.
+- The corresponding start-command task had already reached a terminal state.
+- The useful linkage signals were:
+  - process command name (`claude` or `codex`),
+  - `/proc/<pid>/cwd`,
+  - `/proc/<pid>/cmdline`,
+  - start-command log path under `/tmp/start-command/logs/isolation/screen/`,
+  - screen session name or `STY` when present,
+  - `$ --status <session-id>` status and process IDs when available.
+
+## Redacted representative records
+
+```text
+sessionId: 578ec383-9ef3-43af-b8f5-f0f91f9366bf
+taskUrl: https://github.com/link-assistant/hive-mind/issues/1851
+workspace: /tmp/gh-issue-solver-1780580701084
+status: executed
+processIds.wrapperPid: 88916
+
+pid: 94445
+ppid: 1
+commandName: claude
+cwd: /tmp/gh-issue-solver-1780580701084
+cmdline: claude --output-format stream-json --append-system-prompt "[REDACTED PROMPT]"
+expected: linked to the session above and marked orphaned
+```
+
+```text
+sessionId: 8accdfd7-d36c-446e-8637-8574f215eda0
+taskUrl: https://github.com/link-assistant/hive-mind/issues/1851
+workspace: /tmp/gh-issue-solver-1780602790979
+status: executing
+live: true
+
+pid: 6536
+commandName: codex
+cwd: /tmp/gh-issue-solver-1780602790979
+screenSessionName: 8accdfd7-d36c-446e-8637-8574f215eda0
+expected: linked to the session above and not marked orphaned
+```
+
+## Security note
+
+Committed diagnostics must never include raw bot tokens, GitHub tokens,
+Authorization headers, or full production prompt bodies. The reproducing test
+therefore asserts that formatted process reports redact representative token
+shapes before printing command lines.

--- a/src/cleanup.mjs
+++ b/src/cleanup.mjs
@@ -21,6 +21,8 @@
  *   --force-start-command         allow deleting /tmp/start-command
  *   --include-system              also consider system-owned temp entries
  *   --no-keep-dirty               allow deleting clones with unpushed changes
+ *   --processes                   map claude/codex/etc. PIDs to task sessions
+ *   --kill-orphaned-agents        signal orphaned terminal-session agents
  *   --apt --journal --docker --npm   Ubuntu/system cleanup (opt-in)
  *   --system                      shorthand for --apt --journal --npm
  *   --sudo                        prefix package-manager commands with sudo
@@ -34,12 +36,39 @@ import { promises as fsp } from 'node:fs';
 import { execSync } from 'node:child_process';
 
 import { classifyEntries, summarize, formatBytes, describeReason, buildActiveMatchers, DEFAULT_PROTECTED_NAMES } from './cleanup.lib.mjs';
-import { getTempRoot, listTempEntries, getPathSize, readFolderGitInfo, listProcessHeldPaths, getActiveTasks, removePath, runSystemCleanup } from './cleanup.os.lib.mjs';
+import { getTempRoot, listTempEntries, getPathSize, readFolderGitInfo, listProcessHeldPaths, getActiveTasks, removePath, runSystemCleanup, collectProcessDebugReport, signalOrphanedAgentTrees } from './cleanup.os.lib.mjs';
+import { formatProcessDebugReport } from './process-debug.lib.mjs';
 
 const args = process.argv.slice(2);
 
 function hasFlag(...names) {
   return names.some(n => args.includes(n));
+}
+
+function getFlagValue(name) {
+  const exact = args.indexOf(name);
+  if (exact >= 0 && args[exact + 1] && !args[exact + 1].startsWith('-')) return args[exact + 1];
+  const prefix = `${name}=`;
+  const withEquals = args.find(arg => arg.startsWith(prefix));
+  return withEquals ? withEquals.slice(prefix.length) : null;
+}
+
+function getFlagValues(name) {
+  const values = [];
+  const prefix = `${name}=`;
+  for (let i = 0; i < args.length; i++) {
+    const arg = args[i];
+    if (arg === name && args[i + 1] && !args[i + 1].startsWith('-')) values.push(args[i + 1]);
+    else if (arg.startsWith(prefix)) values.push(arg.slice(prefix.length));
+  }
+  return values;
+}
+
+function parsePidList(values) {
+  return values
+    .flatMap(value => String(value || '').split(','))
+    .map(value => Number(value.trim()))
+    .filter(value => Number.isInteger(value) && value > 0);
 }
 
 // ---------------------------------------------------------------------------
@@ -75,6 +104,16 @@ Options:
   --no-sessions               Do not query '$ --status' for active sessions
   --no-resolve-branches       Do not resolve PR head branches via gh
 
+Process diagnostics:
+  --processes, --debug-processes
+                              Map claude/codex/gemini/qwen/opencode PIDs to
+                              hive-mind task sessions and workspaces
+  --pid <pid[,pid...]>        Include specific non-agent PIDs in the report
+  --kill-orphaned-agents      Signal orphaned agent processes whose task
+                              session has already reached a terminal status
+                              (dry-run unless --force is also set)
+  --signal <name>             Signal for --kill-orphaned-agents [SIGTERM]
+
 System / Ubuntu cleanup (opt-in):
   --apt                       apt-get clean / autoclean / autoremove
   --journal                   journalctl --vacuum-time=2weeks
@@ -103,6 +142,10 @@ const options = {
   keepDirty: !hasFlag('--no-keep-dirty'),
   useSessions: !hasFlag('--no-sessions'),
   resolveBranches: !hasFlag('--no-resolve-branches'),
+  debugProcesses: hasFlag('--processes', '--debug-processes'),
+  killOrphanedAgents: hasFlag('--kill-orphaned-agents'),
+  targetPids: parsePidList(getFlagValues('--pid')),
+  signal: getFlagValue('--signal') || 'SIGTERM',
   verbose: hasFlag('--verbose', '-v'),
   apt: hasFlag('--apt', '--system'),
   journal: hasFlag('--journal', '--system'),
@@ -110,6 +153,7 @@ const options = {
   npm: hasFlag('--npm', '--system'),
   sudo: hasFlag('--sudo'),
 };
+if (options.targetPids.length > 0) options.debugProcesses = true;
 
 const timestamp = new Date().toISOString().replace(/[:.]/g, '-');
 const scriptDir = path.dirname(process.argv[1]);
@@ -155,6 +199,36 @@ async function main() {
   await log(`📂 Temp root: ${tempRoot}`);
   if (options.dryRun) await log('📝 DRY RUN — nothing will be deleted\n');
   else if (options.force) await log('⚠️  FORCE — deleting without confirmation\n');
+
+  if (options.debugProcesses || options.killOrphanedAgents) {
+    const report = await collectProcessDebugReport({ useSessions: options.useSessions, targetPids: options.targetPids });
+    await log('');
+    await log(formatProcessDebugReport(report));
+
+    if (options.killOrphanedAgents) {
+      if (report.orphans.length === 0) {
+        await log('\n✅ No orphaned terminal-session agent processes found.');
+      } else if (options.dryRun || !options.force) {
+        await log(`\n📝 Dry run: would send ${options.signal} to orphaned agent roots: ${report.orphans.map(item => item.pid).join(', ')}`);
+        await log('Re-run with --force to signal these process trees.');
+      } else {
+        await log(`\n🧯 Sending ${options.signal} to orphaned agent process trees...`);
+        const killed = signalOrphanedAgentTrees(report, { signal: options.signal, currentPid: process.pid });
+        let ok = 0;
+        let failed = 0;
+        for (const tree of killed) {
+          const pids = tree.results.map(result => `${result.pid}${result.ok ? '' : ' (failed)'}`).join(', ') || '(none)';
+          await log(`   root ${tree.rootPid}: ${pids}`);
+          ok += tree.results.filter(result => result.ok).length;
+          failed += tree.results.filter(result => !result.ok).length;
+        }
+        await log(`\n✅ Signalled ${ok} processes${failed ? `, ${failed} failed` : ''}.`);
+      }
+    }
+
+    await log(`\n📁 Log file: ${logFile}`);
+    return;
+  }
 
   // 1. Enumerate candidate entries.
   const entries = listTempEntries(tempRoot);

--- a/src/cleanup.os.lib.mjs
+++ b/src/cleanup.os.lib.mjs
@@ -20,6 +20,7 @@ import os from 'node:os';
 import { execFileSync } from 'node:child_process';
 
 import { extractTaskRefsFromCommand, parseRemoteUrl } from './cleanup.lib.mjs';
+import { correlateProcesses, parseStartCommandLogMetadata, redactProcessText } from './process-debug.lib.mjs';
 
 /** Run a command, returning trimmed stdout or null on any failure. */
 function tryExec(cmd, args, options = {}) {
@@ -189,6 +190,346 @@ export function listProcessHeldPaths(tempRoot) {
     }
   }
   return held;
+}
+
+function parseProcStat(raw) {
+  if (!raw) return null;
+  const open = raw.indexOf('(');
+  const close = raw.lastIndexOf(')');
+  if (open < 0 || close < open) return null;
+  const commandName = raw.slice(open + 1, close);
+  const fields = raw
+    .slice(close + 2)
+    .trim()
+    .split(/\s+/);
+  return {
+    commandName,
+    state: fields[0] || null,
+    ppid: Number(fields[1]) || 0,
+    pgid: Number(fields[2]) || null,
+    sid: Number(fields[3]) || null,
+  };
+}
+
+function readProcText(filePath) {
+  try {
+    return fs.readFileSync(filePath, 'utf8');
+  } catch {
+    return null;
+  }
+}
+
+function readProcLink(filePath) {
+  try {
+    return fs.readlinkSync(filePath);
+  } catch {
+    return null;
+  }
+}
+
+function readProcCmdline(pid, fallbackName) {
+  const raw = readProcText(`/proc/${pid}/cmdline`);
+  const cmdline = raw ? raw.replace(/\0/g, ' ').trim() : '';
+  return cmdline || fallbackName || '';
+}
+
+function readProcScreenSessionName(pid) {
+  const raw = readProcText(`/proc/${pid}/environ`);
+  if (!raw) return null;
+  const sty = raw
+    .split('\0')
+    .find(line => line.startsWith('STY='))
+    ?.slice(4)
+    ?.trim();
+  if (!sty) return null;
+  return sty.replace(/^\d+\./, '') || sty;
+}
+
+/**
+ * Snapshot Linux process records used by process diagnostics and orphan
+ * cleanup. Returns an empty list when procfs is unavailable.
+ *
+ * @returns {Array<{pid: number, ppid: number, pgid: number|null, sid: number|null, state: string|null, commandName: string|null, cmdline: string, cwd: string|null, exe: string|null, screenSessionName: string|null}>}
+ */
+export function listProcessRecords() {
+  let pids;
+  try {
+    pids = fs.readdirSync('/proc').filter(name => /^\d+$/.test(name));
+  } catch {
+    return [];
+  }
+
+  const records = [];
+  for (const pidText of pids) {
+    const pid = Number(pidText);
+    const stat = parseProcStat(readProcText(`/proc/${pid}/stat`));
+    if (!stat) continue;
+    records.push({
+      pid,
+      ppid: stat.ppid,
+      pgid: stat.pgid,
+      sid: stat.sid,
+      state: stat.state,
+      commandName: stat.commandName,
+      cmdline: readProcCmdline(pid, stat.commandName),
+      cwd: readProcLink(`/proc/${pid}/cwd`),
+      exe: readProcLink(`/proc/${pid}/exe`),
+      screenSessionName: readProcScreenSessionName(pid),
+    });
+  }
+  return records;
+}
+
+/**
+ * Discover GNU screen sessions and their backing screen PIDs.
+ *
+ * @returns {Array<{screenPid: number, sessionName: string, displayName: string, attached: boolean, live: boolean}>}
+ */
+export function listScreenSessions() {
+  const out = tryExec('screen', ['-ls']);
+  if (!out) return [];
+  const sessions = [];
+  for (const line of out.split('\n')) {
+    const match = line.match(/^\s*(\d+)\.([^\s]+)\s+\((Attached|Detached)\)/i);
+    if (!match) continue;
+    sessions.push({
+      screenPid: Number(match[1]),
+      sessionName: match[2],
+      displayName: `${match[1]}.${match[2]}`,
+      attached: match[3].toLowerCase() === 'attached',
+      live: true,
+    });
+  }
+  return sessions;
+}
+
+function listStartCommandLogFiles(logRoot, maxFiles) {
+  const files = [];
+  const stack = [logRoot];
+  while (stack.length > 0) {
+    const current = stack.pop();
+    let stat;
+    try {
+      stat = fs.statSync(current);
+    } catch {
+      continue;
+    }
+    if (stat.isDirectory()) {
+      let entries;
+      try {
+        entries = fs.readdirSync(current);
+      } catch {
+        continue;
+      }
+      for (const entry of entries) stack.push(path.join(current, entry));
+    } else if (stat.isFile() && current.endsWith('.log')) {
+      files.push({ path: current, mtimeMs: stat.mtimeMs });
+    }
+  }
+  return files
+    .sort((a, b) => b.mtimeMs - a.mtimeMs)
+    .slice(0, maxFiles)
+    .map(file => file.path);
+}
+
+function readFilePrefix(filePath, maxBytes) {
+  let fd;
+  try {
+    fd = fs.openSync(filePath, 'r');
+    const buffer = Buffer.alloc(maxBytes);
+    const bytesRead = fs.readSync(fd, buffer, 0, maxBytes, 0);
+    return buffer.subarray(0, bytesRead).toString('utf8');
+  } catch {
+    return '';
+  } finally {
+    if (fd !== undefined) {
+      try {
+        fs.closeSync(fd);
+      } catch {
+        /* ignore */
+      }
+    }
+  }
+}
+
+function mergeSession(map, session) {
+  if (!session) return;
+  const key = session.sessionId || session.uuid || session.sessionName || session.screenSessionName || session.logPath;
+  if (!key) return;
+  const existing = map.get(key) || {};
+  const mergedProcessIds = { ...(existing.processIds || {}), ...(session.processIds || {}) };
+  map.set(key, {
+    ...existing,
+    ...session,
+    processIds: mergedProcessIds,
+    sessionId: session.sessionId || existing.sessionId || session.uuid || existing.uuid || null,
+    uuid: session.uuid || existing.uuid || session.sessionId || existing.sessionId || null,
+    sessionName: session.sessionName || existing.sessionName || session.screenSessionName || existing.screenSessionName || null,
+    screenSessionName: session.screenSessionName || existing.screenSessionName || session.sessionName || existing.sessionName || null,
+    live: session.live === true || existing.live === true,
+    command: session.command || existing.command || null,
+    taskUrl: session.taskUrl || existing.taskUrl || null,
+    workspace: session.workspace || existing.workspace || session.workingDirectory || existing.workingDirectory || null,
+    logPath: session.logPath || existing.logPath || null,
+    tool: session.tool || existing.tool || null,
+    status: session.status || existing.status || null,
+  });
+}
+
+/**
+ * Collect start-command session/task metadata from logs, live screen sessions,
+ * and optional `$ --status` lookups.
+ *
+ * @param {Object} [options]
+ * @param {string} [options.logRoot='/tmp/start-command/logs']
+ * @param {number} [options.maxLogFiles=500]
+ * @param {number} [options.maxLogBytes=262144]
+ * @param {number} [options.maxStatusQueries=200]
+ * @param {boolean} [options.useSessions=true]
+ * @returns {Promise<Array>}
+ */
+export async function collectProcessDebugSessions(options = {}) {
+  const { logRoot = '/tmp/start-command/logs', maxLogFiles = 500, maxLogBytes = 256 * 1024, maxStatusQueries = 200, useSessions = true } = options;
+
+  const sessions = new Map();
+
+  for (const logPath of listStartCommandLogFiles(logRoot, maxLogFiles)) {
+    const metadata = parseStartCommandLogMetadata({
+      logPath,
+      text: readFilePrefix(logPath, maxLogBytes),
+    });
+    mergeSession(sessions, metadata);
+  }
+
+  for (const screenSession of listScreenSessions()) {
+    mergeSession(sessions, {
+      sessionId: screenSession.sessionName,
+      sessionName: screenSession.sessionName,
+      screenSessionName: screenSession.sessionName,
+      processIds: { screenPid: screenSession.screenPid },
+      live: true,
+    });
+  }
+
+  if (!useSessions || sessions.size === 0) return [...sessions.values()];
+
+  let querySessionStatus;
+  try {
+    ({ querySessionStatus } = await import('./isolation-runner.lib.mjs'));
+  } catch {
+    return [...sessions.values()];
+  }
+
+  const queryCandidates = [...sessions.values()].sort((a, b) => (b.live === true) - (a.live === true)).slice(0, maxStatusQueries);
+
+  for (const session of queryCandidates) {
+    const id = session.sessionId || session.uuid || session.sessionName;
+    if (!id) continue;
+    let status;
+    try {
+      status = await querySessionStatus(id);
+    } catch {
+      continue;
+    }
+    if (!status?.exists) continue;
+    mergeSession(sessions, {
+      sessionId: status.uuid || id,
+      uuid: status.uuid || id,
+      status: status.status || session.status || null,
+      command: status.command ? redactProcessText(status.command) : session.command || null,
+      taskUrl: status.command ? extractTaskRefsFromCommand(status.command).map(ref => `https://github.com/${ref.owner}/${ref.repo}/${ref.type === 'pull' ? 'pull' : 'issues'}/${ref.number}`)[0] : session.taskUrl || null,
+      workspace: status.workingDirectory || session.workspace || null,
+      workingDirectory: status.workingDirectory || null,
+      logPath: status.logPath || session.logPath || null,
+      sessionName: status.sessionName || session.sessionName || id,
+      screenSessionName: status.sessionName || session.screenSessionName || session.sessionName || id,
+      processIds: status.processIds || {},
+      live: session.live === true || status.status === 'executing' || status.status === 'running',
+    });
+  }
+
+  return [...sessions.values()];
+}
+
+/**
+ * Build a redacted process debug report from the real OS state.
+ *
+ * @param {Object} [options]
+ * @returns {Promise<{items: Array, orphans: Array, sessions: Array}>}
+ */
+export async function collectProcessDebugReport(options = {}) {
+  const processes = listProcessRecords();
+  const sessions = await collectProcessDebugSessions(options);
+  const report = correlateProcesses({ processes, sessions, currentPid: process.pid, targetPids: options.targetPids || [] });
+  return {
+    ...report,
+    processCount: processes.length,
+    sessionCount: sessions.length,
+  };
+}
+
+function buildChildrenMap(processes) {
+  const children = new Map();
+  for (const record of processes || []) {
+    if (!record?.pid || !record?.ppid) continue;
+    if (!children.has(record.ppid)) children.set(record.ppid, []);
+    children.get(record.ppid).push(record.pid);
+  }
+  return children;
+}
+
+function collectProcessTree(rootPid, children) {
+  const seen = new Set();
+  const ordered = [];
+  const visit = pid => {
+    if (!pid || seen.has(pid)) return;
+    seen.add(pid);
+    for (const child of children.get(pid) || []) visit(child);
+    ordered.push(pid);
+  };
+  visit(rootPid);
+  return ordered;
+}
+
+/**
+ * Send a signal to a process tree, children first.
+ *
+ * @param {number} rootPid
+ * @param {Array} processes
+ * @param {{signal?: string, currentPid?: number}} [options]
+ * @returns {Array<{pid: number, signal: string, ok: boolean, error?: string}>}
+ */
+export function signalProcessTree(rootPid, processes, options = {}) {
+  const signal = options.signal || 'SIGTERM';
+  const currentPid = options.currentPid || process.pid;
+  const children = buildChildrenMap(processes);
+  const targets = collectProcessTree(Number(rootPid), children).filter(pid => pid !== currentPid && pid > 1);
+  const results = [];
+
+  for (const pid of targets) {
+    try {
+      process.kill(pid, signal);
+      results.push({ pid, signal, ok: true });
+    } catch (error) {
+      results.push({ pid, signal, ok: false, error: error.message });
+    }
+  }
+  return results;
+}
+
+/**
+ * Signal every orphaned agent tree from a previously collected report.
+ *
+ * @param {{orphans?: Array}} report
+ * @param {Object} [options]
+ * @returns {Array<{rootPid: number, results: Array}>}
+ */
+export function signalOrphanedAgentTrees(report, options = {}) {
+  const processes = listProcessRecords();
+  return (report.orphans || []).map(orphan => ({
+    rootPid: orphan.pid,
+    results: signalProcessTree(orphan.pid, processes, options),
+  }));
 }
 
 /**

--- a/src/isolation-runner.lib.mjs
+++ b/src/isolation-runner.lib.mjs
@@ -25,6 +25,16 @@ const VALID_ISOLATION_BACKENDS = ['screen', 'tmux', 'docker'];
 const RUNNING_SESSION_STATUSES = new Set(['executing', 'running']);
 const TERMINAL_SESSION_STATUSES = new Set(['executed', 'completed', 'failed', 'cancelled', 'canceled', 'error']);
 
+function normalizeProcessIds(value) {
+  if (!value || typeof value !== 'object') return {};
+  const out = {};
+  for (const [key, raw] of Object.entries(value)) {
+    const number = Number(raw);
+    if (Number.isInteger(number) && number > 0) out[key] = number;
+  }
+  return out;
+}
+
 /**
  * Generate a UUID v4 for unique session identification
  * @returns {string} UUID v4 string
@@ -41,12 +51,12 @@ export function generateSessionId() {
  * Keep the parser tolerant so completion monitoring survives either format.
  *
  * @param {string} output - Raw stdout from `$ --status`
- * @returns {{exists: boolean, uuid: string|null, status: string|null, exitCode: number|null, startTime: string|null, endTime: string|null, currentTime: string|null, logPath: string|null, command: string|null, isolation: string|null, workingDirectory: string|null, raw: string}}
+ * @returns {{exists: boolean, uuid: string|null, status: string|null, exitCode: number|null, startTime: string|null, endTime: string|null, currentTime: string|null, logPath: string|null, command: string|null, isolation: string|null, workingDirectory: string|null, sessionName: string|null, processIds: Object, raw: string}}
  */
 export function parseSessionStatusOutput(output) {
   const raw = (output || '').trim();
   if (!raw) {
-    return { exists: false, uuid: null, status: null, exitCode: null, startTime: null, endTime: null, currentTime: null, logPath: null, command: null, isolation: null, workingDirectory: null, raw: '' };
+    return { exists: false, uuid: null, status: null, exitCode: null, startTime: null, endTime: null, currentTime: null, logPath: null, command: null, isolation: null, workingDirectory: null, sessionName: null, processIds: {}, raw: '' };
   }
 
   try {
@@ -58,6 +68,9 @@ export function parseSessionStatusOutput(output) {
     // field — keep accepting all three so we are tolerant of future renames.
     // See https://github.com/link-assistant/hive-mind/issues/1700.
     const isolationCandidate = (typeof data?.isolation === 'string' && data.isolation) || (typeof data?.options?.isolated === 'string' && data.options.isolated) || (typeof data?.options?.isolation === 'string' && data.options.isolation) || null;
+    const topPid = Number(data?.pid);
+    const processIds = normalizeProcessIds(data?.processIds);
+    if (Number.isInteger(topPid) && topPid > 0 && processIds.pid == null) processIds.pid = topPid;
     return {
       exists: true,
       uuid: data?.uuid || null,
@@ -70,6 +83,8 @@ export function parseSessionStatusOutput(output) {
       command: data?.command || null,
       isolation: isolationCandidate ? isolationCandidate.toLowerCase() : null,
       workingDirectory: data?.workingDirectory || null,
+      sessionName: data?.sessionName || data?.options?.sessionName || null,
+      processIds,
       raw,
     };
   } catch {
@@ -95,6 +110,12 @@ export function parseSessionStatusOutput(output) {
   // returned null for every real session and made /log + /terminal_watch
   // reject screen/tmux/docker sessions. See issue #1700.
   const isolationText = readField('isolated') || readField('isolation');
+  const processIds = {};
+  for (const name of ['pid', 'wrapperPid', 'childPid', 'processPid', 'commandPid']) {
+    const value = readField(name);
+    const number = Number(value);
+    if (Number.isInteger(number) && number > 0) processIds[name] = number;
+  }
 
   return {
     exists: Boolean(status || firstLine),
@@ -108,6 +129,8 @@ export function parseSessionStatusOutput(output) {
     command: readField('command'),
     isolation: isolationText?.toLowerCase() || null,
     workingDirectory: readField('workingDirectory'),
+    sessionName: readField('sessionName'),
+    processIds,
     raw,
   };
 }
@@ -234,7 +257,7 @@ export async function querySessionStatus(sessionId, verbose = false) {
     if (verbose) {
       console.log('[VERBOSE] isolation-runner: Cannot query status - $ binary not found');
     }
-    return { exists: false, uuid: null, status: null, exitCode: null, startTime: null, endTime: null, currentTime: null, logPath: null, command: null, isolation: null, workingDirectory: null, raw: '' };
+    return { exists: false, uuid: null, status: null, exitCode: null, startTime: null, endTime: null, currentTime: null, logPath: null, command: null, isolation: null, workingDirectory: null, sessionName: null, processIds: {}, raw: '' };
   }
 
   try {
@@ -251,7 +274,7 @@ export async function querySessionStatus(sessionId, verbose = false) {
     if (verbose) {
       console.log(`[VERBOSE] isolation-runner: Status query error: ${error.message}`);
     }
-    return { exists: false, uuid: null, status: null, exitCode: null, startTime: null, endTime: null, currentTime: null, logPath: null, command: null, isolation: null, workingDirectory: null, raw: '' };
+    return { exists: false, uuid: null, status: null, exitCode: null, startTime: null, endTime: null, currentTime: null, logPath: null, command: null, isolation: null, workingDirectory: null, sessionName: null, processIds: {}, raw: '' };
   }
 }
 

--- a/src/process-debug.lib.mjs
+++ b/src/process-debug.lib.mjs
@@ -1,0 +1,361 @@
+/**
+ * Pure process/session correlation helpers for cleanup process diagnostics
+ * (issue #1851).
+ *
+ * This module intentionally avoids /proc, screen, filesystem, and network
+ * access. The OS layer supplies process records and start-command session
+ * metadata; this file only parses, matches, redacts, and formats.
+ */
+
+import path from 'node:path';
+
+import { extractTaskRefsFromCommand } from './cleanup.lib.mjs';
+
+const AGENT_KINDS = ['claude', 'codex', 'gemini', 'qwen', 'opencode'];
+const RUNNING_STATUSES = new Set(['executing', 'running']);
+const TERMINAL_STATUSES = new Set(['executed', 'completed', 'failed', 'cancelled', 'canceled', 'error']);
+
+function taskUrlFromRef(ref) {
+  if (!ref) return null;
+  const kind = ref.type === 'pull' ? 'pull' : 'issues';
+  return `https://github.com/${ref.owner}/${ref.repo}/${kind}/${ref.number}`;
+}
+
+function firstTaskUrl(text) {
+  const refs = extractTaskRefsFromCommand(text || '');
+  return taskUrlFromRef(refs[0]);
+}
+
+function normalizeWhitespace(value) {
+  return String(value || '')
+    .replace(/\s+/g, ' ')
+    .trim();
+}
+
+function toPositiveInteger(value) {
+  const number = Number(value);
+  return Number.isInteger(number) && number > 0 ? number : null;
+}
+
+function normalizeProcessIds(value) {
+  const out = {};
+  if (!value || typeof value !== 'object') return out;
+  for (const [key, raw] of Object.entries(value)) {
+    const number = toPositiveInteger(raw);
+    if (number) out[key] = number;
+  }
+  return out;
+}
+
+function normalizePath(value) {
+  if (!value || typeof value !== 'string') return null;
+  return value.trim().replace(/\/+$/, '') || null;
+}
+
+function isPathInside(candidate, parent) {
+  const child = normalizePath(candidate);
+  const root = normalizePath(parent);
+  if (!child || !root) return false;
+  return child === root || child.startsWith(root + path.sep);
+}
+
+function containsToken(text, token) {
+  return Boolean(text && token && String(text).includes(String(token)));
+}
+
+function readFlagValue(command, flag) {
+  if (!command) return null;
+  const re = new RegExp(`(?:^|\\s)${flag}(?:=|\\s+)("([^"]+)"|'([^']+)'|\\S+)`, 'i');
+  const match = command.match(re);
+  return match ? (match[2] || match[3] || match[1] || '').replace(/^["']|["']$/g, '') : null;
+}
+
+function extractWorkspace(text) {
+  if (!text) return null;
+  const clean = value => {
+    const raw = String(value || '')
+      .trim()
+      .replace(/^["']|["']$/g, '');
+    const tmpMatch = raw.match(/\/tmp\/gh-issue-solver-[A-Za-z0-9._-]+/);
+    if (tmpMatch) return normalizePath(tmpMatch[0]);
+    return normalizePath(raw.split(/\\n|\s/)[0]);
+  };
+  const patterns = [/Your prepared working directory:\s*([^\r\n]+)/i, /Creating temporary directory:\s*([^\r\n]+)/i, /Cloning into ['"]([^'"]+)['"]/i, /\bworking directory:\s*([^\r\n]+)/i, /\bworkspace(?: directory)?:\s*([^\r\n]+)/i, /\((?:cd|pushd)\s+["']?([^"')\s]+)["']?\s+&&/i, /(\/tmp\/gh-issue-solver-[A-Za-z0-9._-]+)/];
+
+  for (const pattern of patterns) {
+    const match = text.match(pattern);
+    const value = match?.[1] ? clean(match[1]) : null;
+    if (value) return normalizePath(value);
+  }
+  return null;
+}
+
+function detectTool(command, text) {
+  const fromFlag = readFlagValue(command, '--tool');
+  if (fromFlag) return String(fromFlag).toLowerCase();
+  const haystack = `${command || ''}\n${text || ''}`.toLowerCase();
+  for (const kind of AGENT_KINDS) {
+    if (new RegExp(`\\b${kind}\\b`, 'i').test(haystack)) return kind;
+  }
+  return null;
+}
+
+export function detectAgentKind(processRecord) {
+  const commandName = String(processRecord?.commandName || '').toLowerCase();
+  const exeBase = path.basename(String(processRecord?.exe || '')).toLowerCase();
+  const cmdline = String(processRecord?.cmdline || '').toLowerCase();
+  const combined = `${commandName} ${exeBase} ${cmdline}`;
+
+  for (const kind of AGENT_KINDS) {
+    if (commandName === kind || exeBase === kind) return kind;
+    if (new RegExp(`(?:^|[\\s/.-])${kind}(?:$|[\\s/.-])`).test(combined)) return kind;
+  }
+  return null;
+}
+
+/**
+ * Synchronous redaction for process command lines and log snippets. Process
+ * debugging runs inside cleanup, so it cannot rely on async full-log
+ * sanitizers. Keep this conservative and token-shape based.
+ *
+ * @param {string} text
+ * @returns {string}
+ */
+export function redactProcessText(text) {
+  let out = String(text ?? '');
+  out = out.replace(/\b(\d{6,12}):([A-Za-z0-9_-]{20,})\b/g, '$1:[REDACTED]');
+  out = out.replace(/\bgithub_pat_[A-Za-z0-9_]{20,}\b/g, 'github_pat_[REDACTED]');
+  out = out.replace(/\bgh[pousr]_[A-Za-z0-9_]{20,}\b/g, match => `${match.slice(0, 4)}[REDACTED]`);
+  out = out.replace(/\bsk-ant-[A-Za-z0-9_-]{20,}\b/g, 'sk-ant-[REDACTED]');
+  out = out.replace(/\bsk-[A-Za-z0-9_-]{20,}\b/g, 'sk-[REDACTED]');
+  out = out.replace(/\bxox[baprs]-[A-Za-z0-9-]{20,}\b/g, match => `${match.slice(0, 5)}[REDACTED]`);
+  out = out.replace(/\bnpm_[A-Za-z0-9]{20,}\b/g, 'npm_[REDACTED]');
+  out = out.replace(/\bhf_[A-Za-z0-9]{20,}\b/g, 'hf_[REDACTED]');
+  out = out.replace(/(Authorization:\s*Bearer\s+)([A-Za-z0-9._~+/=-]{10,})/gi, '$1[REDACTED]');
+  out = out.replace(/((?:api[_-]?key|token|secret|password|bot[_-]?token)\s*[:=]\s*['"]?)([A-Za-z0-9._~+/:=-]{12,})(['"]?)/gi, '$1[REDACTED]$3');
+  return out;
+}
+
+/**
+ * Extract useful metadata from a start-command isolation log. The logs commonly
+ * contain the original command, the temporary worktree path, and the command
+ * that launches the selected agent.
+ *
+ * @param {{logPath?: string|null, text?: string|null, sessionId?: string|null}} input
+ * @returns {{sessionId: string|null, command: string|null, taskUrl: string|null, workspace: string|null, tool: string|null, logPath: string|null}}
+ */
+export function parseStartCommandLogMetadata(input = {}) {
+  const logPath = input.logPath || null;
+  const text = String(input.text || '');
+  const command = text.match(/^Command:\s*(.+)$/im)?.[1]?.trim() || null;
+  const sessionId = input.sessionId || (logPath ? path.basename(logPath).replace(/\.[^.]+$/, '') : null) || null;
+
+  const taskUrl = firstTaskUrl(command) || firstTaskUrl(text);
+  const workspace = extractWorkspace(text);
+  const tool = detectTool(command, text);
+
+  return {
+    sessionId,
+    command: command ? redactProcessText(command) : null,
+    taskUrl,
+    workspace,
+    tool,
+    logPath,
+  };
+}
+
+function normalizeSession(input) {
+  const command = input?.command ? String(input.command) : null;
+  const status = input?.status ? String(input.status).toLowerCase() : null;
+  const processIds = normalizeProcessIds(input?.processIds);
+  const sessionId = input?.sessionId || input?.uuid || input?.id || null;
+  const sessionName = input?.sessionName || input?.screenSessionName || sessionId || null;
+  const taskUrl = input?.taskUrl || firstTaskUrl(command);
+  const live = input?.live === true || RUNNING_STATUSES.has(status);
+
+  return {
+    ...input,
+    sessionId,
+    uuid: input?.uuid || sessionId,
+    sessionName,
+    screenSessionName: input?.screenSessionName || sessionName,
+    status,
+    command,
+    taskUrl,
+    workspace: normalizePath(input?.workspace || input?.workingDirectory || null),
+    tool: input?.tool ? String(input.tool).toLowerCase() : detectTool(command, command),
+    logPath: input?.logPath || null,
+    processIds,
+    live,
+  };
+}
+
+function normalizeProcess(input) {
+  return {
+    ...input,
+    pid: toPositiveInteger(input?.pid),
+    ppid: toPositiveInteger(input?.ppid),
+    pgid: toPositiveInteger(input?.pgid) || null,
+    sid: toPositiveInteger(input?.sid) || null,
+    state: input?.state || null,
+    commandName: input?.commandName || null,
+    cmdline: normalizeWhitespace(input?.cmdline || input?.command || ''),
+    cwd: normalizePath(input?.cwd || null),
+    exe: input?.exe || null,
+    screenSessionName: input?.screenSessionName || null,
+  };
+}
+
+function scoreSessionMatch(processRecord, session) {
+  const reasons = [];
+  const processIdValues = new Set(Object.values(session.processIds || {}).filter(Boolean));
+
+  if (processIdValues.has(processRecord.pid)) reasons.push('pid-session-process');
+  if (processIdValues.has(processRecord.ppid)) reasons.push('parent-session-process');
+  if (processIdValues.has(processRecord.pgid)) reasons.push('process-group-session-process');
+  if (processIdValues.has(processRecord.sid)) reasons.push('session-id-session-process');
+
+  if (processRecord.screenSessionName) {
+    const names = new Set([session.screenSessionName, session.sessionName, session.sessionId].filter(Boolean));
+    if (names.has(processRecord.screenSessionName)) reasons.push('screen-session');
+  }
+
+  if (session.workspace && processRecord.cwd && isPathInside(processRecord.cwd, session.workspace)) {
+    reasons.push('cwd-workspace');
+  }
+  if (session.workspace && containsToken(processRecord.cmdline, session.workspace)) {
+    reasons.push('cmd-workspace');
+  }
+  if (session.taskUrl && containsToken(processRecord.cmdline, session.taskUrl)) {
+    reasons.push('cmd-task-url');
+  }
+
+  const agentKind = detectAgentKind(processRecord);
+  if (agentKind && session.tool && agentKind === session.tool) reasons.push('agent-tool');
+  if (reasons.length === 1 && reasons[0] === 'agent-tool') {
+    return { score: 0, reasons: [] };
+  }
+
+  const weights = {
+    'pid-session-process': 100,
+    'parent-session-process': 90,
+    'process-group-session-process': 80,
+    'session-id-session-process': 80,
+    'screen-session': 75,
+    'cwd-workspace': 60,
+    'cmd-workspace': 50,
+    'cmd-task-url': 45,
+    'agent-tool': 10,
+  };
+  const score = reasons.reduce((sum, reason) => sum + (weights[reason] || 1), 0);
+  return { score, reasons };
+}
+
+function chooseSession(processRecord, sessions) {
+  let best = null;
+  for (const session of sessions) {
+    const match = scoreSessionMatch(processRecord, session);
+    if (match.score <= 0) continue;
+    if (!best || match.score > best.score) {
+      best = { session, score: match.score, reasons: match.reasons };
+    }
+  }
+  return best;
+}
+
+function isOrphanedAgent(processRecord, session, agentKind, currentPid) {
+  if (!agentKind || !session || processRecord.pid === currentPid) return false;
+  const status = String(session.status || '').toLowerCase();
+  const terminal = TERMINAL_STATUSES.has(status);
+  if (!terminal) return false;
+  if (session.live) return false;
+  return processRecord.ppid === 1 || processRecord.ppid == null;
+}
+
+/**
+ * Correlate process records with start-command session/task records.
+ *
+ * @param {{processes: Array, sessions: Array, currentPid?: number|null}} input
+ * @returns {{items: Array, orphans: Array, sessions: Array}}
+ */
+export function correlateProcesses(input = {}) {
+  const sessions = (input.sessions || []).map(normalizeSession).filter(session => session.sessionId || session.taskUrl || session.workspace);
+  const currentPid = toPositiveInteger(input.currentPid) || null;
+  const targetPids = new Set((input.targetPids || []).map(toPositiveInteger).filter(Boolean));
+  const items = [];
+
+  for (const rawProcess of input.processes || []) {
+    const processRecord = normalizeProcess(rawProcess);
+    if (!processRecord.pid) continue;
+
+    const agentKind = detectAgentKind(processRecord);
+    const match = chooseSession(processRecord, sessions);
+    const targeted = targetPids.has(processRecord.pid);
+    const strongMatch = match?.reasons?.some(reason => !['cwd-workspace', 'cmd-workspace', 'agent-tool'].includes(reason));
+    if (!agentKind && !targeted && !strongMatch) continue;
+
+    const session = match?.session || null;
+    const orphaned = isOrphanedAgent(processRecord, session, agentKind, currentPid);
+    items.push({
+      ...processRecord,
+      agentKind,
+      sessionId: session?.sessionId || null,
+      sessionName: session?.sessionName || null,
+      screenSessionName: processRecord.screenSessionName || session?.screenSessionName || null,
+      sessionStatus: session?.status || null,
+      sessionLive: session?.live === true,
+      taskUrl: session?.taskUrl || firstTaskUrl(processRecord.cmdline),
+      workspace: session?.workspace || processRecord.cwd || null,
+      logPath: session?.logPath || null,
+      matchReasons: match?.reasons || [],
+      orphaned,
+    });
+  }
+
+  items.sort((a, b) => {
+    if (a.orphaned !== b.orphaned) return a.orphaned ? -1 : 1;
+    return a.pid - b.pid;
+  });
+
+  return {
+    items,
+    orphans: items.filter(item => item.orphaned),
+    sessions,
+  };
+}
+
+function yesNo(value) {
+  return value ? 'yes' : 'no';
+}
+
+/**
+ * Render a console-safe diagnostic report. All command lines are redacted.
+ *
+ * @param {{items?: Array, orphans?: Array}} report
+ * @returns {string}
+ */
+export function formatProcessDebugReport(report = {}) {
+  const items = report.items || [];
+  const orphans = report.orphans || [];
+  const lines = ['Process debug report', '====================', `Matched processes: ${items.length}`, `Orphaned terminal-session agents: ${orphans.length}`];
+
+  if (items.length === 0) {
+    lines.push('', 'No claude/codex/gemini/qwen/opencode processes were linked to hive-mind tasks.');
+    return lines.join('\n');
+  }
+
+  for (const item of items) {
+    lines.push('');
+    lines.push(`PID ${item.pid} ppid=${item.ppid ?? '?'} state=${item.state || '?'} agent=${item.agentKind || 'unknown'} orphan=${yesNo(item.orphaned)}`);
+    if (item.sessionId || item.sessionStatus) {
+      lines.push(`  session: ${item.sessionId || '(unknown)'} status=${item.sessionStatus || '?'} live=${yesNo(item.sessionLive)}`);
+    }
+    if (item.taskUrl) lines.push(`  task: ${item.taskUrl}`);
+    if (item.workspace) lines.push(`  workspace: ${item.workspace}`);
+    if (item.logPath) lines.push(`  log: ${item.logPath}`);
+    if (item.matchReasons?.length) lines.push(`  match: ${item.matchReasons.join(', ')}`);
+    if (item.cmdline) lines.push(`  cmd: ${redactProcessText(item.cmdline)}`);
+  }
+
+  return lines.join('\n');
+}

--- a/tests/test-issue-1851-process-debug.mjs
+++ b/tests/test-issue-1851-process-debug.mjs
@@ -1,0 +1,232 @@
+#!/usr/bin/env node
+/**
+ * @hive-mind-test-suite default
+ *
+ * Issue #1851: process debugging must connect live/orphaned agent PIDs back to
+ * the hive/start-command task session that launched them.
+ */
+
+import assert from 'node:assert/strict';
+
+import { parseSessionStatusOutput } from '../src/isolation-runner.lib.mjs';
+import { correlateProcesses, formatProcessDebugReport, parseStartCommandLogMetadata, redactProcessText } from '../src/process-debug.lib.mjs';
+
+let passed = 0;
+let failed = 0;
+
+function test(name, fn) {
+  try {
+    fn();
+    console.log(`PASSED ${name}`);
+    passed++;
+  } catch (error) {
+    console.log(`FAILED ${name}: ${error.message}`);
+    failed++;
+  }
+}
+
+const issueUrl = 'https://github.com/link-assistant/hive-mind/issues/1851';
+const sessionId = '578ec383-9ef3-43af-b8f5-f0f91f9366bf';
+const workspace = '/tmp/gh-issue-solver-1780580701084';
+const logPath = `/tmp/start-command/logs/isolation/screen/${sessionId}.log`;
+
+test('parseSessionStatusOutput exposes processIds and sessionName from JSON', () => {
+  const parsed = parseSessionStatusOutput(
+    JSON.stringify({
+      uuid: sessionId,
+      pid: 88916,
+      processIds: {
+        wrapperPid: 88916,
+        childPid: 88918,
+      },
+      status: 'executed',
+      exitCode: 1,
+      command: `solve ${issueUrl} --tool claude`,
+      logPath,
+      options: {
+        isolated: 'screen',
+        sessionName: sessionId,
+      },
+    })
+  );
+
+  assert.equal(parsed.uuid, sessionId);
+  assert.equal(parsed.status, 'executed');
+  assert.equal(parsed.processIds.wrapperPid, 88916);
+  assert.equal(parsed.processIds.childPid, 88918);
+  assert.equal(parsed.sessionName, sessionId);
+});
+
+test('parseSessionStatusOutput exposes processIds from links-notation text', () => {
+  const parsed = parseSessionStatusOutput(`
+${sessionId}
+  uuid ${sessionId}
+  pid 88916
+  processIds
+      wrapperPid 88916
+      childPid 88918
+  status executed
+  command "solve ${issueUrl} --tool claude"
+  logPath ${logPath}
+  options
+    isolated screen
+    sessionName ${sessionId}
+`);
+
+  assert.equal(parsed.uuid, sessionId);
+  assert.equal(parsed.processIds.wrapperPid, 88916);
+  assert.equal(parsed.processIds.childPid, 88918);
+  assert.equal(parsed.sessionName, sessionId);
+});
+
+test('parseStartCommandLogMetadata extracts task URL, workspace and tool', () => {
+  const metadata = parseStartCommandLogMetadata({
+    logPath,
+    text: [`Command: solve ${issueUrl} --tool claude --attach-logs`, `Creating temporary directory: ${workspace}`, `Cloning into '${workspace}'...`, `(cd "${workspace}" && claude --output-format stream-json -p "Issue to solve: ${issueUrl}")`].join('\n'),
+  });
+
+  assert.equal(metadata.sessionId, sessionId);
+  assert.equal(metadata.taskUrl, issueUrl);
+  assert.equal(metadata.workspace, workspace);
+  assert.equal(metadata.tool, 'claude');
+});
+
+test('correlateProcesses maps orphaned claude PID to terminal task session', () => {
+  const sessions = [
+    {
+      sessionId,
+      status: 'executed',
+      command: `solve ${issueUrl} --tool claude`,
+      taskUrl: issueUrl,
+      workspace,
+      logPath,
+      processIds: { wrapperPid: 88916 },
+      live: false,
+    },
+  ];
+  const processes = [
+    {
+      pid: 94445,
+      ppid: 1,
+      pgid: 94445,
+      sid: 94445,
+      state: 'R',
+      commandName: 'claude',
+      cmdline: `claude --output-format stream-json --append-system-prompt "Issue to solve: ${issueUrl}"`,
+      cwd: workspace,
+      exe: '/home/box/.local/share/claude/versions/2.1.162',
+      screenSessionName: null,
+    },
+  ];
+
+  const report = correlateProcesses({ processes, sessions, currentPid: 1234 });
+  assert.equal(report.items.length, 1);
+  assert.equal(report.items[0].pid, 94445);
+  assert.equal(report.items[0].agentKind, 'claude');
+  assert.equal(report.items[0].sessionId, sessionId);
+  assert.equal(report.items[0].taskUrl, issueUrl);
+  assert.equal(report.items[0].orphaned, true);
+  assert.equal(report.orphans.length, 1);
+  assert.ok(report.items[0].matchReasons.includes('cwd-workspace'));
+});
+
+test('correlateProcesses does not mark executing screen-backed codex process as orphaned', () => {
+  const sessions = [
+    {
+      sessionId: '8accdfd7-d36c-446e-8637-8574f215eda0',
+      status: 'executing',
+      command: `solve ${issueUrl} --tool codex`,
+      taskUrl: issueUrl,
+      workspace: '/tmp/gh-issue-solver-1780602790979',
+      logPath: '/tmp/start-command/logs/isolation/screen/8accdfd7-d36c-446e-8637-8574f215eda0.log',
+      processIds: { wrapperPid: 1758 },
+      live: true,
+      screenSessionName: '8accdfd7-d36c-446e-8637-8574f215eda0',
+    },
+  ];
+  const processes = [
+    {
+      pid: 6536,
+      ppid: 6517,
+      pgid: 1759,
+      sid: 1759,
+      state: 'S',
+      commandName: 'codex',
+      cmdline: 'codex exec --model gpt-5.5',
+      cwd: '/tmp/gh-issue-solver-1780602790979',
+      exe: '/home/box/.bun/bin/codex',
+      screenSessionName: '8accdfd7-d36c-446e-8637-8574f215eda0',
+    },
+  ];
+
+  const report = correlateProcesses({ processes, sessions, currentPid: 1234 });
+  assert.equal(report.items.length, 1);
+  assert.equal(report.items[0].sessionId, '8accdfd7-d36c-446e-8637-8574f215eda0');
+  assert.equal(report.items[0].orphaned, false);
+  assert.equal(report.orphans.length, 0);
+});
+
+test('correlateProcesses includes targeted non-agent process without broad cwd noise', () => {
+  const sessions = [
+    {
+      sessionId,
+      status: 'executing',
+      taskUrl: issueUrl,
+      workspace,
+      logPath,
+      live: true,
+    },
+  ];
+  const processes = [
+    {
+      pid: 2222,
+      ppid: 100,
+      state: 'S',
+      commandName: 'chrome',
+      cmdline: 'chrome --headless',
+      cwd: workspace,
+    },
+  ];
+
+  assert.equal(correlateProcesses({ processes, sessions, currentPid: 1234 }).items.length, 0);
+
+  const report = correlateProcesses({ processes, sessions, currentPid: 1234, targetPids: [2222] });
+  assert.equal(report.items.length, 1);
+  assert.equal(report.items[0].pid, 2222);
+  assert.equal(report.items[0].agentKind, null);
+  assert.equal(report.items[0].sessionId, sessionId);
+  assert.ok(report.items[0].matchReasons.includes('cwd-workspace'));
+});
+
+test('diagnostic report redacts tokens from command lines', () => {
+  const telegramLikeToken = [['84905', '28355'].join(''), ':', ['AAEY', 'sflpqsH8', 'ocHWgFL2', 'U0GpFbWwFG9dJ1Y'].join('')].join('');
+  const githubLikeToken = ['ghp_', '1234567890abcdef', '1234567890abcdef', '12345678'].join('');
+  const raw = `node bot TELEGRAM_BOT_TOKEN: '${telegramLikeToken}' Authorization: Bearer ${githubLikeToken}`;
+  const sanitized = redactProcessText(raw);
+  assert.ok(!sanitized.includes(telegramLikeToken));
+  assert.ok(!sanitized.includes(githubLikeToken));
+
+  const report = formatProcessDebugReport({
+    items: [
+      {
+        pid: 1,
+        ppid: 0,
+        agentKind: 'node',
+        state: 'S',
+        sessionId,
+        sessionStatus: 'executed',
+        taskUrl: issueUrl,
+        orphaned: false,
+        matchReasons: ['cmd-task-url'],
+        cmdline: raw,
+      },
+    ],
+    orphans: [],
+  });
+  assert.ok(report.includes(issueUrl));
+  assert.ok(!report.includes(telegramLikeToken));
+  assert.ok(!report.includes(githubLikeToken));
+});
+
+console.log(`\nResults: ${passed} passed, ${failed} failed`);
+if (failed > 0) process.exit(1);


### PR DESCRIPTION
## Summary
- Adds `cleanup --processes` / `--debug-processes` to map claude/codex/gemini/qwen/opencode PIDs to start-command sessions, GitHub tasks, workspaces, logs, and match reasons.
- Adds `cleanup --pid` for arbitrary high-CPU PIDs and `cleanup --kill-orphaned-agents` with dry-run behavior unless `--force` is provided.
- Extends isolation status parsing with process IDs/session names, and adds docs, a changeset, and a redacted issue #1851 case study.

## Tests
- `node tests/test-issue-1851-process-debug.mjs`
- `node tests/test-cleanup-1848.mjs`
- `node tests/test-issue-1700-isolation-parsing.mjs`
- `node tests/test-docs-language-sync.mjs`
- `npm run lint`
- `node src/cleanup.mjs --processes --no-sessions --dry-run`
- `npm test` - all 228 selected test files passed

## Security
- Process diagnostics redact common token shapes before printing command lines.
- The case study stores only redacted structural observations, not raw issue command lines or credentials.


Fixes #1851