### PR TITLE
Fix hive-mind-dind docker exec user

### DIFF
--- a/.changeset/fixed-dind-exec-user.md
+++ b/.changeset/fixed-dind-exec-user.md
@@ -1,0 +1,5 @@
+---
+"@link-assistant/hive-mind": patch
+---
+
+Bump the Docker-in-Docker base image to `konard/box-dind:2.1.4` so `docker exec` sessions default to the `box` user with `/home/box` while dockerd still starts correctly.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -585,9 +585,7 @@ jobs:
             ${{ env.DIND_IMAGE_NAME }}:test \
             bash /verify-docker-image.sh
 
-          docker run --rm --privileged \
-            ${{ env.DIND_IMAGE_NAME }}:test \
-            bash -lc 'docker info && docker run hello-world'
+          bash scripts/verify-dind-exec-defaults.sh "${{ env.DIND_IMAGE_NAME }}:test"
 
           echo ""
           echo "All system, development, and nested Docker verification checks passed!"

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,1 +1,0 @@
-# .gitkeep file auto-generated at 2026-06-05T19:02:12.449Z for PR creation at branch issue-1850-dfad6eac805d for issue https://github.com/link-assistant/hive-mind/issues/1850

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,0 +1,1 @@
+# .gitkeep file auto-generated at 2026-06-05T19:02:12.449Z for PR creation at branch issue-1850-dfad6eac805d for issue https://github.com/link-assistant/hive-mind/issues/1850

--- a/Dockerfile.dind
+++ b/Dockerfile.dind
@@ -7,10 +7,10 @@
 #   docker run --rm --runtime=sysbox-runc konard/hive-mind-dind:latest docker ps
 #
 # Box image version: pinned to a specific release for stable, reproducible builds.
-# To upgrade: update the version tag below and in Dockerfile/coolify/Dockerfile.
+# To upgrade: update the dind version tag below.
 # Latest Box releases: https://github.com/link-foundation/box/releases
 
-FROM konard/box-dind:2.1.1
+FROM konard/box-dind:2.1.4
 ARG HIVE_MIND_VERSION=latest
 
 # --- Environment variables ---
@@ -118,11 +118,3 @@ RUN mkdir -p /home/box/.claude && \
     else \
       echo "configure-claude not present in @link-assistant/hive-mind@latest yet (likely a PR build before the bin is published); skipping baseline - solve re-applies it at runtime"; \
     fi
-
-# Keep the final image as root so /usr/local/bin/dind-entrypoint.sh can start
-# dockerd, then hand the requested command to the box user through Box's
-# standard entrypoint.
-USER root
-SHELL ["/bin/bash", "-c"]
-ENTRYPOINT ["/usr/local/bin/dind-entrypoint.sh"]
-CMD ["/bin/bash"]

--- a/scripts/verify-dind-exec-defaults.sh
+++ b/scripts/verify-dind-exec-defaults.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+image="${1:?Usage: verify-dind-exec-defaults.sh IMAGE}"
+container_name="hive-mind-dind-verify"
+
+echo ""
+echo "=== Verifying Docker-in-Docker exec defaults ==="
+docker rm -f "$container_name" >/dev/null 2>&1 || true
+docker run -d --privileged --name "$container_name" "$image" sleep infinity
+
+cleanup_dind_verify() {
+  docker rm -f "$container_name" >/dev/null 2>&1 || true
+}
+trap cleanup_dind_verify EXIT
+
+dind_ready=0
+for attempt in $(seq 1 60); do
+  if docker exec "$container_name" docker info >/dev/null 2>&1; then
+    dind_ready=1
+    break
+  fi
+  echo "Waiting for inner dockerd to become ready (attempt ${attempt}/60)..."
+  sleep 1
+done
+
+if [ "$dind_ready" != "1" ]; then
+  echo "ERROR: inner dockerd did not become ready"
+  docker logs "$container_name" || true
+  exit 1
+fi
+
+dind_exec_user=$(docker exec "$container_name" whoami)
+echo "docker exec user: ${dind_exec_user}"
+if [ "$dind_exec_user" != "box" ]; then
+  echo "ERROR: docker exec should default to box, got ${dind_exec_user}"
+  exit 1
+fi
+
+dind_exec_home=$(docker exec "$container_name" bash -lc 'echo $HOME')
+echo "docker exec HOME: ${dind_exec_home}"
+if [ "$dind_exec_home" != "/home/box" ]; then
+  echo "ERROR: docker exec HOME should be /home/box, got ${dind_exec_home}"
+  exit 1
+fi
+
+docker exec "$container_name" docker ps
+docker exec "$container_name" pgrep -x dockerd
+docker exec "$container_name" claude --version
+docker exec "$container_name" bun --version
+docker exec "$container_name" bash -lc 'docker info && docker run hello-world'

