### PR TITLE
fix: split oversized Telegram bot messages

### DIFF
--- a/.changeset/telegram-safe-reply-length.md
+++ b/.changeset/telegram-safe-reply-length.md
@@ -1,0 +1,5 @@
+---
+"@link-assistant/hive-mind": patch
+---
+
+Split oversized Telegram text messages in the safe reply/edit helper so localized `/help` output cannot exceed Telegram's 4096-character limit.

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,0 +1,1 @@
+# .gitkeep file auto-generated at 2026-06-08T14:25:28.677Z for PR creation at branch issue-1866-1c7fa7d00b70 for issue https://github.com/link-assistant/hive-mind/issues/1866

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,1 +1,0 @@
-# .gitkeep file auto-generated at 2026-06-08T14:25:28.677Z for PR creation at branch issue-1866-1c7fa7d00b70 for issue https://github.com/link-assistant/hive-mind/issues/1866

--- a/src/telegram-bot.mjs
+++ b/src/telegram-bot.mjs
@@ -40,7 +40,7 @@ const { applySolveToolAlias, getFirstParsedPositionalArg, getSolveCommandNameFro
 const { executeStartScreen: executeStartScreenCommand, buildExecuteAndUpdateMessage } = await import('./telegram-command-execution.lib.mjs');
 const { isChatStopped, getChatStopInfo, getStoppedChatRejectMessage, DEFAULT_STOP_REASON } = await import('./telegram-start-stop-command.lib.mjs');
 const { isOldMessage: _isOldMessage, isGroupChat: _isGroupChat, isChatAuthorized: _isChatAuthorized, isForwardedOrReply: _isForwardedOrReply, extractCommandFromText, extractGitHubUrl: _extractGitHubUrl } = await import('./telegram-message-filters.lib.mjs');
-const { installTelegramFormattingFallback, safeEditMessageText, safeReply } = await import('./telegram-safe-reply.lib.mjs');
+const { installTelegramFormattingFallback, isTelegramFormattingError, isTelegramMessageTooLongError, safeEditMessageText, safeReply, TELEGRAM_TEXT_LIMIT } = await import('./telegram-safe-reply.lib.mjs');
 const { registerTerminalWatchCommand, startAutoTerminalWatchForSession } = await import('./telegram-terminal-watch-command.lib.mjs');
 const { launchBotWithRetry } = await import('./telegram-bot-launcher.lib.mjs');
 const { trackSession, startSessionMonitoring, hasActiveSessionForUrlAsync } = await import('./session-monitor.lib.mjs');
@@ -1214,15 +1214,17 @@ bot.catch((error, ctx) => {
 
   // Try to notify the user about the error with more details
   if (ctx?.reply) {
-    const isTelegramParsingError = error.message && (error.message.includes("can't parse entities") || error.message.includes("Can't parse entities") || error.message.includes("can't find end of") || (error.message.includes('Bad Request') && error.message.includes('400')));
+    const isTelegramParsingError = isTelegramFormattingError(error);
+    const isTelegramTextLimitError = isTelegramMessageTooLongError(error);
 
     let errorMessage;
 
-    if (isTelegramParsingError) {
+    if (isTelegramParsingError || isTelegramTextLimitError) {
       // Issue #1460: Log detailed context for root cause analysis (always logged, not just in verbose mode)
       const userInfo = ctx.from ? { id: ctx.from.id, username: ctx.from.username, first_name: ctx.from.first_name, last_name: ctx.from.last_name } : 'unknown';
-      console.error(`[telegram-bot] Parsing error: ${error.message}`);
-      console.error(`[telegram-bot] Parsing error context - user: ${JSON.stringify(userInfo)}, command: ${ctx.message?.text?.split(' ')[0] || 'unknown'}`);
+      const errorKind = isTelegramTextLimitError ? 'Message length error' : 'Parsing error';
+      console.error(`[telegram-bot] ${errorKind}: ${error.message}`);
+      console.error(`[telegram-bot] ${errorKind} context - user: ${JSON.stringify(userInfo)}, command: ${ctx.message?.text?.split(' ')[0] || 'unknown'}`);
       console.error(`[telegram-bot] User input text: ${ctx.message?.text || 'none'}`);
       if (ctx.message?.text) {
         const visibleInput = makeSpecialCharsVisible(ctx.message.text, { maxLength: 500 });
@@ -1233,8 +1235,11 @@ bot.catch((error, ctx) => {
         }
       }
 
-      // Issue #1460: Show user a simple, non-confusing message — all details are in the logs
-      errorMessage = `❌ Failed to send formatted message. Please try your command again.\n\nIf the issue persists, contact support with Update ID: ${ctx.update.update_id}`;
+      if (isTelegramTextLimitError) {
+        errorMessage = `❌ Telegram rejected an oversized bot message.\n\nThe bot splits messages above ${TELEGRAM_TEXT_LIMIT} characters automatically. Please try your command again.\n\nIf the issue persists, contact support with Update ID: ${ctx.update.update_id}`;
+      } else {
+        errorMessage = `❌ Telegram rejected a formatted bot message, and the fallback handler could not recover automatically.\n\nPlease try your command again.\n\nIf the issue persists, contact support with Update ID: ${ctx.update.update_id}`;
+      }
     } else {
       errorMessage = '❌ An error occurred while processing your request.\n\n';
       if (error.message) {
@@ -1251,20 +1256,13 @@ bot.catch((error, ctx) => {
       if (VERBOSE) errorMessage += `\n\n🔍 Debug info: Update ID: ${ctx.update.update_id}`;
     }
 
-    // Issue #1460: For parsing errors send plain text; otherwise try Markdown first
-    if (isTelegramParsingError) {
-      ctx.reply(errorMessage).catch(fallbackError => {
-        console.error('Failed to send plain text error message:', fallbackError);
+    safeReply(ctx, errorMessage, { fallbackLocale: resolveLocaleFromTelegramCtx(ctx), verbose: VERBOSE }).catch(replyError => {
+      console.error('Failed to send error message to user:', replyError);
+      const plainMessage = `An error occurred while processing your request. Please try again or contact support.\n\nError: ${error.message || 'Unknown error'}`;
+      ctx.reply(plainMessage).catch(fallbackError => {
+        console.error('Failed to send fallback error message:', fallbackError);
       });
-    } else {
-      ctx.reply(errorMessage, { parse_mode: 'Markdown' }).catch(replyError => {
-        console.error('Failed to send error message to user:', replyError);
-        const plainMessage = `An error occurred while processing your request. Please try again or contact support.\n\nError: ${error.message || 'Unknown error'}`;
-        ctx.reply(plainMessage).catch(fallbackError => {
-          console.error('Failed to send fallback error message:', fallbackError);
-        });
-      });
-    }
+    });
   }
 });
 

--- a/src/telegram-safe-reply.lib.mjs
+++ b/src/telegram-safe-reply.lib.mjs
@@ -2,6 +2,7 @@ import { normalizeLocale, t } from './i18n.lib.mjs';
 
 const FORMATTING_FALLBACK_INSTALLED = Symbol.for('hiveMind.telegramFormattingFallbackInstalled');
 const DEFAULT_FORMATTING_FALLBACK_WARNING = '⚠️ Formatting error detected. Showing plain text fallback.';
+export const TELEGRAM_TEXT_LIMIT = 4096;
 const FORMATTING_FALLBACK_WARNINGS = {
   en: DEFAULT_FORMATTING_FALLBACK_WARNING,
   ru: '⚠️ Обнаружена ошибка форматирования. Показываю обычный текст.',
@@ -18,9 +19,18 @@ function splitOptions(options = {}) {
   };
 }
 
+function getTelegramErrorMessage(error) {
+  return error?.description || error?.message || String(error || '');
+}
+
 export function isTelegramFormattingError(error) {
-  const message = error?.description || error?.message || String(error || '');
-  return /can't parse entities/i.test(message) || /can't find end of/i.test(message) || /entity.*parse/i.test(message) || (/bad request/i.test(message) && /400|parse|entity/i.test(message));
+  const message = getTelegramErrorMessage(error);
+  return /can't parse entities/i.test(message) || /can't find end of/i.test(message) || /entity.*parse/i.test(message) || /parse.*entity/i.test(message) || /character .* is reserved/i.test(message) || /unsupported start tag/i.test(message);
+}
+
+export function isTelegramMessageTooLongError(error) {
+  const message = getTelegramErrorMessage(error);
+  return /message is too long/i.test(message) || /message text is too long/i.test(message) || /text is too long/i.test(message) || /message_too_long/i.test(message) || (/bad request/i.test(message) && /too long/i.test(message) && /(message|text|caption)/i.test(message));
 }
 
 export function stripTelegramMarkdown(text) {
@@ -34,6 +44,45 @@ export function stripTelegramMarkdown(text) {
     .replace(/\*([^*\n]+)\*/g, '$1')
     .replace(/_([^_\n]+)_/g, '$1')
     .replace(/`([^`]+)`/g, '$1');
+}
+
+function findTelegramSplitIndex(text, limit) {
+  const minUsefulSplit = Math.floor(limit * 0.45);
+  const separators = ['\n\n', '\n', '. ', '; ', ', ', ' '];
+
+  for (const separator of separators) {
+    const searchEnd = Math.max(0, limit - separator.length);
+    const index = text.lastIndexOf(separator, searchEnd);
+    if (index >= minUsefulSplit) {
+      return index + separator.length;
+    }
+  }
+
+  return limit;
+}
+
+export function splitTelegramMessageText(text, limit = TELEGRAM_TEXT_LIMIT) {
+  const source = String(text ?? '');
+  if (source.length <= limit) return [source];
+
+  const chunks = [];
+  let remaining = source;
+
+  while (remaining.length > limit) {
+    let splitAt = findTelegramSplitIndex(remaining, limit);
+    let chunk = remaining.slice(0, splitAt).trimEnd();
+
+    if (!chunk) {
+      splitAt = limit;
+      chunk = remaining.slice(0, splitAt);
+    }
+
+    chunks.push(chunk);
+    remaining = remaining.slice(splitAt).trimStart();
+  }
+
+  if (remaining) chunks.push(remaining);
+  return chunks;
 }
 
 function getFormattingFallbackWarning(locale) {
@@ -50,7 +99,7 @@ export function buildTelegramFormattingFallbackText(text, options = {}) {
 }
 
 function logFormattingFailure(scope, error, text, verbose = false, fallbackText = null) {
-  const message = error?.description || error?.message || String(error || '');
+  const message = getTelegramErrorMessage(error);
   console.error(`[telegram-bot] ${scope}: formatted Telegram message failed: ${message}`);
   if (verbose) {
     const originalBytes = Buffer.byteLength(String(text ?? ''), 'utf-8');
@@ -76,54 +125,241 @@ function logFormattingFailure(scope, error, text, verbose = false, fallbackText 
   }
 }
 
+function logMessageTooLongFailure(scope, error, text, verbose = false, fallbackText = null) {
+  const message = getTelegramErrorMessage(error);
+  console.error(`[telegram-bot] ${scope}: Telegram message exceeded ${TELEGRAM_TEXT_LIMIT} character limit: ${message}`);
+  if (verbose) {
+    const original = String(text ?? '');
+    console.error(`[telegram-bot] ${scope}: Oversized message (${original.length} chars, ${Buffer.byteLength(original, 'utf-8')} bytes): ${original}`);
+    if (fallbackText !== null) {
+      const fallback = String(fallbackText ?? '');
+      console.error(`[telegram-bot] ${scope}: Plain text fallback (${fallback.length} chars, ${Buffer.byteLength(fallback, 'utf-8')} bytes): ${fallback}`);
+    }
+  }
+}
+
+function logChunking(scope, text, chunks, verbose = false) {
+  if (chunks.length <= 1) return;
+  const source = String(text ?? '');
+  console.warn(`[telegram-bot] ${scope}: Telegram text is ${source.length} chars (${Buffer.byteLength(source, 'utf-8')} bytes), splitting into ${chunks.length} messages (limit ${TELEGRAM_TEXT_LIMIT}).`);
+  if (verbose) {
+    chunks.forEach((chunk, index) => {
+      console.error(`[telegram-bot] ${scope}: Chunk ${index + 1}/${chunks.length} (${chunk.length} chars, ${Buffer.byteLength(chunk, 'utf-8')} bytes): ${chunk}`);
+    });
+  }
+}
+
+function getPlainTextOptions(telegramOptions) {
+  return { ...telegramOptions, parse_mode: undefined, entities: undefined };
+}
+
+async function sendPlainTextChunks({ text, telegramOptions, scope, verbose, sendChunk }) {
+  const plainOptions = getPlainTextOptions(telegramOptions);
+  const chunks = splitTelegramMessageText(text);
+  logChunking(`${scope}:plainText`, text, chunks, verbose);
+
+  let firstResult;
+  for (const chunk of chunks) {
+    const result = await sendChunk(chunk, plainOptions);
+    if (firstResult === undefined) firstResult = result;
+  }
+  return firstResult;
+}
+
+async function sendTelegramTextChunks({ text, telegramOptions, fallbackLocale, verbose, scope, sendChunk }) {
+  const chunks = splitTelegramMessageText(text);
+  logChunking(scope, text, chunks, verbose);
+
+  let firstResult;
+  for (const chunk of chunks) {
+    try {
+      const result = await sendChunk(chunk, telegramOptions);
+      if (firstResult === undefined) firstResult = result;
+    } catch (error) {
+      let fallbackText;
+      if (isTelegramFormattingError(error)) {
+        fallbackText = buildTelegramFormattingFallbackText(chunk, { fallbackLocale });
+        logFormattingFailure(scope, error, chunk, verbose, fallbackText);
+      } else if (isTelegramMessageTooLongError(error)) {
+        fallbackText = stripTelegramMarkdown(chunk);
+        logMessageTooLongFailure(scope, error, chunk, verbose, fallbackText);
+      } else {
+        throw error;
+      }
+
+      const result = await sendPlainTextChunks({
+        text: fallbackText,
+        telegramOptions,
+        scope,
+        verbose,
+        sendChunk,
+      });
+      if (firstResult === undefined) firstResult = result;
+    }
+  }
+
+  return firstResult;
+}
+
+async function sendRemainingEditChunks({ chunks, telegramOptions, fallbackLocale, verbose, scope, sendFollowUpChunk }) {
+  if (chunks.length === 0) return undefined;
+  if (!sendFollowUpChunk) {
+    console.error(`[telegram-bot] ${scope}: cannot send ${chunks.length} remaining chunk(s) after edit because chat_id is unavailable.`);
+    return undefined;
+  }
+
+  return await sendTelegramTextChunks({
+    text: chunks.join('\n'),
+    telegramOptions,
+    fallbackLocale,
+    verbose,
+    scope: `${scope}:followUp`,
+    sendChunk: sendFollowUpChunk,
+  });
+}
+
+async function sendPlainRemainingEditChunks({ chunks, telegramOptions, verbose, scope, sendFollowUpChunk }) {
+  if (chunks.length === 0) return undefined;
+  if (!sendFollowUpChunk) {
+    console.error(`[telegram-bot] ${scope}: cannot send ${chunks.length} plain-text fallback chunk(s) after edit because chat_id is unavailable.`);
+    return undefined;
+  }
+
+  return await sendPlainTextChunks({
+    text: chunks.join('\n'),
+    telegramOptions,
+    scope: `${scope}:followUp`,
+    verbose,
+    sendChunk: sendFollowUpChunk,
+  });
+}
+
+async function editTelegramTextChunks({ text, telegramOptions, fallbackLocale, verbose, scope, editChunk, sendFollowUpChunk }) {
+  const chunks = splitTelegramMessageText(text);
+  logChunking(scope, text, chunks, verbose);
+
+  const [firstChunk, ...remainingChunks] = chunks;
+  try {
+    const result = await editChunk(firstChunk, telegramOptions);
+    await sendRemainingEditChunks({
+      chunks: remainingChunks,
+      telegramOptions,
+      fallbackLocale,
+      verbose,
+      scope,
+      sendFollowUpChunk,
+    });
+    return result;
+  } catch (error) {
+    let fallbackText;
+    if (isTelegramFormattingError(error)) {
+      fallbackText = buildTelegramFormattingFallbackText(firstChunk, { fallbackLocale });
+      logFormattingFailure(scope, error, firstChunk, verbose, fallbackText);
+    } else if (isTelegramMessageTooLongError(error)) {
+      fallbackText = stripTelegramMarkdown(firstChunk);
+      logMessageTooLongFailure(scope, error, firstChunk, verbose, fallbackText);
+    } else {
+      throw error;
+    }
+
+    const plainOptions = getPlainTextOptions(telegramOptions);
+    const fallbackChunks = splitTelegramMessageText(fallbackText);
+    logChunking(`${scope}:plainText`, fallbackText, fallbackChunks, verbose);
+    const [firstFallbackChunk, ...remainingFallbackChunks] = fallbackChunks;
+    const result = await editChunk(firstFallbackChunk, plainOptions);
+    await sendPlainRemainingEditChunks({
+      chunks: [...remainingFallbackChunks, ...remainingChunks.map(stripTelegramMarkdown)],
+      telegramOptions,
+      verbose,
+      scope,
+      sendFollowUpChunk,
+    });
+    return result;
+  }
+}
+
 // Issue #1460/#1497/#1788: try Markdown first, fall back to localized plain text on parsing errors.
 export async function safeReply(ctx, text, options = {}) {
   const { telegramOptions, fallbackLocale, verbose } = splitOptions(options);
   const firstOptions = { parse_mode: 'Markdown', ...telegramOptions };
-  try {
-    return await ctx.reply(text, firstOptions);
-  } catch (error) {
-    if (!isTelegramFormattingError(error)) throw error;
-    const fallbackText = buildTelegramFormattingFallbackText(text, { fallbackLocale });
-    logFormattingFailure('safeReply', error, text, verbose, fallbackText);
-    return await ctx.reply(fallbackText, { ...telegramOptions, parse_mode: undefined });
-  }
+  return await sendTelegramTextChunks({
+    text,
+    telegramOptions: firstOptions,
+    fallbackLocale,
+    verbose,
+    scope: 'safeReply',
+    sendChunk: (chunk, chunkOptions) => ctx.reply(chunk, chunkOptions),
+  });
 }
 
 export async function safeEditMessageText(telegram, chatId, messageId, inlineMessageId, text, options = {}) {
   const { telegramOptions, fallbackLocale, verbose } = splitOptions(options);
   const firstOptions = { parse_mode: 'Markdown', ...telegramOptions };
-  try {
-    return await telegram.editMessageText(chatId, messageId, inlineMessageId, text, firstOptions);
-  } catch (error) {
-    if (!isTelegramFormattingError(error)) throw error;
-    const fallbackText = buildTelegramFormattingFallbackText(text, { fallbackLocale });
-    logFormattingFailure('safeEditMessageText', error, text, verbose, fallbackText);
-    return await telegram.editMessageText(chatId, messageId, inlineMessageId, fallbackText, { ...telegramOptions, parse_mode: undefined });
-  }
+  return await editTelegramTextChunks({
+    text,
+    telegramOptions: firstOptions,
+    fallbackLocale,
+    verbose,
+    scope: 'safeEditMessageText',
+    editChunk: (chunk, chunkOptions) => telegram.editMessageText(chatId, messageId, inlineMessageId, chunk, chunkOptions),
+    sendFollowUpChunk: chatId !== undefined && chatId !== null && typeof telegram.sendMessage === 'function' ? (chunk, chunkOptions) => telegram.sendMessage(chatId, chunk, chunkOptions) : null,
+  });
 }
 
-function wrapTelegramMethod(telegram, methodName, textIndex, optionsIndex, defaults = {}) {
-  const original = telegram?.[methodName];
+function wrapTelegramSendMessage(telegram, defaults = {}) {
+  const original = telegram?.sendMessage;
   if (typeof original !== 'function') return;
 
-  telegram[methodName] = async function wrappedTelegramMessageMethod(...args) {
-    const text = args[textIndex];
-    const originalOptions = args[optionsIndex] || {};
+  telegram.sendMessage = async function wrappedTelegramSendMessage(...args) {
+    const text = args[1];
+    const originalOptions = args[2] || {};
     const { telegramOptions, fallbackLocale, verbose } = splitOptions(originalOptions);
-    args[optionsIndex] = telegramOptions;
+    args[2] = telegramOptions;
 
-    try {
-      return await original.apply(this, args);
-    } catch (error) {
-      if (!isTelegramFormattingError(error) || typeof text !== 'string') throw error;
-      const fallbackText = buildTelegramFormattingFallbackText(text, { fallbackLocale: fallbackLocale || defaults.fallbackLocale });
-      logFormattingFailure(methodName, error, text, verbose || defaults.verbose, fallbackText);
-      const retryArgs = [...args];
-      retryArgs[textIndex] = fallbackText;
-      retryArgs[optionsIndex] = { ...telegramOptions, parse_mode: undefined };
-      return await original.apply(this, retryArgs);
-    }
+    if (typeof text !== 'string') return await original.apply(this, args);
+
+    return await sendTelegramTextChunks({
+      text,
+      telegramOptions,
+      fallbackLocale: fallbackLocale || defaults.fallbackLocale,
+      verbose: verbose || defaults.verbose,
+      scope: 'sendMessage',
+      sendChunk: (chunk, chunkOptions) => {
+        const chunkArgs = [...args];
+        chunkArgs[1] = chunk;
+        chunkArgs[2] = chunkOptions;
+        return original.apply(this, chunkArgs);
+      },
+    });
+  };
+}
+
+function wrapTelegramEditMessageText(telegram, defaults = {}) {
+  const original = telegram?.editMessageText;
+  if (typeof original !== 'function') return;
+
+  telegram.editMessageText = async function wrappedTelegramEditMessageText(...args) {
+    const text = args[3];
+    const originalOptions = args[4] || {};
+    const { telegramOptions, fallbackLocale, verbose } = splitOptions(originalOptions);
+    args[4] = telegramOptions;
+
+    if (typeof text !== 'string') return await original.apply(this, args);
+
+    return await editTelegramTextChunks({
+      text,
+      telegramOptions,
+      fallbackLocale: fallbackLocale || defaults.fallbackLocale,
+      verbose: verbose || defaults.verbose,
+      scope: 'editMessageText',
+      editChunk: (chunk, chunkOptions) => {
+        const chunkArgs = [...args];
+        chunkArgs[3] = chunk;
+        chunkArgs[4] = chunkOptions;
+        return original.apply(this, chunkArgs);
+      },
+      sendFollowUpChunk: args[0] !== undefined && args[0] !== null && typeof this.sendMessage === 'function' ? (chunk, chunkOptions) => this.sendMessage(args[0], chunk, chunkOptions) : null,
+    });
   };
 }
 
@@ -135,8 +371,8 @@ export function installTelegramFormattingFallback(telegram, options = {}) {
     verbose: Boolean(options.verbose),
   };
 
-  wrapTelegramMethod(telegram, 'sendMessage', 1, 2, defaults);
-  wrapTelegramMethod(telegram, 'editMessageText', 3, 4, defaults);
+  wrapTelegramSendMessage(telegram, defaults);
+  wrapTelegramEditMessageText(telegram, defaults);
   telegram[FORMATTING_FALLBACK_INSTALLED] = true;
   return telegram;
 }

--- a/tests/test-telegram-safe-reply-issue-1497.mjs
+++ b/tests/test-telegram-safe-reply-issue-1497.mjs
@@ -12,7 +12,13 @@
 
 import { escapeMarkdown, cleanNonPrintableChars, makeSpecialCharsVisible } from '../src/telegram-markdown.lib.mjs';
 import { buildUserMention } from '../src/buildUserMention.lib.mjs';
-import { installTelegramFormattingFallback, safeReply } from '../src/telegram-safe-reply.lib.mjs';
+import { buildModelOptionDescription } from '../src/models/index.mjs';
+import { initI18n, preloadAllLocales } from '../src/i18n.lib.mjs';
+import { buildTelegramHelpMessage } from '../src/telegram-ui-messages.lib.mjs';
+import { installTelegramFormattingFallback, isTelegramFormattingError, safeReply } from '../src/telegram-safe-reply.lib.mjs';
+
+await initI18n();
+await preloadAllLocales();
 
 let passed = 0;
 let failed = 0;
@@ -306,6 +312,58 @@ function stripMarkdown(text) {
   assertEqual(calls[1].options.parse_mode, undefined, 'Fallback removes parse mode');
   assert(calls[1].text.includes('Обнаружена ошибка форматирования'), 'Fallback warns in user locale');
   assert(calls[1].text.includes('Broken help message'), 'Fallback includes original message content as plain text');
+}
+
+// Test: message length errors are handled as Telegram length-limit errors, not formatting errors
+{
+  const error = new Error('400: Bad Request: message is too long');
+  assert(!isTelegramFormattingError(error), 'Telegram message length errors are not classified as formatting errors');
+}
+
+// Test: Russian /help exceeds Telegram's 4096-character sendMessage limit and is split safely
+{
+  const message = buildTelegramHelpMessage({
+    locale: 'ru',
+    chatId: -1002975819706,
+    chatType: 'supergroup',
+    chatTitle: 'Pull Request from Hive Mind',
+    topicId: 32470,
+    solveEnabled: true,
+    taskEnabled: true,
+    hiveEnabled: true,
+    solveOverrides: ['--attach-logs', '--verbose', '--no-tool-check', '--disable-report-issue'],
+    hiveOverrides: ['--all-issues', '--once', '--skip-issues-with-prs', '--attach-logs', '--verbose', '--no-tool-check', '--disable-report-issue'],
+    showLimitsEnabled: true,
+    isolationBackend: 'screen',
+    modelDescription: buildModelOptionDescription(),
+    restrictedMode: true,
+    authorized: true,
+  });
+  assert(message.length > 4096, 'Russian /help reproduces the Telegram message length limit');
+
+  const calls = [];
+  const ctx = {
+    reply: async (text, options = {}) => {
+      calls.push({ text, options });
+      if (text.length > 4096) throw new Error('400: Bad Request: message is too long');
+      return { message_id: calls.length };
+    },
+  };
+
+  await safeReply(ctx, message, { fallbackLocale: 'ru' });
+  assert(calls.length > 1, 'safeReply splits oversized localized help into multiple messages');
+  assert(
+    calls.every(call => call.text.length <= 4096),
+    'Every split help chunk stays within Telegram sendMessage limit'
+  );
+  assert(
+    calls.every(call => call.options.parse_mode === 'Markdown'),
+    'Split help chunks keep Markdown formatting'
+  );
+  assert(
+    calls.every(call => checkTelegramMarkdown(call.text) === null),
+    'Every split help chunk is valid Telegram Markdown'
+  );
 }
 
 // Test: automatic Telegram client wrapper retries sendMessage/editMessageText


### PR DESCRIPTION
Fixes #1866

## Root Cause
The Russian `/help` response can grow beyond Telegram's `sendMessage` text limit. In the reproduced issue configuration it is 4378 characters, which exceeds Telegram's 4096-character message limit. The global error handler also treated generic `400 Bad Request` responses as Markdown parsing failures, so Telegram length-limit errors surfaced as `Failed to send formatted message.`

## Reproduction
The regression test builds the localized Russian `/help` message with realistic enabled-command and override settings, verifies it exceeds 4096 characters, and simulates Telegram rejecting any oversized send.

## Changes
- Split oversized Telegram text through the shared safe reply/edit helper before sending.
- Apply the same split/fallback behavior to installed `sendMessage` and `editMessageText` wrappers.
- Keep Markdown formatting on valid chunks and fall back per chunk to localized plain text for Telegram entity parsing errors.
- Classify Telegram length-limit errors separately from Markdown formatting errors in the global bot error handler.
- Add a patch changeset for the Telegram safe reply fix.

## Verification
- `node tests/test-telegram-safe-reply-issue-1497.mjs`
- `npm run lint`
- `npm test` (`All 231 selected test file(s) passed.`)
- `npx prettier --check src/telegram-safe-reply.lib.mjs src/telegram-bot.mjs tests/test-telegram-safe-reply-issue-1497.mjs .changeset/telegram-safe-reply-length.md`