--- a/tests/test-docker-dind-variant.mjs
+++ b/tests/test-docker-dind-variant.mjs
@@ -20,6 +20,10 @@ const assertIncludes = (content, expected, filePath) => {
   assert.ok(content.includes(expected), `${filePath} should include ${expected}`);
 };
 
+const assertExcludes = (content, unexpected, filePath) => {
+  assert.ok(!content.includes(unexpected), `${filePath} should not include ${unexpected}`);
+};
+
 const assertFileExists = async filePath => {
   try {
     const stat = await fs.stat(path.join(repoRoot, filePath));
@@ -33,10 +37,12 @@ const assertFileExists = async filePath => {
 };
 
 await assertFileExists('Dockerfile.dind');
+await assertFileExists('scripts/verify-dind-exec-defaults.sh');
 
 const dindDockerfile = await read('Dockerfile.dind');
+const verifyDindExecDefaults = await read('scripts/verify-dind-exec-defaults.sh');
 
-assertIncludes(dindDockerfile, 'FROM konard/box-dind:2.1.1', 'Dockerfile.dind');
+assertIncludes(dindDockerfile, 'FROM konard/box-dind:2.1.4', 'Dockerfile.dind');
 assertIncludes(dindDockerfile, 'ARG HIVE_MIND_VERSION=latest', 'Dockerfile.dind');
 assertIncludes(dindDockerfile, 'ENV HIVE_MIND_IMAGE_VARIANT=dind', 'Dockerfile.dind');
 assertIncludes(dindDockerfile, 'ENV DIND_STORAGE_DRIVER="vfs"', 'Dockerfile.dind');
@@ -44,9 +50,8 @@ assertIncludes(dindDockerfile, 'bun install -g "@link-assistant/hive-mind@${HIVE
 assertIncludes(dindDockerfile, 'test "$(hive --version)" = "${HIVE_MIND_VERSION}"', 'Dockerfile.dind');
 assertIncludes(dindDockerfile, 'configure-claude --settings-path /home/box/.claude/settings.json', 'Dockerfile.dind');
 assertIncludes(dindDockerfile, 'configure-claude --settings-path /home/box/.claude/settings.json --verify', 'Dockerfile.dind');
-assertIncludes(dindDockerfile, 'USER root', 'Dockerfile.dind');
-assertIncludes(dindDockerfile, 'ENTRYPOINT ["/usr/local/bin/dind-entrypoint.sh"]', 'Dockerfile.dind');
-assertIncludes(dindDockerfile, 'CMD ["/bin/bash"]', 'Dockerfile.dind');
+assertExcludes(dindDockerfile, 'USER root', 'Dockerfile.dind');
+assertExcludes(dindDockerfile, 'Keep the final image as root', 'Dockerfile.dind');
 
 const detectCodeChanges = await read('scripts/detect-code-changes.mjs');
 assertIncludes(detectCodeChanges, 'Dockerfile.dind', 'scripts/detect-code-changes.mjs');
@@ -68,7 +73,14 @@ assertIncludes(dockerPrSection, 'docker build --progress=plain -f Dockerfile.din
 assertIncludes(dockerPrSection, 'build-dind-output.log', '.github/workflows/release.yml');
 assertIncludes(dockerPrSection, '${{ env.DIND_IMAGE_NAME }}:test', '.github/workflows/release.yml');
 assertIncludes(dockerPrSection, 'docker run --rm --privileged', '.github/workflows/release.yml');
-assertIncludes(dockerPrSection, 'docker run hello-world', '.github/workflows/release.yml');
+assertIncludes(dockerPrSection, 'bash scripts/verify-dind-exec-defaults.sh "${{ env.DIND_IMAGE_NAME }}:test"', '.github/workflows/release.yml');
+
+assertIncludes(verifyDindExecDefaults, 'container_name="hive-mind-dind-verify"', 'scripts/verify-dind-exec-defaults.sh');
+assertIncludes(verifyDindExecDefaults, 'docker exec "$container_name" whoami', 'scripts/verify-dind-exec-defaults.sh');
+assertIncludes(verifyDindExecDefaults, 'docker exec "$container_name" bash -lc \'echo $HOME\'', 'scripts/verify-dind-exec-defaults.sh');
+assertIncludes(verifyDindExecDefaults, 'docker exec "$container_name" docker ps', 'scripts/verify-dind-exec-defaults.sh');
+assertIncludes(verifyDindExecDefaults, 'docker exec "$container_name" pgrep -x dockerd', 'scripts/verify-dind-exec-defaults.sh');
+assertIncludes(verifyDindExecDefaults, 'docker run hello-world', 'scripts/verify-dind-exec-defaults.sh');
 
 assertIncludes(releaseYml, 'docker-publish-dind:\n    name: Docker Publish DinD', '.github/workflows/release.yml');
 assertIncludes(releaseYml, 'docker-publish-dind-merge:\n    name: Docker Publish DinD (Merge)', '.github/workflows/release.yml');


### PR DESCRIPTION
## Summary

Fixes #1850.

This updates the Docker-in-Docker image to inherit the fixed `konard/box-dind:2.1.4` base and removes the stale final `USER root`/entrypoint override from `Dockerfile.dind`. The resulting image keeps dockerd startup behavior from the base image while making `docker exec` sessions default to `box` with `HOME=/home/box`.

## Reproduction

Before this change, the dind image ended as `USER root`, so a running container reproduced the issue with:

```bash
docker run -d --privileged --name hive-mind konard/hive-mind-dind:latest sleep infinity
docker exec hive-mind whoami
```

Expected: `box`
Actual before fix: `root`

## Verification

Automated coverage added/updated:

- `tests/test-docker-dind-variant.mjs` now asserts `Dockerfile.dind` uses `konard/box-dind:2.1.4` and no longer contains the stale final root override.
- `scripts/verify-dind-exec-defaults.sh` is called by the Docker PR check after the dind image build. It starts a privileged dind container, waits for inner dockerd, and verifies:
  - `docker exec ... whoami` prints `box`
  - `docker exec ... bash -lc 'echo $HOME'` prints `/home/box`
  - `docker exec ... docker ps` works
  - `dockerd` is running
  - `claude --version`, `bun --version`, and `docker run hello-world` work inside the exec session

Local checks run:

```bash
node tests/test-docker-dind-variant.mjs
npm test
npm run format:check
npm run lint
npm run check:duplication
bash scripts/check-mjs-syntax.sh
bash scripts/check-file-line-limits.sh
node scripts/validate-changeset.mjs
bash -n scripts/verify-dind-exec-defaults.sh
git diff --check
```

Local Docker image verification was not run because this prepared environment does not have the `docker` CLI available (`docker: command not found`). The PR workflow now runs the Docker smoke test in CI.
