### PR TITLE
fix(errors): reject meaningless stream fragments in tool failures (#1941)

### DIFF
--- a/.changeset/issue-1941-meaningless-error-fragment.md
+++ b/.changeset/issue-1941-meaningless-error-fragment.md
@@ -1,0 +1,12 @@
+---
+'@link-assistant/hive-mind': patch
+---
+
+Stop surfacing meaningless stream fragments as tool errors (#1941). When a tool
+run is interrupted mid-stream (CTRL+C / SIGINT, exit code 130), the last captured
+stdout line could be a stray structural character such as a lone `}`, which leaked
+into the GitHub failure comment as "CLAUDE execution failed with }". A new shared
+`isMeaningfulErrorText` helper (any error with at least one Unicode letter or digit
+is real; pure punctuation is not) now guards the `extractToolErrorCore` chokepoint,
+and a new `buildToolErrorMessage` helper labels interruptions explicitly
+("Claude command interrupted (CTRL+C)") across the Claude and OpenCode runners.

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,0 +1,1 @@
+# .gitkeep file auto-generated at 2026-06-18T11:53:38.896Z for PR creation at branch issue-1941-37b623189463 for issue https://github.com/link-assistant/hive-mind/issues/1941

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,1 +1,0 @@
-# .gitkeep file auto-generated at 2026-06-18T11:53:38.896Z for PR creation at branch issue-1941-37b623189463 for issue https://github.com/link-assistant/hive-mind/issues/1941

--- a/docs/case-studies/issue-1941/README.md
+++ b/docs/case-studies/issue-1941/README.md
@@ -1,0 +1,195 @@
+# Case Study — Issue #1941: `CLAUDE execution failed with }` (meaningless error fragment on interruption)
+
+- **Issue:** [#1941 — Failed to deliver working session](https://github.com/link-assistant/hive-mind/issues/1941)
+- **Pull Request:** [#1942](https://github.com/link-assistant/hive-mind/pull/1942)
+- **Reported from:** [G-Ivan-A/hybrid-Intelligence-lab#252 (comment 4741631558)](https://github.com/G-Ivan-A/hybrid-Intelligence-lab/pull/252#issuecomment-4741631558) — `failed by {`
+- **Full failure log:** [Gist `91dd416b…`](https://gist.githubusercontent.com/konard/91dd416b5e3bfeaed43ec2b2c1824c78/raw/0fe1f53ab82ba2b5f9995e106e701fb7ea2f08e2/solution-draft-log-pr-1781783305174.txt) (727 KB) — archived at [`data/solution-draft-log.txt`](./data/solution-draft-log.txt)
+- **Date analyzed:** 2026-06-18
+- **Related prior work:** [#1845](https://github.com/link-assistant/hive-mind/issues/1845) (surface the core error message) — this issue is a direct follow-up.
+
+---
+
+## 1. Requirements extracted from the issue
+
+| #   | Requirement                                                                                                                                      | Status                                                                                              |
+| --- | ------------------------------------------------------------------------------------------------------------------------------------------------ | --------------------------------------------------------------------------------------------------- |
+| R1  | Download all logs/data about the issue into `./docs/case-studies/issue-1941/` and compile it.                                                    | ✅ [`data/`](./data) (issue JSON, failure comment, full log, error excerpt)                         |
+| R2  | Deep case study: reconstruct timeline, list all requirements, find root cause(s), propose solutions/plans, check known libraries; search online. | ✅ This document (§2–§7)                                                                            |
+| R3  | If not enough data to find root cause, add debug output / verbose mode for the next iteration.                                                   | ✅ Root cause found from existing logs; verbose tracing already present and was sufficient (see §4) |
+| R4  | If the issue relates to another repository/project, report it there with reproducible examples, workarounds, and fix suggestions.                | ✅ Analyzed — the bug is entirely internal to hive-mind; nothing to report upstream (see §7)        |
+| R5  | Apply the fix across the **entire codebase** — if the problem exists in multiple places, fix all of them.                                        | ✅ Shared chokepoint + every tool runner (claude/opencode); other runners already handled (see §5)  |
+| R6  | Plan and execute everything in the single PR #1942.                                                                                              | ✅                                                                                                  |
+
+---
+
+## 2. Timeline / sequence of events
+
+Reconstructed from [`data/solution-draft-log.txt`](./data/solution-draft-log.txt). The session was solving **`G-Ivan-A/hybrid-Intelligence-lab` issue #251** (draft PR #252, branch `issue-251-45845bc22310`). All timestamps UTC.
+
+| Time                  | Event                                                                                                                                 | Log evidence                                 |
+| --------------------- | ------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------- |
+| 11:43:30.676          | `solve.mjs` session starts; log file opened.                                                                                          | line 1                                       |
+| 11:43:52              | Branch pushed (`Push exit code: 0`); draft PR #252 created.                                                                           | line 299, 359                                |
+| 11:44:11 → 11:48      | Claude CLI streams ~40+ normal `assistant`/`tool` turns, all `"interrupted": false`, doing real work on the target repo.              | lines 506–5470                               |
+| 11:48:22.382          | A normal Anthropic API request **succeeds** (`post …/v1/messages succeeded with status 200 in 1786ms`).                               | line 5477                                    |
+| 11:48:22.392 → 22.499 | hive-mind's **verbose mode** dumps the raw `Response`/`ReadableStream` object to the log, line by line, ending with a lone `}`.       | lines 5478–5564                              |
+| **11:48:23.225**      | **`⚠️ Session interrupted by user (CTRL+C)`** — the process receives SIGINT.                                                          | line 5574                                    |
+| 11:48:23.226          | `❌ Claude command failed with exit code 130` (130 = 128 + SIGINT).                                                                   | line 5577                                    |
+| 11:48:23.229 →        | Auto-commit of uncommitted changes succeeds; failure logs attached to PR.                                                             | lines 5578+                                  |
+| (downstream)          | The GitHub failure comment renders **`CLAUDE execution failed with }`** — the stray `}` captured at interrupt time leaks to the user. | [failure comment](./data/failure-comment.md) |
+
+**Key observation:** the run was **not** an API failure — the last HTTP call returned `200`. The session was **interrupted (CTRL+C, exit 130)** while the verbose logger was mid-way through printing a multi-line object dump. The very last non-JSON line printed before the interrupt was a closing brace `}`, and that single character became the user-facing error.
+
+---
+
+## 3. Reproducing the bug
+
+The bug is the transformation `lastMessage = "}"` → `"CLAUDE execution failed with }"`. It is reproduced deterministically by the unit test [`tests/test-issue-1941-meaningless-error-fragment.test.mjs`](../../../tests/test-issue-1941-meaningless-error-fragment.test.mjs):
+
+```js
+// The shape claude.lib.mjs returned when interrupted mid-stream (BEFORE the fix):
+const toolResult = { success: false, errorInfo: { message: '}', exitCode: 130 } };
+formatToolExecutionFailure({ tool: 'claude', toolResult });
+// BEFORE fix → "CLAUDE execution failed with }"
+// AFTER  fix → "CLAUDE execution failed"           (junk fragment rejected)
+```
+
+Run it with:
+
+```bash
+node tests/test-issue-1941-meaningless-error-fragment.test.mjs
+```
+
+---
+
+## 4. Root cause analysis
+
+### 4.1 Where the `}` comes from
+
+In `src/claude.lib.mjs`, the stream-reading loop tries to `JSON.parse` each line. When a line is **not** JSON (e.g. one line of a `console.log`-style object dump emitted by `command-stream`'s verbose HTTP logging), it falls into the catch branch and stores the raw line as the "last message":
+
+```js
+// src/claude.lib.mjs (the catch branch)
+} catch (parseError) {
+  // Not JSON or parsing failed, output as-is if it's not empty
+  if (line.trim() && !line.includes('node:internal')) {
+    await log(line, { stream: 'raw' });
+    lastMessage = line;          // <-- a lone "}" lands here
+    ...
+  }
+}
+```
+
+During the verbose `Response` object dump, the final non-empty line was just `}`. So `lastMessage === '}'` at the moment the user pressed CTRL+C.
+
+### 4.2 Where it leaked to the user
+
+When the command exits non-zero, the tool runner builds its failure return as:
+
+```js
+// BEFORE (src/claude.lib.mjs)
+errorInfo: {
+  message: (lastMessage || `Claude command failed with exit code ${exitCode}`, exitCode);
+}
+```
+
+Because `lastMessage` was the truthy string `"}"`, the `||` fallback was skipped and `"}"` became `errorInfo.message`. The shared error-surfacing chokepoint introduced in issue #1845 (`extractToolErrorCore` → `formatToolExecutionFailure`) then faithfully rendered it as:
+
+```
+CLAUDE execution failed with }
+```
+
+### 4.3 The two real defects
+
+1. **Meaningless fragments are treated as real errors.** A string containing no letters or digits (`}`, `{`, `,`, `[]`, …) carries no diagnostic value but passed the truthiness check and propagated everywhere.
+2. **Interruptions weren't labeled as interruptions.** Exit code 130 (SIGINT/CTRL+C) is a _user/operator interruption_, not a Claude error. The terminal already printed `⚠️ Session interrupted by user (CTRL+C)`, but the structured `errorInfo.message` — the part that reaches the GitHub comment — did not say so. (`src/agent.lib.mjs` already special-cased exit 130; the Claude/OpenCode runners did not.)
+
+### 4.4 Was there enough data? (R3)
+
+Yes. hive-mind's existing verbose tracing captured the full interrupt sequence (lines 5574–5577), the preceding successful HTTP 200, and the object dump that produced the `}`. No additional debug output was needed to find the root cause. The fix itself improves future diagnosis by labeling interrupts explicitly.
+
+---
+
+## 5. The fix (applied across the whole codebase — R5)
+
+Two small, shared helpers in `src/lib.mjs`, then wired into every place that builds a tool-failure message.
+
+### 5.1 `src/lib.mjs` — shared helpers + chokepoint guard
+
+```js
+// A fragment with no letters or digits is not a real error message.
+export const isMeaningfulErrorText = value => {
+  if (!value || typeof value !== 'string') return false;
+  const collapsed = value.replace(/\s+/g, ' ').trim();
+  if (!collapsed) return false;
+  return /[\p{L}\p{N}]/u.test(collapsed);
+};
+
+// Choose a clean error message: the tool's own message only when meaningful,
+// otherwise an interrupt label (exit 130) or a generic fallback.
+export const buildToolErrorMessage = ({ lastMessage, exitCode, fallback, toolLabel = 'Tool' } = {}) => {
+  if (isMeaningfulErrorText(lastMessage)) return lastMessage.replace(/\s+/g, ' ').trim();
+  if (exitCode === 130) return `${toolLabel} command interrupted (CTRL+C)`;
+  return fallback;
+};
+```
+
+`extractToolErrorCore` (the single chokepoint feeding the GitHub comment, the terminal "Error details:", and retry logic) now rejects meaningless cores, so **even pre-existing/edge call sites that bypass `buildToolErrorMessage` cannot surface a junk fragment**:
+
+```js
+if (!rawCore || typeof rawCore !== 'string') return null;
+if (!isMeaningfulErrorText(rawCore)) return null; // Issue #1941
+```
+
+This is defence-in-depth: the source is cleaned **and** the surface is guarded.
+
+### 5.2 Tool runners
+
+| File                   | Change                                                                                                                                        |
+| ---------------------- | --------------------------------------------------------------------------------------------------------------------------------------------- |
+| `src/claude.lib.mjs`   | All three failure-return sites now build `errorInfo.message` via `buildToolErrorMessage({ … toolLabel: 'Claude' })`.                          |
+| `src/opencode.lib.mjs` | Failure-return site uses `buildToolErrorMessage`, preferring a meaningful `lastMessage` else the accumulated output, `toolLabel: 'OpenCode'`. |
+| `src/agent.lib.mjs`    | Already special-cased exit 130 (`Agent command interrupted (CTRL+C)`) — the pattern this fix generalises. No change needed.                   |
+| `src/codex.lib.mjs`    | Reviewed — does not store a raw fall-through line as the error message, and is additionally protected by the §5.1 chokepoint guard.           |
+
+### 5.3 Result
+
+| Scenario                                         | Before                            | After                                                              |
+| ------------------------------------------------ | --------------------------------- | ------------------------------------------------------------------ |
+| CTRL+C interrupt (exit 130), `lastMessage = "}"` | `CLAUDE execution failed with }`  | `CLAUDE execution failed with Claude command interrupted (CTRL+C)` |
+| Junk fragment, non-interrupt exit code           | `CLAUDE execution failed with }`  | `CLAUDE execution failed` (clean generic fallback)                 |
+| Genuine error (`API Error: Output blocked …`)    | unchanged (already worked, #1845) | unchanged — meaningful text is always preserved                    |
+
+---
+
+## 6. Known components / libraries considered
+
+| Option                                                  | Verdict                                                                                                                                                           |
+| ------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Unicode property escapes `/[\p{L}\p{N}]/u` (built-in)   | ✅ Chosen — zero-dependency, correctly handles non-ASCII (Cyrillic/CJK) error text; the target session was Russian-language.                                      |
+| `validator.js` / `is-alphanumeric` npm packages         | ❌ Overkill for a one-line predicate; adds a dependency and most are ASCII-only.                                                                                  |
+| Stricter JSON-only stream parsing (drop non-JSON lines) | ❌ Too risky — some genuine errors (terms-acceptance prompts, plain `Error:` lines) arrive as non-JSON and must be kept. The fragment filter is the surgical fix. |
+| Signal-based exit detection (`exitCode === 130`)        | ✅ Standard POSIX convention (128 + SIGINT) already used by `agent.lib.mjs`; reused for consistency.                                                              |
+
+---
+
+## 7. Upstream / cross-repository reporting (R4)
+
+The bug is **100 % internal to hive-mind**:
+
+- The Anthropic API call **succeeded** (HTTP 200) immediately before the failure — no upstream API fault.
+- The `}` originated from hive-mind's own verbose object-dump logging combined with hive-mind's own `lastMessage` capture and failure-message construction.
+- The interruption (CTRL+C / SIGINT) is an operator/orchestration event, not a defect in any external project.
+
+There is therefore **no external repository to file an issue against**. The upstream PR comment on `G-Ivan-A/hybrid-Intelligence-lab#252` was merely the _symptom surface_; the fix belongs here.
+
+---
+
+## 8. Files in this case study
+
+| Path                                                           | Description                                                                                     |
+| -------------------------------------------------------------- | ----------------------------------------------------------------------------------------------- |
+| [`data/issue-1941.json`](./data/issue-1941.json)               | The GitHub issue payload (title, body, author, labels).                                         |
+| [`data/failure-comment.md`](./data/failure-comment.md)         | The upstream `🚨 Solution Draft Failed` comment showing `CLAUDE execution failed with }`.       |
+| [`data/solution-draft-log.txt`](./data/solution-draft-log.txt) | The complete 5,617-line failure log from the Gist.                                              |
+| [`data/error-excerpt.txt`](./data/error-excerpt.txt)           | The key log lines: the HTTP-200 success, the object dump, and the CTRL+C interrupt at exit 130. |

--- a/docs/case-studies/issue-1941/README.md
+++ b/docs/case-studies/issue-1941/README.md
@@ -86,11 +86,9 @@ During the verbose `Response` object dump, the final non-empty line was just `}`
 
 When the command exits non-zero, the tool runner builds its failure return as:
 
-```js
+```text
 // BEFORE (src/claude.lib.mjs)
-errorInfo: {
-  message: (lastMessage || `Claude command failed with exit code ${exitCode}`, exitCode);
-}
+errorInfo: { message: lastMessage || `Claude command failed with exit code ${exitCode}`, exitCode }
 ```
 
 Because `lastMessage` was the truthy string `"}"`, the `||` fallback was skipped and `"}"` became `errorInfo.message`. The shared error-surfacing chokepoint introduced in issue #1845 (`extractToolErrorCore` → `formatToolExecutionFailure`) then faithfully rendered it as:

--- a/docs/case-studies/issue-1941/README.md
+++ b/docs/case-studies/issue-1941/README.md
@@ -11,14 +11,14 @@
 
 ## 1. Requirements extracted from the issue
 
-| #   | Requirement                                                                                                                                      | Status                                                                                              |
-| --- | ------------------------------------------------------------------------------------------------------------------------------------------------ | --------------------------------------------------------------------------------------------------- |
-| R1  | Download all logs/data about the issue into `./docs/case-studies/issue-1941/` and compile it.                                                    | ✅ [`data/`](./data) (issue JSON, failure comment, full log, error excerpt)                         |
-| R2  | Deep case study: reconstruct timeline, list all requirements, find root cause(s), propose solutions/plans, check known libraries; search online. | ✅ This document (§2–§7)                                                                            |
-| R3  | If not enough data to find root cause, add debug output / verbose mode for the next iteration.                                                   | ✅ Root cause found from existing logs; verbose tracing already present and was sufficient (see §4) |
-| R4  | If the issue relates to another repository/project, report it there with reproducible examples, workarounds, and fix suggestions.                | ✅ Analyzed — the bug is entirely internal to hive-mind; nothing to report upstream (see §7)        |
-| R5  | Apply the fix across the **entire codebase** — if the problem exists in multiple places, fix all of them.                                        | ✅ Shared chokepoint + every tool runner (claude/opencode); other runners already handled (see §5)  |
-| R6  | Plan and execute everything in the single PR #1942.                                                                                              | ✅                                                                                                  |
+| #   | Requirement                                                                                                                                      | Status                                                                                                 |
+| --- | ------------------------------------------------------------------------------------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------ |
+| R1  | Download all logs/data about the issue into `./docs/case-studies/issue-1941/` and compile it.                                                    | ✅ [`data/`](./data) (issue JSON, failure comment, full log, error excerpt)                            |
+| R2  | Deep case study: reconstruct timeline, list all requirements, find root cause(s), propose solutions/plans, check known libraries; search online. | ✅ This document (§2–§7)                                                                               |
+| R3  | If not enough data to find root cause, add debug output / verbose mode for the next iteration.                                                   | ✅ Root cause found from existing logs; verbose tracing already present and was sufficient (see §4)    |
+| R4  | If the issue relates to another repository/project, report it there with reproducible examples, workarounds, and fix suggestions.                | ✅ Analyzed — the bug is entirely internal to hive-mind; nothing to report upstream (see §7)           |
+| R5  | Apply the fix across the **entire codebase** — if the problem exists in multiple places, fix all of them.                                        | ✅ Shared chokepoint + every tool runner (claude/opencode/gemini/qwen); agent already handled (see §5) |
+| R6  | Plan and execute everything in the single PR #1942.                                                                                              | ✅                                                                                                     |
 
 ---
 
@@ -147,6 +147,8 @@ This is defence-in-depth: the source is cleaned **and** the surface is guarded.
 | ---------------------- | --------------------------------------------------------------------------------------------------------------------------------------------- |
 | `src/claude.lib.mjs`   | All three failure-return sites now build `errorInfo.message` via `buildToolErrorMessage({ … toolLabel: 'Claude' })`.                          |
 | `src/opencode.lib.mjs` | Failure-return site uses `buildToolErrorMessage`, preferring a meaningful `lastMessage` else the accumulated output, `toolLabel: 'OpenCode'`. |
+| `src/gemini.lib.mjs`   | Failure-return site uses `buildToolErrorMessage({ lastMessage: errorText, … toolLabel: 'Gemini' })`.                                          |
+| `src/qwen.lib.mjs`     | Failure-return site uses `buildToolErrorMessage({ lastMessage: combinedErrorText \|\| errorMessage, … toolLabel: 'Qwen Code' })`.             |
 | `src/agent.lib.mjs`    | Already special-cased exit 130 (`Agent command interrupted (CTRL+C)`) — the pattern this fix generalises. No change needed.                   |
 | `src/codex.lib.mjs`    | Reviewed — does not store a raw fall-through line as the error message, and is additionally protected by the §5.1 chokepoint guard.           |
 

--- a/docs/case-studies/issue-1941/data/error-excerpt.txt
+++ b/docs/case-studies/issue-1941/data/error-excerpt.txt
@@ -1,0 +1,26 @@
+Error excerpt — issue #1941
+Source: solution-draft-log.txt (full log downloaded from the Gist linked in the upstream failure comment)
+Repository under solve: G-Ivan-A/hybrid-Intelligence-lab, PR #252 (head branch issue-251-45845bc22310)
+
+----- interruption & failure (log lines 5573-5577) -----
+[2026-06-18T11:48:23.225Z] [INFO] 
+[2026-06-18T11:48:23.225Z] [INFO] ⚠️  Session interrupted by user (CTRL+C)
+[2026-06-18T11:48:23.226Z] [ERROR] 
+[2026-06-18T11:48:23.226Z] [ERROR] 
+[2026-06-18T11:48:23.226Z] [ERROR] ❌ Claude command failed with exit code 130
+
+----- preceding context: API call had SUCCEEDED (status 200) right before CTRL+C (lines 5477-5480) -----
+[2026-06-18T11:48:22.382Z] [INFO] [log_80eedd, request-id: "req_011CcAfxtVots3JssSPk6XPW"] post https://api.anthropic.com/v1/messages?beta=true succeeded with status 200 in 1786ms
+[2026-06-18T11:48:22.392Z] [INFO] [log_80eedd] response start {
+[2026-06-18T11:48:22.399Z] [INFO]   url: "https://api.anthropic.com/v1/messages?beta=true",
+[2026-06-18T11:48:22.400Z] [INFO]   status: 200,
+
+----- the verbose Response/ReadableStream object dump whose final printed token was a lone '}' (lines 5560-5564) -----
+[2026-06-18T11:48:22.492Z] [INFO]   status: 200,
+[2026-06-18T11:48:22.492Z] [INFO]   body: sU {
+[2026-06-18T11:48:22.493Z] [INFO]     iterator: [AsyncGeneratorFunction: s],
+[2026-06-18T11:48:22.493Z] [INFO]     controller: AbortController {
+[2026-06-18T11:48:22.493Z] [INFO]       signal: [AbortSignal ...],
+
+----- resulting GitHub failure comment (G-Ivan-A/hybrid-Intelligence-lab#252, comment 4741631558) -----
+CLAUDE execution failed with }

--- a/docs/case-studies/issue-1941/data/failure-comment.md
+++ b/docs/case-studies/issue-1941/data/failure-comment.md
@@ -1,0 +1,21 @@
+## 🚨 Solution Draft Failed
+
+The automated solution draft encountered an error:
+
+```
+CLAUDE execution failed with }
+```
+
+### 🤖 **Models used:**
+
+- Tool: Anthropic Claude Code
+- Requested: `opus`
+- **Model: Claude Opus 4.8** (`claude-opus-4-8`)
+
+### 📎 **Failure log uploaded as Gist** (727KB)
+
+- [View complete failure log](https://gist.githubusercontent.com/konard/91dd416b5e3bfeaed43ec2b2c1824c78/raw/0fe1f53ab82ba2b5f9995e106e701fb7ea2f08e2/solution-draft-log-pr-1781783305174.txt)
+
+---
+
+_Now working session is ended, feel free to review and add any feedback on the solution draft._

--- a/docs/case-studies/issue-1941/data/issue-1941.json
+++ b/docs/case-studies/issue-1941/data/issue-1941.json
@@ -1,0 +1,10 @@
+{
+  "author": { "id": "MDQ6VXNlcjE0MzE5MDQ=", "is_bot": false, "login": "konard", "name": "Konstantin Diachenko" },
+  "body": "https://github.com/G-Ivan-A/hybrid-Intelligence-lab/pull/252#issuecomment-4741631558 (`failed by {`)\n\nhttps://gist.githubusercontent.com/konard/91dd416b5e3bfeaed43ec2b2c1824c78/raw/0fe1f53ab82ba2b5f9995e106e701fb7ea2f08e2/solution-draft-log-pr-1781783305174.txt - full log\n\nWe need to download all logs and data related about the issue to this repository, make sure we compile that data to `./docs/case-studies/issue-{id}` folder, and use it to do deep case study analysis (also make sure to search online for additional facts and data), in which we will reconstruct timeline/sequence of events, list of each and all requirements from the issue, find root causes of the each problem, and propose possible solutions and solution plans for each requirement (we should also check known existing components/libraries, that solve similar problem or can help in solutions).\n\nIf there is not enough data to find actual root cause, add debug output and verbose mode if not present, that will allow us to find root cause on next iteration.\n\nIf issue related to any other repository/project, where we can report issues on GitHub, please do so. Each issue must contain reproducible examples, workarounds and suggestions for fix the issue in code. Also double check to fully apply requirements to entire codebase, so if we have issue in multiple places, it should be fixed in all them.\n\nPlease plan and execute everything in this single pull request, you have unlimited time and context, as context auto-compacts and you can continue indefinitely, until it is each and every requirement fully addressed, and everything is totally done.",
+  "createdAt": "2026-06-18T11:52:30Z",
+  "labels": [{ "id": "LA_kwDOPUU0qc8AAAACGYm6iw", "name": "bug", "description": "Something isn't working", "color": "d73a4a" }],
+  "number": 1941,
+  "state": "OPEN",
+  "title": "Failed to deliver working session",
+  "url": "https://github.com/link-assistant/hive-mind/issues/1941"
+}

--- a/docs/case-studies/issue-1941/data/solution-draft-log.txt
+++ b/docs/case-studies/issue-1941/data/solution-draft-log.txt
@@ -1,0 +1,5617 @@
+# Solve.mjs Log - 2026-06-18T11:43:30.676Z
+
+[2026-06-18T11:43:30.677Z] [INFO] 📁 Log file: /home/box/solve-2026-06-18T11-43-30-676Z.log
+[2026-06-18T11:43:30.679Z] [INFO]    (All output will be logged here)
+[2026-06-18T11:43:31.324Z] [INFO] 
+[2026-06-18T11:43:31.324Z] [INFO] 🚀 solve v2.0.5
+[2026-06-18T11:43:31.326Z] [INFO] 🔧 Raw command executed:
+[2026-06-18T11:43:31.327Z] [INFO]    /home/box/.nvm/versions/node/v20.20.2/bin/node /home/box/.bun/bin/solve https://github.com/G-Ivan-A/hybrid-Intelligence-lab/issues/251 --model opus --tool claude --attach-logs --verbose --no-tool-check --disable-report-issue --language en
+[2026-06-18T11:43:31.328Z] [INFO] 
+[2026-06-18T11:43:31.384Z] [INFO] 
+[2026-06-18T11:43:31.385Z] [WARNING] ⚠️  SECURITY WARNING: --attach-logs is ENABLED
+[2026-06-18T11:43:31.387Z] [INFO] 
+[2026-06-18T11:43:31.388Z] [INFO]    This option will upload the complete solution draft log file to the Pull Request.
+[2026-06-18T11:43:31.389Z] [INFO]    The log may contain sensitive information such as:
+[2026-06-18T11:43:31.390Z] [INFO]    • API keys, tokens, or secrets
+[2026-06-18T11:43:31.390Z] [INFO]    • File paths and directory structures
+[2026-06-18T11:43:31.391Z] [INFO]    • Command outputs and error messages
+[2026-06-18T11:43:31.391Z] [INFO]    • Internal system information
+[2026-06-18T11:43:31.391Z] [INFO] 
+[2026-06-18T11:43:31.392Z] [INFO]    ⚠️  DO NOT use this option with public repositories or if the log
+[2026-06-18T11:43:31.393Z] [INFO]        might contain sensitive data that should not be shared publicly.
+[2026-06-18T11:43:31.393Z] [INFO] 
+[2026-06-18T11:43:31.394Z] [INFO]    Continuing in 5 seconds... (Press Ctrl+C to abort)
+[2026-06-18T11:43:31.394Z] [INFO] 
+[2026-06-18T11:43:31.395Z] [STDOUT]    Countdown: 5 seconds remaining...
+[2026-06-18T11:43:32.396Z] [STDOUT]    Countdown: 4 seconds remaining...
+[2026-06-18T11:43:33.397Z] [STDOUT]    Countdown: 3 seconds remaining...
+[2026-06-18T11:43:34.399Z] [STDOUT]    Countdown: 2 seconds remaining...
+[2026-06-18T11:43:35.400Z] [STDOUT]    Countdown: 1 seconds remaining...
+[2026-06-18T11:43:36.402Z] [STDOUT]    Proceeding with log attachment enabled.                    
+[2026-06-18T11:43:36.402Z] [INFO] 
+[2026-06-18T11:43:36.466Z] [INFO] 💾 Disk space check: 58203MB available (2048MB required) ✅
+[2026-06-18T11:43:36.468Z] [INFO] 🧠 Memory check: 6117MB available, swap: none, total: 6117MB (256MB required) ✅
+[2026-06-18T11:43:36.492Z] [INFO] ⏩ Skipping tool connection validation (dry-run mode or skip-tool-connection-check enabled)
+[2026-06-18T11:43:36.493Z] [INFO] ⏩ Skipping GitHub authentication check (dry-run mode or skip-tool-connection-check enabled)
+[2026-06-18T11:43:36.494Z] [INFO] 🎭 Checking Playwright MCP preflight for Claude Code...
+[2026-06-18T11:43:37.150Z] [STDOUT] Checking MCP server health…
+
+[2026-06-18T11:43:38.416Z] [STDOUT] playwright: npx -y @playwright/mcp@latest --isolated --headless --no-sandbox --timeout-action=600000 --viewport-size 1920x1080 - ✔ Connected
+[2026-06-18T11:43:38.933Z] [INFO] 🎭 Playwright MCP ready for Claude Code
+[2026-06-18T11:43:38.934Z] [INFO] 📋 URL validation:
+[2026-06-18T11:43:38.935Z] [INFO]    Input URL: https://github.com/G-Ivan-A/hybrid-Intelligence-lab/issues/251
+[2026-06-18T11:43:38.935Z] [INFO]    Is Issue URL: true
+[2026-06-18T11:43:38.935Z] [INFO]    Is PR URL: false
+[2026-06-18T11:43:38.936Z] [INFO] 🔍 --auto-accept-invite: Checking for pending invitation to G-Ivan-A/hybrid-Intelligence-lab...
+[2026-06-18T11:43:39.240Z] [INFO]    Found 1 total pending repo invitation(s)
+[2026-06-18T11:43:39.241Z] [INFO]    No pending repository invitation found for G-Ivan-A/hybrid-Intelligence-lab
+[2026-06-18T11:43:39.771Z] [INFO]    Found 0 total pending org invitation(s)
+[2026-06-18T11:43:39.773Z] [INFO]    No pending organization invitation found for G-Ivan-A
+[2026-06-18T11:43:39.773Z] [INFO] ℹ️  --auto-accept-invite: No pending invitation found for G-Ivan-A/hybrid-Intelligence-lab or organization G-Ivan-A
+[2026-06-18T11:43:39.774Z] [INFO] 🔍 Checking repository access for auto-fork...
+[2026-06-18T11:43:40.168Z] [STDOUT] {"admin":false,"maintain":false,"pull":true,"push":false,"triage":false}
+[2026-06-18T11:43:40.567Z] [STDOUT] public
+[2026-06-18T11:43:40.573Z] [INFO]    Repository visibility: public
+[2026-06-18T11:43:40.575Z] [INFO] ✅ Auto-fork: No write access detected, enabling fork mode
+[2026-06-18T11:43:40.577Z] [INFO] ✅ Repository access check: Skipped (fork mode enabled)
+[2026-06-18T11:43:40.946Z] [STDOUT] G-Ivan-A
+[2026-06-18T11:43:41.305Z] [STDOUT] G-Ivan-A/hybrid-Intelligence-lab
+[2026-06-18T11:43:41.849Z] [STDOUT] {"number":251,"title":"creative: Формализация новых AI-классификаций (подпроцессы, артефакты, операции) и интеграция в роадмап Mango с учётом эволюции операций"}
+[2026-06-18T11:43:42.243Z] [STDOUT] public
+[2026-06-18T11:43:42.251Z] [INFO]    Repository visibility: public
+[2026-06-18T11:43:42.253Z] [INFO]    Auto-cleanup default: false (repository is public)
+[2026-06-18T11:43:42.256Z] [INFO] 🔍 Auto-continue enabled: Checking for existing PRs for issue #251...
+[2026-06-18T11:43:42.653Z] [STDOUT] konard
+[2026-06-18T11:43:42.972Z] [STDOUT] {"name":"G-Ivan-A-hybrid-Intelligence-lab"}
+[2026-06-18T11:43:42.977Z] [INFO] 🔍 Fork mode: Checking for existing branches in konard/G-Ivan-A-hybrid-Intelligence-lab...
+[2026-06-18T11:43:43.403Z] [STDOUT] issue-1-8cf0631d8d80
+issue-3-eaeee0c33eb7
+issue-5-1a68138863b8
+issue-7-f99c24cb19b9
+issue-9-45fb6708e5f6
+issue-11-2daaf28f3d4a
+issue-13-f3a0e5791d46
+issue-15-8f5716717901
+issue-17-cd7ba1478946
+issue-19-e38c7e412c6e
+issue-21-c3cfbd77959b
+issue-23-3dfc84cf74f5
+issue-25-9ae263606850
+issue-27-f19da371f6ff
+issue-29-d740fafbd3e1
+issue-31-8c2aa15b1731
+issue-33-703f6ed088cc
+issue-35-68ddf5808bed
+issue-37-6c329b3b44db
+issue-38-d72b2626ca85
+issue-41-8eeeced4d0df
+issue-43-33c40986d885
+issue-45-df81eed30fe4
+issue-47-13b5d2e9255a
+issue-49-c4becb4e7683
+issue-50-15428f2ffaeb
+issue-52-f3727536bbcf
+issue-55-6ad245878787
+issue-57-473503b2c2ae
+issue-59-5b69e33102b9
+issue-61-81bb3ebfe875
+issue-63-f03b061953c7
+issue-65-eec0f8200fee
+issue-67-0df640aed57a
+issue-69-b25ad34c4609
+issue-70-103dc7c41930
+issue-73-32da1fb95f23
+issue-75-7e2a0a91d4bb
+issue-77-8c52916550a9
+issue-79-0f42799320ca
+issue-81-5b0dadcb829e
+issue-83-3dc5db7a3719
+issue-85-d66a3a22622d
+issue-87-2a6604e39eb2
+issue-89-4e63f2595574
+issue-91-2ee668e7499c
+issue-93-ca0b78dcb690
+issue-95-3bc2f0b410a8
+issue-96-60ec6844c82b
+issue-99-e003a02e5af4
+issue-101-c7af77d2c6cb
+issue-103-824c0b67bc84
+issue-105-4e5cfbe827b1
+issue-107-b1881a41b501
+issue-109-2054d45e0ec2
+issue-110-35fc6587ff1e
+issue-111-aa5056583287
+issue-113-09fbc4aff6b9
+issue-114-4f9c20a42362
+issue-115-1007dc922bd9
+issue-116-a0338c0eb3b7
+issue-124-093539a8cf1f
+issue-126-7ac18805f84c
+issue-128-60e33270bae7
+issue-129-cda5454f6205
+issue-132-3bc6dc7d01bd
+issue-133-0494e3630a00
+issue-134-1fe68dbc416c
+issue-138-369556d99d75
+issue-139-ca5b0c289cca
+issue-140-b2a7d3f9273f
+issue-141-ddfb40dc818b
+issue-142-a0322b58e919
+issue-143-a70d173bcb05
+issue-144-77676fa8a1cd
+issue-145-0edb07cd615d
+issue-146-c2f9989fdd5d
+issue-147-2e8eea92564e
+issue-159-27df04f87e1e
+issue-161-bba15f724877
+issue-163-d219d525b467
+issue-165-6e25351f84a9
+issue-166-0726c602f3fe
+issue-169-ae68b9c3ff87
+issue-171-17fdb2254f1a
+issue-173-2064ca6ad710
+issue-175-55099d25b409
+issue-176-eb89f1803b2a
+issue-177-2207ab95c88e
+issue-181-9dc78bc15a3d
+issue-183-f605b3fdf641
+issue-185-654bbadc523e
+issue-186-8e5cdf6bf604
+issue-189-5aae1a7e7713
+issue-191-c26712ae7988
+issue-193-b76c17d98196
+issue-194-5f64560df360
+issue-197-6150839ba49d
+issue-199-adc1af617fc3
+issue-201-959a55eb5074
+[2026-06-18T11:43:43.684Z] [STDOUT] issue-202-62bda07d61f0
+issue-203-d7d3853c3f92
+issue-207-80e06513c720
+issue-209-008a82020787
+issue-211-d430f2baa1b0
+issue-213-33925e92e043
+issue-215-35f3961a178b
+issue-217-4c43638864f0
+issue-218-28b7a24a0ac5
+issue-220-495bf4cda632
+issue-223-5397da486734
+issue-225-02e3f0277ae9
+issue-227-023ec945bd74
+issue-228-f9dfe991505f
+issue-231-b2c2462dd3a2
+issue-233-78c22d69a5af
+issue-235-f14a20d98e5e
+issue-237-410b976dd565
+issue-239-92576bd17916
+issue-240-478c640eefb5
+issue-241-dff25f31ac0e
+issue-245-830ff1173553
+issue-247-d135f27e43d2
+issue-249-0a0d60d7ce82
+main
+[2026-06-18T11:43:44.131Z] [STDOUT] [{"createdAt":"2026-06-18T11:40:19Z","headRefName":"issue-249-0a0d60d7ce82","isDraft":true,"number":250,"state":"OPEN"}]
+[2026-06-18T11:43:44.570Z] [STDOUT] []
+[2026-06-18T11:43:44.576Z] [INFO] 📋 Found 1 existing PR(s) for issue #251
+[2026-06-18T11:43:44.576Z] [INFO]   PR #250: created 0h ago (OPEN, draft)
+[2026-06-18T11:43:44.577Z] [INFO]   PR #250: Branch 'issue-249-0a0d60d7ce82' doesn't match expected pattern 'issue-251-*' - skipping
+[2026-06-18T11:43:44.577Z] [INFO] ⏭️  No suitable PRs found (missing CLAUDE.md/.gitkeep or older than 24h) - creating new PR as usual
+[2026-06-18T11:43:44.577Z] [INFO] 📝 Issue mode: Working with issue #251
+[2026-06-18T11:43:44.578Z] [INFO] 
+[2026-06-18T11:43:44.578Z] [INFO] Creating temporary directory: /tmp/gh-issue-solver-1781783024578
+[2026-06-18T11:43:44.580Z] [INFO] 
+[2026-06-18T11:43:44.580Z] [INFO] 🍴 Fork mode:                ENABLED
+[2026-06-18T11:43:44.581Z] [INFO]  Checking fork status...   
+[2026-06-18T11:43:44.581Z] [INFO] 
+[2026-06-18T11:43:44.954Z] [STDOUT] konard
+[2026-06-18T11:43:44.958Z] [INFO] 🔍 Detecting fork conflicts... 
+[2026-06-18T11:43:45.338Z] [STDOUT] {"fork":false,"source":null}
+[2026-06-18T11:43:45.726Z] [STDOUT] konard
+[2026-06-18T11:43:46.068Z] [STDOUT] konard/G-Ivan-A-hybrid-Intelligence-lab
+[2026-06-18T11:43:46.075Z] [INFO] ✅ No fork conflict:         Safe to proceed
+[2026-06-18T11:43:46.404Z] [STDOUT] {"name":"G-Ivan-A-hybrid-Intelligence-lab"}
+[2026-06-18T11:43:46.407Z] [INFO] ✅ Fork exists:              konard/G-Ivan-A-hybrid-Intelligence-lab
+[2026-06-18T11:43:46.408Z] [INFO] 🔍 Validating fork parent... 
+[2026-06-18T11:43:46.832Z] [STDOUT] {"fork":true,"parent":"G-Ivan-A/hybrid-Intelligence-lab","source":"G-Ivan-A/hybrid-Intelligence-lab"}
+[2026-06-18T11:43:46.839Z] [INFO] ✅ Fork parent validated:    G-Ivan-A/hybrid-Intelligence-lab
+[2026-06-18T11:43:46.840Z] [INFO] 
+[2026-06-18T11:43:46.840Z] [INFO] 📥 Cloning repository:       konard/G-Ivan-A-hybrid-Intelligence-lab
+[2026-06-18T11:43:47.328Z] [STDOUT] Cloning into '/tmp/gh-issue-solver-1781783024578'...
+[2026-06-18T11:43:48.806Z] [STDOUT] From https://github.com/G-Ivan-A/hybrid-Intelligence-lab
+ * [new branch]      main       -> upstream/main
+[2026-06-18T11:43:48.838Z] [INFO] ✅ Cloned to:                /tmp/gh-issue-solver-1781783024578
+[2026-06-18T11:43:48.851Z] [STDOUT] origin	https://github.com/konard/G-Ivan-A-hybrid-Intelligence-lab.git (fetch)
+origin	https://github.com/konard/G-Ivan-A-hybrid-Intelligence-lab.git (push)
+upstream	https://github.com/G-Ivan-A/hybrid-Intelligence-lab.git (fetch)
+upstream	https://github.com/G-Ivan-A/hybrid-Intelligence-lab.git (push)
+[2026-06-18T11:43:48.852Z] [INFO] 🔗 Setting upstream:         G-Ivan-A/hybrid-Intelligence-lab
+[2026-06-18T11:43:48.866Z] [STDOUT] https://github.com/G-Ivan-A/hybrid-Intelligence-lab.git
+[2026-06-18T11:43:48.868Z] [INFO] ℹ️ Upstream exists:          Using existing upstream remote
+[2026-06-18T11:43:48.869Z] [INFO] 🔄 Fetching upstream...      
+[2026-06-18T11:43:49.221Z] [INFO] ✅ Upstream fetched:         Successfully
+[2026-06-18T11:43:49.222Z] [INFO] 🔄 Syncing default branch... 
+[2026-06-18T11:43:49.238Z] [STDOUT] main
+[2026-06-18T11:43:49.618Z] [STDOUT] main
+[2026-06-18T11:43:49.624Z] [INFO] ℹ️ Default branch:           main
+[2026-06-18T11:43:49.661Z] [STDOUT] HEAD is now at 0d0264e Merge pull request #248 from konard/issue-247-d135f27e43d2
+[2026-06-18T11:43:49.662Z] [INFO] ✅ Default branch synced:    with upstream/main
+[2026-06-18T11:43:50.105Z] [STDOUT] konard
+[2026-06-18T11:43:50.110Z] [INFO] 🔄 Pushing to fork:          main branch
+[2026-06-18T11:43:50.672Z] [STDOUT] Everything up-to-date
+[2026-06-18T11:43:50.687Z] [INFO] ✅ Fork updated:             Default branch pushed to fork
+[2026-06-18T11:43:50.775Z] [STDOUT] main
+[2026-06-18T11:43:50.788Z] [STDOUT] 0d0**********************************d0e
+[2026-06-18T11:43:50.789Z] [INFO] 
+[2026-06-18T11:43:50.789Z] [INFO] 📌 Default branch:           main
+[2026-06-18T11:43:50.804Z] [INFO] 
+[2026-06-18T11:43:50.804Z] [INFO] 🌿 Creating branch:          issue-251-45845bc22310 from main (default)
+[2026-06-18T11:43:50.818Z] [STDERR] Switched to a new branch 'issue-251-45845bc22310'
+[2026-06-18T11:43:50.819Z] [STDOUT] branch 'issue-251-45845bc22310' set up to track 'origin/main'.
+[2026-06-18T11:43:50.820Z] [INFO] 🔍 Verifying:                Branch creation...
+[2026-06-18T11:43:50.830Z] [STDOUT] issue-251-45845bc22310
+[2026-06-18T11:43:50.831Z] [INFO] ✅ Branch created:           issue-251-45845bc22310
+[2026-06-18T11:43:50.831Z] [INFO] ✅ Current branch:           issue-251-45845bc22310
+[2026-06-18T11:43:50.831Z] [INFO]    Branch operation: Create new branch
+[2026-06-18T11:43:50.832Z] [INFO]    Branch verification: Matches expected
+[2026-06-18T11:43:50.835Z] [INFO] 
+[2026-06-18T11:43:50.835Z] [INFO] 🚀 Auto PR creation:         ENABLED
+[2026-06-18T11:43:50.836Z] [INFO]      Creating:               Initial commit and draft PR...
+[2026-06-18T11:43:50.836Z] [INFO] 
+[2026-06-18T11:43:50.837Z] [INFO]    Using .gitkeep mode (--claude-file=false, --gitkeep-file=true, --auto-gitkeep-file=true)
+[2026-06-18T11:43:50.837Z] [INFO] 📝 Creating:                 .gitkeep (default)
+[2026-06-18T11:43:50.838Z] [INFO]    Issue URL from argv['issue-url']: https://github.com/G-Ivan-A/hybrid-Intelligence-lab/issues/251
+[2026-06-18T11:43:50.839Z] [INFO]    Issue URL from argv._[0]: https://github.com/G-Ivan-A/hybrid-Intelligence-lab/issues/251
+[2026-06-18T11:43:50.841Z] [INFO]    Final issue URL: https://github.com/G-Ivan-A/hybrid-Intelligence-lab/issues/251
+[2026-06-18T11:43:50.843Z] [INFO] ✅ File created:             .gitkeep
+[2026-06-18T11:43:50.843Z] [INFO] 📦 Adding file:              To git staging
+[2026-06-18T11:43:50.870Z] [STDOUT] A  .gitkeep
+[2026-06-18T11:43:50.872Z] [INFO]    Git status after add: A  .gitkeep
+[2026-06-18T11:43:50.873Z] [INFO] 📝 Creating commit:          With .gitkeep file
+[2026-06-18T11:43:50.892Z] [STDOUT] [issue-251-45845bc22310 beabc49] Initial commit with task details
+ 1 file changed, 1 insertion(+)
+ create mode 100644 .gitkeep
+[2026-06-18T11:43:50.894Z] [INFO] ✅ Commit created:           Successfully with .gitkeep
+[2026-06-18T11:43:50.895Z] [INFO]    Commit output: [issue-251-45845bc22310 beabc49] Initial commit with task details
+[2026-06-18T11:43:50.895Z] [INFO]  1 file changed, 1 insertion(+)
+[2026-06-18T11:43:50.895Z] [INFO]  create mode 100644 .gitkeep
+[2026-06-18T11:43:50.907Z] [STDOUT] bea**********************************245
+[2026-06-18T11:43:50.908Z] [INFO]    Commit hash: beabc49...
+[2026-06-18T11:43:50.918Z] [STDOUT] beabc49 Initial commit with task details
+[2026-06-18T11:43:50.919Z] [INFO]    Latest commit: beabc49 Initial commit with task details
+[2026-06-18T11:43:50.933Z] [INFO]    Git status: clean
+[2026-06-18T11:43:50.946Z] [STDOUT] origin	https://github.com/konard/G-Ivan-A-hybrid-Intelligence-lab.git (fetch)
+origin	https://github.com/konard/G-Ivan-A-hybrid-Intelligence-lab.git (push)
+upstream	https://github.com/G-Ivan-A/hybrid-Intelligence-lab.git (fetch)
+upstream	https://github.com/G-Ivan-A/hybrid-Intelligence-lab.git (push)
+[2026-06-18T11:43:50.947Z] [INFO]    Remotes: origin	https://github.com/konard/G-Ivan-A-hybrid-Intelligence-lab.git (fetch)
+[2026-06-18T11:43:50.961Z] [STDOUT] * issue-251-45845bc22310 beabc49 [origin/main: ahead 1] Initial commit with task details
+  main                   0d0264e [origin/main] Merge pull request #248 from konard/issue-247-d135f27e43d2
+[2026-06-18T11:43:50.964Z] [INFO]    Branch info: * issue-251-45845bc22310 beabc49 [origin/main: ahead 1] Initial commit with task details
+[2026-06-18T11:43:50.964Z] [INFO]   main                   0d0264e [origin/main] Merge pull request #248 from konard/issue-247-d135f27e43d2
+[2026-06-18T11:43:50.965Z] [INFO] 📤 Pushing branch:           To remote repository...
+[2026-06-18T11:43:50.965Z] [INFO]    Push command: git push -u origin issue-251-45845bc22310
+[2026-06-18T11:43:52.231Z] [STDOUT] remote: 
+remote: Create a pull request for 'issue-251-45845bc22310' on GitHub by visiting:        
+remote:      https://github.com/konard/G-Ivan-A-hybrid-Intelligence-lab/pull/new/issue-251-45845bc22310        
+remote: 
+[2026-06-18T11:43:52.233Z] [STDOUT] To https://github.com/konard/G-Ivan-A-hybrid-Intelligence-lab.git
+ * [new branch]      issue-251-45845bc22310 -> issue-251-45845bc22310
+[2026-06-18T11:43:52.241Z] [STDOUT] branch 'issue-251-45845bc22310' set up to track 'origin/issue-251-45845bc22310'.
+[2026-06-18T11:43:52.243Z] [INFO]    Push exit code: 0
+[2026-06-18T11:43:52.244Z] [INFO]    Push output: remote: 
+[2026-06-18T11:43:52.244Z] [INFO] remote: Create a pull request for 'issue-251-45845bc22310' on GitHub by visiting:        
+[2026-06-18T11:43:52.244Z] [INFO] remote:      https://github.com/konard/G-Ivan-A-hybrid-Intelligence-lab/pull/new/issue-251-45845bc22310        
+[2026-06-18T11:43:52.244Z] [INFO] remote: 
+[2026-06-18T11:43:52.244Z] [INFO] To https://github.com/konard/G-Ivan-A-hybrid-Intelligence-lab.git
+[2026-06-18T11:43:52.244Z] [INFO]  * [new branch]      issue-251-45845bc22310 -> issue-251-45845bc22310
+[2026-06-18T11:43:52.244Z] [INFO] branch 'issue-251-45845bc22310' set up to track 'origin/issue-251-45845bc22310'.
+[2026-06-18T11:43:52.245Z] [INFO] ✅ Branch pushed:            Successfully to remote
+[2026-06-18T11:43:52.246Z] [INFO]    Push output: remote: 
+[2026-06-18T11:43:52.246Z] [INFO] remote: Create a pull request for 'issue-251-45845bc22310' on GitHub by visiting:        
+[2026-06-18T11:43:52.246Z] [INFO] remote:      https://github.com/konard/G-Ivan-A-hybrid-Intelligence-lab/pull/new/issue-251-45845bc22310        
+[2026-06-18T11:43:52.246Z] [INFO] remote: 
+[2026-06-18T11:43:52.246Z] [INFO] To https://github.com/konard/G-Ivan-A-hybrid-Intelligence-lab.git
+[2026-06-18T11:43:52.246Z] [INFO]  * [new branch]      issue-251-45845bc22310 -> issue-251-45845bc22310
+[2026-06-18T11:43:52.246Z] [INFO] branch 'issue-251-45845bc22310' set up to track 'origin/issue-251-45845bc22310'.
+[2026-06-18T11:43:52.247Z] [INFO]    Waiting for GitHub to sync...
+[2026-06-18T11:43:54.802Z] [STDOUT] 1
+[2026-06-18T11:43:54.808Z] [INFO]    Compare API check: 1 commit(s) ahead of main
+[2026-06-18T11:43:54.809Z] [INFO]    GitHub compare API ready: 1 commit(s) found
+[2026-06-18T11:43:55.181Z] [STDOUT] issue-251-45845bc22310
+[2026-06-18T11:43:55.186Z] [INFO]    Branch verified on GitHub: issue-251-45845bc22310
+[2026-06-18T11:43:55.531Z] [STDOUT] bea**********************************245
+[2026-06-18T11:43:55.539Z] [INFO]    Remote commit SHA: beabc49...
+[2026-06-18T11:43:55.540Z] [INFO] 📋 Getting issue:            Title from GitHub...
+[2026-06-18T11:43:55.861Z] [STDOUT] creative: Формализация новых AI-классификаций (подпроцессы, артефакты, операции) и интеграция в роадмап Mango с учётом эволюции операций
+[2026-06-18T11:43:55.868Z] [INFO]    Issue title: "creative: Формализация новых AI-классификаций (подпроцессы, артефакты, операции) и интеграция в роадмап Mango с учётом эволюции операций"
+[2026-06-18T11:43:55.870Z] [INFO] 👤 Getting user:             Current GitHub account...
+[2026-06-18T11:43:56.273Z] [STDOUT] konard
+[2026-06-18T11:43:56.279Z] [INFO]    Current user: konard
+[2026-06-18T11:43:56.779Z] [INFO]    User is not a collaborator (will skip assignment)
+[2026-06-18T11:43:56.781Z] [INFO]    User is not a collaborator (will skip assignment)
+[2026-06-18T11:43:56.781Z] [INFO] 🔄 Fetching:                 Latest main branch...
+[2026-06-18T11:43:57.110Z] [INFO] ✅ Base updated:             Fetched latest main
+[2026-06-18T11:43:57.111Z] [INFO] 🔍 Checking:                 Commits between branches...
+[2026-06-18T11:43:57.124Z] [STDOUT] 1
+[2026-06-18T11:43:57.125Z] [INFO]    Commits ahead of origin/main: 1
+[2026-06-18T11:43:57.126Z] [INFO] ✅ Commits found:            1 commit(s) ahead
+[2026-06-18T11:43:57.127Z] [INFO] 🔀 Creating PR:              Draft pull request...
+[2026-06-18T11:43:57.127Z] [INFO] 🎯 Target branch:            main (default)
+[2026-06-18T11:43:57.128Z] [INFO]    PR Title: [WIP] creative: Формализация новых AI-классификаций (подпроцессы, артефакты, операции) и интеграция в роадмап Mango с учётом эволюции операций
+[2026-06-18T11:43:57.128Z] [INFO]    Base branch: main
+[2026-06-18T11:43:57.128Z] [INFO]    Head branch: issue-251-45845bc22310
+[2026-06-18T11:43:57.129Z] [INFO]    Assignee: konard
+[2026-06-18T11:43:57.129Z] [INFO]    PR Body:
+[2026-06-18T11:43:57.129Z] [INFO] ## 🤖 AI-Powered Solution Draft
+[2026-06-18T11:43:57.129Z] [INFO] 
+[2026-06-18T11:43:57.129Z] [INFO] This pull request is being automatically generated to solve issue G-Ivan-A/hybrid-Intelligence-lab#251.
+[2026-06-18T11:43:57.129Z] [INFO] 
+[2026-06-18T11:43:57.129Z] [INFO] ### 📋 Issue Reference
+[2026-06-18T11:43:57.129Z] [INFO] Fixes G-Ivan-A/hybrid-Intelligence-lab#251
+[2026-06-18T11:43:57.129Z] [INFO] 
+[2026-06-18T11:43:57.129Z] [INFO] ### 🚧 Status
+[2026-06-18T11:43:57.129Z] [INFO] **Work in Progress** - The AI assistant is currently analyzing and implementing the solution draft.
+[2026-06-18T11:43:57.129Z] [INFO] 
+[2026-06-18T11:43:57.129Z] [INFO] ### 📝 Implementation Details
+[2026-06-18T11:43:57.129Z] [INFO] _Details will be added as the solution draft is developed..._
+[2026-06-18T11:43:57.129Z] [INFO] 
+[2026-06-18T11:43:57.129Z] [INFO] ---
+[2026-06-18T11:43:57.129Z] [INFO] *This PR was created automatically by the AI issue solver*
+[2026-06-18T11:43:57.130Z] [INFO]    Command: cd "/tmp/gh-issue-solver-1781783024578" && gh pr create --draft --title "$(cat '/tmp/pr-title-1781783037130.txt')" --body-file "/tmp/pr-body-1781783037129.md" --base main --head konard:issue-251-45845bc22310 --repo G-Ivan-A/hybrid-Intelligence-lab
+[2026-06-18T11:43:58.875Z] [INFO]    gh pr create stdout: https://github.com/G-Ivan-A/hybrid-Intelligence-lab/pull/252
+[2026-06-18T11:43:58.876Z] [INFO] 🔍 Verifying:                PR creation...
+[2026-06-18T11:44:01.245Z] [STDOUT] {"number":252,"state":"OPEN","url":"https://github.com/G-Ivan-A/hybrid-Intelligence-lab/pull/252"}
+[2026-06-18T11:44:01.260Z] [INFO] ✅ Verification:             PR exists on GitHub (attempt 1/5)
+[2026-06-18T11:44:01.261Z] [INFO] ✅ PR created:               #252
+[2026-06-18T11:44:01.261Z] [INFO] 📍 PR URL:                   https://github.com/G-Ivan-A/hybrid-Intelligence-lab/pull/252
+[2026-06-18T11:44:01.265Z] [INFO] ℹ️ Note:                     Could not assign (no permission)
+[2026-06-18T11:44:01.266Z] [INFO] 🔗 Linking:                  Issue #251 to PR #252...
+[2026-06-18T11:44:01.686Z] [STDOUT] I_kwDOQvNwgs8AAAABF6pifw
+[2026-06-18T11:44:01.693Z] [INFO]    Issue node ID: I_kwDOQvNwgs8AAAABF6pifw
+[2026-06-18T11:44:02.149Z] [STDOUT] PR_kwDOQvNwgs7n7CFG
+[2026-06-18T11:44:02.187Z] [INFO]    PR node ID: PR_kwDOQvNwgs7n7CFG
+[2026-06-18T11:44:02.771Z] [STDOUT] 251
+[2026-06-18T11:44:02.778Z] [INFO] ✅ Link verified:            Issue #251 → PR #252
+[2026-06-18T11:44:05.593Z] [STDOUT] konard
+[2026-06-18T11:44:05.599Z] [INFO]   👤 Current user:           konard
+[2026-06-18T11:44:05.600Z] [INFO] 
+[2026-06-18T11:44:05.600Z] [INFO] 📊 Comment counting conditions:
+[2026-06-18T11:44:05.601Z] [INFO]    prNumber: 252
+[2026-06-18T11:44:05.602Z] [INFO]    branchName: issue-251-45845bc22310
+[2026-06-18T11:44:05.604Z] [INFO]    isContinueMode: false
+[2026-06-18T11:44:05.605Z] [INFO]    Will count comments: true
+[2026-06-18T11:44:05.606Z] [INFO] 💬 Counting comments:        Checking for new comments since last commit...
+[2026-06-18T11:44:05.607Z] [INFO]    PR #252 on branch: issue-251-45845bc22310
+[2026-06-18T11:44:05.607Z] [INFO]    Owner/Repo: G-Ivan-A/hybrid-Intelligence-lab
+[2026-06-18T11:44:05.607Z] [INFO]    Repository path: /tmp/gh-issue-solver-1781783024578
+[2026-06-18T11:44:05.622Z] [STDOUT] 2026-06-18T11:43:50+00:00
+[2026-06-18T11:44:05.624Z] [INFO]   📅 Last commit time:       2026-06-18T11:43:50.000Z
+[2026-06-18T11:44:05.939Z] [STDOUT] []
+[2026-06-18T11:44:06.341Z] [STDOUT] []
+[2026-06-18T11:44:06.697Z] [STDOUT] []
+[2026-06-18T11:44:06.706Z] [INFO]   💬 New PR comments:        0
+[2026-06-18T11:44:06.708Z] [INFO]   💬 New PR review comments: 0
+[2026-06-18T11:44:06.710Z] [INFO]   💬 New issue comments:     0
+[2026-06-18T11:44:06.711Z] [INFO]    Total new comments: 0
+[2026-06-18T11:44:06.714Z] [INFO]    Comment lines to add: No (saving tokens)
+[2026-06-18T11:44:06.714Z] [INFO]    PR review comments fetched: 0
+[2026-06-18T11:44:06.715Z] [INFO]    PR conversation comments fetched: 0
+[2026-06-18T11:44:06.715Z] [INFO]    Total PR comments checked: 0
+[2026-06-18T11:44:07.553Z] [STDOUT] {"url":"https://api.github.com/repos/G-Ivan-A/hybrid-Intelligence-lab/pulls/252","id":3891011910,"node_id":"PR_kwDOQvNwgs7n7CFG","html_url":"https://github.com/G-Ivan-A/hybrid-Intelligence-lab/pull/252","diff_url":"https://github.com/G-Ivan-A/hybrid-Intelligence-lab/pull/252.diff","patch_url":"https://github.com/G-Ivan-A/hybrid-Intelligence-lab/pull/252.patch","issue_url":"https://api.github.com/repos/G-Ivan-A/hybrid-Intelligence-lab/issues/252","number":252,"state":"open","locked":false,"title":"[WIP] creative: Формализация новых AI-классификаций (подпроцессы, артефакты, операции) и интеграция в роадмап Mango с учётом эволюции операций","user":{"login":"konard","id":1431904,"node_id":"MDQ6VXNlcjE0MzE5MDQ=","avatar_url":"https://avatars.githubusercontent.com/u/1431904?v=4","gravatar_id":"","url":"https://api.github.com/users/konard","html_url":"https://github.com/konard","followers_url":"https://api.github.com/users/konard/followers","following_url":"https://api.github.com/users/konard/following{/other_user}","gists_url":"https://api.github.com/users/konard/gists{/gist_id}","starred_url":"https://api.github.com/users/konard/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/konard/subscriptions","organizations_url":"https://api.github.com/users/konard/orgs","repos_url":"https://api.github.com/users/konard/repos","events_url":"https://api.github.com/users/konard/events{/privacy}","received_events_url":"https://api.github.com/users/konard/received_events","type":"User","user_view_type":"public","site_admin":false},"body":"## 🤖 AI-Powered Solution Draft\n\nThis pull request is being automatically generated to solve issue G-Ivan-A/hybrid-Intelligence-lab#251.\n\n### 📋 Issue Reference\nFixes G-Ivan-A/hybrid-Intelligence-lab#251\n\n### 🚧 Status\n**Work in Progress** - The AI assistant is currently analyzing and implementing the solution draft.\n\n### 📝 Implementation Details\n_Details will be added as the solution draft is developed..._\n\n---\n*This PR was created automatically by the AI issue solver*","created_at":"2026-06-18T11:43:58Z","updated_at":"2026-06-18T11:43:58Z","closed_at":null,"merged_at":null,"merge_commit_sha":"05f202166796531625b2167de313e5e50be2b065","assignees":[],"requested_reviewers":[],"requested_teams":[],"labels":[],"milestone":null,"draft":true,"commits_url":"https://api.github.com/repos/G-Ivan-A/hybrid-Intelligence-lab/pulls/252/commits","review_comments_url":"https://api.github.com/repos/G-Ivan-A/hybrid-Intelligence-lab/pulls/252/comments","review_comment_url":"https://api.github.com/repos/G-Ivan-A/hybrid-Intelligence-lab/pulls/comments{/number}","comments_url":"https://api.github.com/repos/G-Ivan-A/hybrid-Intelligence-lab/issues/252/comments","statuses_url":"https://api.github.com/repos/G-Ivan-A/hybrid-Intelligence-lab/statuses/bea**********************************245","head":{"label":"konard:issue-251-45845bc22310","ref":"issue-251-45845bc22310","sha":"bea**********************************245","user":{"login":"konard","id":1431904,"node_id":"MDQ6VXNlcjE0MzE5MDQ=","avatar_url":"https://avatars.githubusercontent.com/u/1431904?v=4","gravatar_id":"","url":"https://api.github.com/users/konard","html_url":"https://github.com/konard","followers_url":"https://api.github.com/users/konard/followers","following_url":"https://api.github.com/users/konard/following{/other_user}","gists_url":"https://api.github.com/users/konard/gists{/gist_id}","starred_url":"https://api.github.com/users/konard/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/konard/subscriptions","organizations_url":"https://api.github.com/users/konard/orgs","repos_url":"https://api.github.com/users/konard/repos","events_url":"https://api.github.com/users/konard/events{/privacy}","received_events_url":"https://api.github.com/users/konard/received_events","type":"User","user_view_type":"public","site_admin":false},"repo":{"id":1123267463,"node_id":"R_kgDOQvOzhw","name":"G-Ivan-A-hybrid-Intelligence-lab","full_name":"konard/G-Ivan-A-hybrid-Intelligence-lab","private":false,"owner":{"login":"konard","id":1431904,"node_id":"MDQ6VXNlcjE0MzE5MDQ=","avatar_url":"https://avatars.githubusercontent.com/u/1431904?v=4","gravatar_id":"","url":"https://api.github.com/users/konard","html_url":"https://github.com/konard","followers_url":"https://api.github.com/users/konard/followers","following_url":"https://api.github.com/users/konard/following{/other_user}","gists_url":"https://api.github.com/users/konard/gists{/gist_id}","starred_url":"https://api.github.com/users/konard/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/konard/subscriptions","organizations_url":"https://api.github.com/users/konard/orgs","repos_url":"https://api.github.com/users/konard/repos","events_url":"https://api.github.com/users/konard/events{/privacy}","received_events_url":"https://api.github.com/users/konard/received_events","type":"User","user_view_type":"public","site_admin":false},"html_url":"https://github.com/konard/G-Ivan-A-hybrid-Intelligence-lab","description":null,"fork":true,"url":"https://api.github.com/repos/konard/G-Ivan-A-hybrid-Intelligence-lab","forks_url":"https://api.github.com/repos/konard/G-Ivan-A-hybrid-Intelligence-lab/forks","keys_url":"https://api.github.com/repos/konard/G-Ivan-A-hybrid-Intelligence-lab/keys{/key_id}","collaborators_url":"https://api.github.com/repos/konard/G-Ivan-A-hybrid-Intelligence-lab/collaborators{/collaborator}","teams_url":"https://api.github.com/repos/konard/G-Ivan-A-hybrid-Intelligence-lab/teams","hooks_url":"https://api.github.com/repos/konard/G-Ivan-A-hybrid-Intelligence-lab/hooks","issue_events_url":"https://api.github.com/repos/konard/G-Ivan-A-hybrid-Intelligence-lab/issues/events{/number}","events_url":"https://api.github.com/repos/konard/G-Ivan-A-hybrid-Intelligence-lab/events","assignees_url":"https://api.github.com/repos/konard/G-Ivan-A-hybrid-Intelligence-lab/assignees{/user}","branches_url":"https://api.github.com/repos/konard/G-Ivan-A-hybrid-Intelligence-lab/branches{/branch}","tags_url":"https://api.github.com/repos/konard/G-Ivan-A-hybrid-Intelligence-lab/tags","blobs_url":"https://api.github.com/repos/konard/G-Ivan-A-hybrid-Intelligence-lab/git/blobs{/sha}","git_tags_url":"https://api.github.com/repos/konard/G-Ivan-A-hybrid-Intelligence-lab/git/tags{/sha}","git_refs_url":"https://api.github.com/repos/konard/G-Ivan-A-hybrid-Intelligence-lab/git/refs{/sha}","trees_url":"https://api.github.com/repos/konard/G-Ivan-A-hybrid-Intelligence-lab/git/trees{/sha}","statuses_url":"https://api.github.com/repos/konard/G-Ivan-A-hybrid-Intelligence-lab/statuses/{sha}","languages_url":"https://api.github.com/repos/konard/G-Ivan-A-hybrid-Intelligence-lab/languages","stargazers_url":"https://api.github.com/repos/konard/G-Ivan-A-hybrid-Intelligence-lab/stargazers","contributors_url":"https://api.github.com/repos/konard/G-Ivan-A-hybrid-Intelligence-lab/contributors","subscribers_url":"https://api.github.com/repos/konard/G-Ivan-A-hybrid-Intelligence-lab/subscribers","subscription_url":"https://api.github.com/repos/konard/G-Ivan-A-hybrid-Intelligence-lab/subscription","commits_url":"https://api.github.com/repos/konard/G-Ivan-A-hybrid-Intelligence-lab/commits{/sha}","git_commits_url":"https://api.github.com/repos/konard/G-Ivan-A-hybrid-Intelligence-lab/git/commits{/sha}","comments_url":"https://api.github.com/repos/konard/G-Ivan-A-hybrid-Intelligence-lab/comments{/number}","issue_comment_url":"https://api.github.com/repos/konard/G-Ivan-A-hybrid-Intelligence-lab/issues/comments{/number}","contents_url":"https://api.github.com/repos/konard/G-Ivan-A-hybrid-Intelligence-lab/contents/{+path}","compare_url":"https://api.github.com/repos/konard/G-Ivan-A-hybrid-Intelligence-lab/compare/{base}...{head}","merges_url":"https://api.github.com/repos/konard/G-Ivan-A-hybrid-Intelligence-lab/merges","archive_url":"https://api.github.com/repos/konard/G-Ivan-A-hybrid-Intelligence-lab/{archive_format}{/ref}","downloads_url":"https://api.github.com/repos/konard/G-Ivan-A-hybrid-Intelligence-
+[2026-06-18T11:44:07.642Z] [STDOUT] lab/downloads","issues_url":"https://api.github.com/repos/konard/G-Ivan-A-hybrid-Intelligence-lab/issues{/number}","pulls_url":"https://api.github.com/repos/konard/G-Ivan-A-hybrid-Intelligence-lab/pulls{/number}","milestones_url":"https://api.github.com/repos/konard/G-Ivan-A-hybrid-Intelligence-lab/milestones{/number}","notifications_url":"https://api.github.com/repos/konard/G-Ivan-A-hybrid-Intelligence-lab/notifications{?since,all,participating}","labels_url":"https://api.github.com/repos/konard/G-Ivan-A-hybrid-Intelligence-lab/labels{/name}","releases_url":"https://api.github.com/repos/konard/G-Ivan-A-hybrid-Intelligence-lab/releases{/id}","deployments_url":"https://api.github.com/repos/konard/G-Ivan-A-hybrid-Intelligence-lab/deployments","created_at":"2025-12-26T14:16:22Z","updated_at":"2026-06-18T11:40:15Z","pushed_at":"2026-06-18T11:43:51Z","git_url":"git://github.com/konard/G-Ivan-A-hybrid-Intelligence-lab.git","ssh_url":"git@github.com:konard/G-Ivan-A-hybrid-Intelligence-lab.git","clone_url":"https://github.com/konard/G-Ivan-A-hybrid-Intelligence-lab.git","svn_url":"https://github.com/konard/G-Ivan-A-hybrid-Intelligence-lab","homepage":null,"size":5373,"stargazers_count":0,"watchers_count":0,"language":"Shell","has_issues":false,"has_projects":true,"has_downloads":true,"has_wiki":true,"has_pages":false,"has_discussions":false,"forks_count":0,"mirror_url":null,"archived":false,"disabled":false,"open_issues_count":0,"license":{"key":"other","name":"Other","spdx_id":"NOASSERTION","url":null,"node_id":"MDc6TGljZW5zZTA="},"allow_forking":true,"is_template":false,"web_commit_signoff_required":false,"has_pull_requests":true,"pull_request_creation_policy":"all","topics":[],"visibility":"public","forks":0,"open_issues":0,"watchers":0,"default_branch":"main"}},"base":{"label":"G-Ivan-A:main","ref":"main","sha":"0d0**********************************d0e","user":{"login":"G-Ivan-A","id":236820953,"node_id":"U_kgDODh2Z2Q","avatar_url":"https://avatars.githubusercontent.com/u/236820953?v=4","gravatar_id":"","url":"https://api.github.com/users/G-Ivan-A","html_url":"https://github.com/G-Ivan-A","followers_url":"https://api.github.com/users/G-Ivan-A/followers","following_url":"https://api.github.com/users/G-Ivan-A/following{/other_user}","gists_url":"https://api.github.com/users/G-Ivan-A/gists{/gist_id}","starred_url":"https://api.github.com/users/G-Ivan-A/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/G-Ivan-A/subscriptions","organizations_url":"https://api.github.com/users/G-Ivan-A/orgs","repos_url":"https://api.github.com/users/G-Ivan-A/repos","events_url":"https://api.github.com/users/G-Ivan-A/events{/privacy}","received_events_url":"https://api.github.com/users/G-Ivan-A/received_events","type":"User","user_view_type":"public","site_admin":false},"repo":{"id":1123250306,"node_id":"R_kgDOQvNwgg","name":"hybrid-Intelligence-lab","full_name":"G-Ivan-A/hybrid-Intelligence-lab","private":false,"owner":{"login":"G-Ivan-A","id":236820953,"node_id":"U_kgDODh2Z2Q","avatar_url":"https://avatars.githubusercontent.com/u/236820953?v=4","gravatar_id":"","url":"https://api.github.com/users/G-Ivan-A","html_url":"https://github.com/G-Ivan-A","followers_url":"https://api.github.com/users/G-Ivan-A/followers","following_url":"https://api.github.com/users/G-Ivan-A/following{/other_user}","gists_url":"https://api.github.com/users/G-Ivan-A/gists{/gist_id}","starred_url":"https://api.github.com/users/G-Ivan-A/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/G-Ivan-A/subscriptions","organizations_url":"https://api.github.com/users/G-Ivan-A/orgs","repos_url":"https://api.github.com/users/G-Ivan-A/repos","events_url":"https://api.github.com/users/G-Ivan-A/events{/privacy}","received_events_url":"https://api.github.com/users/G-Ivan-A/received_events","type":"User","user_view_type":"public","site_admin":false},"html_url":"https://github.com/G-Ivan-A/hybrid-Intelligence-lab","description":null,"fork":false,"url":"https://api.github.com/repos/G-Ivan-A/hybrid-Intelligence-lab","forks_url":"https://api.github.com/repos/G-Ivan-A/hybrid-Intelligence-lab/forks","keys_url":"https://api.github.com/repos/G-Ivan-A/hybrid-Intelligence-lab/keys{/key_id}","collaborators_url":"https://api.github.com/repos/G-Ivan-A/hybrid-Intelligence-lab/collaborators{/collaborator}","teams_url":"https://api.github.com/repos/G-Ivan-A/hybrid-Intelligence-lab/teams","hooks_url":"https://api.github.com/repos/G-Ivan-A/hybrid-Intelligence-lab/hooks","issue_events_url":"https://api.github.com/repos/G-Ivan-A/hybrid-Intelligence-lab/issues/events{/number}","events_url":"https://api.github.com/repos/G-Ivan-A/hybrid-Intelligence-lab/events","assignees_url":"https://api.github.com/repos/G-Ivan-A/hybrid-Intelligence-lab/assignees{/user}","branches_url":"https://api.github.com/repos/G-Ivan-A/hybrid-Intelligence-lab/branches{/branch}","tags_url":"https://api.github.com/repos/G-Ivan-A/hybrid-Intelligence-lab/tags","blobs_url":"https://api.github.com/repos/G-Ivan-A/hybrid-Intelligence-lab/git/blobs{/sha}","git_tags_url":"https://api.github.com/repos/G-Ivan-A/hybrid-Intelligence-lab/git/tags{/sha}","git_refs_url":"https://api.github.com/repos/G-Ivan-A/hybrid-Intelligence-lab/git/refs{/sha}","trees_url":"https://api.github.com/repos/G-Ivan-A/hybrid-Intelligence-lab/git/trees{/sha}","statuses_url":"https://api.github.com/repos/G-Ivan-A/hybrid-Intelligence-lab/statuses/{sha}","languages_url":"https://api.github.com/repos/G-Ivan-A/hybrid-Intelligence-lab/languages","stargazers_url":"https://api.github.com/repos/G-Ivan-A/hybrid-Intelligence-lab/stargazers","contributors_url":"https://api.github.com/repos/G-Ivan-A/hybrid-Intelligence-lab/contributors","subscribers_url":"https://api.github.com/repos/G-Ivan-A/hybrid-Intelligence-lab/subscribers","subscription_url":"https://api.github.com/repos/G-Ivan-A/hybrid-Intelligence-lab/subscription","commits_url":"https://api.github.com/repos/G-Ivan-A/hybrid-Intelligence-lab/commits{/sha}","git_commits_url":"https://api.github.com/repos/G-Ivan-A/hybrid-Intelligence-lab/git/commits{/sha}","comments_url":"https://api.github.com/repos/G-Ivan-A/hybrid-Intelligence-lab/comments{/number}","issue_comment_url":"https://api.github.com/repos/G-Ivan-A/hybrid-Intelligence-lab/issues/comments{/number}","contents_url":"https://api.github.com/repos/G-Ivan-A/hybrid-Intelligence-lab/contents/{+path}","compare_url":"https://api.github.com/repos/G-Ivan-A/hybrid-Intelligence-lab/compare/{base}...{head}","merges_url":"https://api.github.com/repos/G-Ivan-A/hybrid-Intelligence-lab/merges","archive_url":"https://api.github.com/repos/G-Ivan-A/hybrid-Intelligence-lab/{archive_format}{/ref}","downloads_url":"https://api.github.com/repos/G-Ivan-A/hybrid-Intelligence-lab/downloads","issues_url":"https://api.github.com/repos/G-Ivan-A/hybrid-Intelligence-lab/issues{/number}","pulls_url":"https://api.github.com/repos/G-Ivan-A/hybrid-Intelligence-lab/pulls{/number}","milestones_url":"https://api.github.com/repos/G-Ivan-A/hybrid-Intelligence-lab/milestones{/number}","notifications_url":"https://api.github.com/repos/G-Ivan-A/hybrid-Intelligence-lab/notifications{?since,all,participating}","labels_url":"https://api.github.com/repos/G-Ivan-A/hybrid-Intelligence-lab/labels{/name}","releases_url":"https://api.github.com/repos/G-Ivan-A/hybrid-Intelligence-lab/releases{/id}","deployments_url":"https://api.github.com/repos/G-Ivan-A/hybrid-Intelligence-lab/deployments","created_at":"2025-12-26T13:36:29Z","updated_at":"2026-06-18T10:04:26Z","pushed_at":"2026-06-18T10:04:07Z","git_url":"git://github.com/G-Ivan-A/hybrid-Intelligence-lab.git","ssh_url":"git@github.com:G-Ivan-A/hybrid-Intelligence-lab.git","clone_url":"https://github.com/G-Ivan-A/hybrid-Intelligence-lab.git","svn_url":"https://github.com/G-Ivan-A/hybrid-Intelligence-lab","homepage":null,"size":5368,"stargazers_count":0,"watchers_count":0,"language":"Shell","has_issues":true,"has_projects":true,"has_downloads":true,"has_wiki":true,"has_pages":true,"has_discussions":false,"forks_count":1,"mirror_url":null,"archived":false,"disabled":false,"open_issues_count":4,"license":{"key":"other","name":"Other","spdx_id":"NOASSERTION","url":null,"node_id":"MDc6TGljZW5zZTA="},"allow_forking":true,"is_template":false,"web_commit_signoff_required":false,"has_pull_requests":true,"pull_request_creation_policy":"all","topics":[],"visibility":"public","forks":1,"open_issues":4,"watchers":0,"default_branch":"main"}},"_links":{"self":{"href":"https://api.github.com/repos/G-Ivan-A/hybrid-Intelligence-lab/pulls/252"},"html":{"href":"https://github.com/G-Ivan-A/hybrid-Intelligence-lab/pull/252"},"issue":{"href":"https://api.github.com/repos/G-Ivan-A/hybrid-Intelligence-lab/issues/252"},"comments":{"href":"https://api.github.com/repos/G-Ivan-A/hybrid-Intelligence-lab/issues/252/comments"},"review_comments":{"href":"https://api.github.com/repos/G-Ivan-A/hybrid-Intelligence-lab/pulls/252/comments"},"review_comment":{"href":"https://api.github.com/repos/G-Ivan-A/hybrid-Intelligence-lab/pulls/comments{/number}"},"commits":{"href":"https://api.github.com/repos/G-Ivan-A/hybrid-Intelligence-lab/pulls/252/commits"},"statuses":{"href":"https://api.github.com/repos/G-Ivan-A/hybrid-Intelligence-lab/statuses/bea**********************************245"}},"author_association":"CONTRIBUTOR","auto_merge":null,"assignee":null,"active_lock_reason":null,"merged":false,"mergeable":true,"rebaseable":true,"mergeable_state":"clean","merged_by":null,"comments":0,"review_comments":0,"maintainer_can_modify":true,"commits":1,"additions":1,"deletions":0,"changed_files":1}
+[2026-06-18T11:44:08.012Z] [STDOUT] {"url":"https://api.github.com/repos/G-Ivan-A/hybrid-Intelligence-lab/issues/251","repository_url":"https://api.github.com/repos/G-Ivan-A/hybrid-Intelligence-lab","labels_url":"https://api.github.com/repos/G-Ivan-A/hybrid-Intelligence-lab/issues/251/labels{/name}","comments_url":"https://api.github.com/repos/G-Ivan-A/hybrid-Intelligence-lab/issues/251/comments","events_url":"https://api.github.com/repos/G-Ivan-A/hybrid-Intelligence-lab/issues/251/events","html_url":"https://github.com/G-Ivan-A/hybrid-Intelligence-lab/issues/251","id":4692009599,"node_id":"I_kwDOQvNwgs8AAAABF6pifw","number":251,"title":"creative: Формализация новых AI-классификаций (подпроцессы, артефакты, операции) и интеграция в роадмап Mango с учётом эволюции операций","user":{"login":"G-Ivan-A","id":236820953,"node_id":"U_kgDODh2Z2Q","avatar_url":"https://avatars.githubusercontent.com/u/236820953?v=4","gravatar_id":"","url":"https://api.github.com/users/G-Ivan-A","html_url":"https://github.com/G-Ivan-A","followers_url":"https://api.github.com/users/G-Ivan-A/followers","following_url":"https://api.github.com/users/G-Ivan-A/following{/other_user}","gists_url":"https://api.github.com/users/G-Ivan-A/gists{/gist_id}","starred_url":"https://api.github.com/users/G-Ivan-A/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/G-Ivan-A/subscriptions","organizations_url":"https://api.github.com/users/G-Ivan-A/orgs","repos_url":"https://api.github.com/users/G-Ivan-A/repos","events_url":"https://api.github.com/users/G-Ivan-A/events{/privacy}","received_events_url":"https://api.github.com/users/G-Ivan-A/received_events","type":"User","user_view_type":"public","site_admin":false},"labels":[],"state":"open","locked":false,"assignees":[],"milestone":null,"comments":0,"created_at":"2026-06-18T11:42:56Z","updated_at":"2026-06-18T11:42:56Z","closed_at":null,"assignee":null,"author_association":"OWNER","active_lock_reason":null,"sub_issues_summary":{"total":0,"completed":0,"percent_completed":0},"issue_dependencies_summary":{"blocked_by":0,"total_blocked_by":0,"blocking":0,"total_blocking":0},"body":"## 🔗 Мета\n\n**Labels**: `creative` | `research` | `priority:P2` | `requirements-engineering` | `ai-era` | `roadmap` | `mango-integration`\n**Milestone**: `Sprint 3 — Hybrid Minimum Bootstrap`\n**Depends On**: \n  - PR #248 (Исследование Вигерса — после исправлений P1)\n  - Задача P1 (Исправление и дополнение исследования Вигерса)\n  - PR #242 (Research Memory — процесс исследования источника)\n  - PR #246 (Methodology Research — AI-тренды)\n**Operating Mode**: `Creative` (синтез, формализация, предложения по интеграции) + `Research` (анализ современных AI-фреймворков)\n**Lifecycle Stage**: `Research → RFC`\n\n---\n\n## 🧠 ПОЛНЫЙ КОНТЕКСТ (КРИТИЧЕСКИ ВАЖНО)\n\n### Эволюция мысли\n\n**Этап 1: Исходное исследование (PR #248)**\n- Исследование книги Вигерса \"Разработка требований к ПО\" (2020)\n- Цель: независимо извлечь систему уровней/типов требований, процессов/операций, глоссарий\n- Актуализировать через сравнение 3 трендов (2020/2026/2026 ИИ)\n\n**Этап 2: Исправления P1**\n- Исправлены пути артефактов (research/external-knowledge/, research/mango/)\n- Исправлена классификация (Prompt = интерфейс к Tool, Prompt engineering = подпроцесс)\n- Добавлена база для Фазы 2 (процессы/подпроцессы для AI-агента)\n- Дополнено исследование сравнением с BABOK/ISO/AI\n\n**Этап 3: Финальная синхронизация видения**\n- Prompt engineering = подпроцесс (не операция, не тип требования)\n- Prompt = интерфейс к Tool (не сам Tool)\n- Prompt specification = описательный документ для отладки/guides\n- Новые подпроцессы для Фазы 2 (Разработка AI-агента)\n- AI-assisted операции требуют осознанного перехода в роадмап\n\n**Этап 4: Цель P2**\n- Детально формализовать новые AI-классификации (не просто список, а полноценное описание)\n- Интегрировать в роадмап Mango (как это влияет на эволюцию операций)\n- Подготовить к синхронизации с mango_ba_prompts (С1, С2, С3)\n\n---\n\n### Что мы отвергли и почему\n\n#### ❌ Отвергнуто: \"Просто добавить новые операции в список\"\n**Почему:** Недостаточно. Нужно понять, как новые подпроцессы интегрируются в существующую систему, как они связаны с классическими операциями, как меняется роадмап.\n\n#### ❌ Отвергнуто: \"Заменить классические операции AI-версиями\"\n**Почему:** Классические операции не устаревают, они дополняются AI-ассистированными версиями. Нужно показать эволюцию, а не замену.\n\n#### ❌ Отвергнуто: \"Создать отдельные процессы для AI\"\n**Почему:** AI-разработка — это не отдельный процесс, а расширение существующих процессов. Нужно показать интеграцию, а не изоляцию.\n\n---\n\n### Что мы приняли (ключевые принципы)\n\n#### ✅ Принято: \"Детальная формализация новых AI-классификаций\"\n\n**Новые подпроцессы (дополняют Вигерса):**\n\n1. **Инжиниринг промптов (Prompt Engineering)**\n   - Операции: анализ задачи, написание черновика, тестирование, итерация, валидация\n   - Артефакты: Prompt specification (описательный) + Исполнимый промпт\n   - Связь с классикой: дополняет \"Документирование требований\"\n\n2. **Настройка RAG (RAG Configuration)**\n   - Операции: выбор векторной базы, настройка chunking, настройка retrieval\n   - Артефакты: RAG configuration document\n   - Связь с классикой: дополняет \"Проектирование решений\"\n\n3. **Проектирование оркестрации агентов (Agent Orchestration Design)**\n   - Операции: определение сценариев взаимодействия, проектирование протоколов коммуникации, настройка координации\n   - Артефакты: Agent orchestration diagram\n   - Связь с классикой: дополняет \"Проектирование архитектуры\"\n\n4. **Тестирование AI-компонентов (AI Testing)**\n   - Операции: написание тестовых сценариев, запуск тестов, анализ результатов\n   - Артефакты: AI test suite\n   - Связь с классикой: дополняет \"Валидация требований\"\n\n#### ✅ Принято: \"Интеграция в роадмап Mango (эволюция операций)\"\n\n**Пример эволюции:**\n- Классическая операция: \"Анализ документов\"\n- AI-версия: \"AI-assisted document analysis\"\n- **Не просто \"включение кнопки\"** — требует:\n  - Обучения БА работе с AI-инструментами\n  - Настройки AI-инструментов\n  - Валидации AI-выводов\n  - Интеграции в роадмап\n\n**План перехода:**\n1. Фаза 0 (текущая): Классические операции + базовые промпты\n2. Фаза 1 (Trust & Evidence): AI-assisted операции с валидацией\n3. Фаза 2 (AI-агенты): Полноценные AI-подпроцессы (Prompt engineering, RAG config, Agent orchestration)\n4. Фаза 3 (Мультиагентные системы): Комплексные AI-решения\n\n#### ✅ Принято: \"Подготовка к синхронизации с mango_ba_prompts\"\n\n**Что нужно подготовить:**\n- С1: Ось `requirement_level` (Business → User → Functional → Non-functional)\n- С2: Тип \"Бизнес-правило\" + 5 категорий (Факты, Ограничения, Активаторы, Выводы, Вычисления)\n- С3: Crosswalk Вигерс ↔ операции mango ↔ BCREQ\n\n---\n\n##  Цель задачи\n\n1. **Детально формализовать** новые AI-классификации (подпроцессы, операции, артефакты)\n2. **Интегрировать** в роадмап Mango (эволюция операций)\n3. **Подготовить** к синхронизации с mango_ba_prompts (С1, С2, С3)\n4. **Создать** полноценное описание с примерами (не просто списки)\n\n---\n\n## ✅ ФТ (Функциональные требования)\n\n### ФТ-1: Детальная формализация новых AI-подпроцессов\n\n**Для каждого подпроцесса создать полноценное описание:**\n\n**1. Инжиниринг промптов (Prompt Engineering)**\n\n**Описание:** Подпроцесс создания, тестирования и валидации промптов для AI-компонентов.\n\n**Операции:**\n- Операция 1.1: \"Анализ задачи для промпта\"\n  - Вход: бизнес-требование, контекст\n  - Действие: определение цели промпта, входных/выходных данных\n  - Выход: спецификация задачи для промпта\n- Операция 1.2: \"Написание черновика промпта\"\n  - Вход: спецификация задачи\n  - Действие: создание первой версии промпта\n  - Выход: черновик промпта\n- Операция 1.3: \"Тестирование промпта\"\n  - Вход: черновик промпта, тестовые данные\n  - Действие: запуск промпта, анализ результатов\n  - Выход: результаты тестирования\n- Операция 1.4: \"Итерация промпта\"\n  - Вход: результаты тестирования\n  - Действие: улучшение промпта на основе результатов\n  - Выход: улучшенная версия промпта\n- Операция 1.5: \"Валидация промпта\"\n  - Вход: улучшенная версия промпта\n  - Действие: финальная проверка соответствия требованиям\n  - Выход: валидированный промпт\n\n**Артефакты:**\n- **Prompt specification** (описательный документ):\n  - Назначение промпта\n  - Входные данные\n  - Ожидаемый выход\n  - Контекст (какие знания использует)\n  - Критерии качества\n  - Примеры использования\n  - Связь с бизнес-требованиями\n- **Исполнимый промпт** (исполнимый артефакт):\n  - Текст промпта для LLM\n\n**Связь с классикой:** Дополняет \"Документирование требований\" (Вигерс, глава 10)\n\n---\n\n**2. Настройка RAG (RAG Configuration)**\n\n**Описание:** Подпроцесс настройки Retrieval-Augmented Generation для AI-компонентов.\n\n**Операции:**\n- Операция 2.1: \"Выбор векторной базы\"\n  - Вход: требования к хранению знаний\n  - Действие: анализ доступных решений (Chroma, Pinecone, YDB)\n  - Выход: выбранная векторная база\n- Операция 2.2: \"Настройка chunking\"\n  - Вход: документы для индексации\n  - Действие: определение стратегии разделения документов\n  - Выход: настроенный chunking\n- Операция 2.3: \"Настройка retrieval\"\n  - Вход: векторная база, chunking\n  - Действие: настройка поиска и ранжирования\n  - Выход: настроенный retrieval\n\n**Артефакты:**\n- **RAG configuration document** (описательный документ):\n  - Выбранная векторная база и обоснование\n  - Стратегия chunking\n  - Параметры retrieval\n  - Критерии качества поиска\n\n**Связь с классикой:** Дополняет \"Проектирование решений\" (Вигерс, глава 12)\n\n---\n\n**3. Проектирование оркестрации агентов (Agent Orchestration Design)**\n\n**Описание:** Подпроцесс проектирования взаимодействия между AI-агентами в мультиагентной системе.\n\n**Операции:**\n- Операция 3.1: \"Определение сценариев взаимодействия\"\n  - Вход: бизнес-требования к мультиагентной системе\n  - Действие: определение ролей агентов и сценариев их взаимодействия\n  - Выход: сценарии взаимодействия\n- Операция 3.2: \"Проектирование протоколов коммуникации\"\n  - Вход: сценарии взаимодействия\n  - Действие: определение форматов сообщений и протоколов\n  - Выход: спецификация протоколов\n- Операция 3.3: \"Настройка координации\"\n  - Вход: спецификация протоколов\n  - Действие: настройка координации между агентами\n  - Выход: настроенная оркестрация\n\n**Артефакты:**\n- **Agent orchestration diagram** (описательный документ):\n  - Роли агентов\n  - Сценарии взаимодействия\n  - Протоколы коммуникации\n  - Механизмы координации\n\n**Связь с классикой:** Дополняет \"Проектирование архитектуры\" (Вигерс, глава 19)\n\n---\n\n**4. Тестирование AI-компонентов (AI Testing)**\n\n**Описание:** Подпроцесс тестирования AI-компонентов (промптов, RAG, агентов).\n\n**Операции:**\n- Операция 4.1: \"Написание тестовых сценариев\"\n  - Вход: спецификации AI-компонентов\n  - Действие: создание тестовых сценариев\n  - Выход: тестовые сценарии\n- Операция 4.2: \"Запуск тестов\"\n  - Вход: тестовые сценарии, AI-компоненты\n  - Действие: выполнение тестов\n  - Выход: результаты тестов\n- Операция 4.3: \"Анализ результатов\"\n  - Вход: результаты тестов\n  - Действие: анализ качества AI-компонентов\n  - Выход: отчёт о тестировании\n\n**Артефакты:**\n- **AI test suite** (исполнимый артефакт):\n  - Тестовые сценарии\n  - Ожидаемые результаты\n  - Критерии прохождения\n\n**Связь с классикой:** Дополняет \"Валидация требований\" (Вигерс, глава 17)\n\n---\n\n### ФТ-2: Интеграция в роадмап Mango (эволюция операций)\n\n**Создать раздел: \"Эволюция операций в роадмапе Mango\"**\n\n**Фаза 0 (текущая): Классические операции + базовые промпты**\n- Операции: классические (интервью, анализ документов, документирование)\n- AI-компоненты: базовые промпты (без AI-assisted операций)\n- Артефакты: стандартные (SRS, User Story, Use Case)\n\n**Фаза 1 (Trust & Evidence): AI-assisted операции с валидацией**\n- Операции: классические + AI-assisted версии\n  - Пример: \"Анализ документов\" → \"AI-assisted document analysis\"\n  - Пример: \"Проверка противоречий\" → \"AI-powered consistency checking\"\n- AI-компоненты: промпты с валидацией (Trust & Evidence E0-E4)\n- Артефакты: стандартные + Prompt specification\n\n**Фаза 2 (AI-агенты): Полноценные AI-подпроцессы**\n- Операции: классические + AI-assisted + новые AI-операции\n- AI-компоненты: полноценные подпроцессы (Prompt engineering, RAG config, Agent orchestration)\n- Артефакты: стандартные + AI-specific (Prompt spec, RAG config doc, Agent orchestration diagram)\n\n**Фаза 3 (Мультиагентные системы): Комплексные AI-решения**\n- Операции: полная интеграция классических и AI-операций\n- AI-компоненты: мультиагентные системы\n- Артефакты: комплексные AI-решения\n\n**План перехода для каждой операции:**\n1. **Обучение:** Обучение БА работе с AI-инструментами\n2. **Настройка:** Настройка AI-инструментов\n3. **Валидация:** Валидация AI-выводов\n4. **Интеграция:** Интеграция в роадмап\n\n---\n\n### ФТ-3: Подготовка к синхронизации с mango_ba_prompts\n\n**Подготовить документы для синхронизации:**\n\n**1. С1: Ось `requirement_level`**\n- Описание: ортогональная ось для классификации уровней требований\n- Значения: Business, User, Functional, Non-functional\n- Интеграция: добавить в ADR-003 (онтология БА) как дополнительный тег\n- Пример: требование \"Система должна отвечать за 2 секунды\" → level: Non-functional\n\n**2. С2: Тип \"Бизнес-правило\" + 5 категорий**\n- Опи
+[2026-06-18T11:44:08.013Z] [STDOUT] сание: новый тип артефакта для явного представления бизнес-правил\n- Категории:\n  - Факты (Facts)\n  - Ограничения (Constraints)\n  - Активаторы операций (Operation Activators)\n  - Выводы (Inferences)\n  - Вычисления (Computations)\n- Интеграция: добавить в реестр артефактов ADR-003\n- Пример: \"Если клиент VIP, то скидка 10%\" → тип: Business Rule, категория: Inference\n\n**3. С3: Crosswalk Вигерс ↔ операции mango ↔ BCREQ**\n- Описание: справочная таблица соответствия процессов\n- Формат: таблица с тремя колонками (Вигерс, операции mango, BCREQ)\n- Интеграция: добавить в ADR-004 (таксономия операций) как примечание со ссылкой на RFC Хаба\n- Пример: \"Выявление требований\" (Вигерс) ↔ \"ingestion, understanding\" (mango) ↔ \"П1\" (BCREQ)\n\n---\n\n### ФТ-4: Создание полноценного описания с примерами\n\n**Для каждого нового элемента создать:**\n- Описание (что это, зачем нужно)\n- Пример использования (конкретный кейс)\n- Связь с классикой (как дополняет Вигерса/BABOK)\n- Критерии качества (как проверить, что сделано хорошо)\n\n**Пример для \"Инжиниринг промптов\":**\n\n**Описание:** Подпроцесс создания, тестирования и валидации промптов для AI-компонентов.\n\n**Пример использования:**\n- Бизнес-требование: \"Система должна анализировать документацию заказчика и извлекать требования\"\n- Prompt specification: описание промпта для анализа документации\n- Исполнимый промпт: текст промпта для LLM\n- Тестирование: проверка на тестовых документах\n- Валидация: соответствие критериям качества\n\n**Связь с классикой:** Дополняет \"Документирование требований\" (Вигерс, глава 10)\n\n**Критерии качества:**\n- Промпт соответствует бизнес-требованию\n- Промпт проходит тестирование на тестовых данных\n- Промпт валидирован по критериям качества\n\n---\n\n## ⚠️ НФТ (Нефункциональные требования)\n\n1. **Полнота:** Все новые AI-классификации должны быть детально описаны (не просто списки)\n2. **Примеры:** Для каждого элемента должен быть конкретный пример использования\n3. **Связь с классикой:** Для каждого нового элемента должна быть указана связь с Вигерсом/BABOK\n4. **Интеграция:** Новые элементы должны быть интегрированы в роадмап Mango (не изолированы)\n5. **Двуязычие:** Все термины — русский + английский\n6. **Креативность:** Синтез, формализация, предложения по интеграции — креативные\n7. **Доверенные ресурсы:** Опираться на LangChain, CrewAI, Microsoft AI Toolkit (не выдумывать)\n8. **Вопросы в конце:** Все открытые вопросы должны быть в конце документа с ответами\n9. **kebab-case / полные пути / валидация:** Стандартные требования экосистемы\n\n---\n\n## 📋 Definition of Done\n\n- [ ] Детально формализованы 4 новых AI-подпроцесса (Prompt engineering, RAG config, Agent orchestration, AI testing)\n- [ ] Для каждого подпроцесса описаны операции (вход, действие, выход)\n- [ ] Для каждого подпроцесса описаны артефакты (описательные и исполнимые)\n- [ ] Для каждого подпроцесса указана связь с классикой (Вигерс/BABOK)\n- [ ] Создан раздел \"Эволюция операций в роадмапе Mango\" (4 фазы)\n- [ ] Для каждой фазы описан план перехода (обучение, настройка, валидация, интеграция)\n- [ ] Подготовлены документы для синхронизации с mango_ba_prompts (С1, С2, С3)\n- [ ] Для каждого нового элемента создан полноценный пример использования\n- [ ] Все термины — двуязычные (русский + английский)\n- [ ] Создан файл `research/mango/ai-classifications-formalization-2026-06.md`\n- [ ] Локальная валидация пройдена\n- [ ] Коммит: `creative: Formalize AI-classifications and integrate into Mango roadmap`\n- [ ] Задача в статусе `review`\n\n---\n\n##  Дополнительные материалы\n\n**Репозитории:**\n- mango_ba_prompts: https://github.com/G-Ivan-A/mango_ba_prompts\n- hybrid-Intelligence-lab: https://github.com/G-Ivan-A/hybrid-Intelligence-lab\n\n**Источники для формализации:**\n- LangChain: https://github.com/langchain-ai/langchain\n- CrewAI: https://github.com/crewAIInc/crewAI\n- Microsoft AI Toolkit: https://github.com/microsoft-foundry/foundry-samples\n- AutoGPT: https://github.com/Significant-Gravitas/AutoGPT\n\n**Существующие артефакты (для интеграции):**\n- ADR-003 (Онтология БА): https://github.com/G-Ivan-A/mango_ba_prompts/tree/main/docs/adr\n- ADR-004 (Таксономия операций): https://github.com/G-Ivan-A/mango_ba_prompts/tree/main/docs/adr\n- ADR-009 (Процесс BCREQ): https://github.com/G-Ivan-A/mango_ba_prompts/tree/main/docs/adr\n\n**RFC Хаба (для контекста):**\n- PR #242 (Research Memory): https://github.com/G-Ivan-A/hybrid-Intelligence-lab/blob/main/governance/rfc/research-memory-source-intelligence.md\n- PR #246 (Methodology Research): https://github.com/G-Ivan-A/hybrid-Intelligence-lab/blob/main/governance/rfc/methodology-research-and-proposals.md\n- PR #248 (Исследование Вигерса): https://github.com/G-Ivan-A/hybrid-Intelligence-lab/blob/main/research/mango/requirements-engineering-ai-era-2026.md\n\n---\n\n## ❓ Открытые вопросы\n\n**ОВ-1: Нужно ли создавать отдельные стандарты для AI-подпроцессов?**\n- **Ответ:** Нет, достаточно описания в RFC. Стандарты создаются при возникновении конкретной боли (принцип Anti-Inflation).\n\n**ОВ-2: Как интегрировать AI-assisted операции в существующие стандарты mango?**\n- **Ответ:** Через обновление ADR-004 (таксономия операций) — добавить AI-версии как дополнительные операции к классическим.\n\n**ОВ-3: Нужно ли создавать Prompt specification для всех промптов в mango?**\n- **Ответ:** Нет, только для критичных промптов (используемых в продакшене). Для экспериментальных промптов достаточно исполнимого промпта.\n\n**ОВ-4: Как валидировать AI-выводы в AI-assisted операциях?**\n- **Ответ:** Через Trust & Evidence (E0-E4) — каждый AI-вывод должен иметь уровень доверия. Валидация — это операция \"Проверка AI-вывода\" с критериями качества.\n\n**ОВ-5: Когда начинать Фазу 2 (AI-агенты) в роадмапе Mango?**\n- **Ответ:** После завершения Фазы 1 (Trust & Evidence) и синхронизации с mango_ba_prompts (С1, С2, С3). Ориентировочно: сентябрь 2026.\n\n---\n\n> ⚠️ **Для Исполнителя**:\n> - 🔥 **Режим `Creative` + `Research`**: детальная формализация + креативная интеграция в роадмап\n> - 🎯 **Твоя роль**: формализатор, интегратор, синтезатор\n> - 📋 **ОБЯЗАТЕЛЬНО**: детально формализуй 4 новых AI-подпроцесса (операции, артефакты, связь с классикой)\n> - 🗺️ **ОБЯЗАТЕЛЬНО**: интегрируй в роадмап Mango (4 фазы, план перехода)\n> -  **ОБЯЗАТЕЛЬНО**: подготовь документы для синхронизации с mango_ba_prompts (С1, С2, С3)\n> - 💡 **ОБЯЗАТЕЛЬНО**: создай полноценные примеры для каждого нового элемента\n> - 🌐 **ОБЯЗАТЕЛЬНО**: все термины — русский + английский\n> - ❓ **ОБЯЗАТЕЛЬНО**: вопросы в конце с ответами\n> - ✅ **Результат**: \n>   - Детально формализованные AI-классификации\n>   - Интеграция в роадмап Mango\n>   - Подготовка к синхронизации с mango_ba_prompts\n>   - Полноценные примеры использования","closed_by":null,"reactions":{"url":"https://api.github.com/repos/G-Ivan-A/hybrid-Intelligence-lab/issues/251/reactions","total_count":0,"+1":0,"-1":0,"laugh":0,"hooray":0,"confused":0,"heart":0,"rocket":0,"eyes":0},"timeline_url":"https://api.github.com/repos/G-Ivan-A/hybrid-Intelligence-lab/issues/251/timeline","performed_via_github_app":null,"state_reason":null,"pinned_comment":null}
+[2026-06-18T11:44:08.404Z] [STDOUT] {"id":1123250306,"node_id":"R_kgDOQvNwgg","name":"hybrid-Intelligence-lab","full_name":"G-Ivan-A/hybrid-Intelligence-lab","private":false,"owner":{"login":"G-Ivan-A","id":236820953,"node_id":"U_kgDODh2Z2Q","avatar_url":"https://avatars.githubusercontent.com/u/236820953?v=4","gravatar_id":"","url":"https://api.github.com/users/G-Ivan-A","html_url":"https://github.com/G-Ivan-A","followers_url":"https://api.github.com/users/G-Ivan-A/followers","following_url":"https://api.github.com/users/G-Ivan-A/following{/other_user}","gists_url":"https://api.github.com/users/G-Ivan-A/gists{/gist_id}","starred_url":"https://api.github.com/users/G-Ivan-A/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/G-Ivan-A/subscriptions","organizations_url":"https://api.github.com/users/G-Ivan-A/orgs","repos_url":"https://api.github.com/users/G-Ivan-A/repos","events_url":"https://api.github.com/users/G-Ivan-A/events{/privacy}","received_events_url":"https://api.github.com/users/G-Ivan-A/received_events","type":"User","user_view_type":"public","site_admin":false},"html_url":"https://github.com/G-Ivan-A/hybrid-Intelligence-lab","description":null,"fork":false,"url":"https://api.github.com/repos/G-Ivan-A/hybrid-Intelligence-lab","forks_url":"https://api.github.com/repos/G-Ivan-A/hybrid-Intelligence-lab/forks","keys_url":"https://api.github.com/repos/G-Ivan-A/hybrid-Intelligence-lab/keys{/key_id}","collaborators_url":"https://api.github.com/repos/G-Ivan-A/hybrid-Intelligence-lab/collaborators{/collaborator}","teams_url":"https://api.github.com/repos/G-Ivan-A/hybrid-Intelligence-lab/teams","hooks_url":"https://api.github.com/repos/G-Ivan-A/hybrid-Intelligence-lab/hooks","issue_events_url":"https://api.github.com/repos/G-Ivan-A/hybrid-Intelligence-lab/issues/events{/number}","events_url":"https://api.github.com/repos/G-Ivan-A/hybrid-Intelligence-lab/events","assignees_url":"https://api.github.com/repos/G-Ivan-A/hybrid-Intelligence-lab/assignees{/user}","branches_url":"https://api.github.com/repos/G-Ivan-A/hybrid-Intelligence-lab/branches{/branch}","tags_url":"https://api.github.com/repos/G-Ivan-A/hybrid-Intelligence-lab/tags","blobs_url":"https://api.github.com/repos/G-Ivan-A/hybrid-Intelligence-lab/git/blobs{/sha}","git_tags_url":"https://api.github.com/repos/G-Ivan-A/hybrid-Intelligence-lab/git/tags{/sha}","git_refs_url":"https://api.github.com/repos/G-Ivan-A/hybrid-Intelligence-lab/git/refs{/sha}","trees_url":"https://api.github.com/repos/G-Ivan-A/hybrid-Intelligence-lab/git/trees{/sha}","statuses_url":"https://api.github.com/repos/G-Ivan-A/hybrid-Intelligence-lab/statuses/{sha}","languages_url":"https://api.github.com/repos/G-Ivan-A/hybrid-Intelligence-lab/languages","stargazers_url":"https://api.github.com/repos/G-Ivan-A/hybrid-Intelligence-lab/stargazers","contributors_url":"https://api.github.com/repos/G-Ivan-A/hybrid-Intelligence-lab/contributors","subscribers_url":"https://api.github.com/repos/G-Ivan-A/hybrid-Intelligence-lab/subscribers","subscription_url":"https://api.github.com/repos/G-Ivan-A/hybrid-Intelligence-lab/subscription","commits_url":"https://api.github.com/repos/G-Ivan-A/hybrid-Intelligence-lab/commits{/sha}","git_commits_url":"https://api.github.com/repos/G-Ivan-A/hybrid-Intelligence-lab/git/commits{/sha}","comments_url":"https://api.github.com/repos/G-Ivan-A/hybrid-Intelligence-lab/comments{/number}","issue_comment_url":"https://api.github.com/repos/G-Ivan-A/hybrid-Intelligence-lab/issues/comments{/number}","contents_url":"https://api.github.com/repos/G-Ivan-A/hybrid-Intelligence-lab/contents/{+path}","compare_url":"https://api.github.com/repos/G-Ivan-A/hybrid-Intelligence-lab/compare/{base}...{head}","merges_url":"https://api.github.com/repos/G-Ivan-A/hybrid-Intelligence-lab/merges","archive_url":"https://api.github.com/repos/G-Ivan-A/hybrid-Intelligence-lab/{archive_format}{/ref}","downloads_url":"https://api.github.com/repos/G-Ivan-A/hybrid-Intelligence-lab/downloads","issues_url":"https://api.github.com/repos/G-Ivan-A/hybrid-Intelligence-lab/issues{/number}","pulls_url":"https://api.github.com/repos/G-Ivan-A/hybrid-Intelligence-lab/pulls{/number}","milestones_url":"https://api.github.com/repos/G-Ivan-A/hybrid-Intelligence-lab/milestones{/number}","notifications_url":"https://api.github.com/repos/G-Ivan-A/hybrid-Intelligence-lab/notifications{?since,all,participating}","labels_url":"https://api.github.com/repos/G-Ivan-A/hybrid-Intelligence-lab/labels{/name}","releases_url":"https://api.github.com/repos/G-Ivan-A/hybrid-Intelligence-lab/releases{/id}","deployments_url":"https://api.github.com/repos/G-Ivan-A/hybrid-Intelligence-lab/deployments","created_at":"2025-12-26T13:36:29Z","updated_at":"2026-06-18T10:04:26Z","pushed_at":"2026-06-18T10:04:07Z","git_url":"git://github.com/G-Ivan-A/hybrid-Intelligence-lab.git","ssh_url":"git@github.com:G-Ivan-A/hybrid-Intelligence-lab.git","clone_url":"https://github.com/G-Ivan-A/hybrid-Intelligence-lab.git","svn_url":"https://github.com/G-Ivan-A/hybrid-Intelligence-lab","homepage":null,"size":5368,"stargazers_count":0,"watchers_count":0,"language":"Shell","has_issues":true,"has_projects":true,"has_downloads":true,"has_wiki":true,"has_pages":true,"has_discussions":false,"forks_count":1,"mirror_url":null,"archived":false,"disabled":false,"open_issues_count":4,"license":{"key":"other","name":"Other","spdx_id":"NOASSERTION","url":null,"node_id":"MDc6TGljZW5zZTA="},"allow_forking":true,"is_template":false,"web_commit_signoff_required":false,"has_pull_requests":true,"pull_request_creation_policy":"all","topics":[],"visibility":"public","forks":1,"open_issues":4,"watchers":0,"default_branch":"main","permissions":{"admin":false,"maintain":false,"push":false,"triage":false,"pull":true},"temp_clone_token":"","network_count":1,"subscribers_count":0}
+[2026-06-18T11:44:08.595Z] [STDOUT] {
+  "message": "Not Found",
+  "documentation_url": "https://docs.github.com/rest",
+  "status": "404"
+}
+[2026-06-18T11:44:08.596Z] [STDERR] gh: Not Found (HTTP 404)
+[2026-06-18T11:44:09.261Z] [STDOUT] bea**********************************245
+[2026-06-18T11:44:09.634Z] [STDOUT] [{"total_count":0,"check_runs":[]}
+[2026-06-18T11:44:09.634Z] [STDOUT] ]
+[2026-06-18T11:44:10.071Z] [STDOUT] []
+[2026-06-18T11:44:10.081Z] [INFO]    Feedback info will be added to prompt:
+[2026-06-18T11:44:10.083Z] [INFO]      - Pull request description was edited after last commit
+[2026-06-18T11:44:10.083Z] [INFO] 📅 Getting timestamps:       From GitHub servers...
+[2026-06-18T11:44:10.424Z] [STDOUT] 2026-06-18T11:42:56Z
+[2026-06-18T11:44:10.442Z] [INFO]   📝 Issue updated:          2026-06-18T11:42:56.000Z
+[2026-06-18T11:44:10.843Z] [STDOUT] []
+[2026-06-18T11:44:10.861Z] [INFO]   💬 Comments:               None found
+[2026-06-18T11:44:11.289Z] [STDOUT] [{"createdAt":"2026-06-18T11:43:58Z"}]
+[2026-06-18T11:44:11.296Z] [INFO]   🔀 Recent PR:              2026-06-18T11:43:58.000Z
+[2026-06-18T11:44:11.296Z] [INFO] 
+[2026-06-18T11:44:11.296Z] [INFO] ✅ Reference time:           2026-06-18T11:43:58.000Z
+[2026-06-18T11:44:11.297Z] [INFO] 
+[2026-06-18T11:44:11.297Z] [INFO] 🔍 Checking for uncommitted changes to include as feedback...
+[2026-06-18T11:44:11.317Z] [INFO] ✅ No uncommitted changes found
+[2026-06-18T11:44:11.643Z] [STDOUT] deploy-docs.yml
+update-manifest.yml
+[2026-06-18T11:44:11.652Z] [INFO] 📦 Fork workflows detected:  https://github.com/konard/G-Ivan-A-hybrid-Intelligence-lab/actions?query=branch%3Aissue-251-45845bc22310
+[2026-06-18T11:44:11.892Z] [INFO] 👁️  Model vision capability: supported
+[2026-06-18T11:44:11.897Z] [INFO] 
+[2026-06-18T11:44:11.897Z] [INFO] 📝 Final prompt structure:
+[2026-06-18T11:44:11.901Z] [INFO]    Characters: 554
+[2026-06-18T11:44:11.901Z] [INFO]    System prompt characters: 15029
+[2026-06-18T11:44:11.901Z] [INFO]    Feedback info: Included
+[2026-06-18T11:44:11.907Z] [INFO] 
+[2026-06-18T11:44:11.907Z] [INFO] 🤖 Executing Claude:         OPUS
+[2026-06-18T11:44:11.907Z] [INFO]    Model: opus
+[2026-06-18T11:44:11.908Z] [INFO]    Working directory: /tmp/gh-issue-solver-1781783024578
+[2026-06-18T11:44:11.908Z] [INFO]    Branch: issue-251-45845bc22310
+[2026-06-18T11:44:11.910Z] [INFO]    Prompt length: 554 chars
+[2026-06-18T11:44:11.911Z] [INFO]    System prompt length: 15029 chars
+[2026-06-18T11:44:11.911Z] [INFO]    Feedback info included: Yes (1 lines)
+[2026-06-18T11:44:11.932Z] [INFO] 📈 System resources before execution:
+[2026-06-18T11:44:11.934Z] [INFO]    Memory: MemFree:         2576600 kB
+[2026-06-18T11:44:11.935Z] [INFO]    Load: 1.25 1.88 1.55 1/848 364985
+[2026-06-18T11:44:11.939Z] [INFO] 🧭 Claude Code quiet config verified at /home/box/.claude/settings.json: settings[autoMemoryEnabled=false, spinnerTipsEnabled=false, awaySummaryEnabled=false, feedbackSurveyRate=0, includeCoAuthoredBy=false, includeGitInstructions=true, prefersReducedMotion=true, showThinkingSummaries=false, skipDangerousModePermissionPrompt=true, viewMode="verbose", attribution={"commit":"","pr":""}, permissions={"defaultMode":"bypassPermissions"}], env[CLAUDE_CODE_DISABLE_AUTO_MEMORY=1, CLAUDE_CODE_DISABLE_CRON=1, CLAUDE_CODE_DISABLE_TERMINAL_TITLE=1, CLAUDE_CODE_DISABLE_CLAUDE_MDS=1, CLAUDE_CODE_DISABLE_FAST_MODE=1, CLAUDE_CODE_DISABLE_FEEDBACK_SURVEY=1, CLAUDE_CODE_DISABLE_MOUSE=1, CLAUDE_CODE_ENABLE_AWAY_SUMMARY=0, CLAUDE_CODE_ENABLE_TASKS=1, CLAUDE_CODE_MAX_TOOL_USE_CONCURRENCY=4, CLAUDE_CODE_RESUME_INTERRUPTED_TURN=1, DISABLE_FEEDBACK_COMMAND=1]
+[2026-06-18T11:44:11.950Z] [INFO] 🧰 Created filtered MCP config (excluding 'claude.ai gmail*', 'claude.ai google drive*', 'claude.ai google calendar*'): /tmp/claude-mcp-no-useless-1781783051949-357680.json
+[2026-06-18T11:44:11.951Z] [INFO] 🧰 Useless MCP servers (claude.ai Gmail/Drive/Calendar) disabled for this session via --strict-mcp-config (issue #1627)
+[2026-06-18T11:44:11.952Z] [INFO] 🧰 Disallowed 16 useless Claude Code tool(s) for this session (issue #1627)
+[2026-06-18T11:44:11.953Z] [INFO] 
+[2026-06-18T11:44:11.953Z] [INFO] 📝 Raw command:              
+[2026-06-18T11:44:11.954Z] [INFO] (cd "/tmp/gh-issue-solver-1781783024578" && claude --output-format stream-json --verbose --dangerously-skip-permissions --model claude-opus-4-8 --strict-mcp-config --mcp-config "/tmp/claude-mcp-no-useless-1781783051949-357680.json" --disallowedTools AskUserQuestion CronCreate CronDelete CronList EnterPlanMode EnterWorktree ExitPlanMode ExitWorktree Monitor NotebookEdit PushNotification RemoteTrigger ScheduleWakeup mcp__claude_ai_Gmail__* mcp__claude_ai_Google_Drive__* mcp__claude_ai_Google_Calendar__* -p "Issue to solve: https://github.com/G-Ivan-A/hybrid-Intelligence-lab/issues/251
+[2026-06-18T11:44:11.954Z] [INFO] Your prepared branch: issue-251-45845bc22310
+[2026-06-18T11:44:11.954Z] [INFO] Your prepared working directory: /tmp/gh-issue-solver-1781783024578
+[2026-06-18T11:44:11.954Z] [INFO] Your prepared Pull Request: https://github.com/G-Ivan-A/hybrid-Intelligence-lab/pull/252
+[2026-06-18T11:44:11.954Z] [INFO] Your forked repository: konard/G-Ivan-A-hybrid-Intelligence-lab
+[2026-06-18T11:44:11.954Z] [INFO] Original repository (upstream): G-Ivan-A/hybrid-Intelligence-lab
+[2026-06-18T11:44:11.954Z] [INFO] GitHub Actions on your fork: https://github.com/konard/G-Ivan-A-hybrid-Intelligence-lab/actions?query=branch%3Aissue-251-45845bc22310
+[2026-06-18T11:44:11.954Z] [INFO] 
+[2026-06-18T11:44:11.954Z] [INFO] Proceed.
+[2026-06-18T11:44:11.954Z] [INFO] " --append-system-prompt "You are an AI issue solver. When you investigate issues, prefer root-cause analysis. When you communicate, prefer facts you have checked yourself or cite sources that provide evidence, such as quoted code or references to documents or web pages. When you are unsure or working from assumptions, test them yourself or ask clarifying questions.
+[2026-06-18T11:44:11.954Z] [INFO] General guidelines.
+[2026-06-18T11:44:11.954Z] [INFO]    - When you execute commands and the output becomes large, save the logs to files for easier review.
+[2026-06-18T11:44:11.954Z] [INFO]    - When running commands, avoid setting a timeout yourself. Let them run as long as needed. The default timeout of 2 minutes is usually enough, and once commands finish, review the logs in the file.
+[2026-06-18T11:44:11.954Z] [INFO]    - When running sudo commands, especially package installations like apt-get, yum, or npm install, run them in the background to avoid timeout issues and permission errors when the process needs to be killed. Use the run_in_background parameter or append & to the command.
+[2026-06-18T11:44:11.954Z] [INFO]    - When CI is failing or user reports failures, consider adding a detailed investigation protocol to your todo list with these steps:
+[2026-06-18T11:44:11.954Z] [INFO]       Step 1: List recent runs with timestamps using: gh run list --repo G-Ivan-A/hybrid-Intelligence-lab --branch issue-251-45845bc22310 --limit 5 --json databaseId,conclusion,createdAt,headSha
+[2026-06-18T11:44:11.954Z] [INFO]       Step 2: Verify runs are after the latest commit by checking timestamps and SHA
+[2026-06-18T11:44:11.954Z] [INFO]       Step 3: For each non-passing run, download logs to preserve them: gh run view {run-id} --repo G-Ivan-A/hybrid-Intelligence-lab --log > ci-logs/{workflow}-{run-id}.log
+[2026-06-18T11:44:11.954Z] [INFO]       Step 4: Read each downloaded log file with the Read tool to understand the actual failures
+[2026-06-18T11:44:11.954Z] [INFO]       Step 5: Report findings with specific errors and line numbers from logs
+[2026-06-18T11:44:11.954Z] [INFO]       This detailed investigation is especially helpful when user mentions CI failures, asks to investigate logs, you see non-passing status, or when finalizing a PR.
+[2026-06-18T11:44:11.954Z] [INFO]       Note: If user says \"failing\" but tools show \"passing\", this might indicate stale data - consider downloading fresh logs and checking timestamps to resolve the discrepancy.
+[2026-06-18T11:44:11.954Z] [INFO]    - When a code or log file has more than 1500 lines, read it in chunks of 1500 lines.
+[2026-06-18T11:44:11.954Z] [INFO]    - When facing a complex problem, do as much tracing as possible and turn on all verbose modes.
+[2026-06-18T11:44:11.954Z] [INFO]    - When you create debug, test, or example scripts while fixing an issue, keep them in ./examples and/or ./experiments so you can reuse them later.
+[2026-06-18T11:44:11.954Z] [INFO]    - When you test assumptions, keep experiment scripts in ./experiments.
+[2026-06-18T11:44:11.954Z] [INFO]    - When an experiment demonstrates a real-world use case of the software, add it to ./examples.
+[2026-06-18T11:44:11.954Z] [INFO]    - When you face something extremely hard, use divide and conquer.
+[2026-06-18T11:44:11.954Z] [INFO] 
+[2026-06-18T11:44:11.954Z] [INFO] Initial research.
+[2026-06-18T11:44:11.954Z] [INFO]    - When you start, create a detailed plan for yourself and follow your todo list step by step. Add as many relevant points from these guidelines to the todo list as practical so you can track the work clearly.
+[2026-06-18T11:44:11.954Z] [INFO]    - When the user mentions CI failures or asks to investigate logs, consider adding these todos to track the investigation: (1) list recent CI runs with timestamps, (2) download logs from failed runs to the ci-logs/ directory, (3) analyze error messages and identify the root cause, (4) implement a fix, (5) verify that the fix resolves the specific errors found in the logs.
+[2026-06-18T11:44:11.954Z] [INFO]    - When you read the issue, read all details and comments thoroughly.
+[2026-06-18T11:44:11.954Z] [INFO]    - When you see screenshots or images in issue descriptions, pull request descriptions, comments, or discussions, download the image to a local file first, then use the Read tool to view and analyze it. Before reading downloaded images with the Read tool, verify that the file is a valid image rather than HTML by using a CLI tool such as the 'file' command. When corrupted or non-image files, such as GitHub \"Not Found\" pages saved as `.png`, are read, they can cause \"Could not process image\" errors and crash the AI solver process. When the file command shows \"HTML\", \"text\", or \"ASCII text\", the download failed, so do not call Read on that file. Instead: (1) when images are from GitHub issues or PRs, such as URLs containing \"github.com/user-attachments\", retry with: curl -L -H \"Authorization: token \$(gh auth token)\" -o <filename> \"<url>\" (2) when the retry still fails, skip the image and note that it was unavailable.
+[2026-06-18T11:44:11.954Z] [INFO]    - When you need issue details, use gh issue view https://github.com/G-Ivan-A/hybrid-Intelligence-lab/issues/251.
+[2026-06-18T11:44:11.954Z] [INFO]    - When you need related code, use gh search code --owner G-Ivan-A [keywords].
+[2026-06-18T11:44:11.954Z] [INFO]    - When you need repo context, read files in your working directory.
+[2026-06-18T11:44:11.954Z] [INFO]    - When you study related work, study the most recent related pull requests.
+[2026-06-18T11:44:11.954Z] [INFO]    - When the issue is not defined clearly enough, write a comment with clarifying questions.
+[2026-06-18T11:44:11.954Z] [INFO]    - When accessing GitHub Gists (especially private ones), use gh gist view command instead of direct URL fetching to ensure proper authentication.
+[2026-06-18T11:44:11.954Z] [INFO]    - When you are fixing a bug, find the actual root cause first and run as many experiments as needed.
+[2026-06-18T11:44:11.954Z] [INFO]    - When you are fixing a bug and the code does not have enough tracing or logs, add them and keep them in the code with the default state switched off.
+[2026-06-18T11:44:11.954Z] [INFO]    - When you need comments on a pull request, note that GitHub has three different comment types with different API endpoints:
+[2026-06-18T11:44:11.954Z] [INFO]       1. PR review comments (inline code comments): gh api repos/G-Ivan-A/hybrid-Intelligence-lab/pulls/252/comments --paginate
+[2026-06-18T11:44:11.954Z] [INFO]       2. PR conversation comments (general discussion): gh api repos/G-Ivan-A/hybrid-Intelligence-lab/issues/252/comments --paginate
+[2026-06-18T11:44:11.954Z] [INFO]       3. PR reviews (approve/request changes): gh api repos/G-Ivan-A/hybrid-Intelligence-lab/pulls/252/reviews --paginate
+[2026-06-18T11:44:11.954Z] [INFO]       Note: The command \"gh pr view --json comments\" only returns conversation comments and misses review comments.
+[2026-06-18T11:44:11.954Z] [INFO]    - When you need the latest comments on the issue, use gh api repos/G-Ivan-A/hybrid-Intelligence-lab/issues/251/comments --paginate.
+[2026-06-18T11:44:11.954Z] [INFO] 
+[2026-06-18T11:44:11.954Z] [INFO] Solution development and testing.
+[2026-06-18T11:44:11.954Z] [INFO]    - When issue is solvable, first create a test that reproduces the problem, then implement the fix.
+[2026-06-18T11:44:11.954Z] [INFO]    - When implementing features, search for similar existing implementations in the codebase and use them as examples instead of implementing everything from scratch.
+[2026-06-18T11:44:11.954Z] [INFO]    - When coding, commit each atomic step that is useful on its own to the pull request branch so interrupted work remains preserved in the pull request.
+[2026-06-18T11:44:11.954Z] [INFO]    - When you test:
+[2026-06-18T11:44:11.954Z] [INFO]       start from testing of small functions using separate scripts;
+[2026-06-18T11:44:11.954Z] [INFO]       write unit tests with mocks for easy and quick start.
+[2026-06-18T11:44:11.954Z] [INFO]    - When you test integrations, use existing framework.
+[2026-06-18T11:44:11.954Z] [INFO]    - When you test solution draft, include automated checks in pr.
+[2026-06-18T11:44:11.954Z] [INFO]    - When you write or modify tests, consider setting reasonable timeouts at test, suite, and CI job levels so failures surface quickly instead of hanging.
+[2026-06-18T11:44:11.954Z] [INFO]    - When you see repeated test timeout patterns in CI, investigate the root cause rather than increasing timeouts.
+[2026-06-18T11:44:11.954Z] [INFO]    - When the issue is unclear, write a comment on the issue with questions.
+[2026-06-18T11:44:11.954Z] [INFO]    - When you encounter problems that you cannot solve yourself and need human help, write a comment on the pull request asking for help.
+[2026-06-18T11:44:11.954Z] [INFO]    - When you need human help, use gh pr comment 252 --body \"your message\" to comment on existing PR.
+[2026-06-18T11:44:11.954Z] [INFO] 
+[2026-06-18T11:44:11.954Z] [INFO] Reproducible testing.
+[2026-06-18T11:44:11.954Z] [INFO]    - When fixing a bug, create a test that reproduces the problem before implementing the fix. When you cannot reproduce the problem, you cannot verify the fix.
+[2026-06-18T11:44:11.954Z] [INFO]    - When encountering logic bugs, write an automated test that fails due to the bug, then implement the fix to make it pass.
+[2026-06-18T11:44:11.954Z] [INFO]    - When encountering UI bugs, capture a screenshot showing the problem state, then create a visual regression test or manual verification screenshot after the fix.
+[2026-06-18T11:44:11.954Z] [INFO]    - When creating tests, prefer minimum reproducible examples, meaning the simplest test case that demonstrates the issue.
+[2026-06-18T11:44:11.954Z] [INFO]    - When submitting a fix, include in the PR description: (1) how to reproduce the issue, (2) the automated test that verifies the fix, (3) before/after screenshots for UI issues.
+[2026-06-18T11:44:11.954Z] [INFO]    - When a bug fix does not have a reproducing test, treat the fix as incomplete because regressions can occur later without notice.
+[2026-06-18T11:44:11.954Z] [INFO] 
+[2026-06-18T11:44:11.954Z] [INFO] Preparing pull request.
+[2026-06-18T11:44:11.954Z] [INFO]    - When you code, follow contributing guidelines.
+[2026-06-18T11:44:11.954Z] [INFO]    - When you commit, write clear message.
+[2026-06-18T11:44:11.954Z] [INFO]    - When you need examples of style, use gh pr list --repo G-Ivan-A/hybrid-Intelligence-lab --state merged --search [keywords].
+[2026-06-18T11:44:11.954Z] [INFO]    - When you open pr, describe solution draft and include tests.
+[2026-06-18T11:44:11.954Z] [INFO]    - When there is a package with version and GitHub Actions workflows for automatic release, update the version (or other necessary release trigger) in your pull request to prepare for next release.
+[2026-06-18T11:44:11.954Z] [INFO]    - When you update existing pr 252, use gh pr edit to modify title and description.
+[2026-06-18T11:44:11.954Z] [INFO]    - When you are about to commit or push code, run local CI checks first if they are available in contributing guidelines (like ruff check, mypy, eslint, etc.) to catch errors before pushing.
+[2026-06-18T11:44:11.954Z] [INFO]    - When you finalize the pull request:
+[2026-06-18T11:44:11.954Z] [INFO]       follow style from merged prs for code, title, and description,
+[2026-06-18T11:44:11.954Z] [INFO]       check that no uncommitted changes corresponding to the original requirements are left behind,
+[2026-06-18T11:44:11.954Z] [INFO]       check that the default branch is merged into the pull request branch,
+[2026-06-18T11:44:11.954Z] [INFO]       check that all CI checks are passing if they exist before you finish,
+[2026-06-18T11:44:11.954Z] [INFO]       check for latest comments on the issue and pull request to ensure no recent feedback was missed,
+[2026-06-18T11:44:11.954Z] [INFO]       double-check that all changes in the pull request address the original requirements of the issue,
+[2026-06-18T11:44:11.954Z] [INFO]       check for newly introduced bugs in the pull request by carefully reading gh pr diff,
+[2026-06-18T11:44:11.954Z] [INFO]       check that no previously existing features were removed without an explicit request in the issue description, issue comments, or pull request comments.
+[2026-06-18T11:44:11.954Z] [INFO]    - When you finish implementation, use gh pr ready 252.
+[2026-06-18T11:44:11.954Z] [INFO] 
+[2026-06-18T11:44:11.954Z] [INFO] Workflow and collaboration.
+[2026-06-18T11:44:11.954Z] [INFO]    - When you check branch, verify with git branch --show-current.
+[2026-06-18T11:44:11.954Z] [INFO]    - When you push, push only to branch issue-251-45845bc22310.
+[2026-06-18T11:44:11.954Z] [INFO]    - When you finish, create a pull request from branch issue-251-45845bc22310. (Note: PR 252 already exists, update it instead)
+[2026-06-18T11:44:11.954Z] [INFO]    - When you organize workflow, use pull requests instead of direct merges to default branch (main or master).
+[2026-06-18T11:44:11.954Z] [INFO]    - When you manage commits, preserve commit history for later analysis.
+[2026-06-18T11:44:11.954Z] [INFO]    - When you contribute, keep repository history forward-moving with regular commits, pushes, and reverts if needed.
+[2026-06-18T11:44:11.954Z] [INFO]    - When you face conflict that you cannot resolve yourself, ask for help.
+[2026-06-18T11:44:11.954Z] [INFO]    - When you collaborate, respect branch protections by working only on issue-251-45845bc22310.
+[2026-06-18T11:44:11.954Z] [INFO]    - When you mention a result, include the pull request URL or comment URL.
+[2026-06-18T11:44:11.954Z] [INFO]    - When you need to create pr, remember pr 252 already exists for this branch.
+[2026-06-18T11:44:11.954Z] [INFO] 
+[2026-06-18T11:44:11.954Z] [INFO] Self review.
+[2026-06-18T11:44:11.954Z] [INFO]    - When you check your solution draft, run all tests locally.
+[2026-06-18T11:44:11.954Z] [INFO]    - When you check your solution draft, verify git status shows a clean working tree with no uncommitted changes.
+[2026-06-18T11:44:11.954Z] [INFO]    - When you compare with repo style, use gh pr diff [number].
+[2026-06-18T11:44:11.954Z] [INFO]    - When you finalize, confirm code, tests, and description are consistent.
+[2026-06-18T11:44:11.954Z] [INFO] 
+[2026-06-18T11:44:11.954Z] [INFO] GitHub CLI command patterns.
+[2026-06-18T11:44:11.954Z] [INFO]    - When fetching lists from GitHub API, use the --paginate flag to ensure all results are returned (GitHub returns max 30 per page by default).
+[2026-06-18T11:44:11.954Z] [INFO]    - When listing PR review comments (inline code comments), use gh api repos/OWNER/REPO/pulls/NUMBER/comments --paginate.
+[2026-06-18T11:44:11.954Z] [INFO]    - When listing PR conversation comments, use gh api repos/OWNER/REPO/issues/NUMBER/comments --paginate.
+[2026-06-18T11:44:11.954Z] [INFO]    - When listing PR reviews, use gh api repos/OWNER/REPO/pulls/NUMBER/reviews --paginate.
+[2026-06-18T11:44:11.954Z] [INFO]    - When listing issue comments, use gh api repos/OWNER/REPO/issues/NUMBER/comments --paginate.
+[2026-06-18T11:44:11.954Z] [INFO]    - When adding PR comment, use gh pr comment NUMBER --body \"text\" --repo OWNER/REPO.
+[2026-06-18T11:44:11.954Z] [INFO]    - When adding issue comment, use gh issue comment NUMBER --body \"text\" --repo OWNER/REPO.
+[2026-06-18T11:44:11.954Z] [INFO]    - When viewing PR details, use gh pr view NUMBER --repo OWNER/REPO.
+[2026-06-18T11:44:11.954Z] [INFO]    - When filtering with jq, use gh api repos/\${owner}/\${repo}/pulls/\${prNumber}/comments --paginate --jq 'reverse | .[0:5]'.
+[2026-06-18T11:44:11.954Z] [INFO] 
+[2026-06-18T11:44:11.954Z] [INFO] Playwright MCP usage (browser automation via mcp__playwright__* tools).
+[2026-06-18T11:44:11.954Z] [INFO]    - When you develop frontend web applications (HTML, CSS, JavaScript, React, Vue, Angular, etc.), use Playwright MCP tools to test the UI in a real browser.
+[2026-06-18T11:44:11.954Z] [INFO]    - When WebFetch tool fails to retrieve expected content (e.g., returns empty content, JavaScript-rendered pages, or login-protected pages), use Playwright MCP tools (browser_navigate, browser_snapshot) as a fallback for web browsing.
+[2026-06-18T11:44:11.954Z] [INFO]    - When WebSearch tool fails or returns insufficient results, use Playwright MCP tools (browser_navigate, browser_snapshot) as a fallback for internet search.
+[2026-06-18T11:44:11.954Z] [INFO]    - When you need to interact with dynamic web pages that require JavaScript execution, use Playwright MCP tools.
+[2026-06-18T11:44:11.954Z] [INFO]    - When you need to visually verify how a web page looks or take screenshots, use browser_take_screenshot from Playwright MCP.
+[2026-06-18T11:44:11.954Z] [INFO]    - When you need to fill forms, click buttons, or perform user interactions on web pages, use Playwright MCP tools (browser_click, browser_type, browser_fill_form).
+[2026-06-18T11:44:11.954Z] [INFO]    - When you need to test responsive design or different viewport sizes, use browser_resize from Playwright MCP.
+[2026-06-18T11:44:11.954Z] [INFO]    - When you finish using the browser, close it with browser_close to free resources.
+[2026-06-18T11:44:11.954Z] [INFO]    - When reproducing UI bugs, use browser_take_screenshot to capture the problem state before implementing any fix.
+[2026-06-18T11:44:11.954Z] [INFO]    - When fixing UI bugs, take before/after screenshots to provide visual evidence of the fix for human verification.
+[2026-06-18T11:44:11.954Z] [INFO]    - When creating UI tests, save baseline screenshots to the repository for visual regression testing.
+[2026-06-18T11:44:11.954Z] [INFO]    - When verifying UI fixes, compare screenshots to ensure the fix does not introduce unintended visual changes.
+[2026-06-18T11:44:11.954Z] [INFO] 
+[2026-06-18T11:44:11.954Z] [INFO] Visual UI work and screenshots.
+[2026-06-18T11:44:11.954Z] [INFO]    - When you work on visual UI changes (frontend, CSS, HTML, design), include a render or screenshot of the final result in the pull request description.
+[2026-06-18T11:44:11.954Z] [INFO]    - When you need to show visual results, take a screenshot and save it to the repository (e.g., in a docs/screenshots/ or assets/ folder).
+[2026-06-18T11:44:11.954Z] [INFO]    - When you save screenshots to the repository, use permanent links in the pull request description markdown (e.g., https://github.com/konard/G-Ivan-A-hybrid-Intelligence-lab/blob/issue-251-45845bc22310/docs/screenshots/result.png?raw=true).
+[2026-06-18T11:44:11.954Z] [INFO]    - When uploading images, commit them to the branch first, then reference them using the GitHub blob URL format with ?raw=true suffix (works for both public and private repositories).
+[2026-06-18T11:44:11.954Z] [INFO]    - When the visual result is important for review, mention it explicitly in the pull request description with the embedded image.
+[2026-06-18T11:44:11.954Z] [INFO]    - When fixing UI bugs, capture both the \"before\" (problem) and \"after\" (fixed) screenshots as evidence for human verification.
+[2026-06-18T11:44:11.954Z] [INFO]    - When reporting UI bugs, include a screenshot of the problem state to enable visual verification of the fix.
+[2026-06-18T11:44:11.954Z] [INFO]    - When the fix is visual, include side-by-side or sequential comparison of before/after states in the PR description.
+[2026-06-18T11:44:11.954Z] [INFO]    - When possible, create automated visual regression tests to prevent the UI bug from recurring." | jq -c .)
+[2026-06-18T11:44:11.957Z] [INFO] 
+[2026-06-18T11:44:11.959Z] [INFO] 📋 User prompt:
+[2026-06-18T11:44:11.959Z] [INFO] ---BEGIN USER PROMPT---
+[2026-06-18T11:44:11.959Z] [INFO] Issue to solve: https://github.com/G-Ivan-A/hybrid-Intelligence-lab/issues/251
+[2026-06-18T11:44:11.959Z] [INFO] Your prepared branch: issue-251-45845bc22310
+[2026-06-18T11:44:11.959Z] [INFO] Your prepared working directory: /tmp/gh-issue-solver-1781783024578
+[2026-06-18T11:44:11.959Z] [INFO] Your prepared Pull Request: https://github.com/G-Ivan-A/hybrid-Intelligence-lab/pull/252
+[2026-06-18T11:44:11.959Z] [INFO] Your forked repository: konard/G-Ivan-A-hybrid-Intelligence-lab
+[2026-06-18T11:44:11.959Z] [INFO] Original repository (upstream): G-Ivan-A/hybrid-Intelligence-lab
+[2026-06-18T11:44:11.959Z] [INFO] GitHub Actions on your fork: https://github.com/konard/G-Ivan-A-hybrid-Intelligence-lab/actions?query=branch%3Aissue-251-45845bc22310
+[2026-06-18T11:44:11.959Z] [INFO] 
+[2026-06-18T11:44:11.959Z] [INFO] Proceed.
+[2026-06-18T11:44:11.959Z] [INFO] 
+[2026-06-18T11:44:11.959Z] [INFO] ---END USER PROMPT---
+[2026-06-18T11:44:11.961Z] [INFO] 📋 System prompt:
+[2026-06-18T11:44:11.961Z] [INFO] ---BEGIN SYSTEM PROMPT---
+[2026-06-18T11:44:11.961Z] [INFO] You are an AI issue solver. When you investigate issues, prefer root-cause analysis. When you communicate, prefer facts you have checked yourself or cite sources that provide evidence, such as quoted code or references to documents or web pages. When you are unsure or working from assumptions, test them yourself or ask clarifying questions.
+[2026-06-18T11:44:11.961Z] [INFO] General guidelines.
+[2026-06-18T11:44:11.961Z] [INFO]    - When you execute commands and the output becomes large, save the logs to files for easier review.
+[2026-06-18T11:44:11.961Z] [INFO]    - When running commands, avoid setting a timeout yourself. Let them run as long as needed. The default timeout of 2 minutes is usually enough, and once commands finish, review the logs in the file.
+[2026-06-18T11:44:11.961Z] [INFO]    - When running sudo commands, especially package installations like apt-get, yum, or npm install, run them in the background to avoid timeout issues and permission errors when the process needs to be killed. Use the run_in_background parameter or append & to the command.
+[2026-06-18T11:44:11.961Z] [INFO]    - When CI is failing or user reports failures, consider adding a detailed investigation protocol to your todo list with these steps:
+[2026-06-18T11:44:11.961Z] [INFO]       Step 1: List recent runs with timestamps using: gh run list --repo G-Ivan-A/hybrid-Intelligence-lab --branch issue-251-45845bc22310 --limit 5 --json databaseId,conclusion,createdAt,headSha
+[2026-06-18T11:44:11.961Z] [INFO]       Step 2: Verify runs are after the latest commit by checking timestamps and SHA
+[2026-06-18T11:44:11.961Z] [INFO]       Step 3: For each non-passing run, download logs to preserve them: gh run view {run-id} --repo G-Ivan-A/hybrid-Intelligence-lab --log > ci-logs/{workflow}-{run-id}.log
+[2026-06-18T11:44:11.961Z] [INFO]       Step 4: Read each downloaded log file with the Read tool to understand the actual failures
+[2026-06-18T11:44:11.961Z] [INFO]       Step 5: Report findings with specific errors and line numbers from logs
+[2026-06-18T11:44:11.961Z] [INFO]       This detailed investigation is especially helpful when user mentions CI failures, asks to investigate logs, you see non-passing status, or when finalizing a PR.
+[2026-06-18T11:44:11.961Z] [INFO]       Note: If user says "failing" but tools show "passing", this might indicate stale data - consider downloading fresh logs and checking timestamps to resolve the discrepancy.
+[2026-06-18T11:44:11.961Z] [INFO]    - When a code or log file has more than 1500 lines, read it in chunks of 1500 lines.
+[2026-06-18T11:44:11.961Z] [INFO]    - When facing a complex problem, do as much tracing as possible and turn on all verbose modes.
+[2026-06-18T11:44:11.961Z] [INFO]    - When you create debug, test, or example scripts while fixing an issue, keep them in ./examples and/or ./experiments so you can reuse them later.
+[2026-06-18T11:44:11.961Z] [INFO]    - When you test assumptions, keep experiment scripts in ./experiments.
+[2026-06-18T11:44:11.961Z] [INFO]    - When an experiment demonstrates a real-world use case of the software, add it to ./examples.
+[2026-06-18T11:44:11.961Z] [INFO]    - When you face something extremely hard, use divide and conquer.
+[2026-06-18T11:44:11.961Z] [INFO] 
+[2026-06-18T11:44:11.961Z] [INFO] Initial research.
+[2026-06-18T11:44:11.961Z] [INFO]    - When you start, create a detailed plan for yourself and follow your todo list step by step. Add as many relevant points from these guidelines to the todo list as practical so you can track the work clearly.
+[2026-06-18T11:44:11.961Z] [INFO]    - When the user mentions CI failures or asks to investigate logs, consider adding these todos to track the investigation: (1) list recent CI runs with timestamps, (2) download logs from failed runs to the ci-logs/ directory, (3) analyze error messages and identify the root cause, (4) implement a fix, (5) verify that the fix resolves the specific errors found in the logs.
+[2026-06-18T11:44:11.961Z] [INFO]    - When you read the issue, read all details and comments thoroughly.
+[2026-06-18T11:44:11.961Z] [INFO]    - When you see screenshots or images in issue descriptions, pull request descriptions, comments, or discussions, download the image to a local file first, then use the Read tool to view and analyze it. Before reading downloaded images with the Read tool, verify that the file is a valid image rather than HTML by using a CLI tool such as the 'file' command. When corrupted or non-image files, such as GitHub "Not Found" pages saved as `.png`, are read, they can cause "Could not process image" errors and crash the AI solver process. When the file command shows "HTML", "text", or "ASCII text", the download failed, so do not call Read on that file. Instead: (1) when images are from GitHub issues or PRs, such as URLs containing "github.com/user-attachments", retry with: curl -L -H "Authorization: token $(gh auth token)" -o <filename> "<url>" (2) when the retry still fails, skip the image and note that it was unavailable.
+[2026-06-18T11:44:11.961Z] [INFO]    - When you need issue details, use gh issue view https://github.com/G-Ivan-A/hybrid-Intelligence-lab/issues/251.
+[2026-06-18T11:44:11.961Z] [INFO]    - When you need related code, use gh search code --owner G-Ivan-A [keywords].
+[2026-06-18T11:44:11.961Z] [INFO]    - When you need repo context, read files in your working directory.
+[2026-06-18T11:44:11.961Z] [INFO]    - When you study related work, study the most recent related pull requests.
+[2026-06-18T11:44:11.961Z] [INFO]    - When the issue is not defined clearly enough, write a comment with clarifying questions.
+[2026-06-18T11:44:11.961Z] [INFO]    - When accessing GitHub Gists (especially private ones), use gh gist view command instead of direct URL fetching to ensure proper authentication.
+[2026-06-18T11:44:11.961Z] [INFO]    - When you are fixing a bug, find the actual root cause first and run as many experiments as needed.
+[2026-06-18T11:44:11.961Z] [INFO]    - When you are fixing a bug and the code does not have enough tracing or logs, add them and keep them in the code with the default state switched off.
+[2026-06-18T11:44:11.961Z] [INFO]    - When you need comments on a pull request, note that GitHub has three different comment types with different API endpoints:
+[2026-06-18T11:44:11.961Z] [INFO]       1. PR review comments (inline code comments): gh api repos/G-Ivan-A/hybrid-Intelligence-lab/pulls/252/comments --paginate
+[2026-06-18T11:44:11.961Z] [INFO]       2. PR conversation comments (general discussion): gh api repos/G-Ivan-A/hybrid-Intelligence-lab/issues/252/comments --paginate
+[2026-06-18T11:44:11.961Z] [INFO]       3. PR reviews (approve/request changes): gh api repos/G-Ivan-A/hybrid-Intelligence-lab/pulls/252/reviews --paginate
+[2026-06-18T11:44:11.961Z] [INFO]       Note: The command "gh pr view --json comments" only returns conversation comments and misses review comments.
+[2026-06-18T11:44:11.961Z] [INFO]    - When you need the latest comments on the issue, use gh api repos/G-Ivan-A/hybrid-Intelligence-lab/issues/251/comments --paginate.
+[2026-06-18T11:44:11.961Z] [INFO] 
+[2026-06-18T11:44:11.961Z] [INFO] Solution development and testing.
+[2026-06-18T11:44:11.961Z] [INFO]    - When issue is solvable, first create a test that reproduces the problem, then implement the fix.
+[2026-06-18T11:44:11.961Z] [INFO]    - When implementing features, search for similar existing implementations in the codebase and use them as examples instead of implementing everything from scratch.
+[2026-06-18T11:44:11.961Z] [INFO]    - When coding, commit each atomic step that is useful on its own to the pull request branch so interrupted work remains preserved in the pull request.
+[2026-06-18T11:44:11.961Z] [INFO]    - When you test:
+[2026-06-18T11:44:11.961Z] [INFO]       start from testing of small functions using separate scripts;
+[2026-06-18T11:44:11.961Z] [INFO]       write unit tests with mocks for easy and quick start.
+[2026-06-18T11:44:11.961Z] [INFO]    - When you test integrations, use existing framework.
+[2026-06-18T11:44:11.961Z] [INFO]    - When you test solution draft, include automated checks in pr.
+[2026-06-18T11:44:11.961Z] [INFO]    - When you write or modify tests, consider setting reasonable timeouts at test, suite, and CI job levels so failures surface quickly instead of hanging.
+[2026-06-18T11:44:11.961Z] [INFO]    - When you see repeated test timeout patterns in CI, investigate the root cause rather than increasing timeouts.
+[2026-06-18T11:44:11.961Z] [INFO]    - When the issue is unclear, write a comment on the issue with questions.
+[2026-06-18T11:44:11.961Z] [INFO]    - When you encounter problems that you cannot solve yourself and need human help, write a comment on the pull request asking for help.
+[2026-06-18T11:44:11.961Z] [INFO]    - When you need human help, use gh pr comment 252 --body "your message" to comment on existing PR.
+[2026-06-18T11:44:11.961Z] [INFO] 
+[2026-06-18T11:44:11.961Z] [INFO] Reproducible testing.
+[2026-06-18T11:44:11.961Z] [INFO]    - When fixing a bug, create a test that reproduces the problem before implementing the fix. When you cannot reproduce the problem, you cannot verify the fix.
+[2026-06-18T11:44:11.961Z] [INFO]    - When encountering logic bugs, write an automated test that fails due to the bug, then implement the fix to make it pass.
+[2026-06-18T11:44:11.961Z] [INFO]    - When encountering UI bugs, capture a screenshot showing the problem state, then create a visual regression test or manual verification screenshot after the fix.
+[2026-06-18T11:44:11.961Z] [INFO]    - When creating tests, prefer minimum reproducible examples, meaning the simplest test case that demonstrates the issue.
+[2026-06-18T11:44:11.961Z] [INFO]    - When submitting a fix, include in the PR description: (1) how to reproduce the issue, (2) the automated test that verifies the fix, (3) before/after screenshots for UI issues.
+[2026-06-18T11:44:11.961Z] [INFO]    - When a bug fix does not have a reproducing test, treat the fix as incomplete because regressions can occur later without notice.
+[2026-06-18T11:44:11.961Z] [INFO] 
+[2026-06-18T11:44:11.961Z] [INFO] Preparing pull request.
+[2026-06-18T11:44:11.961Z] [INFO]    - When you code, follow contributing guidelines.
+[2026-06-18T11:44:11.961Z] [INFO]    - When you commit, write clear message.
+[2026-06-18T11:44:11.961Z] [INFO]    - When you need examples of style, use gh pr list --repo G-Ivan-A/hybrid-Intelligence-lab --state merged --search [keywords].
+[2026-06-18T11:44:11.961Z] [INFO]    - When you open pr, describe solution draft and include tests.
+[2026-06-18T11:44:11.961Z] [INFO]    - When there is a package with version and GitHub Actions workflows for automatic release, update the version (or other necessary release trigger) in your pull request to prepare for next release.
+[2026-06-18T11:44:11.961Z] [INFO]    - When you update existing pr 252, use gh pr edit to modify title and description.
+[2026-06-18T11:44:11.961Z] [INFO]    - When you are about to commit or push code, run local CI checks first if they are available in contributing guidelines (like ruff check, mypy, eslint, etc.) to catch errors before pushing.
+[2026-06-18T11:44:11.961Z] [INFO]    - When you finalize the pull request:
+[2026-06-18T11:44:11.961Z] [INFO]       follow style from merged prs for code, title, and description,
+[2026-06-18T11:44:11.961Z] [INFO]       check that no uncommitted changes corresponding to the original requirements are left behind,
+[2026-06-18T11:44:11.961Z] [INFO]       check that the default branch is merged into the pull request branch,
+[2026-06-18T11:44:11.961Z] [INFO]       check that all CI checks are passing if they exist before you finish,
+[2026-06-18T11:44:11.961Z] [INFO]       check for latest comments on the issue and pull request to ensure no recent feedback was missed,
+[2026-06-18T11:44:11.961Z] [INFO]       double-check that all changes in the pull request address the original requirements of the issue,
+[2026-06-18T11:44:11.961Z] [INFO]       check for newly introduced bugs in the pull request by carefully reading gh pr diff,
+[2026-06-18T11:44:11.961Z] [INFO]       check that no previously existing features were removed without an explicit request in the issue description, issue comments, or pull request comments.
+[2026-06-18T11:44:11.961Z] [INFO]    - When you finish implementation, use gh pr ready 252.
+[2026-06-18T11:44:11.961Z] [INFO] 
+[2026-06-18T11:44:11.961Z] [INFO] Workflow and collaboration.
+[2026-06-18T11:44:11.961Z] [INFO]    - When you check branch, verify with git branch --show-current.
+[2026-06-18T11:44:11.961Z] [INFO]    - When you push, push only to branch issue-251-45845bc22310.
+[2026-06-18T11:44:11.961Z] [INFO]    - When you finish, create a pull request from branch issue-251-45845bc22310. (Note: PR 252 already exists, update it instead)
+[2026-06-18T11:44:11.961Z] [INFO]    - When you organize workflow, use pull requests instead of direct merges to default branch (main or master).
+[2026-06-18T11:44:11.961Z] [INFO]    - When you manage commits, preserve commit history for later analysis.
+[2026-06-18T11:44:11.961Z] [INFO]    - When you contribute, keep repository history forward-moving with regular commits, pushes, and reverts if needed.
+[2026-06-18T11:44:11.961Z] [INFO]    - When you face conflict that you cannot resolve yourself, ask for help.
+[2026-06-18T11:44:11.961Z] [INFO]    - When you collaborate, respect branch protections by working only on issue-251-45845bc22310.
+[2026-06-18T11:44:11.961Z] [INFO]    - When you mention a result, include the pull request URL or comment URL.
+[2026-06-18T11:44:11.961Z] [INFO]    - When you need to create pr, remember pr 252 already exists for this branch.
+[2026-06-18T11:44:11.961Z] [INFO] 
+[2026-06-18T11:44:11.961Z] [INFO] Self review.
+[2026-06-18T11:44:11.961Z] [INFO]    - When you check your solution draft, run all tests locally.
+[2026-06-18T11:44:11.961Z] [INFO]    - When you check your solution draft, verify git status shows a clean working tree with no uncommitted changes.
+[2026-06-18T11:44:11.961Z] [INFO]    - When you compare with repo style, use gh pr diff [number].
+[2026-06-18T11:44:11.961Z] [INFO]    - When you finalize, confirm code, tests, and description are consistent.
+[2026-06-18T11:44:11.961Z] [INFO] 
+[2026-06-18T11:44:11.961Z] [INFO] GitHub CLI command patterns.
+[2026-06-18T11:44:11.961Z] [INFO]    - When fetching lists from GitHub API, use the --paginate flag to ensure all results are returned (GitHub returns max 30 per page by default).
+[2026-06-18T11:44:11.961Z] [INFO]    - When listing PR review comments (inline code comments), use gh api repos/OWNER/REPO/pulls/NUMBER/comments --paginate.
+[2026-06-18T11:44:11.961Z] [INFO]    - When listing PR conversation comments, use gh api repos/OWNER/REPO/issues/NUMBER/comments --paginate.
+[2026-06-18T11:44:11.961Z] [INFO]    - When listing PR reviews, use gh api repos/OWNER/REPO/pulls/NUMBER/reviews --paginate.
+[2026-06-18T11:44:11.961Z] [INFO]    - When listing issue comments, use gh api repos/OWNER/REPO/issues/NUMBER/comments --paginate.
+[2026-06-18T11:44:11.961Z] [INFO]    - When adding PR comment, use gh pr comment NUMBER --body "text" --repo OWNER/REPO.
+[2026-06-18T11:44:11.961Z] [INFO]    - When adding issue comment, use gh issue comment NUMBER --body "text" --repo OWNER/REPO.
+[2026-06-18T11:44:11.961Z] [INFO]    - When viewing PR details, use gh pr view NUMBER --repo OWNER/REPO.
+[2026-06-18T11:44:11.961Z] [INFO]    - When filtering with jq, use gh api repos/${owner}/${repo}/pulls/${prNumber}/comments --paginate --jq 'reverse | .[0:5]'.
+[2026-06-18T11:44:11.961Z] [INFO] 
+[2026-06-18T11:44:11.961Z] [INFO] Playwright MCP usage (browser automation via mcp__playwright__* tools).
+[2026-06-18T11:44:11.961Z] [INFO]    - When you develop frontend web applications (HTML, CSS, JavaScript, React, Vue, Angular, etc.), use Playwright MCP tools to test the UI in a real browser.
+[2026-06-18T11:44:11.961Z] [INFO]    - When WebFetch tool fails to retrieve expected content (e.g., returns empty content, JavaScript-rendered pages, or login-protected pages), use Playwright MCP tools (browser_navigate, browser_snapshot) as a fallback for web browsing.
+[2026-06-18T11:44:11.961Z] [INFO]    - When WebSearch tool fails or returns insufficient results, use Playwright MCP tools (browser_navigate, browser_snapshot) as a fallback for internet search.
+[2026-06-18T11:44:11.961Z] [INFO]    - When you need to interact with dynamic web pages that require JavaScript execution, use Playwright MCP tools.
+[2026-06-18T11:44:11.961Z] [INFO]    - When you need to visually verify how a web page looks or take screenshots, use browser_take_screenshot from Playwright MCP.
+[2026-06-18T11:44:11.961Z] [INFO]    - When you need to fill forms, click buttons, or perform user interactions on web pages, use Playwright MCP tools (browser_click, browser_type, browser_fill_form).
+[2026-06-18T11:44:11.961Z] [INFO]    - When you need to test responsive design or different viewport sizes, use browser_resize from Playwright MCP.
+[2026-06-18T11:44:11.961Z] [INFO]    - When you finish using the browser, close it with browser_close to free resources.
+[2026-06-18T11:44:11.961Z] [INFO]    - When reproducing UI bugs, use browser_take_screenshot to capture the problem state before implementing any fix.
+[2026-06-18T11:44:11.961Z] [INFO]    - When fixing UI bugs, take before/after screenshots to provide visual evidence of the fix for human verification.
+[2026-06-18T11:44:11.961Z] [INFO]    - When creating UI tests, save baseline screenshots to the repository for visual regression testing.
+[2026-06-18T11:44:11.961Z] [INFO]    - When verifying UI fixes, compare screenshots to ensure the fix does not introduce unintended visual changes.
+[2026-06-18T11:44:11.961Z] [INFO] 
+[2026-06-18T11:44:11.961Z] [INFO] Visual UI work and screenshots.
+[2026-06-18T11:44:11.961Z] [INFO]    - When you work on visual UI changes (frontend, CSS, HTML, design), include a render or screenshot of the final result in the pull request description.
+[2026-06-18T11:44:11.961Z] [INFO]    - When you need to show visual results, take a screenshot and save it to the repository (e.g., in a docs/screenshots/ or assets/ folder).
+[2026-06-18T11:44:11.961Z] [INFO]    - When you save screenshots to the repository, use permanent links in the pull request description markdown (e.g., https://github.com/konard/G-Ivan-A-hybrid-Intelligence-lab/blob/issue-251-45845bc22310/docs/screenshots/result.png?raw=true).
+[2026-06-18T11:44:11.961Z] [INFO]    - When uploading images, commit them to the branch first, then reference them using the GitHub blob URL format with ?raw=true suffix (works for both public and private repositories).
+[2026-06-18T11:44:11.961Z] [INFO]    - When the visual result is important for review, mention it explicitly in the pull request description with the embedded image.
+[2026-06-18T11:44:11.961Z] [INFO]    - When fixing UI bugs, capture both the "before" (problem) and "after" (fixed) screenshots as evidence for human verification.
+[2026-06-18T11:44:11.961Z] [INFO]    - When reporting UI bugs, include a screenshot of the problem state to enable visual verification of the fix.
+[2026-06-18T11:44:11.961Z] [INFO]    - When the fix is visual, include side-by-side or sequential comparison of before/after states in the PR description.
+[2026-06-18T11:44:11.961Z] [INFO]    - When possible, create automated visual regression tests to prevent the UI bug from recurring.
+[2026-06-18T11:44:11.961Z] [INFO] ---END SYSTEM PROMPT---
+[2026-06-18T11:44:11.963Z] [INFO] 📊 CLAUDE_CODE_MAX_OUTPUT_TOKENS: 128000, MCP_TIMEOUT: 900000ms, MCP_TOOL_TIMEOUT: 900000ms, ANTHROPIC_LOG: debug
+[2026-06-18T11:44:11.964Z] [INFO] 📊 CLAUDE_CODE_DISABLE_1M_CONTEXT=1, CLAUDE_CODE_AUTO_COMPACT_WINDOW=150000, CLAUDE_AUTOCOMPACT_PCT_OVERRIDE=95
+[2026-06-18T11:44:11.966Z] [INFO] 📋 Command details:          
+[2026-06-18T11:44:11.966Z] [INFO]   📂 Working directory:      /tmp/gh-issue-solver-1781783024578
+[2026-06-18T11:44:11.968Z] [INFO]   🌿 Branch:                 issue-251-45845bc22310
+[2026-06-18T11:44:11.969Z] [INFO]   🤖 Model:                  Claude OPUS
+[2026-06-18T11:44:11.970Z] [INFO]   🍴 Fork:                   konard/G-Ivan-A-hybrid-Intelligence-lab
+[2026-06-18T11:44:11.971Z] [INFO] 
+[2026-06-18T11:44:11.971Z] [INFO] ▶️ Streaming output:         
+[2026-06-18T11:44:11.971Z] [INFO] 
+[2026-06-18T11:44:12.845Z] [INFO] {
+[2026-06-18T11:44:12.845Z] [INFO]   "type": "system",
+[2026-06-18T11:44:12.845Z] [INFO]   "subtype": "init",
+[2026-06-18T11:44:12.845Z] [INFO]   "cwd": "/tmp/gh-issue-solver-1781783024578",
+[2026-06-18T11:44:12.845Z] [INFO]   "session_id": "d65e890a-db60-43f7-aea3-691500f7e26c",
+[2026-06-18T11:44:12.845Z] [INFO]   "tools": [
+[2026-06-18T11:44:12.845Z] [INFO]     "Task",
+[2026-06-18T11:44:12.845Z] [INFO]     "Bash",
+[2026-06-18T11:44:12.845Z] [INFO]     "DesignSync",
+[2026-06-18T11:44:12.845Z] [INFO]     "Edit",
+[2026-06-18T11:44:12.845Z] [INFO]     "Read",
+[2026-06-18T11:44:12.845Z] [INFO]     "Skill",
+[2026-06-18T11:44:12.845Z] [INFO]     "TaskCreate",
+[2026-06-18T11:44:12.845Z] [INFO]     "TaskGet",
+[2026-06-18T11:44:12.845Z] [INFO]     "TaskList",
+[2026-06-18T11:44:12.845Z] [INFO]     "TaskOutput",
+[2026-06-18T11:44:12.845Z] [INFO]     "TaskStop",
+[2026-06-18T11:44:12.845Z] [INFO]     "TaskUpdate",
+[2026-06-18T11:44:12.845Z] [INFO]     "ToolSearch",
+[2026-06-18T11:44:12.845Z] [INFO]     "WebFetch",
+[2026-06-18T11:44:12.845Z] [INFO]     "WebSearch",
+[2026-06-18T11:44:12.845Z] [INFO]     "Workflow",
+[2026-06-18T11:44:12.845Z] [INFO]     "Write"
+[2026-06-18T11:44:12.845Z] [INFO]   ],
+[2026-06-18T11:44:12.845Z] [INFO]   "mcp_servers": [
+[2026-06-18T11:44:12.845Z] [INFO]     {
+[2026-06-18T11:44:12.845Z] [INFO]       "name": "playwright",
+[2026-06-18T11:44:12.845Z] [INFO]       "status": "pending"
+[2026-06-18T11:44:12.845Z] [INFO]     }
+[2026-06-18T11:44:12.845Z] [INFO]   ],
+[2026-06-18T11:44:12.845Z] [INFO]   "model": "claude-opus-4-8",
+[2026-06-18T11:44:12.845Z] [INFO]   "permissionMode": "bypassPermissions",
+[2026-06-18T11:44:12.845Z] [INFO]   "slash_commands": [
+[2026-06-18T11:44:12.845Z] [INFO]     "deep-research",
+[2026-06-18T11:44:12.845Z] [INFO]     "design-sync",
+[2026-06-18T11:44:12.845Z] [INFO]     "update-config",
+[2026-06-18T11:44:12.845Z] [INFO]     "verify",
+[2026-06-18T11:44:12.845Z] [INFO]     "debug",
+[2026-06-18T11:44:12.845Z] [INFO]     "code-review",
+[2026-06-18T11:44:12.845Z] [INFO]     "simplify",
+[2026-06-18T11:44:12.845Z] [INFO]     "batch",
+[2026-06-18T11:44:12.845Z] [INFO]     "fewer-permission-prompts",
+[2026-06-18T11:44:12.845Z] [INFO]     "schedule",
+[2026-06-18T11:44:12.845Z] [INFO]     "claude-api",
+[2026-06-18T11:44:12.845Z] [INFO]     "run",
+[2026-06-18T11:44:12.845Z] [INFO]     "run-skill-generator",
+[2026-06-18T11:44:12.845Z] [INFO]     "clear",
+[2026-06-18T11:44:12.845Z] [INFO]     "compact",
+[2026-06-18T11:44:12.845Z] [INFO]     "config",
+[2026-06-18T11:44:12.845Z] [INFO]     "context",
+[2026-06-18T11:44:12.845Z] [INFO]     "heapdump",
+[2026-06-18T11:44:12.845Z] [INFO]     "init",
+[2026-06-18T11:44:12.845Z] [INFO]     "reload-skills",
+[2026-06-18T11:44:12.845Z] [INFO]     "review",
+[2026-06-18T11:44:12.845Z] [INFO]     "security-review",
+[2026-06-18T11:44:12.845Z] [INFO]     "usage-credits",
+[2026-06-18T11:44:12.845Z] [INFO]     "extra-usage",
+[2026-06-18T11:44:12.845Z] [INFO]     "usage",
+[2026-06-18T11:44:12.845Z] [INFO]     "insights",
+[2026-06-18T11:44:12.845Z] [INFO]     "goal",
+[2026-06-18T11:44:12.845Z] [INFO]     "team-onboarding"
+[2026-06-18T11:44:12.845Z] [INFO]   ],
+[2026-06-18T11:44:12.845Z] [INFO]   "apiKeySource": "none",
+[2026-06-18T11:44:12.845Z] [INFO]   "claude_code_version": "2.1.181",
+[2026-06-18T11:44:12.845Z] [INFO]   "output_style": "default",
+[2026-06-18T11:44:12.845Z] [INFO]   "agents": [
+[2026-06-18T11:44:12.845Z] [INFO]     "claude",
+[2026-06-18T11:44:12.845Z] [INFO]     "Explore",
+[2026-06-18T11:44:12.845Z] [INFO]     "general-purpose",
+[2026-06-18T11:44:12.845Z] [INFO]     "Plan",
+[2026-06-18T11:44:12.845Z] [INFO]     "statusline-setup"
+[2026-06-18T11:44:12.845Z] [INFO]   ],
+[2026-06-18T11:44:12.845Z] [INFO]   "skills": [
+[2026-06-18T11:44:12.845Z] [INFO]     "deep-research",
+[2026-06-18T11:44:12.845Z] [INFO]     "design-sync",
+[2026-06-18T11:44:12.845Z] [INFO]     "update-config",
+[2026-06-18T11:44:12.845Z] [INFO]     "verify",
+[2026-06-18T11:44:12.845Z] [INFO]     "debug",
+[2026-06-18T11:44:12.845Z] [INFO]     "code-review",
+[2026-06-18T11:44:12.845Z] [INFO]     "simplify",
+[2026-06-18T11:44:12.845Z] [INFO]     "batch",
+[2026-06-18T11:44:12.845Z] [INFO]     "fewer-permission-prompts",
+[2026-06-18T11:44:12.845Z] [INFO]     "schedule",
+[2026-06-18T11:44:12.845Z] [INFO]     "claude-api",
+[2026-06-18T11:44:12.845Z] [INFO]     "run",
+[2026-06-18T11:44:12.845Z] [INFO]     "run-skill-generator"
+[2026-06-18T11:44:12.845Z] [INFO]   ],
+[2026-06-18T11:44:12.845Z] [INFO]   "plugins": [],
+[2026-06-18T11:44:12.845Z] [INFO]   "analytics_disabled": false,
+[2026-06-18T11:44:12.845Z] [INFO]   "product_feedback_disabled": false,
+[2026-06-18T11:44:12.845Z] [INFO]   "uuid": "a2c0e9e3-b7f0-49d0-8e1f-d14ce1117deb",
+[2026-06-18T11:44:12.845Z] [INFO]   "fast_mode_state": "off"
+[2026-06-18T11:44:12.845Z] [INFO] }
+[2026-06-18T11:44:12.848Z] [INFO] 📌 Session ID: d65e890a-db60-43f7-aea3-691500f7e26c
+[2026-06-18T11:44:12.860Z] [INFO] 📁 Log renamed to: /home/box/d65e890a-db60-43f7-aea3-691500f7e26c.log
+[2026-06-18T11:44:12.865Z] [INFO] [log_df5fd0] sending request {
+[2026-06-18T11:44:12.867Z] [INFO]   method: "post",
+[2026-06-18T11:44:12.881Z] [INFO]   url: "https://api.anthropic.com/v1/messages?beta=true",
+[2026-06-18T11:44:12.883Z] [INFO]   options: {
+[2026-06-18T11:44:12.883Z] [INFO]     method: "post",
+[2026-06-18T11:44:12.884Z] [INFO]     path: "/v1/messages?beta=true",
+[2026-06-18T11:44:12.885Z] [INFO]     body: {
+[2026-06-18T11:44:12.885Z] [INFO]       model: "claude-opus-4-8",
+[2026-06-18T11:44:12.885Z] [INFO]       messages: [
+[2026-06-18T11:44:12.886Z] [INFO]         [Object ...], [Object ...]
+[2026-06-18T11:44:12.886Z] [INFO]       ],
+[2026-06-18T11:44:12.887Z] [INFO]       system: [
+[2026-06-18T11:44:12.887Z] [INFO]         [Object ...], [Object ...], [Object ...], [Object ...]
+[2026-06-18T11:44:12.887Z] [INFO]       ],
+[2026-06-18T11:44:12.888Z] [INFO]       tools: [
+[2026-06-18T11:44:12.888Z] [INFO]         [Object ...], [Object ...], [Object ...], [Object ...], [Object ...], [Object ...], [Object ...], [Object ...]
+[2026-06-18T11:44:12.888Z] [INFO]       ],
+[2026-06-18T11:44:12.888Z] [INFO]       tool_choice: undefined,
+[2026-06-18T11:44:12.889Z] [INFO]       metadata: [Object ...],
+[2026-06-18T11:44:12.889Z] [INFO]       max_tokens: 128000,
+[2026-06-18T11:44:12.889Z] [INFO]       thinking: [Object ...],
+[2026-06-18T11:44:12.889Z] [INFO]       context_management: [Object ...],
+[2026-06-18T11:44:12.889Z] [INFO]       output_config: [Object ...],
+[2026-06-18T11:44:12.889Z] [INFO]       diagnostics: [Object ...],
+[2026-06-18T11:44:12.890Z] [INFO]       stream: true,
+[2026-06-18T11:44:12.890Z] [INFO]     },
+[2026-06-18T11:44:12.890Z] [INFO]     timeout: 600000,
+[2026-06-18T11:44:12.890Z] [INFO]     signal: AbortSignal {
+[2026-06-18T11:44:12.891Z] [INFO]       [Symbol(events.maxEventTargetListeners)]: 50,
+[2026-06-18T11:44:12.891Z] [INFO]       [Symbol(events.maxEventTargetListenersWarned)]: false,
+[2026-06-18T11:44:12.891Z] [INFO]       aborted: false,
+[2026-06-18T11:44:12.891Z] [INFO]       reason: undefined,
+[2026-06-18T11:44:12.892Z] [INFO]       onabort: null,
+[2026-06-18T11:44:12.893Z] [INFO]       throwIfAborted: [Function: throwIfAborted],
+[2026-06-18T11:44:12.893Z] [INFO]       addEventListener: [Function: addEventListener],
+[2026-06-18T11:44:12.893Z] [INFO]       removeEventListener: [Function: removeEventListener],
+[2026-06-18T11:44:12.893Z] [INFO]       dispatchEvent: [Function: dispatchEvent],
+[2026-06-18T11:44:12.894Z] [INFO]     },
+[2026-06-18T11:44:12.894Z] [INFO]     stream: true,
+[2026-06-18T11:44:12.895Z] [INFO]   },
+[2026-06-18T11:44:12.895Z] [INFO]   headers: {
+[2026-06-18T11:44:12.895Z] [INFO]     accept: "application/json",
+[2026-06-18T11:44:12.895Z] [INFO]     "anthropic-beta": "claude-code-20250219,oauth-2025-04-20,interleaved-thinking-2025-05-14,thinking-token-count-2026-05-13,context-management-2025-06-27,prompt-caching-scope-2026-01-05,mid-conversation-system-2026-04-07,advisor-tool-2026-03-01,advanced-tool-use-2025-11-20,effort-2025-11-24,extended-cache-ttl-2025-04-11,cache-diagnosis-2026-04-07",
+[2026-06-18T11:44:12.896Z] [INFO]     "anthropic-dangerous-direct-browser-access": "true",
+[2026-06-18T11:44:12.896Z] [INFO]     "anthropic-version": "2023-06-01",
+[2026-06-18T11:44:12.896Z] [INFO]     authorization: "***",
+[2026-06-18T11:44:12.897Z] [INFO]     "content-type": "application/json",
+[2026-06-18T11:44:12.897Z] [INFO]     "user-agent": "claude-cli/2.1.181 (external, sdk-cli)",
+[2026-06-18T11:44:12.898Z] [INFO]     "x-app": "cli",
+[2026-06-18T11:44:12.898Z] [INFO]     "x-claude-code-session-id": "d65e890a-db60-43f7-aea3-691500f7e26c",
+[2026-06-18T11:44:12.901Z] [INFO]     "x-client-request-id": "d0cea104-b5ac-4f8a-b3fc-7e9029b01c60",
+[2026-06-18T11:44:12.902Z] [INFO]     "x-stainless-arch": "x64",
+[2026-06-18T11:44:12.903Z] [INFO]     "x-stainless-lang": "js",
+[2026-06-18T11:44:12.903Z] [INFO]     "x-stainless-os": "Linux",
+[2026-06-18T11:44:12.906Z] [INFO]     "x-stainless-package-version": "0.94.0",
+[2026-06-18T11:44:12.907Z] [INFO]     "x-stainless-retry-count": "0",
+[2026-06-18T11:44:12.909Z] [INFO]     "x-stainless-runtime": "node",
+[2026-06-18T11:44:12.910Z] [INFO]     "x-stainless-runtime-version": "v24.3.0",
+[2026-06-18T11:44:12.911Z] [INFO]     "x-stainless-timeout": "600",
+[2026-06-18T11:44:12.912Z] [INFO]   },
+[2026-06-18T11:44:12.912Z] [INFO] }
+[2026-06-18T11:44:15.705Z] [INFO] [log_df5fd0, request-id: "req_011CcAfedMyn3sN6aTWR1T5i"] post https://api.anthropic.com/v1/messages?beta=true succeeded with status 200 in 2839ms
+[2026-06-18T11:44:15.706Z] [INFO] [log_df5fd0] response start {
+[2026-06-18T11:44:15.707Z] [INFO]   url: "https://api.anthropic.com/v1/messages?beta=true",
+[2026-06-18T11:44:15.708Z] [INFO]   status: 200,
+[2026-06-18T11:44:15.710Z] [INFO]   headers: {
+[2026-06-18T11:44:15.711Z] [INFO]     "anthropic-organization-id": "ebc2ac93-f86f-4d15-aff3-de8830d8d789",
+[2026-06-18T11:44:15.711Z] [INFO]     "anthropic-ratelimit-unified-5h-reset": "1781787000",
+[2026-06-18T11:44:15.712Z] [INFO]     "anthropic-ratelimit-unified-5h-status": "allowed",
+[2026-06-18T11:44:15.712Z] [INFO]     "anthropic-ratelimit-unified-5h-utilization": "0.33",
+[2026-06-18T11:44:15.712Z] [INFO]     "anthropic-ratelimit-unified-7d-reset": "1782212400",
+[2026-06-18T11:44:15.713Z] [INFO]     "anthropic-ratelimit-unified-7d-status": "allowed",
+[2026-06-18T11:44:15.713Z] [INFO]     "anthropic-ratelimit-unified-7d-utilization": "0.62",
+[2026-06-18T11:44:15.713Z] [INFO]     "anthropic-ratelimit-unified-fallback-percentage": "0.5",
+[2026-06-18T11:44:15.713Z] [INFO]     "anthropic-ratelimit-unified-overage-disabled-reason": "org_level_disabled",
+[2026-06-18T11:44:15.714Z] [INFO]     "anthropic-ratelimit-unified-overage-status": "rejected",
+[2026-06-18T11:44:15.714Z] [INFO]     "anthropic-ratelimit-unified-representative-claim": "five_hour",
+[2026-06-18T11:44:15.715Z] [INFO]     "anthropic-ratelimit-unified-reset": "1781787000",
+[2026-06-18T11:44:15.715Z] [INFO]     "anthropic-ratelimit-unified-status": "allowed",
+[2026-06-18T11:44:15.715Z] [INFO]     "cache-control": "no-cache",
+[2026-06-18T11:44:15.716Z] [INFO]     "cf-cache-status": "DYNAMIC",
+[2026-06-18T11:44:15.716Z] [INFO]     "cf-ray": "a0da0a708f83dc48-FRA",
+[2026-06-18T11:44:15.717Z] [INFO]     connection: "keep-alive",
+[2026-06-18T11:44:15.718Z] [INFO]     "content-encoding": "gzip",
+[2026-06-18T11:44:15.718Z] [INFO]     "content-security-policy": "default-src 'none'; frame-ancestors 'none'",
+[2026-06-18T11:44:15.719Z] [INFO]     "content-type": "text/event-stream; charset=utf-8",
+[2026-06-18T11:44:15.720Z] [INFO]     date: "Thu, 18 Jun 2026 11:44:15 GMT",
+[2026-06-18T11:44:15.721Z] [INFO]     "request-id": "req_011CcAfedMyn3sN6aTWR1T5i",
+[2026-06-18T11:44:15.721Z] [INFO]     server: "cloudflare",
+[2026-06-18T11:44:15.722Z] [INFO]     "strict-transport-security": "max-age=31536000; includeSubDomains; preload",
+[2026-06-18T11:44:15.723Z] [INFO]     traceresponse: "00-9d4d095ebb677fdf618fc940e72d19a9-a19e161c0d6d820d-01",
+[2026-06-18T11:44:15.725Z] [INFO]     "transfer-encoding": "chunked",
+[2026-06-18T11:44:15.725Z] [INFO]     vary: "Accept-Encoding",
+[2026-06-18T11:44:15.727Z] [INFO]     "x-robots-tag": "none",
+[2026-06-18T11:44:15.728Z] [INFO]     "set-cookie": "***",
+[2026-06-18T11:44:15.729Z] [INFO]   },
+[2026-06-18T11:44:15.729Z] [INFO]   durationMs: 2839,
+[2026-06-18T11:44:15.730Z] [INFO] }
+[2026-06-18T11:44:15.730Z] [INFO] response 200 https://api.anthropic.com/v1/messages?beta=true Headers {
+[2026-06-18T11:44:15.730Z] [INFO]   "date": "Thu, 18 Jun 2026 11:44:15 GMT",
+[2026-06-18T11:44:15.731Z] [INFO]   "content-type": "text/event-stream; charset=utf-8",
+[2026-06-18T11:44:15.732Z] [INFO]   "transfer-encoding": "chunked",
+[2026-06-18T11:44:15.732Z] [INFO]   "connection": "keep-alive",
+[2026-06-18T11:44:15.733Z] [INFO]   "cache-control": "no-cache",
+[2026-06-18T11:44:15.734Z] [INFO]   "strict-transport-security": "max-age=31536000; includeSubDomains; preload",
+[2026-06-18T11:44:15.735Z] [INFO]   "content-encoding": "gzip",
+[2026-06-18T11:44:15.737Z] [INFO]   "vary": "Accept-Encoding",
+[2026-06-18T11:44:15.737Z] [INFO]   "content-security-policy": "default-src 'none'; frame-ancestors 'none'",
+[2026-06-18T11:44:15.739Z] [INFO]   "set-cookie": [ "_cfuvid=pBYOTEU8pTXWseZvWl_BXKRKQXQgXuHNayK3FEiW8VY-1781783052.8856137-1.0.1.1-UpJDgCOCg1f35gqJHwxmGO44VxQaQFToykVtlQwxxf0; HttpOnly; SameSite=None; Secure; Path=/; Domain=api.anthropic.com" ],
+[2026-06-18T11:44:15.742Z] [INFO]   "anthropic-ratelimit-unified-status": "allowed",
+[2026-06-18T11:44:15.743Z] [INFO]   "anthropic-ratelimit-unified-5h-status": "allowed",
+[2026-06-18T11:44:15.744Z] [INFO]   "anthropic-ratelimit-unified-5h-reset": "1781787000",
+[2026-06-18T11:44:15.747Z] [INFO]   "anthropic-ratelimit-unified-5h-utilization": "0.33",
+[2026-06-18T11:44:15.747Z] [INFO]   "anthropic-ratelimit-unified-7d-status": "allowed",
+[2026-06-18T11:44:15.749Z] [INFO]   "anthropic-ratelimit-unified-7d-reset": "1782212400",
+[2026-06-18T11:44:15.749Z] [INFO]   "anthropic-ratelimit-unified-7d-utilization": "0.62",
+[2026-06-18T11:44:15.749Z] [INFO]   "anthropic-ratelimit-unified-representative-claim": "five_hour",
+[2026-06-18T11:44:15.750Z] [INFO]   "anthropic-ratelimit-unified-fallback-percentage": "0.5",
+[2026-06-18T11:44:15.751Z] [INFO]   "anthropic-ratelimit-unified-reset": "1781787000",
+[2026-06-18T11:44:15.751Z] [INFO]   "anthropic-ratelimit-unified-overage-disabled-reason": "org_level_disabled",
+[2026-06-18T11:44:15.752Z] [INFO]   "anthropic-ratelimit-unified-overage-status": "rejected",
+[2026-06-18T11:44:15.752Z] [INFO]   "request-id": "req_011CcAfedMyn3sN6aTWR1T5i",
+[2026-06-18T11:44:15.753Z] [INFO]   "anthropic-organization-id": "ebc2ac93-f86f-4d15-aff3-de8830d8d789",
+[2026-06-18T11:44:15.754Z] [INFO]   "traceresponse": "00-9d4d095ebb677fdf618fc940e72d19a9-a19e161c0d6d820d-01",
+[2026-06-18T11:44:15.755Z] [INFO]   "server": "cloudflare",
+[2026-06-18T11:44:15.756Z] [INFO]   "cf-cache-status": "DYNAMIC",
+[2026-06-18T11:44:15.756Z] [INFO]   "x-robots-tag": "none",
+[2026-06-18T11:44:15.757Z] [INFO]   "cf-ray": "a0da0a708f83dc48-FRA",
+[2026-06-18T11:44:15.758Z] [INFO] } ReadableStream {
+[2026-06-18T11:44:15.759Z] [INFO]   blob: [Function: blob],
+[2026-06-18T11:44:15.760Z] [INFO]   bytes: [Function: bytes],
+[2026-06-18T11:44:15.760Z] [INFO]   cancel: [Function],
+[2026-06-18T11:44:15.761Z] [INFO]   getReader: [Function],
+[2026-06-18T11:44:15.762Z] [INFO]   json: [Function: json],
+[2026-06-18T11:44:15.763Z] [INFO]   locked: [Getter],
+[2026-06-18T11:44:15.764Z] [INFO]   pipeThrough: [Function],
+[2026-06-18T11:44:15.765Z] [INFO]   pipeTo: [Function],
+[2026-06-18T11:44:15.766Z] [INFO]   tee: [Function],
+[2026-06-18T11:44:15.768Z] [INFO]   text: [Function: text],
+[2026-06-18T11:44:15.769Z] [INFO]   values: [Function],
+[2026-06-18T11:44:15.769Z] [INFO]   [Symbol(Symbol.asyncIterator)]: [Function],
+[2026-06-18T11:44:15.770Z] [INFO] }
+[2026-06-18T11:44:15.772Z] [INFO] [log_df5fd0] response parsed {
+[2026-06-18T11:44:15.774Z] [INFO]   url: "https://api.anthropic.com/v1/messages?beta=true",
+[2026-06-18T11:44:15.775Z] [INFO]   status: 200,
+[2026-06-18T11:44:15.777Z] [INFO]   body: sU {
+[2026-06-18T11:44:15.778Z] [INFO]     iterator: [AsyncGeneratorFunction: s],
+[2026-06-18T11:44:15.778Z] [INFO]     controller: AbortController {
+[2026-06-18T11:44:15.778Z] [INFO]       signal: [AbortSignal ...],
+[2026-06-18T11:44:15.778Z] [INFO]       abort: [Function: abort],
+[2026-06-18T11:44:15.779Z] [INFO]     },
+[2026-06-18T11:44:15.779Z] [INFO]     [Symbol(Symbol.asyncIterator)]: [Function],
+[2026-06-18T11:44:15.780Z] [INFO]     tee: [Function: tee],
+[2026-06-18T11:44:15.780Z] [INFO]     toReadableStream: [Function: toReadableStream],
+[2026-06-18T11:44:15.781Z] [INFO]   },
+[2026-06-18T11:44:15.781Z] [INFO]   durationMs: 2840,
+[2026-06-18T11:44:15.781Z] [INFO] }
+[2026-06-18T11:44:16.115Z] [INFO] {
+[2026-06-18T11:44:16.115Z] [INFO]   "type": "assistant",
+[2026-06-18T11:44:16.115Z] [INFO]   "message": {
+[2026-06-18T11:44:16.115Z] [INFO]     "model": "claude-opus-4-8",
+[2026-06-18T11:44:16.115Z] [INFO]     "id": "msg_01Ru7uQ82CKTpTUqgpzU1Wiw",
+[2026-06-18T11:44:16.115Z] [INFO]     "type": "message",
+[2026-06-18T11:44:16.115Z] [INFO]     "role": "assistant",
+[2026-06-18T11:44:16.115Z] [INFO]     "content": [
+[2026-06-18T11:44:16.115Z] [INFO]       {
+[2026-06-18T11:44:16.115Z] [INFO]         "type": "thinking",
+[2026-06-18T11:44:16.115Z] [INFO]         "thinking": "",
+[2026-06-18T11:44:16.115Z] [INFO]         "signature": "EucBCmMIDhgCKkDpYhdEGxTHNrNVOjXWTfqQlZHvSP5fpYA7/GzX8FTg5clEzrg8XjaAMu+jac08ABwp7mfMbFmlyBgGGFS5H9WhMg9jbGF1ZGUtb3B1cy00LTg4AEIIdGhpbmtpbmcSDGTnHWfcvlk091ZkiRoMuPp9lJ4M2yhTnM4hIjDbR5rYwTa83VepE4iJT6rgNMWRzvM/SUsnP/RBfKmURHskNBRAUTkZb6gGzW1lF/UqMq5By89MDmLhrwycNCT1civgGlqGlE/BDEy3pHaKJXaNhU81G1v2Zda30W5WN18iAt1TGAE="
+[2026-06-18T11:44:16.115Z] [INFO]       }
+[2026-06-18T11:44:16.115Z] [INFO]     ],
+[2026-06-18T11:44:16.115Z] [INFO]     "stop_reason": null,
+[2026-06-18T11:44:16.115Z] [INFO]     "stop_sequence": null,
+[2026-06-18T11:44:16.115Z] [INFO]     "stop_details": null,
+[2026-06-18T11:44:16.115Z] [INFO]     "usage": {
+[2026-06-18T11:44:16.115Z] [INFO]       "input_tokens": 2410,
+[2026-06-18T11:44:16.115Z] [INFO]       "cache_creation_input_tokens": 6908,
+[2026-06-18T11:44:16.115Z] [INFO]       "cache_read_input_tokens": 12672,
+[2026-06-18T11:44:16.115Z] [INFO]       "cache_creation": {
+[2026-06-18T11:44:16.115Z] [INFO]         "ephemeral_5m_input_tokens": 0,
+[2026-06-18T11:44:16.115Z] [INFO]         "ephemeral_1h_input_tokens": 6908
+[2026-06-18T11:44:16.115Z] [INFO]       },
+[2026-06-18T11:44:16.115Z] [INFO]       "output_tokens": 7,
+[2026-06-18T11:44:16.115Z] [INFO]       "service_tier": "standard",
+[2026-06-18T11:44:16.115Z] [INFO]       "inference_geo": "not_available"
+[2026-06-18T11:44:16.115Z] [INFO]     },
+[2026-06-18T11:44:16.115Z] [INFO]     "diagnostics": null,
+[2026-06-18T11:44:16.115Z] [INFO]     "context_management": null
+[2026-06-18T11:44:16.115Z] [INFO]   },
+[2026-06-18T11:44:16.115Z] [INFO]   "parent_tool_use_id": null,
+[2026-06-18T11:44:16.115Z] [INFO]   "session_id": "d65e890a-db60-43f7-aea3-691500f7e26c",
+[2026-06-18T11:44:16.115Z] [INFO]   "uuid": "527cbc32-2012-4b80-b14a-2482bc71b406",
+[2026-06-18T11:44:16.115Z] [INFO]   "request_id": "req_011CcAfedMyn3sN6aTWR1T5i"
+[2026-06-18T11:44:16.115Z] [INFO] }
+[2026-06-18T11:44:17.117Z] [INFO] {
+[2026-06-18T11:44:17.117Z] [INFO]   "type": "assistant",
+[2026-06-18T11:44:17.117Z] [INFO]   "message": {
+[2026-06-18T11:44:17.117Z] [INFO]     "model": "claude-opus-4-8",
+[2026-06-18T11:44:17.117Z] [INFO]     "id": "msg_01Ru7uQ82CKTpTUqgpzU1Wiw",
+[2026-06-18T11:44:17.117Z] [INFO]     "type": "message",
+[2026-06-18T11:44:17.117Z] [INFO]     "role": "assistant",
+[2026-06-18T11:44:17.117Z] [INFO]     "content": [
+[2026-06-18T11:44:17.117Z] [INFO]       {
+[2026-06-18T11:44:17.117Z] [INFO]         "type": "tool_use",
+[2026-06-18T11:44:17.117Z] [INFO]         "id": "toolu_01KdFWNWofwscBf59D4m3ZA1",
+[2026-06-18T11:44:17.117Z] [INFO]         "name": "Bash",
+[2026-06-18T11:44:17.117Z] [INFO]         "input": {
+[2026-06-18T11:44:17.117Z] [INFO]           "command": "gh issue view https://github.com/G-Ivan-A/hybrid-Intelligence-lab/issues/251",
+[2026-06-18T11:44:17.117Z] [INFO]           "description": "View issue 251"
+[2026-06-18T11:44:17.117Z] [INFO]         },
+[2026-06-18T11:44:17.117Z] [INFO]         "caller": {
+[2026-06-18T11:44:17.117Z] [INFO]           "type": "direct"
+[2026-06-18T11:44:17.117Z] [INFO]         }
+[2026-06-18T11:44:17.117Z] [INFO]       }
+[2026-06-18T11:44:17.117Z] [INFO]     ],
+[2026-06-18T11:44:17.117Z] [INFO]     "stop_reason": null,
+[2026-06-18T11:44:17.117Z] [INFO]     "stop_sequence": null,
+[2026-06-18T11:44:17.117Z] [INFO]     "stop_details": null,
+[2026-06-18T11:44:17.117Z] [INFO]     "usage": {
+[2026-06-18T11:44:17.117Z] [INFO]       "input_tokens": 2410,
+[2026-06-18T11:44:17.117Z] [INFO]       "cache_creation_input_tokens": 6908,
+[2026-06-18T11:44:17.117Z] [INFO]       "cache_read_input_tokens": 12672,
+[2026-06-18T11:44:17.117Z] [INFO]       "cache_creation": {
+[2026-06-18T11:44:17.117Z] [INFO]         "ephemeral_5m_input_tokens": 0,
+[2026-06-18T11:44:17.117Z] [INFO]         "ephemeral_1h_input_tokens": 6908
+[2026-06-18T11:44:17.117Z] [INFO]       },
+[2026-06-18T11:44:17.117Z] [INFO]       "output_tokens": 7,
+[2026-06-18T11:44:17.117Z] [INFO]       "service_tier": "standard",
+[2026-06-18T11:44:17.117Z] [INFO]       "inference_geo": "not_available"
+[2026-06-18T11:44:17.117Z] [INFO]     },
+[2026-06-18T11:44:17.117Z] [INFO]     "diagnostics": null,
+[2026-06-18T11:44:17.117Z] [INFO]     "context_management": null
+[2026-06-18T11:44:17.117Z] [INFO]   },
+[2026-06-18T11:44:17.117Z] [INFO]   "parent_tool_use_id": null,
+[2026-06-18T11:44:17.117Z] [INFO]   "session_id": "d65e890a-db60-43f7-aea3-691500f7e26c",
+[2026-06-18T11:44:17.117Z] [INFO]   "uuid": "1f85171f-1b3b-414f-870a-c962b9bebd99",
+[2026-06-18T11:44:17.117Z] [INFO]   "request_id": "req_011CcAfedMyn3sN6aTWR1T5i"
+[2026-06-18T11:44:17.117Z] [INFO] }
+[2026-06-18T11:44:17.920Z] [INFO] {
+[2026-06-18T11:44:17.920Z] [INFO]   "type": "assistant",
+[2026-06-18T11:44:17.920Z] [INFO]   "message": {
+[2026-06-18T11:44:17.920Z] [INFO]     "model": "claude-opus-4-8",
+[2026-06-18T11:44:17.920Z] [INFO]     "id": "msg_01Ru7uQ82CKTpTUqgpzU1Wiw",
+[2026-06-18T11:44:17.920Z] [INFO]     "type": "message",
+[2026-06-18T11:44:17.920Z] [INFO]     "role": "assistant",
+[2026-06-18T11:44:17.920Z] [INFO]     "content": [
+[2026-06-18T11:44:17.920Z] [INFO]       {
+[2026-06-18T11:44:17.920Z] [INFO]         "type": "tool_use",
+[2026-06-18T11:44:17.920Z] [INFO]         "id": "toolu_01PyRnsKrNrJdBDDemg4YL1M",
+[2026-06-18T11:44:17.920Z] [INFO]         "name": "Bash",
+[2026-06-18T11:44:17.920Z] [INFO]         "input": {
+[2026-06-18T11:44:17.920Z] [INFO]           "command": "ls -la && git log --oneline -10",
+[2026-06-18T11:44:17.920Z] [INFO]           "description": "List files and git log"
+[2026-06-18T11:44:17.920Z] [INFO]         },
+[2026-06-18T11:44:17.920Z] [INFO]         "caller": {
+[2026-06-18T11:44:17.920Z] [INFO]           "type": "direct"
+[2026-06-18T11:44:17.920Z] [INFO]         }
+[2026-06-18T11:44:17.920Z] [INFO]       }
+[2026-06-18T11:44:17.920Z] [INFO]     ],
+[2026-06-18T11:44:17.920Z] [INFO]     "stop_reason": null,
+[2026-06-18T11:44:17.920Z] [INFO]     "stop_sequence": null,
+[2026-06-18T11:44:17.920Z] [INFO]     "stop_details": null,
+[2026-06-18T11:44:17.920Z] [INFO]     "usage": {
+[2026-06-18T11:44:17.920Z] [INFO]       "input_tokens": 2410,
+[2026-06-18T11:44:17.920Z] [INFO]       "cache_creation_input_tokens": 6908,
+[2026-06-18T11:44:17.920Z] [INFO]       "cache_read_input_tokens": 12672,
+[2026-06-18T11:44:17.920Z] [INFO]       "cache_creation": {
+[2026-06-18T11:44:17.920Z] [INFO]         "ephemeral_5m_input_tokens": 0,
+[2026-06-18T11:44:17.920Z] [INFO]         "ephemeral_1h_input_tokens": 6908
+[2026-06-18T11:44:17.920Z] [INFO]       },
+[2026-06-18T11:44:17.920Z] [INFO]       "output_tokens": 7,
+[2026-06-18T11:44:17.920Z] [INFO]       "service_tier": "standard",
+[2026-06-18T11:44:17.920Z] [INFO]       "inference_geo": "not_available"
+[2026-06-18T11:44:17.920Z] [INFO]     },
+[2026-06-18T11:44:17.920Z] [INFO]     "diagnostics": null,
+[2026-06-18T11:44:17.920Z] [INFO]     "context_management": null
+[2026-06-18T11:44:17.920Z] [INFO]   },
+[2026-06-18T11:44:17.920Z] [INFO]   "parent_tool_use_id": null,
+[2026-06-18T11:44:17.920Z] [INFO]   "session_id": "d65e890a-db60-43f7-aea3-691500f7e26c",
+[2026-06-18T11:44:17.920Z] [INFO]   "uuid": "f3cd4abf-0584-473b-8b3e-f717f8b7bf95",
+[2026-06-18T11:44:17.920Z] [INFO]   "request_id": "req_011CcAfedMyn3sN6aTWR1T5i"
+[2026-06-18T11:44:17.920Z] [INFO] }
+[2026-06-18T11:44:18.004Z] [INFO] {
+[2026-06-18T11:44:18.004Z] [INFO]   "type": "rate_limit_event",
+[2026-06-18T11:44:18.004Z] [INFO]   "rate_limit_info": {
+[2026-06-18T11:44:18.004Z] [INFO]     "status": "allowed_warning",
+[2026-06-18T11:44:18.004Z] [INFO]     "resetsAt": 1782212400,
+[2026-06-18T11:44:18.004Z] [INFO]     "rateLimitType": "seven_day",
+[2026-06-18T11:44:18.004Z] [INFO]     "utilization": 0.62,
+[2026-06-18T11:44:18.004Z] [INFO]     "isUsingOverage": false
+[2026-06-18T11:44:18.004Z] [INFO]   },
+[2026-06-18T11:44:18.004Z] [INFO]   "uuid": "0c4fdb17-20d1-4538-98d6-087aba4735b4",
+[2026-06-18T11:44:18.004Z] [INFO]   "session_id": "d65e890a-db60-43f7-aea3-691500f7e26c"
+[2026-06-18T11:44:18.004Z] [INFO] }
+[2026-06-18T11:44:20.442Z] [INFO] {
+[2026-06-18T11:44:20.442Z] [INFO]   "type": "user",
+[2026-06-18T11:44:20.442Z] [INFO]   "message": {
+[2026-06-18T11:44:20.442Z] [INFO]     "role": "user",
+[2026-06-18T11:44:20.442Z] [INFO]     "content": [
+[2026-06-18T11:44:20.442Z] [INFO]       {
+[2026-06-18T11:44:20.442Z] [INFO]         "tool_use_id": "toolu_01KdFWNWofwscBf59D4m3ZA1",
+[2026-06-18T11:44:20.442Z] [INFO]         "type": "tool_result",
+[2026-06-18T11:44:20.442Z] [INFO]         "content": "title:\tcreative: Формализация новых AI-классификаций (подпроцессы, артефакты, операции) и интеграция в роадмап Mango с учётом эволюции операций\nstate:\tOPEN\nauthor:\tG-Ivan-A (Ivan Gulienko)\nlabels:\t\ncomments:\t0\nassignees:\t\nprojects:\t\nmilestone:\t\nissue-type:\t\nparent:\t\nsub-issues:\t\nsub-issues-completed:\t\nblocked-by:\t\nblocking:\t\nnumber:\t251\n--\n## 🔗 Мета\n\n**Labels**: `creative` | `research` | `priority:P2` | `requirements-engineering` | `ai-era` | `roadmap` | `mango-integration`\n**Milestone**: `Sprint 3 — Hybrid Minimum Bootstrap`\n**Depends On**: \n  - PR #248 (Исследование Вигерса — после исправлений P1)\n  - Задача P1 (Исправление и дополнение исследования Вигерса)\n  - PR #242 (Research Memory — процесс исследования источника)\n  - PR #246 (Methodology Research — AI-тренды)\n**Operating Mode**: `Creative` (синтез, формализация, предложения по интеграции) + `Research` (анализ современных AI-фреймворков)\n**Lifecycle Stage**: `Research → RFC`\n\n---\n\n## 🧠 ПОЛНЫЙ КОНТЕКСТ (КРИТИЧЕСКИ ВАЖНО)\n\n### Эволюция мысли\n\n**Этап 1: Исходное исследование (PR #248)**\n- Исследование книги Вигерса \"Разработка требований к ПО\" (2020)\n- Цель: независимо извлечь систему уровней/типов требований, процессов/операций, глоссарий\n- Актуализировать через сравнение 3 трендов (2020/2026/2026 ИИ)\n\n**Этап 2: Исправления P1**\n- Исправлены пути артефактов (research/external-knowledge/, research/mango/)\n- Исправлена классификация (Prompt = интерфейс к Tool, Prompt engineering = подпроцесс)\n- Добавлена база для Фазы 2 (процессы/подпроцессы для AI-агента)\n- Дополнено исследование сравнением с BABOK/ISO/AI\n\n**Этап 3: Финальная синхронизация видения**\n- Prompt engineering = подпроцесс (не операция, не тип требования)\n- Prompt = интерфейс к Tool (не сам Tool)\n- Prompt specification = описательный документ для отладки/guides\n- Новые подпроцессы для Фазы 2 (Разработка AI-агента)\n- AI-assisted операции требуют осознанного перехода в роадмап\n\n**Этап 4: Цель P2**\n- Детально формализовать новые AI-классификации (не просто список, а полноценное описание)\n- Интегрировать в роадмап Mango (как это влияет на эволюцию операций)\n- Подготовить к синхронизации с mango_ba_prompts (С1, С2, С3)\n\n---\n\n### Что мы отвергли и почему\n\n#### ❌ Отвергнуто: \"Просто добавить новые операции в список\"\n**Почему:** Недостаточно. Нужно понять, как новые подпроцессы интегрируются в существующую систему, как они связаны с классическими операциями, как меняется роадмап.\n\n#### ❌ Отвергнуто: \"Заменить классические операции AI-версиями\"\n**Почему:** Классические операции не устаревают, они дополняются AI-ассистированными версиями. Нужно показать эволюцию, а не замену.\n\n#### ❌ Отвергнуто: \"Создать отдельные процессы для AI\"\n**Почему:** AI-разработка — это не отдельный процесс, а расширение существующих процессов. Нужно показать интеграцию, а не изоляцию.\n\n---\n\n### Что мы приняли (ключевые принципы)\n\n#### ✅ Принято: \"Детальная формализация новых AI-классификаций\"\n\n**Новые подпроцессы (дополняют Вигерса):**\n\n1. **Инжиниринг промптов (Prompt Engineering)**\n   - Операции: анализ задачи, написание черновика, тестирование, итерация, валидация\n   - Артефакты: Prompt specification (описательный) + Исполнимый промпт\n   - Связь с классикой: дополняет \"Документирование требований\"\n\n2. **Настройка RAG (RAG Configuration)**\n   - Операции: выбор векторной базы, настройка chunking, настройка retrieval\n   - Артефакты: RAG configuration document\n   - Связь с классикой: дополняет \"Проектирование решений\"\n\n3. **Проектирование оркестрации агентов (Agent Orchestration Design)**\n   - Операции: определение сценариев взаимодействия, проектирование протоколов коммуникации, настройка координации\n   - Артефакты: Agent orchestration diagram\n   - Связь с классикой: дополняет \"Проектирование архитектуры\"\n\n4. **Тестирование AI-компонентов (AI Testing)**\n   - Операции: написание тестовых сценариев, запуск тестов, анализ результатов\n   - Артефакты: AI test suite\n   - Связь с классикой: дополняет \"Валидация требований\"\n\n#### ✅ Принято: \"Интеграция в роадмап Mango (эволюция операций)\"\n\n**Пример эволюции:**\n- Классическая операция: \"Анализ документов\"\n- AI-версия: \"AI-assisted document analysis\"\n- **Не просто \"включение кнопки\"** — требует:\n  - Обучения БА работе с AI-инструментами\n  - Настройки AI-инструментов\n  - Валидации AI-выводов\n  - Интеграции в роадмап\n\n**План перехода:**\n1. Фаза 0 (текущая): Классические операции + базовые промпты\n2. Фаза 1 (Trust & Evidence): AI-assisted операции с валидацией\n3. Фаза 2 (AI-агенты): Полноценные AI-подпроцессы (Prompt engineering, RAG config, Agent orchestration)\n4. Фаза 3 (Мультиагентные системы): Комплексные AI-решения\n\n#### ✅ Принято: \"Подготовка к синхронизации с mango_ba_prompts\"\n\n**Что нужно подготовить:**\n- С1: Ось `requirement_level` (Business → User → Functional → Non-functional)\n- С2: Тип \"Бизнес-правило\" + 5 категорий (Факты, Ограничения, Активаторы, Выводы, Вычисления)\n- С3: Crosswalk Вигерс ↔ операции mango ↔ BCREQ\n\n---\n\n##  Цель задачи\n\n1. **Детально формализовать** новые AI-классификации (подпроцессы, операции, артефакты)\n2. **Интегрировать** в роадмап Mango (эволюция операций)\n3. **Подготовить** к синхронизации с mango_ba_prompts (С1, С2, С3)\n4. **Создать** полноценное описание с примерами (не просто списки)\n\n---\n\n## ✅ ФТ (Функциональные требования)\n\n### ФТ-1: Детальная формализация новых AI-подпроцессов\n\n**Для каждого подпроцесса создать полноценное описание:**\n\n**1. Инжиниринг промптов (Prompt Engineering)**\n\n**Описание:** Подпроцесс создания, тестирования и валидации промптов для AI-компонентов.\n\n**Операции:**\n- Операция 1.1: \"Анализ задачи для промпта\"\n  - Вход: бизнес-требование, контекст\n  - Действие: определение цели промпта, входных/выходных данных\n  - Выход: спецификация задачи для промпта\n- Операция 1.2: \"Написание черновика промпта\"\n  - Вход: спецификация задачи\n  - Действие: создание первой версии промпта\n  - Выход: черновик промпта\n- Операция 1.3: \"Тестирование промпта\"\n  - Вход: черновик промпта, тестовые данные\n  - Действие: запуск промпта, анализ результатов\n  - Выход: результаты тестирования\n- Операция 1.4: \"Итерация промпта\"\n  - Вход: результаты тестирования\n  - Действие: улучшение промпта на основе результатов\n  - Выход: улучшенная версия промпта\n- Операция 1.5: \"Валидация промпта\"\n  - Вход: улучшенная версия промпта\n  - Действие: финальная проверка соответствия требованиям\n  - Выход: валидированный промпт\n\n**Артефакты:**\n- **Prompt specification** (описательный документ):\n  - Назначение промпта\n  - Входные данные\n  - Ожидаемый выход\n  - Контекст (какие знания использует)\n  - Критерии качества\n  - Примеры использования\n  - Связь с бизнес-требованиями\n- **Исполнимый промпт** (исполнимый артефакт):\n  - Текст промпта для LLM\n\n**Связь с классикой:** Дополняет \"Документирование требований\" (Вигерс, глава 10)\n\n---\n\n**2. Настройка RAG (RAG Configuration)**\n\n**Описание:** Подпроцесс настройки Retrieval-Augmented Generation для AI-компонентов.\n\n**Операции:**\n- Операция 2.1: \"Выбор векторной базы\"\n  - Вход: требования к хранению знаний\n  - Действие: анализ доступных решений (Chroma, Pinecone, YDB)\n  - Выход: выбранная векторная база\n- Операция 2.2: \"Настройка chunking\"\n  - Вход: документы для индексации\n  - Действие: определение стратегии разделения документов\n  - Выход: настроенный chunking\n- Операция 2.3: \"Настройка retrieval\"\n  - Вход: векторная база, chunking\n  - Действие: настройка поиска и ранжирования\n  - Выход: настроенный retrieval\n\n**Артефакты:**\n- **RAG configuration document** (описательный документ):\n  - Выбранная векторная база и обоснование\n  - Стратегия chunking\n  - Параметры retrieval\n  - Критерии качества поиска\n\n**Связь с классикой:** Дополняет \"Проектирование решений\" (Вигерс, глава 12)\n\n---\n\n**3. Проектирование оркестрации агентов (Agent Orchestration Design)**\n\n**Описание:** Подпроцесс проектирования взаимодействия между AI-агентами в мультиагентной системе.\n\n**Операции:**\n- Операция 3.1: \"Определение сценариев взаимодействия\"\n  - Вход: бизнес-требования к мультиагентной системе\n  - Действие: определение ролей агентов и сценариев их взаимодействия\n  - Выход: сценарии взаимодействия\n- Операция 3.2: \"Проектирование протоколов коммуникации\"\n  - Вход: сценарии взаимодействия\n  - Действие: определение форматов сообщений и протоколов\n  - Выход: спецификация протоколов\n- Операция 3.3: \"Настройка координации\"\n  - Вход: спецификация протоколов\n  - Действие: настройка координации между агентами\n  - Выход: настроенная оркестрация\n\n**Артефакты:**\n- **Agent orchestration diagram** (описательный документ):\n  - Роли агентов\n  - Сценарии взаимодействия\n  - Протоколы коммуникации\n  - Механизмы координации\n\n**Связь с классикой:** Дополняет \"Проектирование архитектуры\" (Вигерс, глава 19)\n\n---\n\n**4. Тестирование AI-компонентов (AI Testing)**\n\n**Описание:** Подпроцесс тестирования AI-компонентов (промптов, RAG, агентов).\n\n**Операции:**\n- Операция 4.1: \"Написание тестовых сценариев\"\n  - Вход: спецификации AI-компонентов\n  - Действие: создание тестовых сценариев\n  - Выход: тестовые сценарии\n- Операция 4.2: \"Запуск тестов\"\n  - Вход: тестовые сценарии, AI-компоненты\n  - Действие: выполнение тестов\n  - Выход: результаты тестов\n- Операция 4.3: \"Анализ результатов\"\n  - Вход: результаты тестов\n  - Действие: анализ качества AI-компонентов\n  - Выход: отчёт о тестировании\n\n**Артефакты:**\n- **AI test suite** (исполнимый артефакт):\n  - Тестовые сценарии\n  - Ожидаемые результаты\n  - Критерии прохождения\n\n**Связь с классикой:** Дополняет \"Валидация требований\" (Вигерс, глава 17)\n\n---\n\n### ФТ-2: Интеграция в роадмап Mango (эволюция операций)\n\n**Создать раздел: \"Эволюция операций в роадмапе Mango\"**\n\n**Фаза 0 (текущая): Классические операции + базовые промпты**\n- Операции: классические (интервью, анализ документов, документирование)\n- AI-компоненты: базовые промпты (без AI-assisted операций)\n- Артефакты: стандартные (SRS, User Story, Use Case)\n\n**Фаза 1 (Trust & Evidence): AI-assisted операции с валидацией**\n- Операции: классические + AI-assisted версии\n  - Пример: \"Анализ документов\" → \"AI-assisted document analysis\"\n  - Пример: \"Проверка противоречий\" → \"AI-powered consistency checking\"\n- AI-компоненты: промпты с валидацией (Trust & Evidence E0-E4)\n- Артефакты: стандартные + Prompt specification\n\n**Фаза 2 (AI-агенты): Полноценные AI-подпроцессы**\n- Операции: классические + AI-assisted + новые AI-операции\n- AI-компоненты: полноценные подпроцессы (Prompt engineering, RAG config, Agent orchestration)\n- Артефакты: стандартные + AI-specific (Prompt spec, RAG config doc, Agent orchestration diagram)\n\n**Фаза 3 (Мультиагентные системы): Комплексные AI-решения**\n- Операции: полная интеграция классических и AI-операций\n- AI-компоненты: мультиагентные системы\n- Артефакты: комплексные AI-решения\n\n**План перехода для каждой операции:**\n1. **Обучение:** Обучение БА работе с AI-инструментами\n2. **Настройка:** Настройка AI-инструментов\n3. **Валидация:** Валидация AI-выводов\n4. **Интеграция:** Интеграция в роадмап\n\n---\n\n### ФТ-3: Подготовка к синхронизации с mango_ba_prompts\n\n**Подготовить документы для синхронизации:**\n\n**1. С1: Ось `requirement_level`**\n- Описание: ортогональная ось для классификации уровней требований\n- Значения: Business, User, Functional, Non-functional\n- Интеграция: добавить в ADR-003 (онтология БА) как дополнительный тег\n- Пример: требование \"Система должна отвечать за 2 секунды\" → level: Non-functional\n\n**2. С2: Тип \"Бизнес-правило\" + 5 категорий**\n- Описание: новый тип артефакта для явного представления бизнес-правил\n- Категории:\n  - Факты (Facts)\n  - Ограничения (Constraints)\n  - Активаторы операций (Operation Activators)\n  - Выводы (Inferences)\n  - Вычисления (Computations)\n- Интеграция: добавить в реестр артефактов ADR-003\n- Пример: \"Если клиент VIP, то скидка 10%\" → тип: Business Rule, категория: Inference\n\n**3. С3: Crosswalk Вигерс ↔ операции mango ↔ BCREQ**\n- Описание: справочная таблица соответствия процессов\n- Формат: таблица с тремя колонками (Вигерс, операции mango, BCREQ)\n- Интеграция: добавить в ADR-004 (таксономия операций) как примечание со ссылкой на RFC Хаба\n- Пример: \"Выявление требований\" (Вигерс) ↔ \"ingestion, understanding\" (mango) ↔ \"П1\" (BCREQ)\n\n---\n\n### ФТ-4: Создание полноценного описания с примерами\n\n**Для каждого нового элемента создать:**\n- Описание (что это, зачем нужно)\n- Пример использования (конкретный кейс)\n- Связь с классикой (как дополняет Вигерса/BABOK)\n- Критерии качества (как проверить, что сделано хорошо)\n\n**Пример для \"Инжиниринг промптов\":**\n\n**Описание:** Подпроцесс создания, тестирования и валидации промптов для AI-компонентов.\n\n**Пример использования:**\n- Бизнес-требование: \"Система должна анализировать документацию заказчика и извлекать требования\"\n- Prompt specification: описание промпта для анализа документации\n- Исполнимый промпт: текст промпта для LLM\n- Тестирование: проверка на тестовых документах\n- Валидация: соответствие критериям качества\n\n**Связь с классикой:** Дополняет \"Документирование требований\" (Вигерс, глава 10)\n\n**Критерии качества:**\n- Промпт соответствует бизнес-требованию\n- Промпт проходит тестирование на тестовых данных\n- Промпт валидирован по критериям качества\n\n---\n\n## ⚠️ НФТ (Нефункциональные требования)\n\n1. **Полнота:** Все новые AI-классификации должны быть детально описаны (не просто списки)\n2. **Примеры:** Для каждого элемента должен быть конкретный пример использования\n3. **Связь с классикой:** Для каждого нового элемента должна быть указана связь с Вигерсом/BABOK\n4. **Интеграция:** Новые элементы должны быть интегрированы в роадмап Mango (не изолированы)\n5. **Двуязычие:** Все термины — русский + английский\n6. **Креативность:** Синтез, формализация, предложения по интеграции — креативные\n7. **Доверенные ресурсы:** Опираться на LangChain, CrewAI, Microsoft AI Toolkit (не выдумывать)\n8. **Вопросы в конце:** Все открытые вопросы должны быть в конце документа с ответами\n9. **kebab-case / полные пути / валидация:** Стандартные требования экосистемы\n\n---\n\n## 📋 Definition of Done\n\n- [ ] Детально формализованы 4 новых AI-подпроцесса (Prompt engineering, RAG config, Agent orchestration, AI testing)\n- [ ] Для каждого подпроцесса описаны операции (вход, действие, выход)\n- [ ] Для каждого подпроцесса описаны артефакты (описательные и исполнимые)\n- [ ] Для каждого подпроцесса указана связь с классикой (Вигерс/BABOK)\n- [ ] Создан раздел \"Эволюция операций в роадмапе Mango\" (4 фазы)\n- [ ] Для каждой фазы описан план перехода (обучение, настройка, валидация, интеграция)\n- [ ] Подготовлены документы для синхронизации с mango_ba_prompts (С1, С2, С3)\n- [ ] Для каждого нового элемента создан полноценный пример использования\n- [ ] Все термины — двуязычные (русский + английский)\n- [ ] Создан файл `research/mango/ai-classifications-formalization-2026-06.md`\n- [ ] Локальная валидация пройдена\n- [ ] Коммит: `creative: Formalize AI-classifications and integrate into Mango roadmap`\n- [ ] Задача в статусе `review`\n\n---\n\n##  Дополнительные материалы\n\n**Репозитории:**\n- mango_ba_prompts: https://github.com/G-Ivan-A/mango_ba_prompts\n- hybrid-Intelligence-lab: https://github.com/G-Ivan-A/hybrid-Intelligence-lab\n\n**Источники для формализации:**\n- LangChain: https://github.com/langchain-ai/langchain\n- CrewAI: https://github.com/crewAIInc/crewAI\n- Microsoft AI Toolkit: https://github.com/microsoft-foundry/foundry-samples\n- AutoGPT: https://github.com/Significant-Gravitas/AutoGPT\n\n**Существующие артефакты (для интеграции):**\n- ADR-003 (Онтология БА): https://github.com/G-Ivan-A/mango_ba_prompts/tree/main/docs/adr\n- ADR-004 (Таксономия операций): https://github.com/G-Ivan-A/mango_ba_prompts/tree/main/docs/adr\n- ADR-009 (Процесс BCREQ): https://github.com/G-Ivan-A/mango_ba_prompts/tree/main/docs/adr\n\n**RFC Хаба (для контекста):**\n- PR #242 (Research Memory): https://github.com/G-Ivan-A/hybrid-Intelligence-lab/blob/main/governance/rfc/research-memory-source-intelligence.md\n- PR #246 (Methodology Research): https://github.com/G-Ivan-A/hybrid-Intelligence-lab/blob/main/governance/rfc/methodology-research-and-proposals.md\n- PR #248 (Исследование Вигерса): https://github.com/G-Ivan-A/hybrid-Intelligence-lab/blob/main/research/mango/requirements-engineering-ai-era-2026.md\n\n---\n\n## ❓ Открытые вопросы\n\n**ОВ-1: Нужно ли создавать отдельные стандарты для AI-подпроцессов?**\n- **Ответ:** Нет, достаточно описания в RFC. Стандарты создаются при возникновении конкретной боли (принцип Anti-Inflation).\n\n**ОВ-2: Как интегрировать AI-assisted операции в существующие стандарты mango?**\n- **Ответ:** Через обновление ADR-004 (таксономия операций) — добавить AI-версии как дополнительные операции к классическим.\n\n**ОВ-3: Нужно ли создавать Prompt specification для всех промптов в mango?**\n- **Ответ:** Нет, только для критичных промптов (используемых в продакшене). Для экспериментальных промптов достаточно исполнимого промпта.\n\n**ОВ-4: Как валидировать AI-выводы в AI-assisted операциях?**\n- **Ответ:** Через Trust & Evidence (E0-E4) — каждый AI-вывод должен иметь уровень доверия. Валидация — это операция \"Проверка AI-вывода\" с критериями качества.\n\n**ОВ-5: Когда начинать Фазу 2 (AI-агенты) в роадмапе Mango?**\n- **Ответ:** После завершения Фазы 1 (Trust & Evidence) и синхронизации с mango_ba_prompts (С1, С2, С3). Ориентировочно: сентябрь 2026.\n\n---\n\n> ⚠️ **Для Исполнителя**:\n> - 🔥 **Режим `Creative` + `Research`**: детальная формализация + креативная интеграция в роадмап\n> - 🎯 **Твоя роль**: формализатор, интегратор, синтезатор\n> - 📋 **ОБЯЗАТЕЛЬНО**: детально формализуй 4 новых AI-подпроцесса (операции, артефакты, связь с классикой)\n> - 🗺️ **ОБЯЗАТЕЛЬНО**: интегрируй в роадмап Mango (4 фазы, план перехода)\n> -  **ОБЯЗАТЕЛЬНО**: подготовь документы для синхронизации с mango_ba_prompts (С1, С2, С3)\n> - 💡 **ОБЯЗАТЕЛЬНО**: создай полноценные примеры для каждого нового элемента\n> - 🌐 **ОБЯЗАТЕЛЬНО**: все термины — русский + английский\n> - ❓ **ОБЯЗАТЕЛЬНО**: вопросы в конце с ответами\n> - ✅ **Результат**: \n>   - Детально формализованные AI-классификации\n>   - Интеграция в роадмап Mango\n>   - Подготовка к синхронизации с mango_ba_prompts\n>   - Полноценные примеры использования",
+[2026-06-18T11:44:20.442Z] [INFO]         "is_error": false
+[2026-06-18T11:44:20.442Z] [INFO]       }
+[2026-06-18T11:44:20.442Z] [INFO]     ]
+[2026-06-18T11:44:20.442Z] [INFO]   },
+[2026-06-18T11:44:20.442Z] [INFO]   "parent_tool_use_id": null,
+[2026-06-18T11:44:20.442Z] [INFO]   "session_id": "d65e890a-db60-43f7-aea3-691500f7e26c",
+[2026-06-18T11:44:20.442Z] [INFO]   "uuid": "b6d0fb5e-22b5-42ea-92d0-6eea15f4122e",
+[2026-06-18T11:44:20.442Z] [INFO]   "timestamp": "2026-06-18T11:44:20.429Z",
+[2026-06-18T11:44:20.442Z] [INFO]   "tool_use_result": {
+[2026-06-18T11:44:20.442Z] [INFO]     "stdout": "title:\tcreative: Формализация новых AI-классификаций (подпроцессы, артефакты, операции) и интеграция в роадмап Mango с учётом эволюции операций\nstate:\tOPEN\nauthor:\tG-Ivan-A (Ivan Gulienko)\nlabels:\t\ncomments:\t0\nassignees:\t\nprojects:\t\nmilestone:\t\nissue-type:\t\nparent:\t\nsub-issues:\t\nsub-issues-completed:\t\nblocked-by:\t\nblocking:\t\nnumber:\t251\n--\n## 🔗 Мета\n\n**Labels**: `creative` | `research` | `priority:P2` | `requirements-engineering` | `ai-era` | `roadmap` | `mango-integration`\n**Milestone**: `Sprint 3 — Hybrid Minimum Bootstrap`\n**Depends On**: \n  - PR #248 (Исследование Вигерса — после исправлений P1)\n  - Задача P1 (Исправление и дополнение исследования Вигерса)\n  - PR #242 (Research Memory — процесс исследования источника)\n  - PR #246 (Methodology Research — AI-тренды)\n**Operating Mode**: `Creative` (синтез, формализация, предложения по интеграции) + `Research` (анализ современных AI-фреймворков)\n**Lifecycle Stage**: `Research → RFC`\n\n---\n\n## 🧠 ПОЛНЫЙ КОНТЕКСТ (КРИТИЧЕСКИ ВАЖНО)\n\n### Эволюция мысли\n\n**Этап 1: Исходное исследование (PR #248)**\n- Исследование книги Вигерса \"Разработка требований к ПО\" (2020)\n- Цель: независимо извлечь систему уровней/типов требований, процессов/операций, глоссарий\n- Актуализировать через сравнение 3 трендов (2020/2026/2026 ИИ)\n\n**Этап 2: Исправления P1**\n- Исправлены пути артефактов (research/external-knowledge/, research/mango/)\n- Исправлена классификация (Prompt = интерфейс к Tool, Prompt engineering = подпроцесс)\n- Добавлена база для Фазы 2 (процессы/подпроцессы для AI-агента)\n- Дополнено исследование сравнением с BABOK/ISO/AI\n\n**Этап 3: Финальная синхронизация видения**\n- Prompt engineering = подпроцесс (не операция, не тип требования)\n- Prompt = интерфейс к Tool (не сам Tool)\n- Prompt specification = описательный документ для отладки/guides\n- Новые подпроцессы для Фазы 2 (Разработка AI-агента)\n- AI-assisted операции требуют осознанного перехода в роадмап\n\n**Этап 4: Цель P2**\n- Детально формализовать новые AI-классификации (не просто список, а полноценное описание)\n- Интегрировать в роадмап Mango (как это влияет на эволюцию операций)\n- Подготовить к синхронизации с mango_ba_prompts (С1, С2, С3)\n\n---\n\n### Что мы отвергли и почему\n\n#### ❌ Отвергнуто: \"Просто добавить новые операции в список\"\n**Почему:** Недостаточно. Нужно понять, как новые подпроцессы интегрируются в существующую систему, как они связаны с классическими операциями, как меняется роадмап.\n\n#### ❌ Отвергнуто: \"Заменить классические операции AI-версиями\"\n**Почему:** Классические операции не устаревают, они дополняются AI-ассистированными версиями. Нужно показать эволюцию, а не замену.\n\n#### ❌ Отвергнуто: \"Создать отдельные процессы для AI\"\n**Почему:** AI-разработка — это не отдельный процесс, а расширение существующих процессов. Нужно показать интеграцию, а не изоляцию.\n\n---\n\n### Что мы приняли (ключевые принципы)\n\n#### ✅ Принято: \"Детальная формализация новых AI-классификаций\"\n\n**Новые подпроцессы (дополняют Вигерса):**\n\n1. **Инжиниринг промптов (Prompt Engineering)**\n   - Операции: анализ задачи, написание черновика, тестирование, итерация, валидация\n   - Артефакты: Prompt specification (описательный) + Исполнимый промпт\n   - Связь с классикой: дополняет \"Документирование требований\"\n\n2. **Настройка RAG (RAG Configuration)**\n   - Операции: выбор векторной базы, настройка chunking, настройка retrieval\n   - Артефакты: RAG configuration document\n   - Связь с классикой: дополняет \"Проектирование решений\"\n\n3. **Проектирование оркестрации агентов (Agent Orchestration Design)**\n   - Операции: определение сценариев взаимодействия, проектирование протоколов коммуникации, настройка координации\n   - Артефакты: Agent orchestration diagram\n   - Связь с классикой: дополняет \"Проектирование архитектуры\"\n\n4. **Тестирование AI-компонентов (AI Testing)**\n   - Операции: написание тестовых сценариев, запуск тестов, анализ результатов\n   - Артефакты: AI test suite\n   - Связь с классикой: дополняет \"Валидация требований\"\n\n#### ✅ Принято: \"Интеграция в роадмап Mango (эволюция операций)\"\n\n**Пример эволюции:**\n- Классическая операция: \"Анализ документов\"\n- AI-версия: \"AI-assisted document analysis\"\n- **Не просто \"включение кнопки\"** — требует:\n  - Обучения БА работе с AI-инструментами\n  - Настройки AI-инструментов\n  - Валидации AI-выводов\n  - Интеграции в роадмап\n\n**План перехода:**\n1. Фаза 0 (текущая): Классические операции + базовые промпты\n2. Фаза 1 (Trust & Evidence): AI-assisted операции с валидацией\n3. Фаза 2 (AI-агенты): Полноценные AI-подпроцессы (Prompt engineering, RAG config, Agent orchestration)\n4. Фаза 3 (Мультиагентные системы): Комплексные AI-решения\n\n#### ✅ Принято: \"Подготовка к синхронизации с mango_ba_prompts\"\n\n**Что нужно подготовить:**\n- С1: Ось `requirement_level` (Business → User → Functional → Non-functional)\n- С2: Тип \"Бизнес-правило\" + 5 категорий (Факты, Ограничения, Активаторы, Выводы, Вычисления)\n- С3: Crosswalk Вигерс ↔ операции mango ↔ BCREQ\n\n---\n\n##  Цель задачи\n\n1. **Детально формализовать** новые AI-классификации (подпроцессы, операции, артефакты)\n2. **Интегрировать** в роадмап Mango (эволюция операций)\n3. **Подготовить** к синхронизации с mango_ba_prompts (С1, С2, С3)\n4. **Создать** полноценное описание с примерами (не просто списки)\n\n---\n\n## ✅ ФТ (Функциональные требования)\n\n### ФТ-1: Детальная формализация новых AI-подпроцессов\n\n**Для каждого подпроцесса создать полноценное описание:**\n\n**1. Инжиниринг промптов (Prompt Engineering)**\n\n**Описание:** Подпроцесс создания, тестирования и валидации промптов для AI-компонентов.\n\n**Операции:**\n- Операция 1.1: \"Анализ задачи для промпта\"\n  - Вход: бизнес-требование, контекст\n  - Действие: определение цели промпта, входных/выходных данных\n  - Выход: спецификация задачи для промпта\n- Операция 1.2: \"Написание черновика промпта\"\n  - Вход: спецификация задачи\n  - Действие: создание первой версии промпта\n  - Выход: черновик промпта\n- Операция 1.3: \"Тестирование промпта\"\n  - Вход: черновик промпта, тестовые данные\n  - Действие: запуск промпта, анализ результатов\n  - Выход: результаты тестирования\n- Операция 1.4: \"Итерация промпта\"\n  - Вход: результаты тестирования\n  - Действие: улучшение промпта на основе результатов\n  - Выход: улучшенная версия промпта\n- Операция 1.5: \"Валидация промпта\"\n  - Вход: улучшенная версия промпта\n  - Действие: финальная проверка соответствия требованиям\n  - Выход: валидированный промпт\n\n**Артефакты:**\n- **Prompt specification** (описательный документ):\n  - Назначение промпта\n  - Входные данные\n  - Ожидаемый выход\n  - Контекст (какие знания использует)\n  - Критерии качества\n  - Примеры использования\n  - Связь с бизнес-требованиями\n- **Исполнимый промпт** (исполнимый артефакт):\n  - Текст промпта для LLM\n\n**Связь с классикой:** Дополняет \"Документирование требований\" (Вигерс, глава 10)\n\n---\n\n**2. Настройка RAG (RAG Configuration)**\n\n**Описание:** Подпроцесс настройки Retrieval-Augmented Generation для AI-компонентов.\n\n**Операции:**\n- Операция 2.1: \"Выбор векторной базы\"\n  - Вход: требования к хранению знаний\n  - Действие: анализ доступных решений (Chroma, Pinecone, YDB)\n  - Выход: выбранная векторная база\n- Операция 2.2: \"Настройка chunking\"\n  - Вход: документы для индексации\n  - Действие: определение стратегии разделения документов\n  - Выход: настроенный chunking\n- Операция 2.3: \"Настройка retrieval\"\n  - Вход: векторная база, chunking\n  - Действие: настройка поиска и ранжирования\n  - Выход: настроенный retrieval\n\n**Артефакты:**\n- **RAG configuration document** (описательный документ):\n  - Выбранная векторная база и обоснование\n  - Стратегия chunking\n  - Параметры retrieval\n  - Критерии качества поиска\n\n**Связь с классикой:** Дополняет \"Проектирование решений\" (Вигерс, глава 12)\n\n---\n\n**3. Проектирование оркестрации агентов (Agent Orchestration Design)**\n\n**Описание:** Подпроцесс проектирования взаимодействия между AI-агентами в мультиагентной системе.\n\n**Операции:**\n- Операция 3.1: \"Определение сценариев взаимодействия\"\n  - Вход: бизнес-требования к мультиагентной системе\n  - Действие: определение ролей агентов и сценариев их взаимодействия\n  - Выход: сценарии взаимодействия\n- Операция 3.2: \"Проектирование протоколов коммуникации\"\n  - Вход: сценарии взаимодействия\n  - Действие: определение форматов сообщений и протоколов\n  - Выход: спецификация протоколов\n- Операция 3.3: \"Настройка координации\"\n  - Вход: спецификация протоколов\n  - Действие: настройка координации между агентами\n  - Выход: настроенная оркестрация\n\n**Артефакты:**\n- **Agent orchestration diagram** (описательный документ):\n  - Роли агентов\n  - Сценарии взаимодействия\n  - Протоколы коммуникации\n  - Механизмы координации\n\n**Связь с классикой:** Дополняет \"Проектирование архитектуры\" (Вигерс, глава 19)\n\n---\n\n**4. Тестирование AI-компонентов (AI Testing)**\n\n**Описание:** Подпроцесс тестирования AI-компонентов (промптов, RAG, агентов).\n\n**Операции:**\n- Операция 4.1: \"Написание тестовых сценариев\"\n  - Вход: спецификации AI-компонентов\n  - Действие: создание тестовых сценариев\n  - Выход: тестовые сценарии\n- Операция 4.2: \"Запуск тестов\"\n  - Вход: тестовые сценарии, AI-компоненты\n  - Действие: выполнение тестов\n  - Выход: результаты тестов\n- Операция 4.3: \"Анализ результатов\"\n  - Вход: результаты тестов\n  - Действие: анализ качества AI-компонентов\n  - Выход: отчёт о тестировании\n\n**Артефакты:**\n- **AI test suite** (исполнимый артефакт):\n  - Тестовые сценарии\n  - Ожидаемые результаты\n  - Критерии прохождения\n\n**Связь с классикой:** Дополняет \"Валидация требований\" (Вигерс, глава 17)\n\n---\n\n### ФТ-2: Интеграция в роадмап Mango (эволюция операций)\n\n**Создать раздел: \"Эволюция операций в роадмапе Mango\"**\n\n**Фаза 0 (текущая): Классические операции + базовые промпты**\n- Операции: классические (интервью, анализ документов, документирование)\n- AI-компоненты: базовые промпты (без AI-assisted операций)\n- Артефакты: стандартные (SRS, User Story, Use Case)\n\n**Фаза 1 (Trust & Evidence): AI-assisted операции с валидацией**\n- Операции: классические + AI-assisted версии\n  - Пример: \"Анализ документов\" → \"AI-assisted document analysis\"\n  - Пример: \"Проверка противоречий\" → \"AI-powered consistency checking\"\n- AI-компоненты: промпты с валидацией (Trust & Evidence E0-E4)\n- Артефакты: стандартные + Prompt specification\n\n**Фаза 2 (AI-агенты): Полноценные AI-подпроцессы**\n- Операции: классические + AI-assisted + новые AI-операции\n- AI-компоненты: полноценные подпроцессы (Prompt engineering, RAG config, Agent orchestration)\n- Артефакты: стандартные + AI-specific (Prompt spec, RAG config doc, Agent orchestration diagram)\n\n**Фаза 3 (Мультиагентные системы): Комплексные AI-решения**\n- Операции: полная интеграция классических и AI-операций\n- AI-компоненты: мультиагентные системы\n- Артефакты: комплексные AI-решения\n\n**План перехода для каждой операции:**\n1. **Обучение:** Обучение БА работе с AI-инструментами\n2. **Настройка:** Настройка AI-инструментов\n3. **Валидация:** Валидация AI-выводов\n4. **Интеграция:** Интеграция в роадмап\n\n---\n\n### ФТ-3: Подготовка к синхронизации с mango_ba_prompts\n\n**Подготовить документы для синхронизации:**\n\n**1. С1: Ось `requirement_level`**\n- Описание: ортогональная ось для классификации уровней требований\n- Значения: Business, User, Functional, Non-functional\n- Интеграция: добавить в ADR-003 (онтология БА) как дополнительный тег\n- Пример: требование \"Система должна отвечать за 2 секунды\" → level: Non-functional\n\n**2. С2: Тип \"Бизнес-правило\" + 5 категорий**\n- Описание: новый тип артефакта для явного представления бизнес-правил\n- Категории:\n  - Факты (Facts)\n  - Ограничения (Constraints)\n  - Активаторы операций (Operation Activators)\n  - Выводы (Inferences)\n  - Вычисления (Computations)\n- Интеграция: добавить в реестр артефактов ADR-003\n- Пример: \"Если клиент VIP, то скидка 10%\" → тип: Business Rule, категория: Inference\n\n**3. С3: Crosswalk Вигерс ↔ операции mango ↔ BCREQ**\n- Описание: справочная таблица соответствия процессов\n- Формат: таблица с тремя колонками (Вигерс, операции mango, BCREQ)\n- Интеграция: добавить в ADR-004 (таксономия операций) как примечание со ссылкой на RFC Хаба\n- Пример: \"Выявление требований\" (Вигерс) ↔ \"ingestion, understanding\" (mango) ↔ \"П1\" (BCREQ)\n\n---\n\n### ФТ-4: Создание полноценного описания с примерами\n\n**Для каждого нового элемента создать:**\n- Описание (что это, зачем нужно)\n- Пример использования (конкретный кейс)\n- Связь с классикой (как дополняет Вигерса/BABOK)\n- Критерии качества (как проверить, что сделано хорошо)\n\n**Пример для \"Инжиниринг промптов\":**\n\n**Описание:** Подпроцесс создания, тестирования и валидации промптов для AI-компонентов.\n\n**Пример использования:**\n- Бизнес-требование: \"Система должна анализировать документацию заказчика и извлекать требования\"\n- Prompt specification: описание промпта для анализа документации\n- Исполнимый промпт: текст промпта для LLM\n- Тестирование: проверка на тестовых документах\n- Валидация: соответствие критериям качества\n\n**Связь с классикой:** Дополняет \"Документирование требований\" (Вигерс, глава 10)\n\n**Критерии качества:**\n- Промпт соответствует бизнес-требованию\n- Промпт проходит тестирование на тестовых данных\n- Промпт валидирован по критериям качества\n\n---\n\n## ⚠️ НФТ (Нефункциональные требования)\n\n1. **Полнота:** Все новые AI-классификации должны быть детально описаны (не просто списки)\n2. **Примеры:** Для каждого элемента должен быть конкретный пример использования\n3. **Связь с классикой:** Для каждого нового элемента должна быть указана связь с Вигерсом/BABOK\n4. **Интеграция:** Новые элементы должны быть интегрированы в роадмап Mango (не изолированы)\n5. **Двуязычие:** Все термины — русский + английский\n6. **Креативность:** Синтез, формализация, предложения по интеграции — креативные\n7. **Доверенные ресурсы:** Опираться на LangChain, CrewAI, Microsoft AI Toolkit (не выдумывать)\n8. **Вопросы в конце:** Все открытые вопросы должны быть в конце документа с ответами\n9. **kebab-case / полные пути / валидация:** Стандартные требования экосистемы\n\n---\n\n## 📋 Definition of Done\n\n- [ ] Детально формализованы 4 новых AI-подпроцесса (Prompt engineering, RAG config, Agent orchestration, AI testing)\n- [ ] Для каждого подпроцесса описаны операции (вход, действие, выход)\n- [ ] Для каждого подпроцесса описаны артефакты (описательные и исполнимые)\n- [ ] Для каждого подпроцесса указана связь с классикой (Вигерс/BABOK)\n- [ ] Создан раздел \"Эволюция операций в роадмапе Mango\" (4 фазы)\n- [ ] Для каждой фазы описан план перехода (обучение, настройка, валидация, интеграция)\n- [ ] Подготовлены документы для синхронизации с mango_ba_prompts (С1, С2, С3)\n- [ ] Для каждого нового элемента создан полноценный пример использования\n- [ ] Все термины — двуязычные (русский + английский)\n- [ ] Создан файл `research/mango/ai-classifications-formalization-2026-06.md`\n- [ ] Локальная валидация пройдена\n- [ ] Коммит: `creative: Formalize AI-classifications and integrate into Mango roadmap`\n- [ ] Задача в статусе `review`\n\n---\n\n##  Дополнительные материалы\n\n**Репозитории:**\n- mango_ba_prompts: https://github.com/G-Ivan-A/mango_ba_prompts\n- hybrid-Intelligence-lab: https://github.com/G-Ivan-A/hybrid-Intelligence-lab\n\n**Источники для формализации:**\n- LangChain: https://github.com/langchain-ai/langchain\n- CrewAI: https://github.com/crewAIInc/crewAI\n- Microsoft AI Toolkit: https://github.com/microsoft-foundry/foundry-samples\n- AutoGPT: https://github.com/Significant-Gravitas/AutoGPT\n\n**Существующие артефакты (для интеграции):**\n- ADR-003 (Онтология БА): https://github.com/G-Ivan-A/mango_ba_prompts/tree/main/docs/adr\n- ADR-004 (Таксономия операций): https://github.com/G-Ivan-A/mango_ba_prompts/tree/main/docs/adr\n- ADR-009 (Процесс BCREQ): https://github.com/G-Ivan-A/mango_ba_prompts/tree/main/docs/adr\n\n**RFC Хаба (для контекста):**\n- PR #242 (Research Memory): https://github.com/G-Ivan-A/hybrid-Intelligence-lab/blob/main/governance/rfc/research-memory-source-intelligence.md\n- PR #246 (Methodology Research): https://github.com/G-Ivan-A/hybrid-Intelligence-lab/blob/main/governance/rfc/methodology-research-and-proposals.md\n- PR #248 (Исследование Вигерса): https://github.com/G-Ivan-A/hybrid-Intelligence-lab/blob/main/research/mango/requirements-engineering-ai-era-2026.md\n\n---\n\n## ❓ Открытые вопросы\n\n**ОВ-1: Нужно ли создавать отдельные стандарты для AI-подпроцессов?**\n- **Ответ:** Нет, достаточно описания в RFC. Стандарты создаются при возникновении конкретной боли (принцип Anti-Inflation).\n\n**ОВ-2: Как интегрировать AI-assisted операции в существующие стандарты mango?**\n- **Ответ:** Через обновление ADR-004 (таксономия операций) — добавить AI-версии как дополнительные операции к классическим.\n\n**ОВ-3: Нужно ли создавать Prompt specification для всех промптов в mango?**\n- **Ответ:** Нет, только для критичных промптов (используемых в продакшене). Для экспериментальных промптов достаточно исполнимого промпта.\n\n**ОВ-4: Как валидировать AI-выводы в AI-assisted операциях?**\n- **Ответ:** Через Trust & Evidence (E0-E4) — каждый AI-вывод должен иметь уровень доверия. Валидация — это операция \"Проверка AI-вывода\" с критериями качества.\n\n**ОВ-5: Когда начинать Фазу 2 (AI-агенты) в роадмапе Mango?**\n- **Ответ:** После завершения Фазы 1 (Trust & Evidence) и синхронизации с mango_ba_prompts (С1, С2, С3). Ориентировочно: сентябрь 2026.\n\n---\n\n> ⚠️ **Для Исполнителя**:\n> - 🔥 **Режим `Creative` + `Research`**: детальная формализация + креативная интеграция в роадмап\n> - 🎯 **Твоя роль**: формализатор, интегратор, синтезатор\n> - 📋 **ОБЯЗАТЕЛЬНО**: детально формализуй 4 новых AI-подпроцесса (операции, артефакты, связь с классикой)\n> - 🗺️ **ОБЯЗАТЕЛЬНО**: интегрируй в роадмап Mango (4 фазы, план перехода)\n> -  **ОБЯЗАТЕЛЬНО**: подготовь документы для синхронизации с mango_ba_prompts (С1, С2, С3)\n> - 💡 **ОБЯЗАТЕЛЬНО**: создай полноценные примеры для каждого нового элемента\n> - 🌐 **ОБЯЗАТЕЛЬНО**: все термины — русский + английский\n> - ❓ **ОБЯЗАТЕЛЬНО**: вопросы в конце с ответами\n> - ✅ **Результат**: \n>   - Детально формализованные AI-классификации\n>   - Интеграция в роадмап Mango\n>   - Подготовка к синхронизации с mango_ba_prompts\n>   - Полноценные примеры использования",
+[2026-06-18T11:44:20.442Z] [INFO]     "stderr": "",
+[2026-06-18T11:44:20.442Z] [INFO]     "interrupted": false,
+[2026-06-18T11:44:20.442Z] [INFO]     "isImage": false,
+[2026-06-18T11:44:20.442Z] [INFO]     "noOutputExpected": false
+[2026-06-18T11:44:20.442Z] [INFO]   }
+[2026-06-18T11:44:20.442Z] [INFO] }
+[2026-06-18T11:44:21.322Z] [INFO] {
+[2026-06-18T11:44:21.322Z] [INFO]   "type": "user",
+[2026-06-18T11:44:21.322Z] [INFO]   "message": {
+[2026-06-18T11:44:21.322Z] [INFO]     "role": "user",
+[2026-06-18T11:44:21.322Z] [INFO]     "content": [
+[2026-06-18T11:44:21.322Z] [INFO]       {
+[2026-06-18T11:44:21.322Z] [INFO]         "tool_use_id": "toolu_01PyRnsKrNrJdBDDemg4YL1M",
+[2026-06-18T11:44:21.322Z] [INFO]         "type": "tool_result",
+[2026-06-18T11:44:21.322Z] [INFO]         "content": "total 224\ndrwxr-xr-x 17 box  box   4096 Jun 18 11:43 .\ndrwxrwxrwt  1 root root 12288 Jun 18 11:44 ..\ndrwxr-xr-x  8 box  box   4096 Jun 18 11:44 .git\ndrwxr-xr-x  4 box  box   4096 Jun 18 11:43 .github\n-rw-r--r--  1 box  box    314 Jun 18 11:43 .gitignore\n-rw-r--r--  1 box  box    180 Jun 18 11:43 .gitkeep\n-rw-r--r--  1 box  box  13089 Jun 18 11:43 AI_GOVERNANCE.md\n-rw-r--r--  1 box  box   2684 Jun 18 11:43 AI_PROJECT_CONTEXT-Summary.md\n-rw-r--r--  1 box  box  74655 Jun 18 11:43 CHANGELOG.md\n-rw-r--r--  1 box  box   6910 Jun 18 11:43 CONCEPT.md\n-rw-r--r--  1 box  box   8532 Jun 18 11:43 CONTRIBUTING.md\n-rw-r--r--  1 box  box    671 Jun 18 11:43 LICENSE\n-rw-r--r--  1 box  box  10249 Jun 18 11:43 README.md\ndrwxr-xr-x  4 box  box   4096 Jun 18 11:43 docs\ndrwxr-xr-x  2 box  box   4096 Jun 18 11:43 education\ndrwxr-xr-x  2 box  box   4096 Jun 18 11:43 experiments\ndrwxr-xr-x  2 box  box   4096 Jun 18 11:43 frameworks\ndrwxr-xr-x  3 box  box   4096 Jun 18 11:43 governance\ndrwxr-xr-x  2 box  box   4096 Jun 18 11:43 guides\n-rw-r--r--  1 box  box   6114 Jun 18 11:43 mkdocs.yml\ndrwxr-xr-x  4 box  box   4096 Jun 18 11:43 practices\ndrwxr-xr-x  4 box  box   4096 Jun 18 11:43 projects\ndrwxr-xr-x  7 box  box   4096 Jun 18 11:43 research\ndrwxr-xr-x  2 box  box   4096 Jun 18 11:43 standards\ndrwxr-xr-x  4 box  box   4096 Jun 18 11:43 templates\ndrwxr-xr-x  2 box  box   4096 Jun 18 11:43 tools\ndrwxr-xr-x  3 box  box   4096 Jun 18 11:43 website\nbeabc49 Initial commit with task details\n0d0264e Merge pull request #248 from konard/issue-247-d135f27e43d2\nb1cf170 Revert \"Initial commit with task details\"\ne6fe8ed creative: Research Wigers book with AI-era actualization\na279fea Initial commit with task details\n6ddffdf Merge pull request #246 from konard/issue-245-830ff1173553\nc35884d Revert \"Initial commit with task details\"\nd439fdf creative: Research methodology and standards for Hub/Mango/Open-AI\n0f47b9f Initial commit with task details\n3f4da60 Merge pull request #244 from konard/issue-241-dff25f31ac0e",
+[2026-06-18T11:44:21.322Z] [INFO]         "is_error": false
+[2026-06-18T11:44:21.322Z] [INFO]       }
+[2026-06-18T11:44:21.322Z] [INFO]     ]
+[2026-06-18T11:44:21.322Z] [INFO]   },
+[2026-06-18T11:44:21.322Z] [INFO]   "parent_tool_use_id": null,
+[2026-06-18T11:44:21.322Z] [INFO]   "session_id": "d65e890a-db60-43f7-aea3-691500f7e26c",
+[2026-06-18T11:44:21.322Z] [INFO]   "uuid": "a8c919cd-e4dc-4656-aa36-63b1ed223a35",
+[2026-06-18T11:44:21.322Z] [INFO]   "timestamp": "2026-06-18T11:44:21.318Z",
+[2026-06-18T11:44:21.322Z] [INFO]   "tool_use_result": {
+[2026-06-18T11:44:21.322Z] [INFO]     "stdout": "total 224\ndrwxr-xr-x 17 box  box   4096 Jun 18 11:43 .\ndrwxrwxrwt  1 root root 12288 Jun 18 11:44 ..\ndrwxr-xr-x  8 box  box   4096 Jun 18 11:44 .git\ndrwxr-xr-x  4 box  box   4096 Jun 18 11:43 .github\n-rw-r--r--  1 box  box    314 Jun 18 11:43 .gitignore\n-rw-r--r--  1 box  box    180 Jun 18 11:43 .gitkeep\n-rw-r--r--  1 box  box  13089 Jun 18 11:43 AI_GOVERNANCE.md\n-rw-r--r--  1 box  box   2684 Jun 18 11:43 AI_PROJECT_CONTEXT-Summary.md\n-rw-r--r--  1 box  box  74655 Jun 18 11:43 CHANGELOG.md\n-rw-r--r--  1 box  box   6910 Jun 18 11:43 CONCEPT.md\n-rw-r--r--  1 box  box   8532 Jun 18 11:43 CONTRIBUTING.md\n-rw-r--r--  1 box  box    671 Jun 18 11:43 LICENSE\n-rw-r--r--  1 box  box  10249 Jun 18 11:43 README.md\ndrwxr-xr-x  4 box  box   4096 Jun 18 11:43 docs\ndrwxr-xr-x  2 box  box   4096 Jun 18 11:43 education\ndrwxr-xr-x  2 box  box   4096 Jun 18 11:43 experiments\ndrwxr-xr-x  2 box  box   4096 Jun 18 11:43 frameworks\ndrwxr-xr-x  3 box  box   4096 Jun 18 11:43 governance\ndrwxr-xr-x  2 box  box   4096 Jun 18 11:43 guides\n-rw-r--r--  1 box  box   6114 Jun 18 11:43 mkdocs.yml\ndrwxr-xr-x  4 box  box   4096 Jun 18 11:43 practices\ndrwxr-xr-x  4 box  box   4096 Jun 18 11:43 projects\ndrwxr-xr-x  7 box  box   4096 Jun 18 11:43 research\ndrwxr-xr-x  2 box  box   4096 Jun 18 11:43 standards\ndrwxr-xr-x  4 box  box   4096 Jun 18 11:43 templates\ndrwxr-xr-x  2 box  box   4096 Jun 18 11:43 tools\ndrwxr-xr-x  3 box  box   4096 Jun 18 11:43 website\nbeabc49 Initial commit with task details\n0d0264e Merge pull request #248 from konard/issue-247-d135f27e43d2\nb1cf170 Revert \"Initial commit with task details\"\ne6fe8ed creative: Research Wigers book with AI-era actualization\na279fea Initial commit with task details\n6ddffdf Merge pull request #246 from konard/issue-245-830ff1173553\nc35884d Revert \"Initial commit with task details\"\nd439fdf creative: Research methodology and standards for Hub/Mango/Open-AI\n0f47b9f Initial commit with task details\n3f4da60 Merge pull request #244 from konard/issue-241-dff25f31ac0e",
+[2026-06-18T11:44:21.322Z] [INFO]     "stderr": "",
+[2026-06-18T11:44:21.322Z] [INFO]     "interrupted": false,
+[2026-06-18T11:44:21.322Z] [INFO]     "isImage": false,
+[2026-06-18T11:44:21.322Z] [INFO]     "noOutputExpected": false
+[2026-06-18T11:44:21.322Z] [INFO]   }
+[2026-06-18T11:44:21.322Z] [INFO] }
+[2026-06-18T11:44:21.332Z] [INFO] [log_586c8d] sending request {
+[2026-06-18T11:44:21.333Z] [INFO]   method: "post",
+[2026-06-18T11:44:21.334Z] [INFO]   url: "https://api.anthropic.com/v1/messages?beta=true",
+[2026-06-18T11:44:21.334Z] [INFO]   options: {
+[2026-06-18T11:44:21.334Z] [INFO]     method: "post",
+[2026-06-18T11:44:21.334Z] [INFO]     path: "/v1/messages?beta=true",
+[2026-06-18T11:44:21.335Z] [INFO]     body: {
+[2026-06-18T11:44:21.335Z] [INFO]       model: "claude-opus-4-8",
+[2026-06-18T11:44:21.336Z] [INFO]       messages: [
+[2026-06-18T11:44:21.336Z] [INFO]         [Object ...], [Object ...], [Object ...], [Object ...]
+[2026-06-18T11:44:21.336Z] [INFO]       ],
+[2026-06-18T11:44:21.336Z] [INFO]       system: [
+[2026-06-18T11:44:21.337Z] [INFO]         [Object ...], [Object ...], [Object ...], [Object ...]
+[2026-06-18T11:44:21.337Z] [INFO]       ],
+[2026-06-18T11:44:21.338Z] [INFO]       tools: [
+[2026-06-18T11:44:21.338Z] [INFO]         [Object ...], [Object ...], [Object ...], [Object ...], [Object ...], [Object ...], [Object ...], [Object ...]
+[2026-06-18T11:44:21.339Z] [INFO]       ],
+[2026-06-18T11:44:21.339Z] [INFO]       tool_choice: undefined,
+[2026-06-18T11:44:21.340Z] [INFO]       metadata: [Object ...],
+[2026-06-18T11:44:21.340Z] [INFO]       max_tokens: 128000,
+[2026-06-18T11:44:21.340Z] [INFO]       thinking: [Object ...],
+[2026-06-18T11:44:21.341Z] [INFO]       context_management: [Object ...],
+[2026-06-18T11:44:21.341Z] [INFO]       output_config: [Object ...],
+[2026-06-18T11:44:21.342Z] [INFO]       diagnostics: [Object ...],
+[2026-06-18T11:44:21.342Z] [INFO]       stream: true,
+[2026-06-18T11:44:21.342Z] [INFO]     },
+[2026-06-18T11:44:21.342Z] [INFO]     timeout: 600000,
+[2026-06-18T11:44:21.343Z] [INFO]     signal: AbortSignal {
+[2026-06-18T11:44:21.343Z] [INFO]       [Symbol(events.maxEventTargetListeners)]: 50,
+[2026-06-18T11:44:21.343Z] [INFO]       [Symbol(events.maxEventTargetListenersWarned)]: false,
+[2026-06-18T11:44:21.344Z] [INFO]       aborted: false,
+[2026-06-18T11:44:21.344Z] [INFO]       reason: undefined,
+[2026-06-18T11:44:21.345Z] [INFO]       onabort: null,
+[2026-06-18T11:44:21.347Z] [INFO]       throwIfAborted: [Function: throwIfAborted],
+[2026-06-18T11:44:21.351Z] [INFO]       addEventListener: [Function: addEventListener],
+[2026-06-18T11:44:21.352Z] [INFO]       removeEventListener: [Function: removeEventListener],
+[2026-06-18T11:44:21.353Z] [INFO]       dispatchEvent: [Function: dispatchEvent],
+[2026-06-18T11:44:21.354Z] [INFO]     },
+[2026-06-18T11:44:21.354Z] [INFO]     stream: true,
+[2026-06-18T11:44:21.355Z] [INFO]   },
+[2026-06-18T11:44:21.355Z] [INFO]   headers: {
+[2026-06-18T11:44:21.356Z] [INFO]     accept: "application/json",
+[2026-06-18T11:44:21.357Z] [INFO]     "anthropic-beta": "claude-code-20250219,oauth-2025-04-20,interleaved-thinking-2025-05-14,thinking-token-count-2026-05-13,context-management-2025-06-27,prompt-caching-scope-2026-01-05,mid-conversation-system-2026-04-07,advisor-tool-2026-03-01,advanced-tool-use-2025-11-20,effort-2025-11-24,extended-cache-ttl-2025-04-11,cache-diagnosis-2026-04-07",
+[2026-06-18T11:44:21.358Z] [INFO]     "anthropic-dangerous-direct-browser-access": "true",
+[2026-06-18T11:44:21.359Z] [INFO]     "anthropic-version": "2023-06-01",
+[2026-06-18T11:44:21.360Z] [INFO]     authorization: "***",
+[2026-06-18T11:44:21.360Z] [INFO]     "content-type": "application/json",
+[2026-06-18T11:44:21.364Z] [INFO]     "user-agent": "claude-cli/2.1.181 (external, sdk-cli)",
+[2026-06-18T11:44:21.365Z] [INFO]     "x-app": "cli",
+[2026-06-18T11:44:21.366Z] [INFO]     "x-claude-code-session-id": "d65e890a-db60-43f7-aea3-691500f7e26c",
+[2026-06-18T11:44:21.367Z] [INFO]     "x-client-request-id": "da89b0d8-46c2-48a3-81a5-7c60ec2df3da",
+[2026-06-18T11:44:21.368Z] [INFO]     "x-stainless-arch": "x64",
+[2026-06-18T11:44:21.368Z] [INFO]     "x-stainless-lang": "js",
+[2026-06-18T11:44:21.369Z] [INFO]     "x-stainless-os": "Linux",
+[2026-06-18T11:44:21.369Z] [INFO]     "x-stainless-package-version": "0.94.0",
+[2026-06-18T11:44:21.370Z] [INFO]     "x-stainless-retry-count": "0",
+[2026-06-18T11:44:21.370Z] [INFO]     "x-stainless-runtime": "node",
+[2026-06-18T11:44:21.371Z] [INFO]     "x-stainless-runtime-version": "v24.3.0",
+[2026-06-18T11:44:21.372Z] [INFO]     "x-stainless-timeout": "600",
+[2026-06-18T11:44:21.372Z] [INFO]   },
+[2026-06-18T11:44:21.373Z] [INFO] }
+[2026-06-18T11:44:22.591Z] [INFO] [log_586c8d, request-id: "req_011CcAffFXMGCWGtopsZCvse"] post https://api.anthropic.com/v1/messages?beta=true succeeded with status 200 in 1260ms
+[2026-06-18T11:44:22.592Z] [INFO] [log_586c8d] response start {
+[2026-06-18T11:44:22.593Z] [INFO]   url: "https://api.anthropic.com/v1/messages?beta=true",
+[2026-06-18T11:44:22.595Z] [INFO]   status: 200,
+[2026-06-18T11:44:22.596Z] [INFO]   headers: {
+[2026-06-18T11:44:22.596Z] [INFO]     "anthropic-organization-id": "ebc2ac93-f86f-4d15-aff3-de8830d8d789",
+[2026-06-18T11:44:22.597Z] [INFO]     "anthropic-ratelimit-unified-5h-reset": "1781787000",
+[2026-06-18T11:44:22.598Z] [INFO]     "anthropic-ratelimit-unified-5h-status": "allowed",
+[2026-06-18T11:44:22.599Z] [INFO]     "anthropic-ratelimit-unified-5h-utilization": "0.33",
+[2026-06-18T11:44:22.602Z] [INFO]     "anthropic-ratelimit-unified-7d-reset": "1782212400",
+[2026-06-18T11:44:22.604Z] [INFO]     "anthropic-ratelimit-unified-7d-status": "allowed",
+[2026-06-18T11:44:22.604Z] [INFO]     "anthropic-ratelimit-unified-7d-utilization": "0.62",
+[2026-06-18T11:44:22.606Z] [INFO]     "anthropic-ratelimit-unified-fallback-percentage": "0.5",
+[2026-06-18T11:44:22.607Z] [INFO]     "anthropic-ratelimit-unified-overage-disabled-reason": "org_level_disabled",
+[2026-06-18T11:44:22.609Z] [INFO]     "anthropic-ratelimit-unified-overage-status": "rejected",
+[2026-06-18T11:44:22.609Z] [INFO]     "anthropic-ratelimit-unified-representative-claim": "five_hour",
+[2026-06-18T11:44:22.610Z] [INFO]     "anthropic-ratelimit-unified-reset": "1781787000",
+[2026-06-18T11:44:22.610Z] [INFO]     "anthropic-ratelimit-unified-status": "allowed",
+[2026-06-18T11:44:22.611Z] [INFO]     "cache-control": "no-cache",
+[2026-06-18T11:44:22.611Z] [INFO]     "cf-cache-status": "DYNAMIC",
+[2026-06-18T11:44:22.612Z] [INFO]     "cf-ray": "a0da0aa55c20d295-FRA",
+[2026-06-18T11:44:22.612Z] [INFO]     connection: "keep-alive",
+[2026-06-18T11:44:22.614Z] [INFO]     "content-encoding": "gzip",
+[2026-06-18T11:44:22.615Z] [INFO]     "content-security-policy": "default-src 'none'; frame-ancestors 'none'",
+[2026-06-18T11:44:22.616Z] [INFO]     "content-type": "text/event-stream; charset=utf-8",
+[2026-06-18T11:44:22.617Z] [INFO]     date: "Thu, 18 Jun 2026 11:44:22 GMT",
+[2026-06-18T11:44:22.618Z] [INFO]     "request-id": "req_011CcAffFXMGCWGtopsZCvse",
+[2026-06-18T11:44:22.619Z] [INFO]     server: "cloudflare",
+[2026-06-18T11:44:22.621Z] [INFO]     "strict-transport-security": "max-age=31536000; includeSubDomains; preload",
+[2026-06-18T11:44:22.622Z] [INFO]     traceresponse: "00-ec468d6e284f84eeb85fd73908b134d3-b9d305d0fb9df804-01",
+[2026-06-18T11:44:22.623Z] [INFO]     "transfer-encoding": "chunked",
+[2026-06-18T11:44:22.624Z] [INFO]     vary: "Accept-Encoding",
+[2026-06-18T11:44:22.624Z] [INFO]     "x-robots-tag": "none",
+[2026-06-18T11:44:22.624Z] [INFO]     "set-cookie": "***",
+[2026-06-18T11:44:22.625Z] [INFO]   },
+[2026-06-18T11:44:22.625Z] [INFO]   durationMs: 1260,
+[2026-06-18T11:44:22.625Z] [INFO] }
+[2026-06-18T11:44:22.626Z] [INFO] response 200 https://api.anthropic.com/v1/messages?beta=true Headers {
+[2026-06-18T11:44:22.626Z] [INFO]   "date": "Thu, 18 Jun 2026 11:44:22 GMT",
+[2026-06-18T11:44:22.626Z] [INFO]   "content-type": "text/event-stream; charset=utf-8",
+[2026-06-18T11:44:22.626Z] [INFO]   "transfer-encoding": "chunked",
+[2026-06-18T11:44:22.627Z] [INFO]   "connection": "keep-alive",
+[2026-06-18T11:44:22.627Z] [INFO]   "cache-control": "no-cache",
+[2026-06-18T11:44:22.627Z] [INFO]   "strict-transport-security": "max-age=31536000; includeSubDomains; preload",
+[2026-06-18T11:44:22.627Z] [INFO]   "content-encoding": "gzip",
+[2026-06-18T11:44:22.628Z] [INFO]   "vary": "Accept-Encoding",
+[2026-06-18T11:44:22.628Z] [INFO]   "content-security-policy": "default-src 'none'; frame-ancestors 'none'",
+[2026-06-18T11:44:22.628Z] [INFO]   "set-cookie": [ "_cfuvid=UNt.tGQWBwkyPjgJW3UPry5JItUkf3iJwBWlRxFT0sM-1781783061.3383172-1.0.1.1-eecn9wMFuGVqxWS58bd1PEiqEoBqT7IEXRiSQS9ytY8; HttpOnly; SameSite=None; Secure; Path=/; Domain=api.anthropic.com" ],
+[2026-06-18T11:44:22.629Z] [INFO]   "anthropic-ratelimit-unified-status": "allowed",
+[2026-06-18T11:44:22.629Z] [INFO]   "anthropic-ratelimit-unified-5h-status": "allowed",
+[2026-06-18T11:44:22.629Z] [INFO]   "anthropic-ratelimit-unified-5h-reset": "1781787000",
+[2026-06-18T11:44:22.630Z] [INFO]   "anthropic-ratelimit-unified-5h-utilization": "0.33",
+[2026-06-18T11:44:22.630Z] [INFO]   "anthropic-ratelimit-unified-7d-status": "allowed",
+[2026-06-18T11:44:22.630Z] [INFO]   "anthropic-ratelimit-unified-7d-reset": "1782212400",
+[2026-06-18T11:44:22.631Z] [INFO]   "anthropic-ratelimit-unified-7d-utilization": "0.62",
+[2026-06-18T11:44:22.631Z] [INFO]   "anthropic-ratelimit-unified-representative-claim": "five_hour",
+[2026-06-18T11:44:22.631Z] [INFO]   "anthropic-ratelimit-unified-fallback-percentage": "0.5",
+[2026-06-18T11:44:22.632Z] [INFO]   "anthropic-ratelimit-unified-reset": "1781787000",
+[2026-06-18T11:44:22.632Z] [INFO]   "anthropic-ratelimit-unified-overage-disabled-reason": "org_level_disabled",
+[2026-06-18T11:44:22.632Z] [INFO]   "anthropic-ratelimit-unified-overage-status": "rejected",
+[2026-06-18T11:44:22.633Z] [INFO]   "request-id": "req_011CcAffFXMGCWGtopsZCvse",
+[2026-06-18T11:44:22.634Z] [INFO]   "anthropic-organization-id": "ebc2ac93-f86f-4d15-aff3-de8830d8d789",
+[2026-06-18T11:44:22.636Z] [INFO]   "traceresponse": "00-ec468d6e284f84eeb85fd73908b134d3-b9d305d0fb9df804-01",
+[2026-06-18T11:44:22.638Z] [INFO]   "server": "cloudflare",
+[2026-06-18T11:44:22.639Z] [INFO]   "x-robots-tag": "none",
+[2026-06-18T11:44:22.643Z] [INFO]   "cf-cache-status": "DYNAMIC",
+[2026-06-18T11:44:22.645Z] [INFO]   "cf-ray": "a0da0aa55c20d295-FRA",
+[2026-06-18T11:44:22.647Z] [INFO] } ReadableStream {
+[2026-06-18T11:44:22.651Z] [INFO]   blob: [Function: blob],
+[2026-06-18T11:44:22.652Z] [INFO]   bytes: [Function: bytes],
+[2026-06-18T11:44:22.653Z] [INFO]   cancel: [Function],
+[2026-06-18T11:44:22.655Z] [INFO]   getReader: [Function],
+[2026-06-18T11:44:22.656Z] [INFO]   json: [Function: json],
+[2026-06-18T11:44:22.657Z] [INFO]   locked: [Getter],
+[2026-06-18T11:44:22.659Z] [INFO]   pipeThrough: [Function],
+[2026-06-18T11:44:22.660Z] [INFO]   pipeTo: [Function],
+[2026-06-18T11:44:22.661Z] [INFO]   tee: [Function],
+[2026-06-18T11:44:22.661Z] [INFO]   text: [Function: text],
+[2026-06-18T11:44:22.662Z] [INFO]   values: [Function: values],
+[2026-06-18T11:44:22.664Z] [INFO]   [Symbol(Symbol.asyncIterator)]: [Function: asyncIterator2],
+[2026-06-18T11:44:22.666Z] [INFO] }
+[2026-06-18T11:44:22.666Z] [INFO] [log_586c8d] response parsed {
+[2026-06-18T11:44:22.667Z] [INFO]   url: "https://api.anthropic.com/v1/messages?beta=true",
+[2026-06-18T11:44:22.667Z] [INFO]   status: 200,
+[2026-06-18T11:44:22.668Z] [INFO]   body: sU {
+[2026-06-18T11:44:22.668Z] [INFO]     iterator: [AsyncGeneratorFunction: s],
+[2026-06-18T11:44:22.669Z] [INFO]     controller: AbortController {
+[2026-06-18T11:44:22.670Z] [INFO]       signal: [AbortSignal ...],
+[2026-06-18T11:44:22.671Z] [INFO]       abort: [Function: abort],
+[2026-06-18T11:44:22.672Z] [INFO]     },
+[2026-06-18T11:44:22.673Z] [INFO]     [Symbol(Symbol.asyncIterator)]: [Function],
+[2026-06-18T11:44:22.674Z] [INFO]     tee: [Function: tee],
+[2026-06-18T11:44:22.675Z] [INFO]     toReadableStream: [Function: toReadableStream],
+[2026-06-18T11:44:22.676Z] [INFO]   },
+[2026-06-18T11:44:22.677Z] [INFO]   durationMs: 1260,
+[2026-06-18T11:44:22.678Z] [INFO] }
+[2026-06-18T11:44:24.087Z] [INFO] {
+[2026-06-18T11:44:24.087Z] [INFO]   "type": "system",
+[2026-06-18T11:44:24.087Z] [INFO]   "subtype": "thinking_tokens",
+[2026-06-18T11:44:24.087Z] [INFO]   "estimated_tokens": 50,
+[2026-06-18T11:44:24.087Z] [INFO]   "estimated_tokens_delta": 50,
+[2026-06-18T11:44:24.087Z] [INFO]   "uuid": "82d99262-aea5-42f5-8f29-d8d93ebd5c9a",
+[2026-06-18T11:44:24.087Z] [INFO]   "session_id": "d65e890a-db60-43f7-aea3-691500f7e26c"
+[2026-06-18T11:44:24.087Z] [INFO] }
+[2026-06-18T11:44:24.087Z] [INFO] {
+[2026-06-18T11:44:24.087Z] [INFO]   "type": "system",
+[2026-06-18T11:44:24.087Z] [INFO]   "subtype": "thinking_tokens",
+[2026-06-18T11:44:24.087Z] [INFO]   "estimated_tokens": 114,
+[2026-06-18T11:44:24.087Z] [INFO]   "estimated_tokens_delta": 64,
+[2026-06-18T11:44:24.087Z] [INFO]   "uuid": "a621987a-08b9-49ff-aabe-8e3be6c6f5e5",
+[2026-06-18T11:44:24.087Z] [INFO]   "session_id": "d65e890a-db60-43f7-aea3-691500f7e26c"
+[2026-06-18T11:44:24.087Z] [INFO] }
+[2026-06-18T11:44:24.089Z] [INFO] {
+[2026-06-18T11:44:24.089Z] [INFO]   "type": "assistant",
+[2026-06-18T11:44:24.089Z] [INFO]   "message": {
+[2026-06-18T11:44:24.089Z] [INFO]     "model": "claude-opus-4-8",
+[2026-06-18T11:44:24.089Z] [INFO]     "id": "msg_019og71gngDnDdKpw4vx2TTv",
+[2026-06-18T11:44:24.089Z] [INFO]     "type": "message",
+[2026-06-18T11:44:24.089Z] [INFO]     "role": "assistant",
+[2026-06-18T11:44:24.089Z] [INFO]     "content": [
+[2026-06-18T11:44:24.089Z] [INFO]       {
+[2026-06-18T11:44:24.089Z] [INFO]         "type": "thinking",
+[2026-06-18T11:44:24.089Z] [INFO]         "thinking": "",
+[2026-06-18T11:44:24.089Z] [INFO]         "signature": "EsADCmMIDhgCKkDEfWWbdGmcke9RbLwozpTXRgEcAG/WnPwxWkXVSVhA2WNfJ7I2TYUgKlOcMW5XAalfZNMxDlLTztWH6/qNlWkYMg9jbGF1ZGUtb3B1cy00LTg4AEIIdGhpbmtpbmcSDJkQ45FBFTAA81+i2hoM8oye+E9rt5w8u6oNIjAL72Tk6Naf37RcQHtQKZmeWGrpe8qy1V+jQGM1AccOrux1kcih9KnlsBp9TEPsJ2kqigKlQ+qtkzXjLdDrgs7rsaij8fNlysZD5gSJQVwpDt1XGyJvF7RA/8TrGTOJJWLJnB3O28GIDoTClwzsR1ZWqkZdPY2mOlQvLwM9FKHpEisD4i0b9iAOgR+4+vr61PHoM17k8CQ3Yi9h5NSusg4n3wqnx3bdk1Wk094doZWQzQAyxLDyFGxFL7U1XFLppJU4mSkxTUp0n3gMHCeIaaw4M1S2AvKEe9oVohCifcPspf58gdFMasTYr4eOnQWcZHfsKj5dfggfpOzDrcpiF38ReWfDPD5KNowkgqmO3HVFxgJ0IP4KolQTMYeny9KSDoNYYN4I/IV1bXQlavx6cui2UWQlx0xAm8aMlIkYWBgB"
+[2026-06-18T11:44:24.089Z] [INFO]       }
+[2026-06-18T11:44:24.089Z] [INFO]     ],
+[2026-06-18T11:44:24.089Z] [INFO]     "stop_reason": null,
+[2026-06-18T11:44:24.089Z] [INFO]     "stop_sequence": null,
+[2026-06-18T11:44:24.089Z] [INFO]     "stop_details": null,
+[2026-06-18T11:44:24.089Z] [INFO]     "usage": {
+[2026-06-18T11:44:24.089Z] [INFO]       "input_tokens": 2,
+[2026-06-18T11:44:24.089Z] [INFO]       "cache_creation_input_tokens": 12129,
+[2026-06-18T11:44:24.089Z] [INFO]       "cache_read_input_tokens": 19580,
+[2026-06-18T11:44:24.089Z] [INFO]       "cache_creation": {
+[2026-06-18T11:44:24.089Z] [INFO]         "ephemeral_5m_input_tokens": 0,
+[2026-06-18T11:44:24.089Z] [INFO]         "ephemeral_1h_input_tokens": 12129
+[2026-06-18T11:44:24.089Z] [INFO]       },
+[2026-06-18T11:44:24.089Z] [INFO]       "output_tokens": 2,
+[2026-06-18T11:44:24.089Z] [INFO]       "service_tier": "standard",
+[2026-06-18T11:44:24.089Z] [INFO]       "inference_geo": "not_available"
+[2026-06-18T11:44:24.089Z] [INFO]     },
+[2026-06-18T11:44:24.089Z] [INFO]     "diagnostics": null,
+[2026-06-18T11:44:24.089Z] [INFO]     "context_management": null
+[2026-06-18T11:44:24.089Z] [INFO]   },
+[2026-06-18T11:44:24.089Z] [INFO]   "parent_tool_use_id": null,
+[2026-06-18T11:44:24.089Z] [INFO]   "session_id": "d65e890a-db60-43f7-aea3-691500f7e26c",
+[2026-06-18T11:44:24.089Z] [INFO]   "uuid": "0bb56faa-a49e-4cc3-8dd4-8b8052fd8f2a",
+[2026-06-18T11:44:24.089Z] [INFO]   "request_id": "req_011CcAffFXMGCWGtopsZCvse"
+[2026-06-18T11:44:24.089Z] [INFO] }
+[2026-06-18T11:44:24.615Z] [INFO] {
+[2026-06-18T11:44:24.615Z] [INFO]   "type": "assistant",
+[2026-06-18T11:44:24.615Z] [INFO]   "message": {
+[2026-06-18T11:44:24.615Z] [INFO]     "model": "claude-opus-4-8",
+[2026-06-18T11:44:24.615Z] [INFO]     "id": "msg_019og71gngDnDdKpw4vx2TTv",
+[2026-06-18T11:44:24.615Z] [INFO]     "type": "message",
+[2026-06-18T11:44:24.615Z] [INFO]     "role": "assistant",
+[2026-06-18T11:44:24.615Z] [INFO]     "content": [
+[2026-06-18T11:44:24.615Z] [INFO]       {
+[2026-06-18T11:44:24.615Z] [INFO]         "type": "text",
+[2026-06-18T11:44:24.615Z] [INFO]         "text": "This is a research/documentation task. Let me explore the existing structure to match style and conventions."
+[2026-06-18T11:44:24.615Z] [INFO]       }
+[2026-06-18T11:44:24.615Z] [INFO]     ],
+[2026-06-18T11:44:24.615Z] [INFO]     "stop_reason": null,
+[2026-06-18T11:44:24.615Z] [INFO]     "stop_sequence": null,
+[2026-06-18T11:44:24.615Z] [INFO]     "stop_details": null,
+[2026-06-18T11:44:24.615Z] [INFO]     "usage": {
+[2026-06-18T11:44:24.615Z] [INFO]       "input_tokens": 2,
+[2026-06-18T11:44:24.615Z] [INFO]       "cache_creation_input_tokens": 12129,
+[2026-06-18T11:44:24.615Z] [INFO]       "cache_read_input_tokens": 19580,
+[2026-06-18T11:44:24.615Z] [INFO]       "cache_creation": {
+[2026-06-18T11:44:24.615Z] [INFO]         "ephemeral_5m_input_tokens": 0,
+[2026-06-18T11:44:24.615Z] [INFO]         "ephemeral_1h_input_tokens": 12129
+[2026-06-18T11:44:24.615Z] [INFO]       },
+[2026-06-18T11:44:24.615Z] [INFO]       "output_tokens": 2,
+[2026-06-18T11:44:24.615Z] [INFO]       "service_tier": "standard",
+[2026-06-18T11:44:24.615Z] [INFO]       "inference_geo": "not_available"
+[2026-06-18T11:44:24.615Z] [INFO]     },
+[2026-06-18T11:44:24.615Z] [INFO]     "diagnostics": null,
+[2026-06-18T11:44:24.615Z] [INFO]     "context_management": null
+[2026-06-18T11:44:24.615Z] [INFO]   },
+[2026-06-18T11:44:24.615Z] [INFO]   "parent_tool_use_id": null,
+[2026-06-18T11:44:24.615Z] [INFO]   "session_id": "d65e890a-db60-43f7-aea3-691500f7e26c",
+[2026-06-18T11:44:24.615Z] [INFO]   "uuid": "be8efdb2-8619-47c2-817b-7f3afaa62067",
+[2026-06-18T11:44:24.615Z] [INFO]   "request_id": "req_011CcAffFXMGCWGtopsZCvse"
+[2026-06-18T11:44:24.615Z] [INFO] }
+[2026-06-18T11:44:26.031Z] [INFO] {
+[2026-06-18T11:44:26.031Z] [INFO]   "type": "assistant",
+[2026-06-18T11:44:26.031Z] [INFO]   "message": {
+[2026-06-18T11:44:26.031Z] [INFO]     "model": "claude-opus-4-8",
+[2026-06-18T11:44:26.031Z] [INFO]     "id": "msg_019og71gngDnDdKpw4vx2TTv",
+[2026-06-18T11:44:26.031Z] [INFO]     "type": "message",
+[2026-06-18T11:44:26.031Z] [INFO]     "role": "assistant",
+[2026-06-18T11:44:26.031Z] [INFO]     "content": [
+[2026-06-18T11:44:26.031Z] [INFO]       {
+[2026-06-18T11:44:26.031Z] [INFO]         "type": "tool_use",
+[2026-06-18T11:44:26.031Z] [INFO]         "id": "toolu_01QRueEzfLYsqBiXyn11TWFa",
+[2026-06-18T11:44:26.031Z] [INFO]         "name": "Bash",
+[2026-06-18T11:44:26.031Z] [INFO]         "input": {
+[2026-06-18T11:44:26.031Z] [INFO]           "command": "ls -R research | head -60 && echo \"---CONTRIBUTING---\" && sed -n '1,120p' CONTRIBUTING.md",
+[2026-06-18T11:44:26.031Z] [INFO]           "description": "Explore research dir and contributing"
+[2026-06-18T11:44:26.031Z] [INFO]         },
+[2026-06-18T11:44:26.031Z] [INFO]         "caller": {
+[2026-06-18T11:44:26.031Z] [INFO]           "type": "direct"
+[2026-06-18T11:44:26.031Z] [INFO]         }
+[2026-06-18T11:44:26.031Z] [INFO]       }
+[2026-06-18T11:44:26.031Z] [INFO]     ],
+[2026-06-18T11:44:26.031Z] [INFO]     "stop_reason": null,
+[2026-06-18T11:44:26.031Z] [INFO]     "stop_sequence": null,
+[2026-06-18T11:44:26.031Z] [INFO]     "stop_details": null,
+[2026-06-18T11:44:26.031Z] [INFO]     "usage": {
+[2026-06-18T11:44:26.031Z] [INFO]       "input_tokens": 2,
+[2026-06-18T11:44:26.031Z] [INFO]       "cache_creation_input_tokens": 12129,
+[2026-06-18T11:44:26.031Z] [INFO]       "cache_read_input_tokens": 19580,
+[2026-06-18T11:44:26.031Z] [INFO]       "cache_creation": {
+[2026-06-18T11:44:26.031Z] [INFO]         "ephemeral_5m_input_tokens": 0,
+[2026-06-18T11:44:26.031Z] [INFO]         "ephemeral_1h_input_tokens": 12129
+[2026-06-18T11:44:26.031Z] [INFO]       },
+[2026-06-18T11:44:26.031Z] [INFO]       "output_tokens": 2,
+[2026-06-18T11:44:26.031Z] [INFO]       "service_tier": "standard",
+[2026-06-18T11:44:26.031Z] [INFO]       "inference_geo": "not_available"
+[2026-06-18T11:44:26.031Z] [INFO]     },
+[2026-06-18T11:44:26.031Z] [INFO]     "diagnostics": null,
+[2026-06-18T11:44:26.031Z] [INFO]     "context_management": null
+[2026-06-18T11:44:26.031Z] [INFO]   },
+[2026-06-18T11:44:26.031Z] [INFO]   "parent_tool_use_id": null,
+[2026-06-18T11:44:26.031Z] [INFO]   "session_id": "d65e890a-db60-43f7-aea3-691500f7e26c",
+[2026-06-18T11:44:26.031Z] [INFO]   "uuid": "1f7161e3-5dce-406d-9d7e-15128e1f24f4",
+[2026-06-18T11:44:26.031Z] [INFO]   "request_id": "req_011CcAffFXMGCWGtopsZCvse"
+[2026-06-18T11:44:26.031Z] [INFO] }
+[2026-06-18T11:44:26.992Z] [INFO] {
+[2026-06-18T11:44:26.992Z] [INFO]   "type": "user",
+[2026-06-18T11:44:26.992Z] [INFO]   "message": {
+[2026-06-18T11:44:26.992Z] [INFO]     "role": "user",
+[2026-06-18T11:44:26.992Z] [INFO]     "content": [
+[2026-06-18T11:44:26.992Z] [INFO]       {
+[2026-06-18T11:44:26.992Z] [INFO]         "tool_use_id": "toolu_01QRueEzfLYsqBiXyn11TWFa",
+[2026-06-18T11:44:26.992Z] [INFO]         "type": "tool_result",
+[2026-06-18T11:44:26.992Z] [INFO]         "content": "research:\nREADME.md\ncicd\nexternal-knowledge\ngovernance\nhub\nmango\n\nresearch/cicd:\n2026-06-js-cicd-template-analysis.md\nREADME.md\n\nresearch/external-knowledge:\nREADME.md\nexternal-insights\nexternal-sources-registry.md\n\nresearch/external-knowledge/external-insights:\n12-factor-agents-2026-06.md\nREADME.md\nagent-local-memory-context-2026-06.md\nbuilding-effective-agents-2026-06.md\nspec-driven-development-2026-06.md\nstructured-prompt-driven-development-2026-06.md\n\nresearch/governance:\nREADME.md\ncontract-documentation-format-2026-06.md\nexecutable-contract-format-2026-06.md\ngovernance-folder-structure-decisions-2026-06.md\nresearch-documentation-format-2026-06.md\n\nresearch/hub:\nREADME.md\nai-collaboration-retrospective-2026-06.md\nai-collaboration-retrospective-mango-migration-2026-06.md\necosystem-governance-audit-2026-06.md\nexternal-governance-patterns-review-2026-06.md\nexternal-practice-intake-2026-06.md\ninternational-ai-governance-practices-2026-06.md\nproject-context-and-bootstrap-patterns-2026-05.md\nprompts-classification-audit-2026-05.md\nprompts-classification-standard-2026-05.md\nteam-c-governance-strategy-audit-2026-05.md\nuser-prompts-analysis-2026-05.md\nwigers-requirements-analysis-2026-06.md\n\nresearch/mango:\nREADME.md\ncapability-decomposition-2026-05.md\nclassification-tz.md\nclassification.md\nrag-mapping-roadmap-2026-05.md\nrequirements-flow.md\nrequirements-lifecycle-uncertainty-2026-05.md\ntaxonomy-concept-2026-05.md\n---CONTRIBUTING---\n---\nstatus: canonical\nversion: 1.5\nupdated: 2026-06-15\ntemperature: 0.1\n---\n\n# Contributing\n\nВклад в репозиторий должен сохранять малый размер активных контрактов,\ntraceability и практическую полезность для hybrid human + AI work.\n\n## Workflow\n\n1. Начинайте с GitHub issue, где есть context, scope, язык результата,\n   acceptance criteria и forbidden changes.\n2. Для обычных задач используйте\n   [.github/ISSUE_TEMPLATE/task.md](.github/ISSUE_TEMPLATE/task.md) или\n   GitHub-native форму [.github/ISSUE_TEMPLATE/task.yml](.github/ISSUE_TEMPLATE/task.yml).\n3. Для Creative mode используйте\n   [.github/ISSUE_TEMPLATE/task-creative.md](.github/ISSUE_TEMPLATE/task-creative.md):\n   описывайте цель, constraints и Definition of Done, не предписывая исполнителю\n   лишние шаги реализации.\n4. Выбирайте целевой каталог по\n   [governance/repo-model.md](governance/repo-model.md),\n   [governance/rfc/knowledge-lifecycle-proposal.md](governance/rfc/knowledge-lifecycle-proposal.md) и\n   [governance/rfc/resolve-artifact-location-proposal.md](governance/rfc/resolve-artifact-location-proposal.md),\n   если место артефакта не очевидно.\n5. Используйте ближайший стандарт из [standards/README.md](standards/README.md).\n6. Держите изменение reviewable: одна цель, понятные ссылки, без unrelated\n   restructuring.\n7. Обновляйте навигацию, changelog и artifact map, если новый active artifact\n   становится частью публичного контракта репозитория.\n8. Запускайте локальную проверку перед открытием или обновлением PR.\n\n## AI-Assisted Work\n\nAI agents следуют [AI_GOVERNANCE.md](AI_GOVERNANCE.md): читают issue и\nпоследние комментарии, сохраняют human decision rights, не публикуют sensitive\ndata и работают внутри requested scope.\n\n### Правило авто-заполнения Мета\n\nАвтор задачи может указать только цель и Operating Mode. AI-агент обязан\nдостроить рабочую Мета из активных контрактов:\n\n| Что отсутствует | Как достраивается |\n| --- | --- |\n| Target artifact | По `governance/artifact-map.md`, `governance/repo-model.md` и resolver prompt. |\n| Lifecycle stage | По `governance/rfc/knowledge-lifecycle-proposal.md`; сомнительный переход записывается как gap. |\n| L1-L4 link | Product docs дают L1-L2, governance/standards/templates дают L3-L4. |\n| Validation | Минимум: frontmatter, structure validator, manifest check when templates changed. |\n\nЯвная Мета в issue имеет приоритет, если она не нарушает hard rules. Если\nправило нарушено, агент фиксирует конфликт и запрашивает guidance.\n\nHistorical migration material используется только как source context через\naudit, PR history или явно указанный `source` path. Новый active artifact должен\nпоказывать, откуда перенесено содержание и почему оно остается полезным.\n\n### Консолидация открытых вопросов\n\nПри создании дайджеста сессии, если в ней есть открытые вопросы, Исполнитель\nдолжен добавить их в [`governance/backlog.md`](governance/backlog.md), секция\n«Открытые вопросы». Если вопрос уже есть в BACKLOG — не дублировать, добавить\nссылку на дайджест в колонку «Связанные дайджесты».\n\n### Работа с внешними источниками\n\nПолный свод правил — в\n[research/external-knowledge/README.md](research/external-knowledge/README.md),\nраздел «Правила работы с внешними источниками». Краткая выжимка:\n\n- **Распознавание.** Метка `research`/«исследование» без ссылки = широкий поиск;\n  конкретный URL = изучение именно этого источника.\n- **Фиксация.** Факт изучения → в\n  [реестр](research/external-knowledge/external-sources-registry.md) **ВСЕГДА**.\n  Полезный вывод → инсайт в\n  [external-insights/](research/external-knowledge/external-insights/). Если\n  источник не полезен для текущей фазы, но содержит идеи для будущих фаз или\n  смежных тем, он маркируется тегами `future-phase: X`, `topic: Y` (при\n  необходимости `use-case: Z`) и сохраняется в БЗ как задел на будущее.\n  Повторный анализ инициирует только Пользователь.\n- **Отклонение.** Источники с явными признаками хайпа или воды (нет кода для\n  проверки, нет метрик результата, только маркетинговые обещания) отклоняются\n  полностью: только факт в реестре со статусом `rejected` и пометкой\n  «отклонено», без инсайта.\n- **Чистота.** Факты изучения внешних источников **НЕ** попадают в `CHANGELOG.md`\n  проектов.\n- **Traceability.** Автор/организация, дата и язык фиксируются всегда; лицензия —\n  когда применима.\n\n### Специфика работы с AI-агентами\n\n- Каждый запуск агента - новая сессия. Передавайте summary, issue, PR или\n  handover prompt, если нужен контекст предыдущей работы.\n- Агент не мониторит GitHub comments, review comments и CI после остановки\n  сессии. Для продолжения нужен manual restart.\n- Comment + manual restart означает итерацию в том же PR; merge означает\n  принятие результата; close без merge означает отклонение или отмену.\n- Агент не заполняет пустые поля задачи выдуманными значениями. Недостающий\n  контекст фиксируется как gap или вопрос.\n- В Creative mode допустим обоснованный обход рекомендации Хаба, если он не\n  нарушает hard bans и записан в PR, ADR/RFC или audit.\n\n## Frontmatter\n\nНовые и существенно изменённые Markdown-артефакты используют минимальный\nfrontmatter из [standards/frontmatter-standard.md](standards/frontmatter-standard.md):\n`status`, `version`, `updated`, `temperature`. Дополнительные поля добавляются\nтолько когда их потребляет валидатор, executable contract или migration\nprovenance.\n\n## Локальная проверка\n\n```bash\n./tools/validate-frontmatter.sh .\n./tools/validate-repository-structure.sh\npython3 tools/generate-manifest.py --check\n```",
+[2026-06-18T11:44:26.992Z] [INFO]         "is_error": false
+[2026-06-18T11:44:26.992Z] [INFO]       }
+[2026-06-18T11:44:26.992Z] [INFO]     ]
+[2026-06-18T11:44:26.992Z] [INFO]   },
+[2026-06-18T11:44:26.992Z] [INFO]   "parent_tool_use_id": null,
+[2026-06-18T11:44:26.992Z] [INFO]   "session_id": "d65e890a-db60-43f7-aea3-691500f7e26c",
+[2026-06-18T11:44:26.992Z] [INFO]   "uuid": "ab6eba4b-b624-4ff4-90e9-72e79f97fbf3",
+[2026-06-18T11:44:26.992Z] [INFO]   "timestamp": "2026-06-18T11:44:26.990Z",
+[2026-06-18T11:44:26.992Z] [INFO]   "tool_use_result": {
+[2026-06-18T11:44:26.992Z] [INFO]     "stdout": "research:\nREADME.md\ncicd\nexternal-knowledge\ngovernance\nhub\nmango\n\nresearch/cicd:\n2026-06-js-cicd-template-analysis.md\nREADME.md\n\nresearch/external-knowledge:\nREADME.md\nexternal-insights\nexternal-sources-registry.md\n\nresearch/external-knowledge/external-insights:\n12-factor-agents-2026-06.md\nREADME.md\nagent-local-memory-context-2026-06.md\nbuilding-effective-agents-2026-06.md\nspec-driven-development-2026-06.md\nstructured-prompt-driven-development-2026-06.md\n\nresearch/governance:\nREADME.md\ncontract-documentation-format-2026-06.md\nexecutable-contract-format-2026-06.md\ngovernance-folder-structure-decisions-2026-06.md\nresearch-documentation-format-2026-06.md\n\nresearch/hub:\nREADME.md\nai-collaboration-retrospective-2026-06.md\nai-collaboration-retrospective-mango-migration-2026-06.md\necosystem-governance-audit-2026-06.md\nexternal-governance-patterns-review-2026-06.md\nexternal-practice-intake-2026-06.md\ninternational-ai-governance-practices-2026-06.md\nproject-context-and-bootstrap-patterns-2026-05.md\nprompts-classification-audit-2026-05.md\nprompts-classification-standard-2026-05.md\nteam-c-governance-strategy-audit-2026-05.md\nuser-prompts-analysis-2026-05.md\nwigers-requirements-analysis-2026-06.md\n\nresearch/mango:\nREADME.md\ncapability-decomposition-2026-05.md\nclassification-tz.md\nclassification.md\nrag-mapping-roadmap-2026-05.md\nrequirements-flow.md\nrequirements-lifecycle-uncertainty-2026-05.md\ntaxonomy-concept-2026-05.md\n---CONTRIBUTING---\n---\nstatus: canonical\nversion: 1.5\nupdated: 2026-06-15\ntemperature: 0.1\n---\n\n# Contributing\n\nВклад в репозиторий должен сохранять малый размер активных контрактов,\ntraceability и практическую полезность для hybrid human + AI work.\n\n## Workflow\n\n1. Начинайте с GitHub issue, где есть context, scope, язык результата,\n   acceptance criteria и forbidden changes.\n2. Для обычных задач используйте\n   [.github/ISSUE_TEMPLATE/task.md](.github/ISSUE_TEMPLATE/task.md) или\n   GitHub-native форму [.github/ISSUE_TEMPLATE/task.yml](.github/ISSUE_TEMPLATE/task.yml).\n3. Для Creative mode используйте\n   [.github/ISSUE_TEMPLATE/task-creative.md](.github/ISSUE_TEMPLATE/task-creative.md):\n   описывайте цель, constraints и Definition of Done, не предписывая исполнителю\n   лишние шаги реализации.\n4. Выбирайте целевой каталог по\n   [governance/repo-model.md](governance/repo-model.md),\n   [governance/rfc/knowledge-lifecycle-proposal.md](governance/rfc/knowledge-lifecycle-proposal.md) и\n   [governance/rfc/resolve-artifact-location-proposal.md](governance/rfc/resolve-artifact-location-proposal.md),\n   если место артефакта не очевидно.\n5. Используйте ближайший стандарт из [standards/README.md](standards/README.md).\n6. Держите изменение reviewable: одна цель, понятные ссылки, без unrelated\n   restructuring.\n7. Обновляйте навигацию, changelog и artifact map, если новый active artifact\n   становится частью публичного контракта репозитория.\n8. Запускайте локальную проверку перед открытием или обновлением PR.\n\n## AI-Assisted Work\n\nAI agents следуют [AI_GOVERNANCE.md](AI_GOVERNANCE.md): читают issue и\nпоследние комментарии, сохраняют human decision rights, не публикуют sensitive\ndata и работают внутри requested scope.\n\n### Правило авто-заполнения Мета\n\nАвтор задачи может указать только цель и Operating Mode. AI-агент обязан\nдостроить рабочую Мета из активных контрактов:\n\n| Что отсутствует | Как достраивается |\n| --- | --- |\n| Target artifact | По `governance/artifact-map.md`, `governance/repo-model.md` и resolver prompt. |\n| Lifecycle stage | По `governance/rfc/knowledge-lifecycle-proposal.md`; сомнительный переход записывается как gap. |\n| L1-L4 link | Product docs дают L1-L2, governance/standards/templates дают L3-L4. |\n| Validation | Минимум: frontmatter, structure validator, manifest check when templates changed. |\n\nЯвная Мета в issue имеет приоритет, если она не нарушает hard rules. Если\nправило нарушено, агент фиксирует конфликт и запрашивает guidance.\n\nHistorical migration material используется только как source context через\naudit, PR history или явно указанный `source` path. Новый active artifact должен\nпоказывать, откуда перенесено содержание и почему оно остается полезным.\n\n### Консолидация открытых вопросов\n\nПри создании дайджеста сессии, если в ней есть открытые вопросы, Исполнитель\nдолжен добавить их в [`governance/backlog.md`](governance/backlog.md), секция\n«Открытые вопросы». Если вопрос уже есть в BACKLOG — не дублировать, добавить\nссылку на дайджест в колонку «Связанные дайджесты».\n\n### Работа с внешними источниками\n\nПолный свод правил — в\n[research/external-knowledge/README.md](research/external-knowledge/README.md),\nраздел «Правила работы с внешними источниками». Краткая выжимка:\n\n- **Распознавание.** Метка `research`/«исследование» без ссылки = широкий поиск;\n  конкретный URL = изучение именно этого источника.\n- **Фиксация.** Факт изучения → в\n  [реестр](research/external-knowledge/external-sources-registry.md) **ВСЕГДА**.\n  Полезный вывод → инсайт в\n  [external-insights/](research/external-knowledge/external-insights/). Если\n  источник не полезен для текущей фазы, но содержит идеи для будущих фаз или\n  смежных тем, он маркируется тегами `future-phase: X`, `topic: Y` (при\n  необходимости `use-case: Z`) и сохраняется в БЗ как задел на будущее.\n  Повторный анализ инициирует только Пользователь.\n- **Отклонение.** Источники с явными признаками хайпа или воды (нет кода для\n  проверки, нет метрик результата, только маркетинговые обещания) отклоняются\n  полностью: только факт в реестре со статусом `rejected` и пометкой\n  «отклонено», без инсайта.\n- **Чистота.** Факты изучения внешних источников **НЕ** попадают в `CHANGELOG.md`\n  проектов.\n- **Traceability.** Автор/организация, дата и язык фиксируются всегда; лицензия —\n  когда применима.\n\n### Специфика работы с AI-агентами\n\n- Каждый запуск агента - новая сессия. Передавайте summary, issue, PR или\n  handover prompt, если нужен контекст предыдущей работы.\n- Агент не мониторит GitHub comments, review comments и CI после остановки\n  сессии. Для продолжения нужен manual restart.\n- Comment + manual restart означает итерацию в том же PR; merge означает\n  принятие результата; close без merge означает отклонение или отмену.\n- Агент не заполняет пустые поля задачи выдуманными значениями. Недостающий\n  контекст фиксируется как gap или вопрос.\n- В Creative mode допустим обоснованный обход рекомендации Хаба, если он не\n  нарушает hard bans и записан в PR, ADR/RFC или audit.\n\n## Frontmatter\n\nНовые и существенно изменённые Markdown-артефакты используют минимальный\nfrontmatter из [standards/frontmatter-standard.md](standards/frontmatter-standard.md):\n`status`, `version`, `updated`, `temperature`. Дополнительные поля добавляются\nтолько когда их потребляет валидатор, executable contract или migration\nprovenance.\n\n## Локальная проверка\n\n```bash\n./tools/validate-frontmatter.sh .\n./tools/validate-repository-structure.sh\npython3 tools/generate-manifest.py --check\n```",
+[2026-06-18T11:44:26.992Z] [INFO]     "stderr": "",
+[2026-06-18T11:44:26.992Z] [INFO]     "interrupted": false,
+[2026-06-18T11:44:26.992Z] [INFO]     "isImage": false,
+[2026-06-18T11:44:26.992Z] [INFO]     "noOutputExpected": false
+[2026-06-18T11:44:26.992Z] [INFO]   }
+[2026-06-18T11:44:26.992Z] [INFO] }
+[2026-06-18T11:44:27.198Z] [INFO] {
+[2026-06-18T11:44:27.198Z] [INFO]   "type": "assistant",
+[2026-06-18T11:44:27.198Z] [INFO]   "message": {
+[2026-06-18T11:44:27.198Z] [INFO]     "model": "claude-opus-4-8",
+[2026-06-18T11:44:27.198Z] [INFO]     "id": "msg_019og71gngDnDdKpw4vx2TTv",
+[2026-06-18T11:44:27.198Z] [INFO]     "type": "message",
+[2026-06-18T11:44:27.198Z] [INFO]     "role": "assistant",
+[2026-06-18T11:44:27.198Z] [INFO]     "content": [
+[2026-06-18T11:44:27.198Z] [INFO]       {
+[2026-06-18T11:44:27.198Z] [INFO]         "type": "tool_use",
+[2026-06-18T11:44:27.198Z] [INFO]         "id": "toolu_011c2HXdsNuvwBK6MgkqB4ij",
+[2026-06-18T11:44:27.198Z] [INFO]         "name": "Bash",
+[2026-06-18T11:44:27.198Z] [INFO]         "input": {
+[2026-06-18T11:44:27.198Z] [INFO]           "command": "ls -la research/mango research/external-knowledge 2>/dev/null && echo \"---PR252---\" && gh pr view 252 --json title,body,state | head -40",
+[2026-06-18T11:44:27.198Z] [INFO]           "description": "List mango research and PR"
+[2026-06-18T11:44:27.198Z] [INFO]         },
+[2026-06-18T11:44:27.198Z] [INFO]         "caller": {
+[2026-06-18T11:44:27.198Z] [INFO]           "type": "direct"
+[2026-06-18T11:44:27.198Z] [INFO]         }
+[2026-06-18T11:44:27.198Z] [INFO]       }
+[2026-06-18T11:44:27.198Z] [INFO]     ],
+[2026-06-18T11:44:27.198Z] [INFO]     "stop_reason": null,
+[2026-06-18T11:44:27.198Z] [INFO]     "stop_sequence": null,
+[2026-06-18T11:44:27.198Z] [INFO]     "stop_details": null,
+[2026-06-18T11:44:27.198Z] [INFO]     "usage": {
+[2026-06-18T11:44:27.198Z] [INFO]       "input_tokens": 2,
+[2026-06-18T11:44:27.198Z] [INFO]       "cache_creation_input_tokens": 12129,
+[2026-06-18T11:44:27.198Z] [INFO]       "cache_read_input_tokens": 19580,
+[2026-06-18T11:44:27.198Z] [INFO]       "cache_creation": {
+[2026-06-18T11:44:27.198Z] [INFO]         "ephemeral_5m_input_tokens": 0,
+[2026-06-18T11:44:27.198Z] [INFO]         "ephemeral_1h_input_tokens": 12129
+[2026-06-18T11:44:27.198Z] [INFO]       },
+[2026-06-18T11:44:27.198Z] [INFO]       "output_tokens": 2,
+[2026-06-18T11:44:27.198Z] [INFO]       "service_tier": "standard",
+[2026-06-18T11:44:27.198Z] [INFO]       "inference_geo": "not_available"
+[2026-06-18T11:44:27.198Z] [INFO]     },
+[2026-06-18T11:44:27.198Z] [INFO]     "diagnostics": null,
+[2026-06-18T11:44:27.198Z] [INFO]     "context_management": null
+[2026-06-18T11:44:27.198Z] [INFO]   },
+[2026-06-18T11:44:27.198Z] [INFO]   "parent_tool_use_id": null,
+[2026-06-18T11:44:27.198Z] [INFO]   "session_id": "d65e890a-db60-43f7-aea3-691500f7e26c",
+[2026-06-18T11:44:27.198Z] [INFO]   "uuid": "23f6eed1-4896-4937-b695-e0b492e9f973",
+[2026-06-18T11:44:27.198Z] [INFO]   "request_id": "req_011CcAffFXMGCWGtopsZCvse"
+[2026-06-18T11:44:27.198Z] [INFO] }
+[2026-06-18T11:44:28.528Z] [INFO] {
+[2026-06-18T11:44:28.528Z] [INFO]   "type": "user",
+[2026-06-18T11:44:28.528Z] [INFO]   "message": {
+[2026-06-18T11:44:28.528Z] [INFO]     "role": "user",
+[2026-06-18T11:44:28.528Z] [INFO]     "content": [
+[2026-06-18T11:44:28.528Z] [INFO]       {
+[2026-06-18T11:44:28.528Z] [INFO]         "tool_use_id": "toolu_011c2HXdsNuvwBK6MgkqB4ij",
+[2026-06-18T11:44:28.528Z] [INFO]         "type": "tool_result",
+[2026-06-18T11:44:28.528Z] [INFO]         "content": "research/external-knowledge:\ntotal 52\ndrwxr-xr-x 3 box box  4096 Jun 18 11:43 .\ndrwxr-xr-x 7 box box  4096 Jun 18 11:43 ..\n-rw-r--r-- 1 box box  8757 Jun 18 11:43 README.md\ndrwxr-xr-x 2 box box  4096 Jun 18 11:43 external-insights\n-rw-r--r-- 1 box box 25633 Jun 18 11:43 external-sources-registry.md\n\nresearch/mango:\ntotal 460\ndrwxr-xr-x 2 box box   4096 Jun 18 11:43 .\ndrwxr-xr-x 7 box box   4096 Jun 18 11:43 ..\n-rw-r--r-- 1 box box   2644 Jun 18 11:43 README.md\n-rw-r--r-- 1 box box  90438 Jun 18 11:43 capability-decomposition-2026-05.md\n-rw-r--r-- 1 box box  58692 Jun 18 11:43 classification-tz.md\n-rw-r--r-- 1 box box 122648 Jun 18 11:43 classification.md\n-rw-r--r-- 1 box box  44846 Jun 18 11:43 rag-mapping-roadmap-2026-05.md\n-rw-r--r-- 1 box box  47539 Jun 18 11:43 requirements-flow.md\n-rw-r--r-- 1 box box  52810 Jun 18 11:43 requirements-lifecycle-uncertainty-2026-05.md\n-rw-r--r-- 1 box box  30775 Jun 18 11:43 taxonomy-concept-2026-05.md\n---PR252---\n{\"body\":\"## 🤖 AI-Powered Solution Draft\\n\\nThis pull request is being automatically generated to solve issue G-Ivan-A/hybrid-Intelligence-lab#251.\\n\\n### 📋 Issue Reference\\nFixes G-Ivan-A/hybrid-Intelligence-lab#251\\n\\n### 🚧 Status\\n**Work in Progress** - The AI assistant is currently analyzing and implementing the solution draft.\\n\\n### 📝 Implementation Details\\n_Details will be added as the solution draft is developed..._\\n\\n---\\n*This PR was created automatically by the AI issue solver*\",\"state\":\"OPEN\",\"title\":\"[WIP] creative: Формализация новых AI-классификаций (подпроцессы, артефакты, операции) и интеграция в роадмап Mango с учётом эволюции операций\"}",
+[2026-06-18T11:44:28.528Z] [INFO]         "is_error": false
+[2026-06-18T11:44:28.528Z] [INFO]       }
+[2026-06-18T11:44:28.528Z] [INFO]     ]
+[2026-06-18T11:44:28.528Z] [INFO]   },
+[2026-06-18T11:44:28.528Z] [INFO]   "parent_tool_use_id": null,
+[2026-06-18T11:44:28.528Z] [INFO]   "session_id": "d65e890a-db60-43f7-aea3-691500f7e26c",
+[2026-06-18T11:44:28.528Z] [INFO]   "uuid": "82b6fe3a-3316-4983-832c-e0dd086ef289",
+[2026-06-18T11:44:28.528Z] [INFO]   "timestamp": "2026-06-18T11:44:28.504Z",
+[2026-06-18T11:44:28.528Z] [INFO]   "tool_use_result": {
+[2026-06-18T11:44:28.528Z] [INFO]     "stdout": "research/external-knowledge:\ntotal 52\ndrwxr-xr-x 3 box box  4096 Jun 18 11:43 .\ndrwxr-xr-x 7 box box  4096 Jun 18 11:43 ..\n-rw-r--r-- 1 box box  8757 Jun 18 11:43 README.md\ndrwxr-xr-x 2 box box  4096 Jun 18 11:43 external-insights\n-rw-r--r-- 1 box box 25633 Jun 18 11:43 external-sources-registry.md\n\nresearch/mango:\ntotal 460\ndrwxr-xr-x 2 box box   4096 Jun 18 11:43 .\ndrwxr-xr-x 7 box box   4096 Jun 18 11:43 ..\n-rw-r--r-- 1 box box   2644 Jun 18 11:43 README.md\n-rw-r--r-- 1 box box  90438 Jun 18 11:43 capability-decomposition-2026-05.md\n-rw-r--r-- 1 box box  58692 Jun 18 11:43 classification-tz.md\n-rw-r--r-- 1 box box 122648 Jun 18 11:43 classification.md\n-rw-r--r-- 1 box box  44846 Jun 18 11:43 rag-mapping-roadmap-2026-05.md\n-rw-r--r-- 1 box box  47539 Jun 18 11:43 requirements-flow.md\n-rw-r--r-- 1 box box  52810 Jun 18 11:43 requirements-lifecycle-uncertainty-2026-05.md\n-rw-r--r-- 1 box box  30775 Jun 18 11:43 taxonomy-concept-2026-05.md\n---PR252---\n{\"body\":\"## 🤖 AI-Powered Solution Draft\\n\\nThis pull request is being automatically generated to solve issue G-Ivan-A/hybrid-Intelligence-lab#251.\\n\\n### 📋 Issue Reference\\nFixes G-Ivan-A/hybrid-Intelligence-lab#251\\n\\n### 🚧 Status\\n**Work in Progress** - The AI assistant is currently analyzing and implementing the solution draft.\\n\\n### 📝 Implementation Details\\n_Details will be added as the solution draft is developed..._\\n\\n---\\n*This PR was created automatically by the AI issue solver*\",\"state\":\"OPEN\",\"title\":\"[WIP] creative: Формализация новых AI-классификаций (подпроцессы, артефакты, операции) и интеграция в роадмап Mango с учётом эволюции операций\"}",
+[2026-06-18T11:44:28.528Z] [INFO]     "stderr": "",
+[2026-06-18T11:44:28.528Z] [INFO]     "interrupted": false,
+[2026-06-18T11:44:28.528Z] [INFO]     "isImage": false,
+[2026-06-18T11:44:28.528Z] [INFO]     "noOutputExpected": false
+[2026-06-18T11:44:28.528Z] [INFO]   }
+[2026-06-18T11:44:28.528Z] [INFO] }
+[2026-06-18T11:44:28.538Z] [INFO] [log_cd2df0] sending request {
+[2026-06-18T11:44:28.539Z] [INFO]   method: "post",
+[2026-06-18T11:44:28.543Z] [INFO]   url: "https://api.anthropic.com/v1/messages?beta=true",
+[2026-06-18T11:44:28.544Z] [INFO]   options: {
+[2026-06-18T11:44:28.545Z] [INFO]     method: "post",
+[2026-06-18T11:44:28.547Z] [INFO]     path: "/v1/messages?beta=true",
+[2026-06-18T11:44:28.549Z] [INFO]     body: {
+[2026-06-18T11:44:28.551Z] [INFO]       model: "claude-opus-4-8",
+[2026-06-18T11:44:28.552Z] [INFO]       messages: [
+[2026-06-18T11:44:28.552Z] [INFO]         [Object ...], [Object ...], [Object ...], [Object ...], [Object ...], [Object ...], [Object ...]
+[2026-06-18T11:44:28.553Z] [INFO]       ],
+[2026-06-18T11:44:28.554Z] [INFO]       system: [
+[2026-06-18T11:44:28.555Z] [INFO]         [Object ...], [Object ...], [Object ...], [Object ...]
+[2026-06-18T11:44:28.558Z] [INFO]       ],
+[2026-06-18T11:44:28.558Z] [INFO]       tools: [
+[2026-06-18T11:44:28.558Z] [INFO]         [Object ...], [Object ...], [Object ...], [Object ...], [Object ...], [Object ...], [Object ...], [Object ...]
+[2026-06-18T11:44:28.558Z] [INFO]       ],
+[2026-06-18T11:44:28.558Z] [INFO]       tool_choice: undefined,
+[2026-06-18T11:44:28.559Z] [INFO]       metadata: [Object ...],
+[2026-06-18T11:44:28.560Z] [INFO]       max_tokens: 128000,
+[2026-06-18T11:44:28.561Z] [INFO]       thinking: [Object ...],
+[2026-06-18T11:44:28.562Z] [INFO]       context_management: [Object ...],
+[2026-06-18T11:44:28.563Z] [INFO]       output_config: [Object ...],
+[2026-06-18T11:44:28.563Z] [INFO]       diagnostics: [Object ...],
+[2026-06-18T11:44:28.564Z] [INFO]       stream: true,
+[2026-06-18T11:44:28.564Z] [INFO]     },
+[2026-06-18T11:44:28.565Z] [INFO]     timeout: 600000,
+[2026-06-18T11:44:28.566Z] [INFO]     signal: AbortSignal {
+[2026-06-18T11:44:28.566Z] [INFO]       [Symbol(events.maxEventTargetListeners)]: 50,
+[2026-06-18T11:44:28.566Z] [INFO]       [Symbol(events.maxEventTargetListenersWarned)]: false,
+[2026-06-18T11:44:28.566Z] [INFO]       aborted: false,
+[2026-06-18T11:44:28.566Z] [INFO]       reason: undefined,
+[2026-06-18T11:44:28.569Z] [INFO]       onabort: null,
+[2026-06-18T11:44:28.570Z] [INFO]       throwIfAborted: [Function: throwIfAborted],
+[2026-06-18T11:44:28.570Z] [INFO]       addEventListener: [Function: addEventListener],
+[2026-06-18T11:44:28.571Z] [INFO]       removeEventListener: [Function: removeEventListener],
+[2026-06-18T11:44:28.572Z] [INFO]       dispatchEvent: [Function: dispatchEvent],
+[2026-06-18T11:44:28.572Z] [INFO]     },
+[2026-06-18T11:44:28.573Z] [INFO]     stream: true,
+[2026-06-18T11:44:28.574Z] [INFO]   },
+[2026-06-18T11:44:28.574Z] [INFO]   headers: {
+[2026-06-18T11:44:28.575Z] [INFO]     accept: "application/json",
+[2026-06-18T11:44:28.576Z] [INFO]     "anthropic-beta": "claude-code-20250219,oauth-2025-04-20,interleaved-thinking-2025-05-14,thinking-token-count-2026-05-13,context-management-2025-06-27,prompt-caching-scope-2026-01-05,mid-conversation-system-2026-04-07,advisor-tool-2026-03-01,advanced-tool-use-2025-11-20,effort-2025-11-24,extended-cache-ttl-2025-04-11,cache-diagnosis-2026-04-07",
+[2026-06-18T11:44:28.577Z] [INFO]     "anthropic-dangerous-direct-browser-access": "true",
+[2026-06-18T11:44:28.577Z] [INFO]     "anthropic-version": "2023-06-01",
+[2026-06-18T11:44:28.578Z] [INFO]     authorization: "***",
+[2026-06-18T11:44:28.578Z] [INFO]     "content-type": "application/json",
+[2026-06-18T11:44:28.579Z] [INFO]     "user-agent": "claude-cli/2.1.181 (external, sdk-cli)",
+[2026-06-18T11:44:28.579Z] [INFO]     "x-app": "cli",
+[2026-06-18T11:44:28.579Z] [INFO]     "x-claude-code-session-id": "d65e890a-db60-43f7-aea3-691500f7e26c",
+[2026-06-18T11:44:28.580Z] [INFO]     "x-client-request-id": "e2b32905-f9da-4932-9055-f973a9840e72",
+[2026-06-18T11:44:28.581Z] [INFO]     "x-stainless-arch": "x64",
+[2026-06-18T11:44:28.582Z] [INFO]     "x-stainless-lang": "js",
+[2026-06-18T11:44:28.582Z] [INFO]     "x-stainless-os": "Linux",
+[2026-06-18T11:44:28.582Z] [INFO]     "x-stainless-package-version": "0.94.0",
+[2026-06-18T11:44:28.583Z] [INFO]     "x-stainless-retry-count": "0",
+[2026-06-18T11:44:28.583Z] [INFO]     "x-stainless-runtime": "node",
+[2026-06-18T11:44:28.583Z] [INFO]     "x-stainless-runtime-version": "v24.3.0",
+[2026-06-18T11:44:28.584Z] [INFO]     "x-stainless-timeout": "600",
+[2026-06-18T11:44:28.584Z] [INFO]   },
+[2026-06-18T11:44:28.584Z] [INFO] }
+[2026-06-18T11:44:29.866Z] [INFO] [log_cd2df0, request-id: "req_011CcAffnLW7gdPyCSmq3Ucx"] post https://api.anthropic.com/v1/messages?beta=true succeeded with status 200 in 1327ms
+[2026-06-18T11:44:29.867Z] [INFO] [log_cd2df0] response start {
+[2026-06-18T11:44:29.868Z] [INFO]   url: "https://api.anthropic.com/v1/messages?beta=true",
+[2026-06-18T11:44:29.868Z] [INFO]   status: 200,
+[2026-06-18T11:44:29.869Z] [INFO]   headers: {
+[2026-06-18T11:44:29.869Z] [INFO]     "anthropic-organization-id": "ebc2ac93-f86f-4d15-aff3-de8830d8d789",
+[2026-06-18T11:44:29.869Z] [INFO]     "anthropic-ratelimit-unified-5h-reset": "1781787000",
+[2026-06-18T11:44:29.870Z] [INFO]     "anthropic-ratelimit-unified-5h-status": "allowed",
+[2026-06-18T11:44:29.870Z] [INFO]     "anthropic-ratelimit-unified-5h-utilization": "0.33",
+[2026-06-18T11:44:29.871Z] [INFO]     "anthropic-ratelimit-unified-7d-reset": "1782212400",
+[2026-06-18T11:44:29.871Z] [INFO]     "anthropic-ratelimit-unified-7d-status": "allowed",
+[2026-06-18T11:44:29.871Z] [INFO]     "anthropic-ratelimit-unified-7d-utilization": "0.62",
+[2026-06-18T11:44:29.872Z] [INFO]     "anthropic-ratelimit-unified-fallback-percentage": "0.5",
+[2026-06-18T11:44:29.873Z] [INFO]     "anthropic-ratelimit-unified-overage-disabled-reason": "org_level_disabled",
+[2026-06-18T11:44:29.874Z] [INFO]     "anthropic-ratelimit-unified-overage-status": "rejected",
+[2026-06-18T11:44:29.874Z] [INFO]     "anthropic-ratelimit-unified-representative-claim": "five_hour",
+[2026-06-18T11:44:29.874Z] [INFO]     "anthropic-ratelimit-unified-reset": "1781787000",
+[2026-06-18T11:44:29.875Z] [INFO]     "anthropic-ratelimit-unified-status": "allowed",
+[2026-06-18T11:44:29.875Z] [INFO]     "cache-control": "no-cache",
+[2026-06-18T11:44:29.876Z] [INFO]     "cf-cache-status": "DYNAMIC",
+[2026-06-18T11:44:29.876Z] [INFO]     "cf-ray": "a0da0ad26e60b19e-FRA",
+[2026-06-18T11:44:29.877Z] [INFO]     connection: "keep-alive",
+[2026-06-18T11:44:29.877Z] [INFO]     "content-encoding": "gzip",
+[2026-06-18T11:44:29.878Z] [INFO]     "content-security-policy": "default-src 'none'; frame-ancestors 'none'",
+[2026-06-18T11:44:29.879Z] [INFO]     "content-type": "text/event-stream; charset=utf-8",
+[2026-06-18T11:44:29.879Z] [INFO]     date: "Thu, 18 Jun 2026 11:44:29 GMT",
+[2026-06-18T11:44:29.880Z] [INFO]     "request-id": "req_011CcAffnLW7gdPyCSmq3Ucx",
+[2026-06-18T11:44:29.881Z] [INFO]     server: "cloudflare",
+[2026-06-18T11:44:29.882Z] [INFO]     "strict-transport-security": "max-age=31536000; includeSubDomains; preload",
+[2026-06-18T11:44:29.882Z] [INFO]     traceresponse: "00-4e0cc104dfc46631a7608c3fe716f6a0-4de0868355688ee8-01",
+[2026-06-18T11:44:29.884Z] [INFO]     "transfer-encoding": "chunked",
+[2026-06-18T11:44:29.885Z] [INFO]     vary: "Accept-Encoding",
+[2026-06-18T11:44:29.885Z] [INFO]     "x-robots-tag": "none",
+[2026-06-18T11:44:29.885Z] [INFO]     "set-cookie": "***",
+[2026-06-18T11:44:29.885Z] [INFO]   },
+[2026-06-18T11:44:29.886Z] [INFO]   durationMs: 1327,
+[2026-06-18T11:44:29.886Z] [INFO] }
+[2026-06-18T11:44:29.886Z] [INFO] response 200 https://api.anthropic.com/v1/messages?beta=true Headers {
+[2026-06-18T11:44:29.887Z] [INFO]   "date": "Thu, 18 Jun 2026 11:44:29 GMT",
+[2026-06-18T11:44:29.888Z] [INFO]   "content-type": "text/event-stream; charset=utf-8",
+[2026-06-18T11:44:29.888Z] [INFO]   "transfer-encoding": "chunked",
+[2026-06-18T11:44:29.889Z] [INFO]   "connection": "keep-alive",
+[2026-06-18T11:44:29.889Z] [INFO]   "cache-control": "no-cache",
+[2026-06-18T11:44:29.889Z] [INFO]   "strict-transport-security": "max-age=31536000; includeSubDomains; preload",
+[2026-06-18T11:44:29.889Z] [INFO]   "content-encoding": "gzip",
+[2026-06-18T11:44:29.890Z] [INFO]   "vary": "Accept-Encoding",
+[2026-06-18T11:44:29.890Z] [INFO]   "content-security-policy": "default-src 'none'; frame-ancestors 'none'",
+[2026-06-18T11:44:29.890Z] [INFO]   "set-cookie": [ "_cfuvid=7GXR2G6tbYds7ZRz2tkTaJ8VOXHXQk4EMP9sQySDEdE-1781783068.5460923-1.0.1.1-9I3LRb7GK.iQy8VjAPsG8zJAy6nNE1hztjbIMeAX.Oo; HttpOnly; SameSite=None; Secure; Path=/; Domain=api.anthropic.com" ],
+[2026-06-18T11:44:29.890Z] [INFO]   "anthropic-ratelimit-unified-status": "allowed",
+[2026-06-18T11:44:29.890Z] [INFO]   "anthropic-ratelimit-unified-5h-status": "allowed",
+[2026-06-18T11:44:29.891Z] [INFO]   "anthropic-ratelimit-unified-5h-reset": "1781787000",
+[2026-06-18T11:44:29.891Z] [INFO]   "anthropic-ratelimit-unified-5h-utilization": "0.33",
+[2026-06-18T11:44:29.891Z] [INFO]   "anthropic-ratelimit-unified-7d-status": "allowed",
+[2026-06-18T11:44:29.892Z] [INFO]   "anthropic-ratelimit-unified-7d-reset": "1782212400",
+[2026-06-18T11:44:29.892Z] [INFO]   "anthropic-ratelimit-unified-7d-utilization": "0.62",
+[2026-06-18T11:44:29.893Z] [INFO]   "anthropic-ratelimit-unified-representative-claim": "five_hour",
+[2026-06-18T11:44:29.893Z] [INFO]   "anthropic-ratelimit-unified-fallback-percentage": "0.5",
+[2026-06-18T11:44:29.893Z] [INFO]   "anthropic-ratelimit-unified-reset": "1781787000",
+[2026-06-18T11:44:29.893Z] [INFO]   "anthropic-ratelimit-unified-overage-disabled-reason": "org_level_disabled",
+[2026-06-18T11:44:29.894Z] [INFO]   "anthropic-ratelimit-unified-overage-status": "rejected",
+[2026-06-18T11:44:29.894Z] [INFO]   "request-id": "req_011CcAffnLW7gdPyCSmq3Ucx",
+[2026-06-18T11:44:29.894Z] [INFO]   "anthropic-organization-id": "ebc2ac93-f86f-4d15-aff3-de8830d8d789",
+[2026-06-18T11:44:29.894Z] [INFO]   "traceresponse": "00-4e0cc104dfc46631a7608c3fe716f6a0-4de0868355688ee8-01",
+[2026-06-18T11:44:29.894Z] [INFO]   "server": "cloudflare",
+[2026-06-18T11:44:29.895Z] [INFO]   "cf-cache-status": "DYNAMIC",
+[2026-06-18T11:44:29.895Z] [INFO]   "x-robots-tag": "none",
+[2026-06-18T11:44:29.895Z] [INFO]   "cf-ray": "a0da0ad26e60b19e-FRA",
+[2026-06-18T11:44:29.895Z] [INFO] } ReadableStream {
+[2026-06-18T11:44:29.896Z] [INFO]   blob: [Function: blob],
+[2026-06-18T11:44:29.896Z] [INFO]   bytes: [Function: bytes],
+[2026-06-18T11:44:29.896Z] [INFO]   cancel: [Function],
+[2026-06-18T11:44:29.897Z] [INFO]   getReader: [Function],
+[2026-06-18T11:44:29.897Z] [INFO]   json: [Function: json],
+[2026-06-18T11:44:29.898Z] [INFO]   locked: [Getter],
+[2026-06-18T11:44:29.899Z] [INFO]   pipeThrough: [Function],
+[2026-06-18T11:44:29.900Z] [INFO]   pipeTo: [Function],
+[2026-06-18T11:44:29.901Z] [INFO]   tee: [Function],
+[2026-06-18T11:44:29.902Z] [INFO]   text: [Function: text],
+[2026-06-18T11:44:29.902Z] [INFO]   values: [Function: values],
+[2026-06-18T11:44:29.903Z] [INFO]   [Symbol(Symbol.asyncIterator)]: [Function: asyncIterator2],
+[2026-06-18T11:44:29.903Z] [INFO] }
+[2026-06-18T11:44:29.904Z] [INFO] [log_cd2df0] response parsed {
+[2026-06-18T11:44:29.904Z] [INFO]   url: "https://api.anthropic.com/v1/messages?beta=true",
+[2026-06-18T11:44:29.904Z] [INFO]   status: 200,
+[2026-06-18T11:44:29.904Z] [INFO]   body: sU {
+[2026-06-18T11:44:29.905Z] [INFO]     iterator: [AsyncGeneratorFunction: s],
+[2026-06-18T11:44:29.905Z] [INFO]     controller: AbortController {
+[2026-06-18T11:44:29.905Z] [INFO]       signal: [AbortSignal ...],
+[2026-06-18T11:44:29.906Z] [INFO]       abort: [Function: abort],
+[2026-06-18T11:44:29.906Z] [INFO]     },
+[2026-06-18T11:44:29.906Z] [INFO]     [Symbol(Symbol.asyncIterator)]: [Function],
+[2026-06-18T11:44:29.906Z] [INFO]     tee: [Function: tee],
+[2026-06-18T11:44:29.906Z] [INFO]     toReadableStream: [Function: toReadableStream],
+[2026-06-18T11:44:29.906Z] [INFO]   },
+[2026-06-18T11:44:29.906Z] [INFO]   durationMs: 1328,
+[2026-06-18T11:44:29.907Z] [INFO] }
+[2026-06-18T11:44:30.897Z] [INFO] {
+[2026-06-18T11:44:30.897Z] [INFO]   "type": "assistant",
+[2026-06-18T11:44:30.897Z] [INFO]   "message": {
+[2026-06-18T11:44:30.897Z] [INFO]     "model": "claude-opus-4-8",
+[2026-06-18T11:44:30.897Z] [INFO]     "id": "msg_0125n48VTmVu22DvzRAqWmXh",
+[2026-06-18T11:44:30.897Z] [INFO]     "type": "message",
+[2026-06-18T11:44:30.897Z] [INFO]     "role": "assistant",
+[2026-06-18T11:44:30.897Z] [INFO]     "content": [
+[2026-06-18T11:44:30.897Z] [INFO]       {
+[2026-06-18T11:44:30.897Z] [INFO]         "type": "text",
+[2026-06-18T11:44:30.897Z] [INFO]         "text": "Let me examine the existing Wigers research file (the dependency) and the mango README/style conventions closely."
+[2026-06-18T11:44:30.897Z] [INFO]       }
+[2026-06-18T11:44:30.897Z] [INFO]     ],
+[2026-06-18T11:44:30.897Z] [INFO]     "stop_reason": null,
+[2026-06-18T11:44:30.897Z] [INFO]     "stop_sequence": null,
+[2026-06-18T11:44:30.897Z] [INFO]     "stop_details": null,
+[2026-06-18T11:44:30.897Z] [INFO]     "usage": {
+[2026-06-18T11:44:30.897Z] [INFO]       "input_tokens": 442,
+[2026-06-18T11:44:30.897Z] [INFO]       "cache_creation_input_tokens": 4187,
+[2026-06-18T11:44:30.897Z] [INFO]       "cache_read_input_tokens": 31709,
+[2026-06-18T11:44:30.897Z] [INFO]       "cache_creation": {
+[2026-06-18T11:44:30.897Z] [INFO]         "ephemeral_5m_input_tokens": 0,
+[2026-06-18T11:44:30.897Z] [INFO]         "ephemeral_1h_input_tokens": 4187
+[2026-06-18T11:44:30.897Z] [INFO]       },
+[2026-06-18T11:44:30.897Z] [INFO]       "output_tokens": 4,
+[2026-06-18T11:44:30.897Z] [INFO]       "service_tier": "standard",
+[2026-06-18T11:44:30.897Z] [INFO]       "inference_geo": "not_available"
+[2026-06-18T11:44:30.897Z] [INFO]     },
+[2026-06-18T11:44:30.897Z] [INFO]     "diagnostics": null,
+[2026-06-18T11:44:30.897Z] [INFO]     "context_management": null
+[2026-06-18T11:44:30.897Z] [INFO]   },
+[2026-06-18T11:44:30.897Z] [INFO]   "parent_tool_use_id": null,
+[2026-06-18T11:44:30.897Z] [INFO]   "session_id": "d65e890a-db60-43f7-aea3-691500f7e26c",
+[2026-06-18T11:44:30.897Z] [INFO]   "uuid": "c3629b7a-a99f-4099-aa5e-5a5794ef9d53",
+[2026-06-18T11:44:30.897Z] [INFO]   "request_id": "req_011CcAffnLW7gdPyCSmq3Ucx"
+[2026-06-18T11:44:30.897Z] [INFO] }
+[2026-06-18T11:44:32.456Z] [INFO] {
+[2026-06-18T11:44:32.456Z] [INFO]   "type": "assistant",
+[2026-06-18T11:44:32.456Z] [INFO]   "message": {
+[2026-06-18T11:44:32.456Z] [INFO]     "model": "claude-opus-4-8",
+[2026-06-18T11:44:32.456Z] [INFO]     "id": "msg_0125n48VTmVu22DvzRAqWmXh",
+[2026-06-18T11:44:32.456Z] [INFO]     "type": "message",
+[2026-06-18T11:44:32.456Z] [INFO]     "role": "assistant",
+[2026-06-18T11:44:32.456Z] [INFO]     "content": [
+[2026-06-18T11:44:32.456Z] [INFO]       {
+[2026-06-18T11:44:32.456Z] [INFO]         "type": "tool_use",
+[2026-06-18T11:44:32.456Z] [INFO]         "id": "toolu_01XM593j6w8GSrJ7zJcV3zao",
+[2026-06-18T11:44:32.456Z] [INFO]         "name": "Bash",
+[2026-06-18T11:44:32.456Z] [INFO]         "input": {
+[2026-06-18T11:44:32.456Z] [INFO]           "command": "cat research/mango/README.md && echo \"===FRONTMATTER STD===\" && sed -n '1,60p' standards/frontmatter-standard.md",
+[2026-06-18T11:44:32.456Z] [INFO]           "description": "Read mango README and frontmatter standard"
+[2026-06-18T11:44:32.456Z] [INFO]         },
+[2026-06-18T11:44:32.456Z] [INFO]         "caller": {
+[2026-06-18T11:44:32.456Z] [INFO]           "type": "direct"
+[2026-06-18T11:44:32.456Z] [INFO]         }
+[2026-06-18T11:44:32.456Z] [INFO]       }
+[2026-06-18T11:44:32.456Z] [INFO]     ],
+[2026-06-18T11:44:32.456Z] [INFO]     "stop_reason": null,
+[2026-06-18T11:44:32.456Z] [INFO]     "stop_sequence": null,
+[2026-06-18T11:44:32.456Z] [INFO]     "stop_details": null,
+[2026-06-18T11:44:32.456Z] [INFO]     "usage": {
+[2026-06-18T11:44:32.456Z] [INFO]       "input_tokens": 442,
+[2026-06-18T11:44:32.456Z] [INFO]       "cache_creation_input_tokens": 4187,
+[2026-06-18T11:44:32.456Z] [INFO]       "cache_read_input_tokens": 31709,
+[2026-06-18T11:44:32.456Z] [INFO]       "cache_creation": {
+[2026-06-18T11:44:32.456Z] [INFO]         "ephemeral_5m_input_tokens": 0,
+[2026-06-18T11:44:32.456Z] [INFO]         "ephemeral_1h_input_tokens": 4187
+[2026-06-18T11:44:32.456Z] [INFO]       },
+[2026-06-18T11:44:32.456Z] [INFO]       "output_tokens": 4,
+[2026-06-18T11:44:32.456Z] [INFO]       "service_tier": "standard",
+[2026-06-18T11:44:32.456Z] [INFO]       "inference_geo": "not_available"
+[2026-06-18T11:44:32.456Z] [INFO]     },
+[2026-06-18T11:44:32.456Z] [INFO]     "diagnostics": null,
+[2026-06-18T11:44:32.456Z] [INFO]     "context_management": null
+[2026-06-18T11:44:32.456Z] [INFO]   },
+[2026-06-18T11:44:32.456Z] [INFO]   "parent_tool_use_id": null,
+[2026-06-18T11:44:32.456Z] [INFO]   "session_id": "d65e890a-db60-43f7-aea3-691500f7e26c",
+[2026-06-18T11:44:32.456Z] [INFO]   "uuid": "fe0aef5a-375b-4f4e-83b0-fd8ad52fe876",
+[2026-06-18T11:44:32.456Z] [INFO]   "request_id": "req_011CcAffnLW7gdPyCSmq3Ucx"
+[2026-06-18T11:44:32.456Z] [INFO] }
+[2026-06-18T11:44:33.400Z] [INFO] {
+[2026-06-18T11:44:33.400Z] [INFO]   "type": "user",
+[2026-06-18T11:44:33.400Z] [INFO]   "message": {
+[2026-06-18T11:44:33.400Z] [INFO]     "role": "user",
+[2026-06-18T11:44:33.400Z] [INFO]     "content": [
+[2026-06-18T11:44:33.400Z] [INFO]       {
+[2026-06-18T11:44:33.400Z] [INFO]         "tool_use_id": "toolu_01XM593j6w8GSrJ7zJcV3zao",
+[2026-06-18T11:44:33.400Z] [INFO]         "type": "tool_result",
+[2026-06-18T11:44:33.400Z] [INFO]         "content": "---\nstatus: canonical\nversion: 1.0\nupdated: 2026-05-26\ntemperature: 0.1\nai-generated: false\nsource: research/mango/README-old.md\n---\n\n# Research: MANGO OFFICE\n\nИсследовательские материалы по классификации продуктов, требований,\nдокументационной стратегии и flow анализа тендерных ТЗ MANGO OFFICE.\n\n## Документы\n\n| Документ | Назначение |\n| --- | --- |\n| [classification.md](classification.md) | Рабочая международная и российская классификация IT/Telecom SaaS-продуктов MANGO OFFICE. |\n| [classification-tz.md](classification-tz.md) | Проверка классификатора на корпусе из 30 ТЗ и рекомендации по дополнениям. |\n| [requirements-flow.md](requirements-flow.md) | Flow требований для AI-анализа тендерных ТЗ MANGO OFFICE. |\n| [requirements-lifecycle-uncertainty-2026-05.md](requirements-lifecycle-uncertainty-2026-05.md) | Жизненный цикл требования на доработку: обработка неопределенности, декомпозиция и сравнение с международной практикой. |\n| [rag-mapping-roadmap-2026-05.md](rag-mapping-roadmap-2026-05.md) | Маппинг продуктов/фич как RAG-навигатор, roadmap автоматизации БА и карта применения PlantUML-диаграмм. |\n| [capability-decomposition-2026-05.md](capability-decomposition-2026-05.md) | Справочник атомарных функций пилотных доменов (`voice-ucaas`, `contact-center`, `digital-channels`): параметры, международные источники, примеры ТЗ и связь с НФТ-классами. |\n\n## Воспроизводимость\n\nИсторические HTML-exports публикуются через MkDocs/GitHub Pages и не хранятся\nв репозитории. Исторические scripts для корпуса ТЗ удалены в cleanup issue #49 вместе с\n`experiments-old/`. Метод извлечения и ограничения корпуса сохранены в\n[classification-tz.md](classification-tz.md). Если эксперимент потребуется\nвосстановить, новый воспроизводимый контур должен жить в\n`research/mango/exp-tz-corpus/` по\n[standards/research-profile.md](../../standards/research-profile.md).\n===FRONTMATTER STD===\n---\nstatus: canonical\nversion: 1.0\nupdated: 2026-06-12\ntemperature: 0.1\n---\n\n# Frontmatter Standard\n\nСтандарт фиксирует минимальный frontmatter для активных Markdown-артефактов\nХаба и наследуемых шаблонов. Цель — сохранить traceability без превращения\nmetadata в параллельную базу связей.\n\n## Стороны и область\n\nСтандарт применяют contributors и AI-агенты, которые создают или существенно\nизменяют активные Markdown-документы в `hybrid-Intelligence-lab`, `templates/`\nи наследуемых HTOM/spoke-репозиториях.\n\nСпециализация минимального набора по классам документов зафиксирована в\n[frontmatter-docs-standard.md](frontmatter-docs-standard.md). Этот файл остаётся\nбазовым контрактом, а специализированный стандарт объясняет necessary and\nsufficient поля для standards, guides, RFC, ADR, research, templates и practice\nnodes.\n\nНе распространяется на YAML issue forms, workflow-файлы, код, JSON и внешние\nрепозитории. Legacy-документы приводятся к стандарту при следующем существенном\nизменении, без массовой механической миграции.\n\n## Обязательства\n\n1. Markdown-документ с frontmatter **ДОЛЖЕН** иметь четыре обязательных поля:\n\n   | Поле | Значение | Назначение |\n   | --- | --- | --- |\n   | `status` | `draft` / `reviewed` / `published` / `superseded` / `canonical` / `experimental` / доменный термин | Зрелость артефакта. |\n   | `version` | SemVer `X.Y` или `X.Y.Z` | Версия содержания. |\n   | `updated` | `YYYY-MM-DD` или `{{date}}` в source-template | Дата последнего смыслового изменения. |\n   | `temperature` | число от `0` до `2` | Рекомендуемая температура AI-запуска для воспроизводимой работы с артефактом. |\n\n2. `temperature: 0.1` **СЛЕДУЕТ** использовать для governance-контрактов,\n   стандартов, валидаторов и шаблонов задач: там важнее стабильность, чем\n   вариативность.\n3. Дополнительные поля **НЕ СЛЕДУЕТ** добавлять для навигации, связей,\n   маппинга процессов или владельцев. Эти данные живут в\n   [governance/artifact-map.md](../governance/artifact-map.md), README, ADR/RFC,\n   issue или PR.\n4. Дополнительный frontmatter **МОЖНО** оставить только когда поле прямо\n   потребляется текущим валидатором или исполнимым контрактом\n   (`executable`, `entrypoint`) либо временно нужно для migration provenance\n   (`source`, `source_hub`, `source_sha`, `based_on`).\n5. `ai-generated` **НЕ ЯВЛЯЕТСЯ обязательным полем**. Авторство и доля AI\n   фиксируются в issue, PR, changelog или audit, если это влияет на review.\n6. `status`, `version`, `updated` и `temperature` **НЕ ДОЛЖНЫ** дублироваться в\n   теле документа как отдельные строки \"Версия\", \"Дата\", \"Статус\" без\n   операционной причины.\n\n## Definition of Done\n\n- Новый или существенно изменённый Markdown-артефакт имеет четыре обязательных",
+[2026-06-18T11:44:33.400Z] [INFO]         "is_error": false
+[2026-06-18T11:44:33.400Z] [INFO]       }
+[2026-06-18T11:44:33.400Z] [INFO]     ]
+[2026-06-18T11:44:33.400Z] [INFO]   },
+[2026-06-18T11:44:33.400Z] [INFO]   "parent_tool_use_id": null,
+[2026-06-18T11:44:33.400Z] [INFO]   "session_id": "d65e890a-db60-43f7-aea3-691500f7e26c",
+[2026-06-18T11:44:33.400Z] [INFO]   "uuid": "043277d5-cab1-4350-bbcd-c6890ab72709",
+[2026-06-18T11:44:33.400Z] [INFO]   "timestamp": "2026-06-18T11:44:33.397Z",
+[2026-06-18T11:44:33.400Z] [INFO]   "tool_use_result": {
+[2026-06-18T11:44:33.400Z] [INFO]     "stdout": "---\nstatus: canonical\nversion: 1.0\nupdated: 2026-05-26\ntemperature: 0.1\nai-generated: false\nsource: research/mango/README-old.md\n---\n\n# Research: MANGO OFFICE\n\nИсследовательские материалы по классификации продуктов, требований,\nдокументационной стратегии и flow анализа тендерных ТЗ MANGO OFFICE.\n\n## Документы\n\n| Документ | Назначение |\n| --- | --- |\n| [classification.md](classification.md) | Рабочая международная и российская классификация IT/Telecom SaaS-продуктов MANGO OFFICE. |\n| [classification-tz.md](classification-tz.md) | Проверка классификатора на корпусе из 30 ТЗ и рекомендации по дополнениям. |\n| [requirements-flow.md](requirements-flow.md) | Flow требований для AI-анализа тендерных ТЗ MANGO OFFICE. |\n| [requirements-lifecycle-uncertainty-2026-05.md](requirements-lifecycle-uncertainty-2026-05.md) | Жизненный цикл требования на доработку: обработка неопределенности, декомпозиция и сравнение с международной практикой. |\n| [rag-mapping-roadmap-2026-05.md](rag-mapping-roadmap-2026-05.md) | Маппинг продуктов/фич как RAG-навигатор, roadmap автоматизации БА и карта применения PlantUML-диаграмм. |\n| [capability-decomposition-2026-05.md](capability-decomposition-2026-05.md) | Справочник атомарных функций пилотных доменов (`voice-ucaas`, `contact-center`, `digital-channels`): параметры, международные источники, примеры ТЗ и связь с НФТ-классами. |\n\n## Воспроизводимость\n\nИсторические HTML-exports публикуются через MkDocs/GitHub Pages и не хранятся\nв репозитории. Исторические scripts для корпуса ТЗ удалены в cleanup issue #49 вместе с\n`experiments-old/`. Метод извлечения и ограничения корпуса сохранены в\n[classification-tz.md](classification-tz.md). Если эксперимент потребуется\nвосстановить, новый воспроизводимый контур должен жить в\n`research/mango/exp-tz-corpus/` по\n[standards/research-profile.md](../../standards/research-profile.md).\n===FRONTMATTER STD===\n---\nstatus: canonical\nversion: 1.0\nupdated: 2026-06-12\ntemperature: 0.1\n---\n\n# Frontmatter Standard\n\nСтандарт фиксирует минимальный frontmatter для активных Markdown-артефактов\nХаба и наследуемых шаблонов. Цель — сохранить traceability без превращения\nmetadata в параллельную базу связей.\n\n## Стороны и область\n\nСтандарт применяют contributors и AI-агенты, которые создают или существенно\nизменяют активные Markdown-документы в `hybrid-Intelligence-lab`, `templates/`\nи наследуемых HTOM/spoke-репозиториях.\n\nСпециализация минимального набора по классам документов зафиксирована в\n[frontmatter-docs-standard.md](frontmatter-docs-standard.md). Этот файл остаётся\nбазовым контрактом, а специализированный стандарт объясняет necessary and\nsufficient поля для standards, guides, RFC, ADR, research, templates и practice\nnodes.\n\nНе распространяется на YAML issue forms, workflow-файлы, код, JSON и внешние\nрепозитории. Legacy-документы приводятся к стандарту при следующем существенном\nизменении, без массовой механической миграции.\n\n## Обязательства\n\n1. Markdown-документ с frontmatter **ДОЛЖЕН** иметь четыре обязательных поля:\n\n   | Поле | Значение | Назначение |\n   | --- | --- | --- |\n   | `status` | `draft` / `reviewed` / `published` / `superseded` / `canonical` / `experimental` / доменный термин | Зрелость артефакта. |\n   | `version` | SemVer `X.Y` или `X.Y.Z` | Версия содержания. |\n   | `updated` | `YYYY-MM-DD` или `{{date}}` в source-template | Дата последнего смыслового изменения. |\n   | `temperature` | число от `0` до `2` | Рекомендуемая температура AI-запуска для воспроизводимой работы с артефактом. |\n\n2. `temperature: 0.1` **СЛЕДУЕТ** использовать для governance-контрактов,\n   стандартов, валидаторов и шаблонов задач: там важнее стабильность, чем\n   вариативность.\n3. Дополнительные поля **НЕ СЛЕДУЕТ** добавлять для навигации, связей,\n   маппинга процессов или владельцев. Эти данные живут в\n   [governance/artifact-map.md](../governance/artifact-map.md), README, ADR/RFC,\n   issue или PR.\n4. Дополнительный frontmatter **МОЖНО** оставить только когда поле прямо\n   потребляется текущим валидатором или исполнимым контрактом\n   (`executable`, `entrypoint`) либо временно нужно для migration provenance\n   (`source`, `source_hub`, `source_sha`, `based_on`).\n5. `ai-generated` **НЕ ЯВЛЯЕТСЯ обязательным полем**. Авторство и доля AI\n   фиксируются в issue, PR, changelog или audit, если это влияет на review.\n6. `status`, `version`, `updated` и `temperature` **НЕ ДОЛЖНЫ** дублироваться в\n   теле документа как отдельные строки \"Версия\", \"Дата\", \"Статус\" без\n   операционной причины.\n\n## Definition of Done\n\n- Новый или существенно изменённый Markdown-артефакт имеет четыре обязательных",
+[2026-06-18T11:44:33.400Z] [INFO]     "stderr": "",
+[2026-06-18T11:44:33.400Z] [INFO]     "interrupted": false,
+[2026-06-18T11:44:33.400Z] [INFO]     "isImage": false,
+[2026-06-18T11:44:33.400Z] [INFO]     "noOutputExpected": false
+[2026-06-18T11:44:33.400Z] [INFO]   }
+[2026-06-18T11:44:33.400Z] [INFO] }
+[2026-06-18T11:44:33.600Z] [INFO] {
+[2026-06-18T11:44:33.600Z] [INFO]   "type": "assistant",
+[2026-06-18T11:44:33.600Z] [INFO]   "message": {
+[2026-06-18T11:44:33.600Z] [INFO]     "model": "claude-opus-4-8",
+[2026-06-18T11:44:33.600Z] [INFO]     "id": "msg_0125n48VTmVu22DvzRAqWmXh",
+[2026-06-18T11:44:33.600Z] [INFO]     "type": "message",
+[2026-06-18T11:44:33.600Z] [INFO]     "role": "assistant",
+[2026-06-18T11:44:33.600Z] [INFO]     "content": [
+[2026-06-18T11:44:33.600Z] [INFO]       {
+[2026-06-18T11:44:33.600Z] [INFO]         "type": "tool_use",
+[2026-06-18T11:44:33.600Z] [INFO]         "id": "toolu_019fHGPfTVPZcbcFytFpVB2d",
+[2026-06-18T11:44:33.600Z] [INFO]         "name": "Bash",
+[2026-06-18T11:44:33.600Z] [INFO]         "input": {
+[2026-06-18T11:44:33.600Z] [INFO]           "command": "find . -name \"requirements-engineering-ai-era*\" -o -name \"*wigers*\" -o -name \"*wigers*\" 2>/dev/null | grep -v .git; echo \"---\"; ls research/mango/",
+[2026-06-18T11:44:33.600Z] [INFO]           "description": "Find Wigers research file"
+[2026-06-18T11:44:33.600Z] [INFO]         },
+[2026-06-18T11:44:33.600Z] [INFO]         "caller": {
+[2026-06-18T11:44:33.600Z] [INFO]           "type": "direct"
+[2026-06-18T11:44:33.600Z] [INFO]         }
+[2026-06-18T11:44:33.600Z] [INFO]       }
+[2026-06-18T11:44:33.600Z] [INFO]     ],
+[2026-06-18T11:44:33.600Z] [INFO]     "stop_reason": null,
+[2026-06-18T11:44:33.600Z] [INFO]     "stop_sequence": null,
+[2026-06-18T11:44:33.600Z] [INFO]     "stop_details": null,
+[2026-06-18T11:44:33.600Z] [INFO]     "usage": {
+[2026-06-18T11:44:33.600Z] [INFO]       "input_tokens": 442,
+[2026-06-18T11:44:33.600Z] [INFO]       "cache_creation_input_tokens": 4187,
+[2026-06-18T11:44:33.600Z] [INFO]       "cache_read_input_tokens": 31709,
+[2026-06-18T11:44:33.600Z] [INFO]       "cache_creation": {
+[2026-06-18T11:44:33.600Z] [INFO]         "ephemeral_5m_input_tokens": 0,
+[2026-06-18T11:44:33.600Z] [INFO]         "ephemeral_1h_input_tokens": 4187
+[2026-06-18T11:44:33.600Z] [INFO]       },
+[2026-06-18T11:44:33.600Z] [INFO]       "output_tokens": 4,
+[2026-06-18T11:44:33.600Z] [INFO]       "service_tier": "standard",
+[2026-06-18T11:44:33.600Z] [INFO]       "inference_geo": "not_available"
+[2026-06-18T11:44:33.600Z] [INFO]     },
+[2026-06-18T11:44:33.600Z] [INFO]     "diagnostics": null,
+[2026-06-18T11:44:33.600Z] [INFO]     "context_management": null
+[2026-06-18T11:44:33.600Z] [INFO]   },
+[2026-06-18T11:44:33.600Z] [INFO]   "parent_tool_use_id": null,
+[2026-06-18T11:44:33.600Z] [INFO]   "session_id": "d65e890a-db60-43f7-aea3-691500f7e26c",
+[2026-06-18T11:44:33.600Z] [INFO]   "uuid": "d278c7aa-0801-4840-ba00-a5039b105e38",
+[2026-06-18T11:44:33.600Z] [INFO]   "request_id": "req_011CcAffnLW7gdPyCSmq3Ucx"
+[2026-06-18T11:44:33.600Z] [INFO] }
+[2026-06-18T11:44:34.589Z] [INFO] {
+[2026-06-18T11:44:34.589Z] [INFO]   "type": "user",
+[2026-06-18T11:44:34.589Z] [INFO]   "message": {
+[2026-06-18T11:44:34.589Z] [INFO]     "role": "user",
+[2026-06-18T11:44:34.589Z] [INFO]     "content": [
+[2026-06-18T11:44:34.589Z] [INFO]       {
+[2026-06-18T11:44:34.589Z] [INFO]         "tool_use_id": "toolu_019fHGPfTVPZcbcFytFpVB2d",
+[2026-06-18T11:44:34.589Z] [INFO]         "type": "tool_result",
+[2026-06-18T11:44:34.589Z] [INFO]         "content": "./governance/rfc/requirements-engineering-ai-era-2026.md\n./research/hub/wigers-requirements-analysis-2026-06.md\n---\nREADME.md\ncapability-decomposition-2026-05.md\nclassification-tz.md\nclassification.md\nrag-mapping-roadmap-2026-05.md\nrequirements-flow.md\nrequirements-lifecycle-uncertainty-2026-05.md\ntaxonomy-concept-2026-05.md",
+[2026-06-18T11:44:34.589Z] [INFO]         "is_error": false
+[2026-06-18T11:44:34.589Z] [INFO]       }
+[2026-06-18T11:44:34.589Z] [INFO]     ]
+[2026-06-18T11:44:34.589Z] [INFO]   },
+[2026-06-18T11:44:34.589Z] [INFO]   "parent_tool_use_id": null,
+[2026-06-18T11:44:34.589Z] [INFO]   "session_id": "d65e890a-db60-43f7-aea3-691500f7e26c",
+[2026-06-18T11:44:34.589Z] [INFO]   "uuid": "508d1248-28d4-4e21-ad4b-36d9e6e9de3a",
+[2026-06-18T11:44:34.589Z] [INFO]   "timestamp": "2026-06-18T11:44:34.586Z",
+[2026-06-18T11:44:34.589Z] [INFO]   "tool_use_result": {
+[2026-06-18T11:44:34.589Z] [INFO]     "stdout": "./governance/rfc/requirements-engineering-ai-era-2026.md\n./research/hub/wigers-requirements-analysis-2026-06.md\n---\nREADME.md\ncapability-decomposition-2026-05.md\nclassification-tz.md\nclassification.md\nrag-mapping-roadmap-2026-05.md\nrequirements-flow.md\nrequirements-lifecycle-uncertainty-2026-05.md\ntaxonomy-concept-2026-05.md",
+[2026-06-18T11:44:34.589Z] [INFO]     "stderr": "",
+[2026-06-18T11:44:34.589Z] [INFO]     "interrupted": false,
+[2026-06-18T11:44:34.589Z] [INFO]     "isImage": false,
+[2026-06-18T11:44:34.589Z] [INFO]     "noOutputExpected": false
+[2026-06-18T11:44:34.589Z] [INFO]   }
+[2026-06-18T11:44:34.589Z] [INFO] }
+[2026-06-18T11:44:34.598Z] [INFO] [log_dc232f] sending request {
+[2026-06-18T11:44:34.599Z] [INFO]   method: "post",
+[2026-06-18T11:44:34.599Z] [INFO]   url: "https://api.anthropic.com/v1/messages?beta=true",
+[2026-06-18T11:44:34.599Z] [INFO]   options: {
+[2026-06-18T11:44:34.599Z] [INFO]     method: "post",
+[2026-06-18T11:44:34.601Z] [INFO]     path: "/v1/messages?beta=true",
+[2026-06-18T11:44:34.601Z] [INFO]     body: {
+[2026-06-18T11:44:34.602Z] [INFO]       model: "claude-opus-4-8",
+[2026-06-18T11:44:34.603Z] [INFO]       messages: [
+[2026-06-18T11:44:34.603Z] [INFO]         [Object ...], [Object ...], [Object ...], [Object ...], [Object ...], [Object ...], [Object ...], [Object ...], [Object ...]
+[2026-06-18T11:44:34.604Z] [INFO]       ],
+[2026-06-18T11:44:34.604Z] [INFO]       system: [
+[2026-06-18T11:44:34.604Z] [INFO]         [Object ...], [Object ...], [Object ...], [Object ...]
+[2026-06-18T11:44:34.604Z] [INFO]       ],
+[2026-06-18T11:44:34.605Z] [INFO]       tools: [
+[2026-06-18T11:44:34.605Z] [INFO]         [Object ...], [Object ...], [Object ...], [Object ...], [Object ...], [Object ...], [Object ...], [Object ...]
+[2026-06-18T11:44:34.605Z] [INFO]       ],
+[2026-06-18T11:44:34.606Z] [INFO]       tool_choice: undefined,
+[2026-06-18T11:44:34.606Z] [INFO]       metadata: [Object ...],
+[2026-06-18T11:44:34.607Z] [INFO]       max_tokens: 128000,
+[2026-06-18T11:44:34.607Z] [INFO]       thinking: [Object ...],
+[2026-06-18T11:44:34.607Z] [INFO]       context_management: [Object ...],
+[2026-06-18T11:44:34.607Z] [INFO]       output_config: [Object ...],
+[2026-06-18T11:44:34.608Z] [INFO]       diagnostics: [Object ...],
+[2026-06-18T11:44:34.608Z] [INFO]       stream: true,
+[2026-06-18T11:44:34.609Z] [INFO]     },
+[2026-06-18T11:44:34.609Z] [INFO]     timeout: 600000,
+[2026-06-18T11:44:34.609Z] [INFO]     signal: AbortSignal {
+[2026-06-18T11:44:34.610Z] [INFO]       [Symbol(events.maxEventTargetListeners)]: 50,
+[2026-06-18T11:44:34.610Z] [INFO]       [Symbol(events.maxEventTargetListenersWarned)]: false,
+[2026-06-18T11:44:34.610Z] [INFO]       aborted: false,
+[2026-06-18T11:44:34.611Z] [INFO]       reason: undefined,
+[2026-06-18T11:44:34.611Z] [INFO]       onabort: null,
+[2026-06-18T11:44:34.611Z] [INFO]       throwIfAborted: [Function: throwIfAborted],
+[2026-06-18T11:44:34.611Z] [INFO]       addEventListener: [Function: addEventListener],
+[2026-06-18T11:44:34.612Z] [INFO]       removeEventListener: [Function: removeEventListener],
+[2026-06-18T11:44:34.612Z] [INFO]       dispatchEvent: [Function: dispatchEvent],
+[2026-06-18T11:44:34.612Z] [INFO]     },
+[2026-06-18T11:44:34.612Z] [INFO]     stream: true,
+[2026-06-18T11:44:34.613Z] [INFO]   },
+[2026-06-18T11:44:34.613Z] [INFO]   headers: {
+[2026-06-18T11:44:34.613Z] [INFO]     accept: "application/json",
+[2026-06-18T11:44:34.614Z] [INFO]     "anthropic-beta": "claude-code-20250219,oauth-2025-04-20,interleaved-thinking-2025-05-14,thinking-token-count-2026-05-13,context-management-2025-06-27,prompt-caching-scope-2026-01-05,mid-conversation-system-2026-04-07,advisor-tool-2026-03-01,advanced-tool-use-2025-11-20,effort-2025-11-24,extended-cache-ttl-2025-04-11,cache-diagnosis-2026-04-07",
+[2026-06-18T11:44:34.614Z] [INFO]     "anthropic-dangerous-direct-browser-access": "true",
+[2026-06-18T11:44:34.615Z] [INFO]     "anthropic-version": "2023-06-01",
+[2026-06-18T11:44:34.616Z] [INFO]     authorization: "***",
+[2026-06-18T11:44:34.619Z] [INFO]     "content-type": "application/json",
+[2026-06-18T11:44:34.621Z] [INFO]     "user-agent": "claude-cli/2.1.181 (external, sdk-cli)",
+[2026-06-18T11:44:34.622Z] [INFO]     "x-app": "cli",
+[2026-06-18T11:44:34.623Z] [INFO]     "x-claude-code-session-id": "d65e890a-db60-43f7-aea3-691500f7e26c",
+[2026-06-18T11:44:34.623Z] [INFO]     "x-client-request-id": "6ee7ce4d-042a-4d1b-a70f-6cd0330ed23b",
+[2026-06-18T11:44:34.624Z] [INFO]     "x-stainless-arch": "x64",
+[2026-06-18T11:44:34.624Z] [INFO]     "x-stainless-lang": "js",
+[2026-06-18T11:44:34.624Z] [INFO]     "x-stainless-os": "Linux",
+[2026-06-18T11:44:34.624Z] [INFO]     "x-stainless-package-version": "0.94.0",
+[2026-06-18T11:44:34.624Z] [INFO]     "x-stainless-retry-count": "0",
+[2026-06-18T11:44:34.624Z] [INFO]     "x-stainless-runtime": "node",
+[2026-06-18T11:44:34.625Z] [INFO]     "x-stainless-runtime-version": "v24.3.0",
+[2026-06-18T11:44:34.625Z] [INFO]     "x-stainless-timeout": "600",
+[2026-06-18T11:44:34.625Z] [INFO]   },
+[2026-06-18T11:44:34.625Z] [INFO] }
+[2026-06-18T11:44:35.615Z] [INFO] [log_dc232f, request-id: "req_011CcAfgED14HiJNQqFL8NTr"] post https://api.anthropic.com/v1/messages?beta=true succeeded with status 200 in 1017ms
+[2026-06-18T11:44:35.617Z] [INFO] [log_dc232f] response start {
+[2026-06-18T11:44:35.618Z] [INFO]   url: "https://api.anthropic.com/v1/messages?beta=true",
+[2026-06-18T11:44:35.619Z] [INFO]   status: 200,
+[2026-06-18T11:44:35.621Z] [INFO]   headers: {
+[2026-06-18T11:44:35.626Z] [INFO]     "anthropic-organization-id": "ebc2ac93-f86f-4d15-aff3-de8830d8d789",
+[2026-06-18T11:44:35.627Z] [INFO]     "anthropic-ratelimit-unified-5h-reset": "1781787000",
+[2026-06-18T11:44:35.628Z] [INFO]     "anthropic-ratelimit-unified-5h-status": "allowed",
+[2026-06-18T11:44:35.628Z] [INFO]     "anthropic-ratelimit-unified-5h-utilization": "0.33",
+[2026-06-18T11:44:35.628Z] [INFO]     "anthropic-ratelimit-unified-7d-reset": "1782212400",
+[2026-06-18T11:44:35.629Z] [INFO]     "anthropic-ratelimit-unified-7d-status": "allowed",
+[2026-06-18T11:44:35.629Z] [INFO]     "anthropic-ratelimit-unified-7d-utilization": "0.62",
+[2026-06-18T11:44:35.629Z] [INFO]     "anthropic-ratelimit-unified-fallback-percentage": "0.5",
+[2026-06-18T11:44:35.630Z] [INFO]     "anthropic-ratelimit-unified-overage-disabled-reason": "org_level_disabled",
+[2026-06-18T11:44:35.630Z] [INFO]     "anthropic-ratelimit-unified-overage-status": "rejected",
+[2026-06-18T11:44:35.631Z] [INFO]     "anthropic-ratelimit-unified-representative-claim": "five_hour",
+[2026-06-18T11:44:35.631Z] [INFO]     "anthropic-ratelimit-unified-reset": "1781787000",
+[2026-06-18T11:44:35.631Z] [INFO]     "anthropic-ratelimit-unified-status": "allowed",
+[2026-06-18T11:44:35.631Z] [INFO]     "cache-control": "no-cache",
+[2026-06-18T11:44:35.632Z] [INFO]     "cf-cache-status": "DYNAMIC",
+[2026-06-18T11:44:35.632Z] [INFO]     "cf-ray": "a0da0af848cad295-FRA",
+[2026-06-18T11:44:35.632Z] [INFO]     connection: "keep-alive",
+[2026-06-18T11:44:35.632Z] [INFO]     "content-encoding": "gzip",
+[2026-06-18T11:44:35.632Z] [INFO]     "content-security-policy": "default-src 'none'; frame-ancestors 'none'",
+[2026-06-18T11:44:35.633Z] [INFO]     "content-type": "text/event-stream; charset=utf-8",
+[2026-06-18T11:44:35.633Z] [INFO]     date: "Thu, 18 Jun 2026 11:44:35 GMT",
+[2026-06-18T11:44:35.634Z] [INFO]     "request-id": "req_011CcAfgED14HiJNQqFL8NTr",
+[2026-06-18T11:44:35.634Z] [INFO]     server: "cloudflare",
+[2026-06-18T11:44:35.635Z] [INFO]     "strict-transport-security": "max-age=31536000; includeSubDomains; preload",
+[2026-06-18T11:44:35.635Z] [INFO]     traceresponse: "00-70e27aefeef18f1148430bc88c164b1f-f8e04d28830c221a-01",
+[2026-06-18T11:44:35.637Z] [INFO]     "transfer-encoding": "chunked",
+[2026-06-18T11:44:35.638Z] [INFO]     vary: "Accept-Encoding",
+[2026-06-18T11:44:35.639Z] [INFO]     "x-robots-tag": "none",
+[2026-06-18T11:44:35.640Z] [INFO]     "set-cookie": "***",
+[2026-06-18T11:44:35.640Z] [INFO]   },
+[2026-06-18T11:44:35.642Z] [INFO]   durationMs: 1017,
+[2026-06-18T11:44:35.643Z] [INFO] }
+[2026-06-18T11:44:35.644Z] [INFO] response 200 https://api.anthropic.com/v1/messages?beta=true Headers {
+[2026-06-18T11:44:35.646Z] [INFO]   "date": "Thu, 18 Jun 2026 11:44:35 GMT",
+[2026-06-18T11:44:35.647Z] [INFO]   "content-type": "text/event-stream; charset=utf-8",
+[2026-06-18T11:44:35.647Z] [INFO]   "transfer-encoding": "chunked",
+[2026-06-18T11:44:35.647Z] [INFO]   "connection": "keep-alive",
+[2026-06-18T11:44:35.648Z] [INFO]   "cache-control": "no-cache",
+[2026-06-18T11:44:35.648Z] [INFO]   "strict-transport-security": "max-age=31536000; includeSubDomains; preload",
+[2026-06-18T11:44:35.648Z] [INFO]   "content-encoding": "gzip",
+[2026-06-18T11:44:35.648Z] [INFO]   "vary": "Accept-Encoding",
+[2026-06-18T11:44:35.648Z] [INFO]   "content-security-policy": "default-src 'none'; frame-ancestors 'none'",
+[2026-06-18T11:44:35.648Z] [INFO]   "set-cookie": [ "_cfuvid=7wOrG6hhP74.EVAOF8Ci44bD7qVHp_IEpMfK3TW_2s4-1781783074.6054223-1.0.1.1-4FiCg3aVVzsg2Ee4vPiCfOsk35p2ZHdzJ.sVATiowSU; HttpOnly; SameSite=None; Secure; Path=/; Domain=api.anthropic.com" ],
+[2026-06-18T11:44:35.649Z] [INFO]   "anthropic-ratelimit-unified-status": "allowed",
+[2026-06-18T11:44:35.649Z] [INFO]   "anthropic-ratelimit-unified-5h-status": "allowed",
+[2026-06-18T11:44:35.650Z] [INFO]   "anthropic-ratelimit-unified-5h-reset": "1781787000",
+[2026-06-18T11:44:35.652Z] [INFO]   "anthropic-ratelimit-unified-5h-utilization": "0.33",
+[2026-06-18T11:44:35.652Z] [INFO]   "anthropic-ratelimit-unified-7d-status": "allowed",
+[2026-06-18T11:44:35.653Z] [INFO]   "anthropic-ratelimit-unified-7d-reset": "1782212400",
+[2026-06-18T11:44:35.654Z] [INFO]   "anthropic-ratelimit-unified-7d-utilization": "0.62",
+[2026-06-18T11:44:35.657Z] [INFO]   "anthropic-ratelimit-unified-representative-claim": "five_hour",
+[2026-06-18T11:44:35.660Z] [INFO]   "anthropic-ratelimit-unified-fallback-percentage": "0.5",
+[2026-06-18T11:44:35.661Z] [INFO]   "anthropic-ratelimit-unified-reset": "1781787000",
+[2026-06-18T11:44:35.661Z] [INFO]   "anthropic-ratelimit-unified-overage-disabled-reason": "org_level_disabled",
+[2026-06-18T11:44:35.661Z] [INFO]   "anthropic-ratelimit-unified-overage-status": "rejected",
+[2026-06-18T11:44:35.663Z] [INFO]   "request-id": "req_011CcAfgED14HiJNQqFL8NTr",
+[2026-06-18T11:44:35.664Z] [INFO]   "anthropic-organization-id": "ebc2ac93-f86f-4d15-aff3-de8830d8d789",
+[2026-06-18T11:44:35.666Z] [INFO]   "traceresponse": "00-70e27aefeef18f1148430bc88c164b1f-f8e04d28830c221a-01",
+[2026-06-18T11:44:35.672Z] [INFO]   "server": "cloudflare",
+[2026-06-18T11:44:35.674Z] [INFO]   "x-robots-tag": "none",
+[2026-06-18T11:44:35.676Z] [INFO]   "cf-cache-status": "DYNAMIC",
+[2026-06-18T11:44:35.678Z] [INFO]   "cf-ray": "a0da0af848cad295-FRA",
+[2026-06-18T11:44:35.678Z] [INFO] } ReadableStream {
+[2026-06-18T11:44:35.679Z] [INFO]   blob: [Function: blob],
+[2026-06-18T11:44:35.680Z] [INFO]   bytes: [Function: bytes],
+[2026-06-18T11:44:35.680Z] [INFO]   cancel: [Function],
+[2026-06-18T11:44:35.680Z] [INFO]   getReader: [Function],
+[2026-06-18T11:44:35.680Z] [INFO]   json: [Function: json],
+[2026-06-18T11:44:35.681Z] [INFO]   locked: [Getter],
+[2026-06-18T11:44:35.681Z] [INFO]   pipeThrough: [Function],
+[2026-06-18T11:44:35.682Z] [INFO]   pipeTo: [Function],
+[2026-06-18T11:44:35.682Z] [INFO]   tee: [Function],
+[2026-06-18T11:44:35.683Z] [INFO]   text: [Function: text],
+[2026-06-18T11:44:35.683Z] [INFO]   values: [Function: values],
+[2026-06-18T11:44:35.684Z] [INFO]   [Symbol(Symbol.asyncIterator)]: [Function: asyncIterator2],
+[2026-06-18T11:44:35.686Z] [INFO] }
+[2026-06-18T11:44:35.687Z] [INFO] [log_dc232f] response parsed {
+[2026-06-18T11:44:35.687Z] [INFO]   url: "https://api.anthropic.com/v1/messages?beta=true",
+[2026-06-18T11:44:35.688Z] [INFO]   status: 200,
+[2026-06-18T11:44:35.688Z] [INFO]   body: sU {
+[2026-06-18T11:44:35.688Z] [INFO]     iterator: [AsyncGeneratorFunction: s],
+[2026-06-18T11:44:35.688Z] [INFO]     controller: AbortController {
+[2026-06-18T11:44:35.689Z] [INFO]       signal: [AbortSignal ...],
+[2026-06-18T11:44:35.689Z] [INFO]       abort: [Function: abort],
+[2026-06-18T11:44:35.689Z] [INFO]     },
+[2026-06-18T11:44:35.690Z] [INFO]     [Symbol(Symbol.asyncIterator)]: [Function],
+[2026-06-18T11:44:35.690Z] [INFO]     tee: [Function: tee],
+[2026-06-18T11:44:35.691Z] [INFO]     toReadableStream: [Function: toReadableStream],
+[2026-06-18T11:44:35.691Z] [INFO]   },
+[2026-06-18T11:44:35.692Z] [INFO]   durationMs: 1018,
+[2026-06-18T11:44:35.692Z] [INFO] }
+[2026-06-18T11:44:37.058Z] [INFO] {
+[2026-06-18T11:44:37.058Z] [INFO]   "type": "system",
+[2026-06-18T11:44:37.058Z] [INFO]   "subtype": "thinking_tokens",
+[2026-06-18T11:44:37.058Z] [INFO]   "estimated_tokens": 50,
+[2026-06-18T11:44:37.058Z] [INFO]   "estimated_tokens_delta": 50,
+[2026-06-18T11:44:37.058Z] [INFO]   "uuid": "9a900e72-bfa6-480c-9f9a-518e268a0c76",
+[2026-06-18T11:44:37.058Z] [INFO]   "session_id": "d65e890a-db60-43f7-aea3-691500f7e26c"
+[2026-06-18T11:44:37.058Z] [INFO] }
+[2026-06-18T11:44:37.059Z] [INFO] {
+[2026-06-18T11:44:37.059Z] [INFO]   "type": "system",
+[2026-06-18T11:44:37.059Z] [INFO]   "subtype": "thinking_tokens",
+[2026-06-18T11:44:37.059Z] [INFO]   "estimated_tokens": 136,
+[2026-06-18T11:44:37.059Z] [INFO]   "estimated_tokens_delta": 86,
+[2026-06-18T11:44:37.059Z] [INFO]   "uuid": "9e2fbcd4-1aa0-4420-b7b7-7922cc20f59d",
+[2026-06-18T11:44:37.059Z] [INFO]   "session_id": "d65e890a-db60-43f7-aea3-691500f7e26c"
+[2026-06-18T11:44:37.059Z] [INFO] }
+[2026-06-18T11:44:37.062Z] [INFO] {
+[2026-06-18T11:44:37.062Z] [INFO]   "type": "assistant",
+[2026-06-18T11:44:37.062Z] [INFO]   "message": {
+[2026-06-18T11:44:37.062Z] [INFO]     "model": "claude-opus-4-8",
+[2026-06-18T11:44:37.062Z] [INFO]     "id": "msg_01J85NoCyjhwZxCjrps8ScQ5",
+[2026-06-18T11:44:37.062Z] [INFO]     "type": "message",
+[2026-06-18T11:44:37.062Z] [INFO]     "role": "assistant",
+[2026-06-18T11:44:37.062Z] [INFO]     "content": [
+[2026-06-18T11:44:37.062Z] [INFO]       {
+[2026-06-18T11:44:37.062Z] [INFO]         "type": "thinking",
+[2026-06-18T11:44:37.062Z] [INFO]         "thinking": "",
+[2026-06-18T11:44:37.062Z] [INFO]         "signature": "EpkECmMIDhgCKkABSheGzjxhYcYidmnu08YQ+ZlyM8JOBwoQNktIGNucA1K43vTf7F679FavwH8AzTqUQJJ4mOza9FDguOkSK6LkMg9jbGF1ZGUtb3B1cy00LTg4AEIIdGhpbmtpbmcSDJrGF4Ny9BA4Z+XMNRoMX9TjvvAfgkndF+n0IjBS6ksM7E6H3Gk0vb5BQFIx6rVw18yjb6eji/qzyI3n3UjQXuTLTMH1NecM+7njUZMq4wJmEJzmRETg5QJGymHb3iEc2Jghhzq5jOKGXF2Iwf/r3hlYMluQskTRTprzU4pt6WOqDGXpjsdlCrJZ0JCMW0IeOSaks5L8jpKll9dWztxkbRLaAYCS63OZIwipfjjjV1jyEqzgn9jLiH9ljFHcM8o6AZ6Jankr/sr8uBdPGGmgYOoWlPiBPd2fSAX6Rzr+Evfagp+8lDkJCUGS+WA10EB5rS6IoilWwO9BZ5G176wRocEnyqeb6+YlKAqZzxHaZk3P/nLhQdf5tpeE6vQxfDupgIPzmikbHvvtkWUSBB+E8Ky6cyOySZ0w03OwKY5uStpSdhAgl9jYfwWT3MvH//k8rZLfsdSk9YDNNd+jjsa5rimHK73CwHtXPGMtNOynJ7jv8H7nCAZ2tZA7482x4MqhVb8JemP+14bjThXhf0r7aNKg45vQ9mw/JnbNxK4tenV1H5XEGhUFdY1DZcPR8SXJkwqXGAE="
+[2026-06-18T11:44:37.062Z] [INFO]       }
+[2026-06-18T11:44:37.062Z] [INFO]     ],
+[2026-06-18T11:44:37.062Z] [INFO]     "stop_reason": null,
+[2026-06-18T11:44:37.062Z] [INFO]     "stop_sequence": null,
+[2026-06-18T11:44:37.062Z] [INFO]     "stop_details": null,
+[2026-06-18T11:44:37.062Z] [INFO]     "usage": {
+[2026-06-18T11:44:37.062Z] [INFO]       "input_tokens": 2,
+[2026-06-18T11:44:37.062Z] [INFO]       "cache_creation_input_tokens": 2964,
+[2026-06-18T11:44:37.062Z] [INFO]       "cache_read_input_tokens": 35896,
+[2026-06-18T11:44:37.062Z] [INFO]       "cache_creation": {
+[2026-06-18T11:44:37.062Z] [INFO]         "ephemeral_5m_input_tokens": 0,
+[2026-06-18T11:44:37.062Z] [INFO]         "ephemeral_1h_input_tokens": 2964
+[2026-06-18T11:44:37.062Z] [INFO]       },
+[2026-06-18T11:44:37.062Z] [INFO]       "output_tokens": 2,
+[2026-06-18T11:44:37.062Z] [INFO]       "service_tier": "standard",
+[2026-06-18T11:44:37.062Z] [INFO]       "inference_geo": "not_available"
+[2026-06-18T11:44:37.062Z] [INFO]     },
+[2026-06-18T11:44:37.062Z] [INFO]     "diagnostics": null,
+[2026-06-18T11:44:37.062Z] [INFO]     "context_management": null
+[2026-06-18T11:44:37.062Z] [INFO]   },
+[2026-06-18T11:44:37.062Z] [INFO]   "parent_tool_use_id": null,
+[2026-06-18T11:44:37.062Z] [INFO]   "session_id": "d65e890a-db60-43f7-aea3-691500f7e26c",
+[2026-06-18T11:44:37.062Z] [INFO]   "uuid": "e94cd620-afdd-4818-b74e-16579c260930",
+[2026-06-18T11:44:37.062Z] [INFO]   "request_id": "req_011CcAfgED14HiJNQqFL8NTr"
+[2026-06-18T11:44:37.062Z] [INFO] }
+[2026-06-18T11:44:38.001Z] [INFO] {
+[2026-06-18T11:44:38.001Z] [INFO]   "type": "assistant",
+[2026-06-18T11:44:38.001Z] [INFO]   "message": {
+[2026-06-18T11:44:38.001Z] [INFO]     "model": "claude-opus-4-8",
+[2026-06-18T11:44:38.001Z] [INFO]     "id": "msg_01J85NoCyjhwZxCjrps8ScQ5",
+[2026-06-18T11:44:38.001Z] [INFO]     "type": "message",
+[2026-06-18T11:44:38.001Z] [INFO]     "role": "assistant",
+[2026-06-18T11:44:38.001Z] [INFO]     "content": [
+[2026-06-18T11:44:38.001Z] [INFO]       {
+[2026-06-18T11:44:38.001Z] [INFO]         "type": "text",
+[2026-06-18T11:44:38.001Z] [INFO]         "text": "The issue's referenced Wigers file is actually at `governance/rfc/`. Let me read it and the related Wigers analysis to integrate properly."
+[2026-06-18T11:44:38.001Z] [INFO]       }
+[2026-06-18T11:44:38.001Z] [INFO]     ],
+[2026-06-18T11:44:38.001Z] [INFO]     "stop_reason": null,
+[2026-06-18T11:44:38.001Z] [INFO]     "stop_sequence": null,
+[2026-06-18T11:44:38.001Z] [INFO]     "stop_details": null,
+[2026-06-18T11:44:38.001Z] [INFO]     "usage": {
+[2026-06-18T11:44:38.001Z] [INFO]       "input_tokens": 2,
+[2026-06-18T11:44:38.001Z] [INFO]       "cache_creation_input_tokens": 2964,
+[2026-06-18T11:44:38.001Z] [INFO]       "cache_read_input_tokens": 35896,
+[2026-06-18T11:44:38.001Z] [INFO]       "cache_creation": {
+[2026-06-18T11:44:38.001Z] [INFO]         "ephemeral_5m_input_tokens": 0,
+[2026-06-18T11:44:38.001Z] [INFO]         "ephemeral_1h_input_tokens": 2964
+[2026-06-18T11:44:38.001Z] [INFO]       },
+[2026-06-18T11:44:38.001Z] [INFO]       "output_tokens": 2,
+[2026-06-18T11:44:38.001Z] [INFO]       "service_tier": "standard",
+[2026-06-18T11:44:38.001Z] [INFO]       "inference_geo": "not_available"
+[2026-06-18T11:44:38.001Z] [INFO]     },
+[2026-06-18T11:44:38.001Z] [INFO]     "diagnostics": null,
+[2026-06-18T11:44:38.001Z] [INFO]     "context_management": null
+[2026-06-18T11:44:38.001Z] [INFO]   },
+[2026-06-18T11:44:38.001Z] [INFO]   "parent_tool_use_id": null,
+[2026-06-18T11:44:38.001Z] [INFO]   "session_id": "d65e890a-db60-43f7-aea3-691500f7e26c",
+[2026-06-18T11:44:38.001Z] [INFO]   "uuid": "171e4d11-50ae-41ae-bd3b-764f8af6a175",
+[2026-06-18T11:44:38.001Z] [INFO]   "request_id": "req_011CcAfgED14HiJNQqFL8NTr"
+[2026-06-18T11:44:38.001Z] [INFO] }
+[2026-06-18T11:44:39.103Z] [INFO] {
+[2026-06-18T11:44:39.103Z] [INFO]   "type": "assistant",
+[2026-06-18T11:44:39.103Z] [INFO]   "message": {
+[2026-06-18T11:44:39.103Z] [INFO]     "model": "claude-opus-4-8",
+[2026-06-18T11:44:39.103Z] [INFO]     "id": "msg_01J85NoCyjhwZxCjrps8ScQ5",
+[2026-06-18T11:44:39.103Z] [INFO]     "type": "message",
+[2026-06-18T11:44:39.103Z] [INFO]     "role": "assistant",
+[2026-06-18T11:44:39.103Z] [INFO]     "content": [
+[2026-06-18T11:44:39.103Z] [INFO]       {
+[2026-06-18T11:44:39.103Z] [INFO]         "type": "tool_use",
+[2026-06-18T11:44:39.103Z] [INFO]         "id": "toolu_01D3LbgjzteVFm1xp7wH5QRS",
+[2026-06-18T11:44:39.103Z] [INFO]         "name": "Bash",
+[2026-06-18T11:44:39.103Z] [INFO]         "input": {
+[2026-06-18T11:44:39.103Z] [INFO]           "command": "wc -l governance/rfc/requirements-engineering-ai-era-2026.md research/hub/wigers-requirements-analysis-2026-06.md; echo \"===RFC HEAD===\"; sed -n '1,80p' governance/rfc/requirements-engineering-ai-era-2026.md",
+[2026-06-18T11:44:39.103Z] [INFO]           "description": "Read Wigers RFC head"
+[2026-06-18T11:44:39.103Z] [INFO]         },
+[2026-06-18T11:44:39.103Z] [INFO]         "caller": {
+[2026-06-18T11:44:39.103Z] [INFO]           "type": "direct"
+[2026-06-18T11:44:39.103Z] [INFO]         }
+[2026-06-18T11:44:39.103Z] [INFO]       }
+[2026-06-18T11:44:39.103Z] [INFO]     ],
+[2026-06-18T11:44:39.103Z] [INFO]     "stop_reason": null,
+[2026-06-18T11:44:39.103Z] [INFO]     "stop_sequence": null,
+[2026-06-18T11:44:39.103Z] [INFO]     "stop_details": null,
+[2026-06-18T11:44:39.103Z] [INFO]     "usage": {
+[2026-06-18T11:44:39.103Z] [INFO]       "input_tokens": 2,
+[2026-06-18T11:44:39.103Z] [INFO]       "cache_creation_input_tokens": 2964,
+[2026-06-18T11:44:39.103Z] [INFO]       "cache_read_input_tokens": 35896,
+[2026-06-18T11:44:39.103Z] [INFO]       "cache_creation": {
+[2026-06-18T11:44:39.103Z] [INFO]         "ephemeral_5m_input_tokens": 0,
+[2026-06-18T11:44:39.103Z] [INFO]         "ephemeral_1h_input_tokens": 2964
+[2026-06-18T11:44:39.103Z] [INFO]       },
+[2026-06-18T11:44:39.103Z] [INFO]       "output_tokens": 2,
+[2026-06-18T11:44:39.103Z] [INFO]       "service_tier": "standard",
+[2026-06-18T11:44:39.103Z] [INFO]       "inference_geo": "not_available"
+[2026-06-18T11:44:39.103Z] [INFO]     },
+[2026-06-18T11:44:39.103Z] [INFO]     "diagnostics": null,
+[2026-06-18T11:44:39.103Z] [INFO]     "context_management": null
+[2026-06-18T11:44:39.103Z] [INFO]   },
+[2026-06-18T11:44:39.103Z] [INFO]   "parent_tool_use_id": null,
+[2026-06-18T11:44:39.103Z] [INFO]   "session_id": "d65e890a-db60-43f7-aea3-691500f7e26c",
+[2026-06-18T11:44:39.103Z] [INFO]   "uuid": "dbe8998a-d822-45de-8d8f-a9503cf82034",
+[2026-06-18T11:44:39.103Z] [INFO]   "request_id": "req_011CcAfgED14HiJNQqFL8NTr"
+[2026-06-18T11:44:39.103Z] [INFO] }
+[2026-06-18T11:44:40.017Z] [INFO] {
+[2026-06-18T11:44:40.017Z] [INFO]   "type": "user",
+[2026-06-18T11:44:40.017Z] [INFO]   "message": {
+[2026-06-18T11:44:40.017Z] [INFO]     "role": "user",
+[2026-06-18T11:44:40.017Z] [INFO]     "content": [
+[2026-06-18T11:44:40.017Z] [INFO]       {
+[2026-06-18T11:44:40.017Z] [INFO]         "tool_use_id": "toolu_01D3LbgjzteVFm1xp7wH5QRS",
+[2026-06-18T11:44:40.017Z] [INFO]         "type": "tool_result",
+[2026-06-18T11:44:40.017Z] [INFO]         "content": "  288 governance/rfc/requirements-engineering-ai-era-2026.md\n  437 research/hub/wigers-requirements-analysis-2026-06.md\n  725 total\n===RFC HEAD===\n---\nstatus: draft\nversion: 0.1\nupdated: 2026-06-18\ntemperature: 0.1\n---\n\n# RFC: Requirements Engineering in the AI Era — синхронизация Вигерса и mango-ADR\n\n## Proposal\n\nЗафиксировать результат сравнения **независимо извлечённой системы понятий\nВигерса** (исследование\n[research/hub/wigers-requirements-analysis-2026-06.md](../../research/hub/wigers-requirements-analysis-2026-06.md))\nс действующей онтологией требований проекта `mango_ba_prompts` (ADR #003–#010) и\nпредложить **точечную синхронизацию** там, где mango переизобретает уже устоявшиеся\nу Вигерса понятия («велосипеды») или имеет содержательный пробел.\n\nКонкретно RFC:\n\n1. Сопоставляет четыре измерения Вигерса (уровни / типы / процессы-операции /\n   артефакты) с эквивалентами mango по каждому из релевантных ADR.\n2. Каталогизирует расхождения и **честно разделяет** их на три класса:\n   **(a) настоящий велосипед/пробел**, **(b) нужен мост (alias)**,\n   **(c) обоснованная локализация** (не велосипед).\n3. Предлагает синхронизацию **под реальную операционную боль** (Anti-Inflation,\n   [governance/repo-model.md](../repo-model.md)): какие понятия Вигерса стоит\n   добавить как явную ось/тип, какие — только как crosswalk, какие — оставить как\n   есть.\n\nRFC фиксирует исследование, сравнение и rationale. Любая обязательная норма после\nрешения человека делегируется в active artifact (`standards/`, либо в issue\nпроекта `mango_ba_prompts`) — до этого документ остаётся draft-рекомендацией\n([governance/rfc/README.md](README.md)). RFC **сам по себе не меняет** ни один\nmango-ADR: эти ADR живут в отдельном репозитории и редактируются там.\n\n## Decision Scope\n\n- Это **не** редактирование mango-ADR. ADR #003–#010 находятся в репозитории\n  `mango_ba_prompts` и меняются только через его процесс (issue + PR + ADR). RFC\n  даёт **рекомендации** Хаба, не правки.\n- Это **не** объявление Вигерса обязательным стандартом экосистемы. Вигерс —\n  доверенный источник (Tier 1), его модель используется как **линза сверки**, а не\n  как замена BABOK / ISO 29148 / ГОСТ 34.602, на которых mango построен осознанно.\n- Это **не** ввод AI-трендов как норм. Утверждения AI-эры (§«AI-слой») имеют\n  доверие E1–E2 и статус `Candidate`; они фиксируются как наблюдение, не как\n  стандарт (НФТ Trust & Evidence, [research-memory RFC](research-memory-source-intelligence.md)).\n- Это **не** немедленное создание артефактов в Хабе. Целевые изменения (если\n  приняты) делаются пофазно под боль, а не этим PR.\n- Это **не** замена решений человека. Принятие/отклонение рекомендаций,\n  публикация, синхронизация с mango остаются за Пользователем\n  ([AI_GOVERNANCE.md](../../AI_GOVERNANCE.md), правило 4).\n\n## Почему текущей ситуации недостаточно\n\n**Ключевой факт сверки.** Карл Вигерс — один из самых цитируемых авторов по\nинженерии требований — **не упоминается ни в одном из восьми mango-ADR** (#003–#010)\nи ни в одном связанном стандарте mango. Онтология требований mango построена на\nBABOK Guide v3, ISO/IEC/IEEE 29148:2018, ISO/IEC 25010 и ГОСТ 34.602-2020. Это\n**сознательный и в основном оправданный** выбор (международные + российские\nнормативные стандарты), но он создаёт три риска:\n\n| Вопрос | Ответ |\n| --- | --- |\n| Можно ли обойтись без Вигерса, раз есть BABOK + 29148? | Для большинства слоёв — да. Но Вигерс даёт две вещи, которых в mango нет явно: **семантическую лестницу уровней** (Бизнес→Пользователь→Функция) и **типологию бизнес-правил** (5 категорий). Это содержательные пробелы, а не дубли. |\n| Где риск «велосипеда»? | Там, где mango переизобрёл понятие, давно формализованное у Вигерса, под другим именем и без сверки — и из-за этого теряется связь с огромным корпусом Вигерс-литературы и инструментов. |\n| Что ломается без синхронизации? | Кросс-ссылки между mango-онтологией и общепринятой Вигерс-терминологией невозможны; пробелы (бизнес-правила) остаются незакрытыми; AI-практики (автопроверка правил) не на что опереть. |\n| Почему именно сейчас? | Issue #247 (Depends On PR #242, #246) — окно: 5-слойная модель и ось доверия E0–E4 уже приняты, на них можно положить сверку. |\n\nВывод: нужен не «переход на Вигерса», а **точечная сверка**: добавить недостающее\n(уровни как ось, бизнес-правила как тип), навести мост там, где терминология\nразошлась (операции), и явно признать обоснованные локализации (ТЗ по ГОСТ вместо\nSRS). Это граница данного RFC.\n\n## Карта сравнения: Вигерс ↔ mango-ADR\n\nСравнение по четырём измерениям Вигерса. Колонка «Класс расхождения»:\n**🔴 велосипед/пробел** · **🟡 нужен мост** · **🟢 обоснованная локализация**.\n\n| Измерение Вигерса | Эквивалент в mango | ADR mango | Класс | Краткий вывод |",
+[2026-06-18T11:44:40.017Z] [INFO]         "is_error": false
+[2026-06-18T11:44:40.017Z] [INFO]       }
+[2026-06-18T11:44:40.017Z] [INFO]     ]
+[2026-06-18T11:44:40.017Z] [INFO]   },
+[2026-06-18T11:44:40.017Z] [INFO]   "parent_tool_use_id": null,
+[2026-06-18T11:44:40.017Z] [INFO]   "session_id": "d65e890a-db60-43f7-aea3-691500f7e26c",
+[2026-06-18T11:44:40.017Z] [INFO]   "uuid": "a6a0e4b4-80c2-4857-a212-7c3f90628c57",
+[2026-06-18T11:44:40.017Z] [INFO]   "timestamp": "2026-06-18T11:44:40.014Z",
+[2026-06-18T11:44:40.017Z] [INFO]   "tool_use_result": {
+[2026-06-18T11:44:40.017Z] [INFO]     "stdout": "  288 governance/rfc/requirements-engineering-ai-era-2026.md\n  437 research/hub/wigers-requirements-analysis-2026-06.md\n  725 total\n===RFC HEAD===\n---\nstatus: draft\nversion: 0.1\nupdated: 2026-06-18\ntemperature: 0.1\n---\n\n# RFC: Requirements Engineering in the AI Era — синхронизация Вигерса и mango-ADR\n\n## Proposal\n\nЗафиксировать результат сравнения **независимо извлечённой системы понятий\nВигерса** (исследование\n[research/hub/wigers-requirements-analysis-2026-06.md](../../research/hub/wigers-requirements-analysis-2026-06.md))\nс действующей онтологией требований проекта `mango_ba_prompts` (ADR #003–#010) и\nпредложить **точечную синхронизацию** там, где mango переизобретает уже устоявшиеся\nу Вигерса понятия («велосипеды») или имеет содержательный пробел.\n\nКонкретно RFC:\n\n1. Сопоставляет четыре измерения Вигерса (уровни / типы / процессы-операции /\n   артефакты) с эквивалентами mango по каждому из релевантных ADR.\n2. Каталогизирует расхождения и **честно разделяет** их на три класса:\n   **(a) настоящий велосипед/пробел**, **(b) нужен мост (alias)**,\n   **(c) обоснованная локализация** (не велосипед).\n3. Предлагает синхронизацию **под реальную операционную боль** (Anti-Inflation,\n   [governance/repo-model.md](../repo-model.md)): какие понятия Вигерса стоит\n   добавить как явную ось/тип, какие — только как crosswalk, какие — оставить как\n   есть.\n\nRFC фиксирует исследование, сравнение и rationale. Любая обязательная норма после\nрешения человека делегируется в active artifact (`standards/`, либо в issue\nпроекта `mango_ba_prompts`) — до этого документ остаётся draft-рекомендацией\n([governance/rfc/README.md](README.md)). RFC **сам по себе не меняет** ни один\nmango-ADR: эти ADR живут в отдельном репозитории и редактируются там.\n\n## Decision Scope\n\n- Это **не** редактирование mango-ADR. ADR #003–#010 находятся в репозитории\n  `mango_ba_prompts` и меняются только через его процесс (issue + PR + ADR). RFC\n  даёт **рекомендации** Хаба, не правки.\n- Это **не** объявление Вигерса обязательным стандартом экосистемы. Вигерс —\n  доверенный источник (Tier 1), его модель используется как **линза сверки**, а не\n  как замена BABOK / ISO 29148 / ГОСТ 34.602, на которых mango построен осознанно.\n- Это **не** ввод AI-трендов как норм. Утверждения AI-эры (§«AI-слой») имеют\n  доверие E1–E2 и статус `Candidate`; они фиксируются как наблюдение, не как\n  стандарт (НФТ Trust & Evidence, [research-memory RFC](research-memory-source-intelligence.md)).\n- Это **не** немедленное создание артефактов в Хабе. Целевые изменения (если\n  приняты) делаются пофазно под боль, а не этим PR.\n- Это **не** замена решений человека. Принятие/отклонение рекомендаций,\n  публикация, синхронизация с mango остаются за Пользователем\n  ([AI_GOVERNANCE.md](../../AI_GOVERNANCE.md), правило 4).\n\n## Почему текущей ситуации недостаточно\n\n**Ключевой факт сверки.** Карл Вигерс — один из самых цитируемых авторов по\nинженерии требований — **не упоминается ни в одном из восьми mango-ADR** (#003–#010)\nи ни в одном связанном стандарте mango. Онтология требований mango построена на\nBABOK Guide v3, ISO/IEC/IEEE 29148:2018, ISO/IEC 25010 и ГОСТ 34.602-2020. Это\n**сознательный и в основном оправданный** выбор (международные + российские\nнормативные стандарты), но он создаёт три риска:\n\n| Вопрос | Ответ |\n| --- | --- |\n| Можно ли обойтись без Вигерса, раз есть BABOK + 29148? | Для большинства слоёв — да. Но Вигерс даёт две вещи, которых в mango нет явно: **семантическую лестницу уровней** (Бизнес→Пользователь→Функция) и **типологию бизнес-правил** (5 категорий). Это содержательные пробелы, а не дубли. |\n| Где риск «велосипеда»? | Там, где mango переизобрёл понятие, давно формализованное у Вигерса, под другим именем и без сверки — и из-за этого теряется связь с огромным корпусом Вигерс-литературы и инструментов. |\n| Что ломается без синхронизации? | Кросс-ссылки между mango-онтологией и общепринятой Вигерс-терминологией невозможны; пробелы (бизнес-правила) остаются незакрытыми; AI-практики (автопроверка правил) не на что опереть. |\n| Почему именно сейчас? | Issue #247 (Depends On PR #242, #246) — окно: 5-слойная модель и ось доверия E0–E4 уже приняты, на них можно положить сверку. |\n\nВывод: нужен не «переход на Вигерса», а **точечная сверка**: добавить недостающее\n(уровни как ось, бизнес-правила как тип), навести мост там, где терминология\nразошлась (операции), и явно признать обоснованные локализации (ТЗ по ГОСТ вместо\nSRS). Это граница данного RFC.\n\n## Карта сравнения: Вигерс ↔ mango-ADR\n\nСравнение по четырём измерениям Вигерса. Колонка «Класс расхождения»:\n**🔴 велосипед/пробел** · **🟡 нужен мост** · **🟢 обоснованная локализация**.\n\n| Измерение Вигерса | Эквивалент в mango | ADR mango | Класс | Краткий вывод |",
+[2026-06-18T11:44:40.017Z] [INFO]     "stderr": "",
+[2026-06-18T11:44:40.017Z] [INFO]     "interrupted": false,
+[2026-06-18T11:44:40.017Z] [INFO]     "isImage": false,
+[2026-06-18T11:44:40.017Z] [INFO]     "noOutputExpected": false
+[2026-06-18T11:44:40.017Z] [INFO]   }
+[2026-06-18T11:44:40.017Z] [INFO] }
+[2026-06-18T11:44:40.031Z] [INFO] [log_a5b91a] sending request {
+[2026-06-18T11:44:40.032Z] [INFO]   method: "post",
+[2026-06-18T11:44:40.033Z] [INFO]   url: "https://api.anthropic.com/v1/messages?beta=true",
+[2026-06-18T11:44:40.033Z] [INFO]   options: {
+[2026-06-18T11:44:40.034Z] [INFO]     method: "post",
+[2026-06-18T11:44:40.034Z] [INFO]     path: "/v1/messages?beta=true",
+[2026-06-18T11:44:40.034Z] [INFO]     body: {
+[2026-06-18T11:44:40.035Z] [INFO]       model: "claude-opus-4-8",
+[2026-06-18T11:44:40.035Z] [INFO]       messages: [
+[2026-06-18T11:44:40.035Z] [INFO]         [Object ...], [Object ...], [Object ...], [Object ...], [Object ...], [Object ...], [Object ...], [Object ...], [Object ...], [Object ...], [Object ...], [Object ...]
+[2026-06-18T11:44:40.035Z] [INFO]       ],
+[2026-06-18T11:44:40.036Z] [INFO]       system: [
+[2026-06-18T11:44:40.036Z] [INFO]         [Object ...], [Object ...], [Object ...], [Object ...]
+[2026-06-18T11:44:40.036Z] [INFO]       ],
+[2026-06-18T11:44:40.036Z] [INFO]       tools: [
+[2026-06-18T11:44:40.037Z] [INFO]         [Object ...], [Object ...], [Object ...], [Object ...], [Object ...], [Object ...], [Object ...], [Object ...]
+[2026-06-18T11:44:40.037Z] [INFO]       ],
+[2026-06-18T11:44:40.037Z] [INFO]       tool_choice: undefined,
+[2026-06-18T11:44:40.038Z] [INFO]       metadata: [Object ...],
+[2026-06-18T11:44:40.038Z] [INFO]       max_tokens: 128000,
+[2026-06-18T11:44:40.039Z] [INFO]       thinking: [Object ...],
+[2026-06-18T11:44:40.040Z] [INFO]       context_management: [Object ...],
+[2026-06-18T11:44:40.041Z] [INFO]       output_config: [Object ...],
+[2026-06-18T11:44:40.042Z] [INFO]       diagnostics: [Object ...],
+[2026-06-18T11:44:40.042Z] [INFO]       stream: true,
+[2026-06-18T11:44:40.042Z] [INFO]     },
+[2026-06-18T11:44:40.043Z] [INFO]     timeout: 600000,
+[2026-06-18T11:44:40.043Z] [INFO]     signal: AbortSignal {
+[2026-06-18T11:44:40.043Z] [INFO]       [Symbol(events.maxEventTargetListeners)]: 50,
+[2026-06-18T11:44:40.043Z] [INFO]       [Symbol(events.maxEventTargetListenersWarned)]: false,
+[2026-06-18T11:44:40.043Z] [INFO]       aborted: false,
+[2026-06-18T11:44:40.044Z] [INFO]       reason: undefined,
+[2026-06-18T11:44:40.044Z] [INFO]       onabort: null,
+[2026-06-18T11:44:40.045Z] [INFO]       throwIfAborted: [Function: throwIfAborted],
+[2026-06-18T11:44:40.045Z] [INFO]       addEventListener: [Function: addEventListener],
+[2026-06-18T11:44:40.046Z] [INFO]       removeEventListener: [Function: removeEventListener],
+[2026-06-18T11:44:40.047Z] [INFO]       dispatchEvent: [Function: dispatchEvent],
+[2026-06-18T11:44:40.047Z] [INFO]     },
+[2026-06-18T11:44:40.048Z] [INFO]     stream: true,
+[2026-06-18T11:44:40.049Z] [INFO]   },
+[2026-06-18T11:44:40.049Z] [INFO]   headers: {
+[2026-06-18T11:44:40.049Z] [INFO]     accept: "application/json",
+[2026-06-18T11:44:40.050Z] [INFO]     "anthropic-beta": "claude-code-20250219,oauth-2025-04-20,interleaved-thinking-2025-05-14,thinking-token-count-2026-05-13,context-management-2025-06-27,prompt-caching-scope-2026-01-05,mid-conversation-system-2026-04-07,advisor-tool-2026-03-01,advanced-tool-use-2025-11-20,effort-2025-11-24,extended-cache-ttl-2025-04-11,cache-diagnosis-2026-04-07",
+[2026-06-18T11:44:40.051Z] [INFO]     "anthropic-dangerous-direct-browser-access": "true",
+[2026-06-18T11:44:40.051Z] [INFO]     "anthropic-version": "2023-06-01",
+[2026-06-18T11:44:40.052Z] [INFO]     authorization: "***",
+[2026-06-18T11:44:40.052Z] [INFO]     "content-type": "application/json",
+[2026-06-18T11:44:40.052Z] [INFO]     "user-agent": "claude-cli/2.1.181 (external, sdk-cli)",
+[2026-06-18T11:44:40.052Z] [INFO]     "x-app": "cli",
+[2026-06-18T11:44:40.053Z] [INFO]     "x-claude-code-session-id": "d65e890a-db60-43f7-aea3-691500f7e26c",
+[2026-06-18T11:44:40.054Z] [INFO]     "x-client-request-id": "644f7029-28e5-48c1-a18d-9274020e9a74",
+[2026-06-18T11:44:40.055Z] [INFO]     "x-stainless-arch": "x64",
+[2026-06-18T11:44:40.055Z] [INFO]     "x-stainless-lang": "js",
+[2026-06-18T11:44:40.055Z] [INFO]     "x-stainless-os": "Linux",
+[2026-06-18T11:44:40.055Z] [INFO]     "x-stainless-package-version": "0.94.0",
+[2026-06-18T11:44:40.056Z] [INFO]     "x-stainless-retry-count": "0",
+[2026-06-18T11:44:40.056Z] [INFO]     "x-stainless-runtime": "node",
+[2026-06-18T11:44:40.057Z] [INFO]     "x-stainless-runtime-version": "v24.3.0",
+[2026-06-18T11:44:40.057Z] [INFO]     "x-stainless-timeout": "600",
+[2026-06-18T11:44:40.057Z] [INFO]   },
+[2026-06-18T11:44:40.057Z] [INFO] }
+[2026-06-18T11:44:41.877Z] [INFO] [log_a5b91a, request-id: "req_011CcAfgdsnovwA4UjBMXM7w"] post https://api.anthropic.com/v1/messages?beta=true succeeded with status 200 in 1845ms
+[2026-06-18T11:44:41.878Z] [INFO] [log_a5b91a] response start {
+[2026-06-18T11:44:41.878Z] [INFO]   url: "https://api.anthropic.com/v1/messages?beta=true",
+[2026-06-18T11:44:41.879Z] [INFO]   status: 200,
+[2026-06-18T11:44:41.879Z] [INFO]   headers: {
+[2026-06-18T11:44:41.879Z] [INFO]     "anthropic-organization-id": "ebc2ac93-f86f-4d15-aff3-de8830d8d789",
+[2026-06-18T11:44:41.879Z] [INFO]     "anthropic-ratelimit-unified-5h-reset": "1781787000",
+[2026-06-18T11:44:41.880Z] [INFO]     "anthropic-ratelimit-unified-5h-status": "allowed",
+[2026-06-18T11:44:41.880Z] [INFO]     "anthropic-ratelimit-unified-5h-utilization": "0.33",
+[2026-06-18T11:44:41.880Z] [INFO]     "anthropic-ratelimit-unified-7d-reset": "1782212400",
+[2026-06-18T11:44:41.881Z] [INFO]     "anthropic-ratelimit-unified-7d-status": "allowed",
+[2026-06-18T11:44:41.883Z] [INFO]     "anthropic-ratelimit-unified-7d-utilization": "0.62",
+[2026-06-18T11:44:41.883Z] [INFO]     "anthropic-ratelimit-unified-fallback-percentage": "0.5",
+[2026-06-18T11:44:41.884Z] [INFO]     "anthropic-ratelimit-unified-overage-disabled-reason": "org_level_disabled",
+[2026-06-18T11:44:41.884Z] [INFO]     "anthropic-ratelimit-unified-overage-status": "rejected",
+[2026-06-18T11:44:41.884Z] [INFO]     "anthropic-ratelimit-unified-representative-claim": "five_hour",
+[2026-06-18T11:44:41.885Z] [INFO]     "anthropic-ratelimit-unified-reset": "1781787000",
+[2026-06-18T11:44:41.885Z] [INFO]     "anthropic-ratelimit-unified-status": "allowed",
+[2026-06-18T11:44:41.885Z] [INFO]     "cache-control": "no-cache",
+[2026-06-18T11:44:41.886Z] [INFO]     "cf-cache-status": "DYNAMIC",
+[2026-06-18T11:44:41.886Z] [INFO]     "cf-ray": "a0da0b1a3d09d295-FRA",
+[2026-06-18T11:44:41.886Z] [INFO]     connection: "keep-alive",
+[2026-06-18T11:44:41.887Z] [INFO]     "content-encoding": "gzip",
+[2026-06-18T11:44:41.888Z] [INFO]     "content-security-policy": "default-src 'none'; frame-ancestors 'none'",
+[2026-06-18T11:44:41.888Z] [INFO]     "content-type": "text/event-stream; charset=utf-8",
+[2026-06-18T11:44:41.889Z] [INFO]     date: "Thu, 18 Jun 2026 11:44:41 GMT",
+[2026-06-18T11:44:41.889Z] [INFO]     "request-id": "req_011CcAfgdsnovwA4UjBMXM7w",
+[2026-06-18T11:44:41.889Z] [INFO]     server: "cloudflare",
+[2026-06-18T11:44:41.890Z] [INFO]     "strict-transport-security": "max-age=31536000; includeSubDomains; preload",
+[2026-06-18T11:44:41.890Z] [INFO]     traceresponse: "00-3c95c695450064ce6e532d0a7b93c6f0-ab8c831fe3acbdde-01",
+[2026-06-18T11:44:41.890Z] [INFO]     "transfer-encoding": "chunked",
+[2026-06-18T11:44:41.890Z] [INFO]     vary: "Accept-Encoding",
+[2026-06-18T11:44:41.890Z] [INFO]     "x-robots-tag": "none",
+[2026-06-18T11:44:41.891Z] [INFO]     "set-cookie": "***",
+[2026-06-18T11:44:41.891Z] [INFO]   },
+[2026-06-18T11:44:41.891Z] [INFO]   durationMs: 1845,
+[2026-06-18T11:44:41.891Z] [INFO] }
+[2026-06-18T11:44:41.891Z] [INFO] response 200 https://api.anthropic.com/v1/messages?beta=true Headers {
+[2026-06-18T11:44:41.891Z] [INFO]   "date": "Thu, 18 Jun 2026 11:44:41 GMT",
+[2026-06-18T11:44:41.892Z] [INFO]   "content-type": "text/event-stream; charset=utf-8",
+[2026-06-18T11:44:41.892Z] [INFO]   "transfer-encoding": "chunked",
+[2026-06-18T11:44:41.892Z] [INFO]   "connection": "keep-alive",
+[2026-06-18T11:44:41.892Z] [INFO]   "cache-control": "no-cache",
+[2026-06-18T11:44:41.893Z] [INFO]   "strict-transport-security": "max-age=31536000; includeSubDomains; preload",
+[2026-06-18T11:44:41.893Z] [INFO]   "content-encoding": "gzip",
+[2026-06-18T11:44:41.893Z] [INFO]   "vary": "Accept-Encoding",
+[2026-06-18T11:44:41.893Z] [INFO]   "content-security-policy": "default-src 'none'; frame-ancestors 'none'",
+[2026-06-18T11:44:41.893Z] [INFO]   "set-cookie": [ "_cfuvid=ICWS3DgNndVtTzTqtQP2bAMaPWRHbzJRCX_E1K33pgY-1781783080.0417278-1.0.1.1-DwblJK9L2y2ZAl9eiNbxj7bEa4OjeJhxiCc1wGeer78; HttpOnly; SameSite=None; Secure; Path=/; Domain=api.anthropic.com" ],
+[2026-06-18T11:44:41.894Z] [INFO]   "anthropic-ratelimit-unified-status": "allowed",
+[2026-06-18T11:44:41.894Z] [INFO]   "anthropic-ratelimit-unified-5h-status": "allowed",
+[2026-06-18T11:44:41.894Z] [INFO]   "anthropic-ratelimit-unified-5h-reset": "1781787000",
+[2026-06-18T11:44:41.895Z] [INFO]   "anthropic-ratelimit-unified-5h-utilization": "0.33",
+[2026-06-18T11:44:41.895Z] [INFO]   "anthropic-ratelimit-unified-7d-status": "allowed",
+[2026-06-18T11:44:41.895Z] [INFO]   "anthropic-ratelimit-unified-7d-reset": "1782212400",
+[2026-06-18T11:44:41.895Z] [INFO]   "anthropic-ratelimit-unified-7d-utilization": "0.62",
+[2026-06-18T11:44:41.895Z] [INFO]   "anthropic-ratelimit-unified-representative-claim": "five_hour",
+[2026-06-18T11:44:41.895Z] [INFO]   "anthropic-ratelimit-unified-fallback-percentage": "0.5",
+[2026-06-18T11:44:41.895Z] [INFO]   "anthropic-ratelimit-unified-reset": "1781787000",
+[2026-06-18T11:44:41.896Z] [INFO]   "anthropic-ratelimit-unified-overage-disabled-reason": "org_level_disabled",
+[2026-06-18T11:44:41.896Z] [INFO]   "anthropic-ratelimit-unified-overage-status": "rejected",
+[2026-06-18T11:44:41.896Z] [INFO]   "request-id": "req_011CcAfgdsnovwA4UjBMXM7w",
+[2026-06-18T11:44:41.896Z] [INFO]   "anthropic-organization-id": "ebc2ac93-f86f-4d15-aff3-de8830d8d789",
+[2026-06-18T11:44:41.898Z] [INFO]   "traceresponse": "00-3c95c695450064ce6e532d0a7b93c6f0-ab8c831fe3acbdde-01",
+[2026-06-18T11:44:41.898Z] [INFO]   "server": "cloudflare",
+[2026-06-18T11:44:41.899Z] [INFO]   "x-robots-tag": "none",
+[2026-06-18T11:44:41.899Z] [INFO]   "cf-cache-status": "DYNAMIC",
+[2026-06-18T11:44:41.899Z] [INFO]   "cf-ray": "a0da0b1a3d09d295-FRA",
+[2026-06-18T11:44:41.899Z] [INFO] } ReadableStream {
+[2026-06-18T11:44:41.900Z] [INFO]   blob: [Function: blob],
+[2026-06-18T11:44:41.900Z] [INFO]   bytes: [Function: bytes],
+[2026-06-18T11:44:41.901Z] [INFO]   cancel: [Function],
+[2026-06-18T11:44:41.901Z] [INFO]   getReader: [Function],
+[2026-06-18T11:44:41.901Z] [INFO]   json: [Function: json],
+[2026-06-18T11:44:41.901Z] [INFO]   locked: [Getter],
+[2026-06-18T11:44:41.902Z] [INFO]   pipeThrough: [Function],
+[2026-06-18T11:44:41.902Z] [INFO]   pipeTo: [Function],
+[2026-06-18T11:44:41.902Z] [INFO]   tee: [Function],
+[2026-06-18T11:44:41.902Z] [INFO]   text: [Function: text],
+[2026-06-18T11:44:41.903Z] [INFO]   values: [Function: values],
+[2026-06-18T11:44:41.903Z] [INFO]   [Symbol(Symbol.asyncIterator)]: [Function: asyncIterator2],
+[2026-06-18T11:44:41.903Z] [INFO] }
+[2026-06-18T11:44:41.903Z] [INFO] [log_a5b91a] response parsed {
+[2026-06-18T11:44:41.903Z] [INFO]   url: "https://api.anthropic.com/v1/messages?beta=true",
+[2026-06-18T11:44:41.904Z] [INFO]   status: 200,
+[2026-06-18T11:44:41.904Z] [INFO]   body: sU {
+[2026-06-18T11:44:41.904Z] [INFO]     iterator: [AsyncGeneratorFunction: s],
+[2026-06-18T11:44:41.904Z] [INFO]     controller: AbortController {
+[2026-06-18T11:44:41.904Z] [INFO]       signal: [AbortSignal ...],
+[2026-06-18T11:44:41.905Z] [INFO]       abort: [Function: abort],
+[2026-06-18T11:44:41.906Z] [INFO]     },
+[2026-06-18T11:44:41.907Z] [INFO]     [Symbol(Symbol.asyncIterator)]: [Function],
+[2026-06-18T11:44:41.907Z] [INFO]     tee: [Function: tee],
+[2026-06-18T11:44:41.907Z] [INFO]     toReadableStream: [Function: toReadableStream],
+[2026-06-18T11:44:41.908Z] [INFO]   },
+[2026-06-18T11:44:41.908Z] [INFO]   durationMs: 1846,
+[2026-06-18T11:44:41.908Z] [INFO] }
+[2026-06-18T11:44:43.288Z] [INFO] {
+[2026-06-18T11:44:43.288Z] [INFO]   "type": "assistant",
+[2026-06-18T11:44:43.288Z] [INFO]   "message": {
+[2026-06-18T11:44:43.288Z] [INFO]     "model": "claude-opus-4-8",
+[2026-06-18T11:44:43.288Z] [INFO]     "id": "msg_01QRVJRzhWrvJCihuBudc9DT",
+[2026-06-18T11:44:43.288Z] [INFO]     "type": "message",
+[2026-06-18T11:44:43.288Z] [INFO]     "role": "assistant",
+[2026-06-18T11:44:43.288Z] [INFO]     "content": [
+[2026-06-18T11:44:43.288Z] [INFO]       {
+[2026-06-18T11:44:43.288Z] [INFO]         "type": "thinking",
+[2026-06-18T11:44:43.288Z] [INFO]         "thinking": "",
+[2026-06-18T11:44:43.288Z] [INFO]         "signature": "EoADCmMIDhgCKkCgCnmQykygp92ibO2a8JC9fOXJ23qUroDafLoDV6kZArYjrCVwaMU0zaF3o66uvWKKM/54LPUilMSeJWnJgr8QMg9jbGF1ZGUtb3B1cy00LTg4AEIIdGhpbmtpbmcSDMu35d1CfWLGZr+QGBoMYHUmOnZQX2dsy7JiIjBe71d+yU8VEXhTzosXqNQmX3DE9eM7DycUrmAXeq0ZC6MNx4Oo8iHZwzU7TbJe/VAqygHtbYfsC3jXrbIE2I3K8kYkyF5X9pIu9tWRI4K0Cve4cmfPliRDNY/7AwnnJGRvN/+qE3Tq04PpCdRfOpzMTyexaveuf0OUiwuO90Xnh+qqxLqXaBJoTUAXN4w1FRIgP0ksM2k75uGMBtXHfE9aGGZQP8w3eB72t36zPkR5C1iJwxeswvomLEbS+vmjk918CzmhdUouDZKlvP/S1krGsL9ZX/xcJt6rLdGyGCMmRWQu4ZHjjQzDSI0KzWkgZcgkttkVGwoRh9nzVwAWGAE="
+[2026-06-18T11:44:43.288Z] [INFO]       }
+[2026-06-18T11:44:43.288Z] [INFO]     ],
+[2026-06-18T11:44:43.288Z] [INFO]     "stop_reason": null,
+[2026-06-18T11:44:43.288Z] [INFO]     "stop_sequence": null,
+[2026-06-18T11:44:43.288Z] [INFO]     "stop_details": null,
+[2026-06-18T11:44:43.288Z] [INFO]     "usage": {
+[2026-06-18T11:44:43.288Z] [INFO]       "input_tokens": 131,
+[2026-06-18T11:44:43.288Z] [INFO]       "cache_creation_input_tokens": 2491,
+[2026-06-18T11:44:43.288Z] [INFO]       "cache_read_input_tokens": 38860,
+[2026-06-18T11:44:43.288Z] [INFO]       "cache_creation": {
+[2026-06-18T11:44:43.288Z] [INFO]         "ephemeral_5m_input_tokens": 0,
+[2026-06-18T11:44:43.288Z] [INFO]         "ephemeral_1h_input_tokens": 2491
+[2026-06-18T11:44:43.288Z] [INFO]       },
+[2026-06-18T11:44:43.288Z] [INFO]       "output_tokens": 5,
+[2026-06-18T11:44:43.288Z] [INFO]       "service_tier": "standard",
+[2026-06-18T11:44:43.288Z] [INFO]       "inference_geo": "not_available"
+[2026-06-18T11:44:43.288Z] [INFO]     },
+[2026-06-18T11:44:43.288Z] [INFO]     "diagnostics": null,
+[2026-06-18T11:44:43.288Z] [INFO]     "context_management": null
+[2026-06-18T11:44:43.288Z] [INFO]   },
+[2026-06-18T11:44:43.288Z] [INFO]   "parent_tool_use_id": null,
+[2026-06-18T11:44:43.288Z] [INFO]   "session_id": "d65e890a-db60-43f7-aea3-691500f7e26c",
+[2026-06-18T11:44:43.288Z] [INFO]   "uuid": "e4f32fe7-e287-44ca-9923-45633f617082",
+[2026-06-18T11:44:43.288Z] [INFO]   "request_id": "req_011CcAfgdsnovwA4UjBMXM7w"
+[2026-06-18T11:44:43.288Z] [INFO] }
+[2026-06-18T11:44:44.051Z] [INFO] {
+[2026-06-18T11:44:44.051Z] [INFO]   "type": "assistant",
+[2026-06-18T11:44:44.051Z] [INFO]   "message": {
+[2026-06-18T11:44:44.051Z] [INFO]     "model": "claude-opus-4-8",
+[2026-06-18T11:44:44.051Z] [INFO]     "id": "msg_01QRVJRzhWrvJCihuBudc9DT",
+[2026-06-18T11:44:44.051Z] [INFO]     "type": "message",
+[2026-06-18T11:44:44.051Z] [INFO]     "role": "assistant",
+[2026-06-18T11:44:44.051Z] [INFO]     "content": [
+[2026-06-18T11:44:44.051Z] [INFO]       {
+[2026-06-18T11:44:44.051Z] [INFO]         "type": "tool_use",
+[2026-06-18T11:44:44.051Z] [INFO]         "id": "toolu_016eJZ2RPWUnMSW4CH1wBcBA",
+[2026-06-18T11:44:44.051Z] [INFO]         "name": "Bash",
+[2026-06-18T11:44:44.051Z] [INFO]         "input": {
+[2026-06-18T11:44:44.051Z] [INFO]           "command": "sed -n '80,288p' governance/rfc/requirements-engineering-ai-era-2026.md",
+[2026-06-18T11:44:44.051Z] [INFO]           "description": "Read rest of RFC"
+[2026-06-18T11:44:44.051Z] [INFO]         },
+[2026-06-18T11:44:44.051Z] [INFO]         "caller": {
+[2026-06-18T11:44:44.051Z] [INFO]           "type": "direct"
+[2026-06-18T11:44:44.051Z] [INFO]         }
+[2026-06-18T11:44:44.051Z] [INFO]       }
+[2026-06-18T11:44:44.051Z] [INFO]     ],
+[2026-06-18T11:44:44.051Z] [INFO]     "stop_reason": null,
+[2026-06-18T11:44:44.051Z] [INFO]     "stop_sequence": null,
+[2026-06-18T11:44:44.051Z] [INFO]     "stop_details": null,
+[2026-06-18T11:44:44.051Z] [INFO]     "usage": {
+[2026-06-18T11:44:44.051Z] [INFO]       "input_tokens": 131,
+[2026-06-18T11:44:44.051Z] [INFO]       "cache_creation_input_tokens": 2491,
+[2026-06-18T11:44:44.051Z] [INFO]       "cache_read_input_tokens": 38860,
+[2026-06-18T11:44:44.051Z] [INFO]       "cache_creation": {
+[2026-06-18T11:44:44.051Z] [INFO]         "ephemeral_5m_input_tokens": 0,
+[2026-06-18T11:44:44.051Z] [INFO]         "ephemeral_1h_input_tokens": 2491
+[2026-06-18T11:44:44.051Z] [INFO]       },
+[2026-06-18T11:44:44.051Z] [INFO]       "output_tokens": 5,
+[2026-06-18T11:44:44.051Z] [INFO]       "service_tier": "standard",
+[2026-06-18T11:44:44.051Z] [INFO]       "inference_geo": "not_available"
+[2026-06-18T11:44:44.051Z] [INFO]     },
+[2026-06-18T11:44:44.051Z] [INFO]     "diagnostics": null,
+[2026-06-18T11:44:44.051Z] [INFO]     "context_management": null
+[2026-06-18T11:44:44.051Z] [INFO]   },
+[2026-06-18T11:44:44.051Z] [INFO]   "parent_tool_use_id": null,
+[2026-06-18T11:44:44.051Z] [INFO]   "session_id": "d65e890a-db60-43f7-aea3-691500f7e26c",
+[2026-06-18T11:44:44.051Z] [INFO]   "uuid": "ffeeffc6-67d6-42b7-a63e-e0fe25e30216",
+[2026-06-18T11:44:44.051Z] [INFO]   "request_id": "req_011CcAfgdsnovwA4UjBMXM7w"
+[2026-06-18T11:44:44.051Z] [INFO] }
+[2026-06-18T11:44:45.337Z] [INFO] {
+[2026-06-18T11:44:45.337Z] [INFO]   "type": "user",
+[2026-06-18T11:44:45.337Z] [INFO]   "message": {
+[2026-06-18T11:44:45.337Z] [INFO]     "role": "user",
+[2026-06-18T11:44:45.337Z] [INFO]     "content": [
+[2026-06-18T11:44:45.337Z] [INFO]       {
+[2026-06-18T11:44:45.337Z] [INFO]         "tool_use_id": "toolu_016eJZ2RPWUnMSW4CH1wBcBA",
+[2026-06-18T11:44:45.337Z] [INFO]         "type": "tool_result",
+[2026-06-18T11:44:45.337Z] [INFO]         "content": "| Измерение Вигерса | Эквивалент в mango | ADR mango | Класс | Краткий вывод |\n| --- | --- | --- | --- | --- |\n| **Уровни** Бизнес→Пользователь→Функция (+НФТ) | `Domain→Capability→Feature→Atomic Function` (классификация функциональности) + дерево `BCREQ-NNN.k.m` | [ADR-003](https://github.com/G-Ivan-A/mango_ba_prompts/blob/main/docs/adr/003-ba-ontology.md), [ADR-009](https://github.com/G-Ivan-A/mango_ba_prompts/blob/main/docs/adr/009-bcreq-formation-process.md) | 🔴 | Декомпозиция функциональности ≠ семантическая лестница уровней требования. |\n| **Типы:** Функция / Качество / Ограничение / **Бизнес-правило** | Реестр из 30 артефактов + классификация; качество = ISO 25010; ограничения = «Раздел 6» | [ADR-003](https://github.com/G-Ivan-A/mango_ba_prompts/blob/main/docs/adr/003-ba-ontology.md), [ADR-004](https://github.com/G-Ivan-A/mango_ba_prompts/blob/main/docs/adr/004-operations-taxonomy.md) | 🔴 | **Бизнес-правило как тип (и его 5-категорийная таксономия) отсутствует** в реестре. |\n| **Процессы:** Выявление / Анализ / Спецификация / Проверка + Управление | 13 операций → 6 областей знаний BABOK; конвейер BCREQ П1–П6 | [ADR-004](https://github.com/G-Ivan-A/mango_ba_prompts/blob/main/docs/adr/004-operations-taxonomy.md), [ADR-009](https://github.com/G-Ivan-A/mango_ba_prompts/blob/main/docs/adr/009-bcreq-formation-process.md) | 🟡 | BABOK-операции легитимны и детальнее; нет только crosswalk к Вигерсу. |\n| **Словарь** (Прил. А) | Глоссарий задачи на базе BABOK Glossary + IREB CPRE | [ADR-003](https://github.com/G-Ivan-A/mango_ba_prompts/blob/main/docs/adr/003-ba-ontology.md) (артефакт 7) | 🟢/🟡 | Источники разные; нужна сверка терминов, где определения расходятся. |\n| **SRS** (шаблон, наследие IEEE-830) | ТЗ по ГОСТ 34.602-2020 (артефакт 19), ФТ КК (18) | [ADR-003](https://github.com/G-Ivan-A/mango_ba_prompts/blob/main/docs/adr/003-ba-ontology.md) | 🟢 | Локализация под РФ-рынок оправдана; не велосипед, но можно обогатить. |\n| **Триада** Процесс→Операция→Артефакт | Триада **Операция→Процесс→Артефакт**, расширенная в граф | [ADR-003](https://github.com/G-Ivan-A/mango_ba_prompts/blob/main/docs/adr/003-ba-ontology.md) | 🟢 | Совпадает по сути; направление ребра — деталь нотации. |\n\n## Каталог «велосипедов» и пробелов\n\n### В1 — Уровни требований: декомпозиция функциональности подменяет семантику (🔴)\n\n**Что у Вигерса.** Три уровня — **Бизнес → Пользователь → Функция** — отвечают на\n«зачем → кто/что → как» и образуют **семантическую** лестницу намерения, по которой\nстроится трассировка вверх (функция → бизнес-цель).\n\n**Что в mango.** Две разные конструкции, ни одна из которых не равна лестнице\nуровней:\n\n- `Domain → Capability → Feature → Atomic Function`\n  ([ADR-003](https://github.com/G-Ivan-A/mango_ba_prompts/blob/main/docs/adr/003-ba-ontology.md),\n  классификация функциональности) — это декомпозиция **того, что продукт умеет**, а\n  не уровней требования. Уровни «зачем/кто/как» в ней не выражены.\n- Дерево `BCREQ-NNN.k.m`\n  ([ADR-009](https://github.com/G-Ivan-A/mango_ba_prompts/blob/main/docs/adr/009-bcreq-formation-process.md))\n  — это **структурная глубина** декомпозиции одного требования, тоже не семантика\n  уровня.\n- BABOK даёт лишь дихотомию «требование vs дизайн» (2 градации), а не 3-уровневую\n  лестницу Бизнес/Пользователь/Функция.\n\n**Почему это велосипед/пробел.** Семантика уровней решена неявно и частично, через\nдва других механизма. Из-за этого нельзя однозначно ответить «это бизнес- или\nпользовательское требование», и теряется связь с трассировкой Вигерса.\n\n**Предложение (С1).** Ввести уровень Вигерса как **отдельную ортогональную ось-тег**\n(`requirement_level ∈ {business, user, functional, non-functional}`) поверх\nсуществующей классификации функциональности — **не заменяя** `Domain→…→Atomic\nFunction`. Это даёт семантику без сноса принятой модели (по образцу того, как\n[methodology RFC](methodology-research-and-proposals.md) ввёл ось E0–E4\nортогонально Knowledge Status).\n\n### В2 — Бизнес-правила как тип отсутствуют (🔴, главный пробел)\n\n**Что у Вигерса.** **Бизнес-правило** — самостоятельный тип требования (Гл. 9) с\nтаксономией из 5 категорий: **Факты / Ограничения / Активаторы операций / Выводы /\nВычисления**. Это внешняя норма (политика, закон, формула), которой система обязана\nсоответствовать.\n\n**Что в mango.** В реестре из 30 артефактов\n([ADR-003](https://github.com/G-Ivan-A/mango_ba_prompts/blob/main/docs/adr/003-ba-ontology.md),\n§5) **нет** артефакта `business-rule` и нет эквивалента 5-категорийной таксономии.\nОграничения присутствуют как «Раздел 6» документа, но слиты с НФТ; правила-факты,\nактиваторы, выводы и вычисления отдельно не выделены.\n\n**Почему это важно именно в AI-эру.** Бизнес-правила — **первый кандидат на\nформализацию и автоматическую проверку** ИИ (consistency checking, см. AI-слой\nниже). Без явного типа эту опору не на что положить.\n\n**Предложение (С2).** Добавить в реестр mango тип-артефакт **«Бизнес-правило»** с\n5-категорийной классификацией Вигерса и связью «бизнес-правило → порождает →\nфункцию/ограничение». Это закрытие пробела, а не дубль.\n\n### В3 — Процессы/операции: нужен мост, а не замена (🟡)\n\n**Что у Вигерса.** Разработка требований = **Выявление / Анализ / Спецификация /\nПроверка**, плюс сквозное **Управление требованиями**. Чистая модель 4+1.\n\n**Что в mango.** 13 когнитивных операций, размеченных по 6 областям знаний BABOK\n([ADR-004](https://github.com/G-Ivan-A/mango_ba_prompts/blob/main/docs/adr/004-operations-taxonomy.md)),\nи конвейер BCREQ из 6 подпроцессов\n([ADR-009](https://github.com/G-Ivan-A/mango_ba_prompts/blob/main/docs/adr/009-bcreq-formation-process.md)).\n\n**Почему это НЕ велосипед.** BABOK — легитимный, более гранулярный фреймворк;\nоперации mango покрывают ту же работу детальнее. Проблема лишь в **отсутствии\ncrosswalk**: без него огромный корпус Вигерс-литературы и шаблонов не\nкросс-ссылается на mango.\n\n**Предложение (С3).** Зафиксировать **alias-crosswalk** (без переименований в\nmango — НФТ совместимости mango):\n\n| Процесс Вигерса | Операции mango (ADR-004) | Подпроцесс BCREQ (ADR-009) |\n| --- | --- | --- |\n| Выявление / Elicitation | `ingestion`, `understanding` | П1 |\n| Анализ / Analysis | `modeling`, `research`, `impact_analysis`, `reverse_requirements` | П2, П3 |\n| Спецификация / Specification | `documentation`, `solution_design` | П4 |\n| Проверка / Validation | `validation`, `quality` | П5 |\n| Управление / Management | `governance`, `release_readiness`, `risk_analysis` | П6 |\n\n### В4 — Словарь: разные источники, нужна точечная сверка (🟢/🟡)\n\nГлоссарий mango опирается на BABOK Glossary + IREB CPRE\n([ADR-003](https://github.com/G-Ivan-A/mango_ba_prompts/blob/main/docs/adr/003-ba-ontology.md),\nартефакт 7), словарь Вигерса (Прил. А) — отдельный источник. Это не дубль, но\nопределения местами расходятся (например, «фича/feature» у Вигерса = набор связанных\nфункциональных требований). **Предложение (С4):** при работе над опциональной ФТ-6\n([standards/glossary.md](../../standards/glossary.md)) добавлять термин Вигерса с\nявной пометкой расхождения, если оно есть; не дублировать там, где определения\nсовпадают (Anti-Inflation).\n\n### В5 — SRS vs ТЗ: обоснованная локализация (🟢)\n\nКомплексный документ требований mango — **ТЗ по ГОСТ 34.602-2020** (артефакт 19),\nа не SRS Вигерса (наследие IEEE-830). Это **сознательная локализация** под\nРФ-рынок, не велосипед. **Предложение (С5, опционально):** составить маппинг\nсекций SRS Вигерса (Гл. 10) на разделы ГОСТ ТЗ, чтобы выявить, не теряются ли в ТЗ\nсильные стороны SRS (например, систематизация атрибутов качества) — но **не**\nнавязывать SRS.\n\n## AI-слой: где синхронизация открывает новые возможности\n\nАктуализация на тренд **AI-2026** (детально — в §3.3.3 исследования). Каждое\nутверждение размечено доверием; **ничего из E1–E2 не вносится как стандарт**\n(НФТ Trust & Evidence).\n\n| AI-практика | На что опирается после синхронизации | Доверие |\n| --- | --- | --- |\n| Автоматическая проверка согласованности требований | Профиль аудита mango (9+5 характеристик ISO 29148, [ADR-004](https://github.com/G-Ivan-A/mango_ba_prompts/blob/main/docs/adr/004-operations-taxonomy.md)) + явные **бизнес-правила** (С2) как формализуемая опора. | E2 (Candidate) |\n| AI-трассировка (требование↔код↔тест) | Граф mango (ребро `трассируется`) + ось уровней Вигерса (С1) для трассировки вверх к бизнес-цели. | E1–E2 (Candidate) |\n| AI-ассистированное выявление (суммаризация интервью, черновики US) | Операции `ingestion`/`understanding` + crosswalk «Выявление» (С3). | E1–E2 (Candidate) |\n| **Prompt engineering как новый тип требования** к AI-компоненту | Расширение типологии (В2-подход), но как `Candidate`, не как канон. | E1 (Candidate) |\n\n> 🔒 **Дисциплина доверия.** AI-практики — кандидаты уровня E1–E2. Синхронизация\n> (С1, С2, С3) **создаёт опору** для них, но сами практики становятся нормой только\n> после воспроизводимого подтверждения (Knowledge Status `Candidate` → `Applied`).\n\n## Предложение по синхронизации (сводка)\n\n| # | Рекомендация | Класс | Куда фиксируется | Боль, которую закрывает |\n| --- | --- | --- | --- | --- |\n| С1 | Ось-тег `requirement_level` (Бизнес/Пользователь/Функция/НФТ) поверх классификации функциональности. | 🔴 | issue в `mango_ba_prompts` → ADR-003/стандарт онтологии | Нельзя однозначно определить уровень требования; нет трассировки вверх по Вигерсу. |\n| С2 | Тип-артефакт **«Бизнес-правило»** + 5-категорийная таксономия. | 🔴 | issue в `mango_ba_prompts` → реестр артефактов ADR-003 | Нет опоры для автопроверки правил ИИ; пробел в типологии. |\n| С3 | Alias-crosswalk Вигерс ↔ операции mango ↔ BCREQ (без переименований). | 🟡 | этот RFC (таблица В3) + опц. примечание в таксономии mango | Нет кросс-ссылок с Вигерс-литературой. |\n| С4 | Сверка терминов Вигерса в глоссарии при расхождении определений. | 🟢/🟡 | [standards/glossary.md](../../standards/glossary.md) (ФТ-6, опц.) | Тихие расхождения в терминологии. |\n| С5 | Маппинг секций SRS → разделы ГОСТ ТЗ (диагностика, не замена). | 🟢 | опц. issue/исследование | Возможная потеря сильных сторон SRS в ТЗ. |\n\n> 🧭 **Anti-Inflation.** Приоритет — С1 и С2 (настоящие пробелы под реальную боль).\n> С3 — лёгкий мост (одна таблица). С4/С5 — опциональны и делаются только при\n> возникновении боли. Никаких новых каталогов и «впрок».\n\n## Acceptance Criteria\n\n- Извлечённая система Вигерса сопоставлена с mango-ADR #003–#010 по четырём\n  измерениям (уровни / типы / процессы / артефакты) — таблица «Карта сравнения».\n- «Велосипеды» и пробелы выявлены и **честно классифицированы** (🔴/🟡/🟢), без\n  огульного объявления всего велосипедом.\n- Подтверждён ключевой факт: Вигерс не цитируется ни в одном mango-ADR; основа\n  mango — BABOK + 29148 + 25010 + ГОСТ 34.602-2020.\n- Предложена синхронизация (С1–С5) с привязкой к реальной боли (Anti-Inflation) и\n  указанием, куда фиксируется каждая рекомендация.\n- AI-практики размечены доверием E1–E2 (`Candidate`), ни одна не введена как\n  стандарт (НФТ Trust & Evidence).\n- mango-ADR процитированы по полным URL внешнего репозитория (не редактируются\n  этим RFC); внутренние ссылки разрешимы.\n- Решения accept/reject/синхронизация явно оставлены за человеком.\n\n## Open Decisions\n\n1. **Принять ли С1** (ось `requirement_level`) — и кто инициирует issue в\n   `mango_ba_prompts` (это внешний репозиторий)?\n2. **Принять ли С2** (тип «Бизнес-правило» + 5 категорий) как приоритет №1\n   синхронизации, учитывая ценность для AI-автопроверки?\n3. **Где жить crosswalk С3** — только в этом RFC Хаба, или продублировать\n   примечанием в таксономии mango?\n4. **Делать ли С4/С5 сейчас** или отложить до возникновения конкретной боли\n   (Anti-Inflation)?\n5. **Статус prompt engineering как типа требования** — фиксировать ли его как\n   `Candidate` в Хабе уже сейчас, или ждать воспроизводимых подтверждений?\n6. **Кто владелец синхронизации** между Хабом и `mango_ba_prompts` (репозитории\n   независимы; нужен явный канал)?\n\n## Источники\n\nВнешние стандарты и mango-ADR — по полным URL (mango-ADR в репозитории\n`mango_ba_prompts`, редактируются только там). Первичный источник Вигерса и полный\nразбор измерений — в исследовании\n[research/hub/wigers-requirements-analysis-2026-06.md](../../research/hub/wigers-requirements-analysis-2026-06.md).\n\n- **Первоисточник:** Wiegers, K., Beatty, J. *Software Requirements*, 3rd ed.,\n  Microsoft Press, 2013 (рус. «Разработка требований к ПО», 2020).\n- **mango-ADR (внешний репозиторий `mango_ba_prompts`):**\n  - ADR-003 (онтология БА): <https://github.com/G-Ivan-A/mango_ba_prompts/blob/main/docs/adr/003-ba-ontology.md>\n  - ADR-004 (таксономия операций): <https://github.com/G-Ivan-A/mango_ba_prompts/blob/main/docs/adr/004-operations-taxonomy.md>\n  - ADR-005 (нейминг артефактов): <https://github.com/G-Ivan-A/mango_ba_prompts/blob/main/docs/adr/005-artifact-team-naming.md>\n  - ADR-006 (нейминг промптов): <https://github.com/G-Ivan-A/mango_ba_prompts/blob/main/docs/adr/006-prompt-naming.md>\n  - ADR-007 (стандарт базы знаний): <https://github.com/G-Ivan-A/mango_ba_prompts/blob/main/docs/adr/007-kb-standard.md>\n  - ADR-008 (отраслевые стандарты): <https://github.com/G-Ivan-A/mango_ba_prompts/blob/main/docs/adr/008-industry-standards-standard.md>\n  - ADR-009 (процесс BCREQ): <https://github.com/G-Ivan-A/mango_ba_prompts/blob/main/docs/adr/009-bcreq-formation-process.md>\n  - ADR-010 (UX страниц): <https://github.com/G-Ivan-A/mango_ba_prompts/blob/main/docs/adr/010-pages-ux.md>\n- **Отраслевые стандарты (основа mango):** BABOK Guide v3\n  <https://www.iiba.org/career-resources/a-business-analysis-professionals-foundation-for-success/babok/> ·\n  ISO/IEC/IEEE 29148:2018 <https://www.iso.org/standard/72089.html> ·\n  ISO/IEC 25010 <https://www.iso.org/standard/78176.html> ·\n  ГОСТ 34.602-2020 <https://docs.cntd.ru/document/1200181804>.\n\n## Связанные артефакты\n\n- [research/hub/wigers-requirements-analysis-2026-06.md](../../research/hub/wigers-requirements-analysis-2026-06.md)\n  — независимое извлечение Вигерса (ФТ-1…ФТ-4), доказательная база этого RFC.\n- [governance/rfc/research-memory-source-intelligence.md](research-memory-source-intelligence.md)\n  — PR #242: Knowledge Status (`Candidate`/`Applied`), source intelligence (для\n  разметки AI-практик).\n- [governance/rfc/methodology-research-and-proposals.md](methodology-research-and-proposals.md)\n  — PR #246: 5-слойная модель и ось доверия E0–E4 (использованы для классификации).\n- [AI_GOVERNANCE.md](../../AI_GOVERNANCE.md) — Operating Modes, правило 4 (решения\n  за человеком), Creative-mode.\n- [governance/repo-model.md](../repo-model.md) — Anti-Inflation principle.\n- [standards/glossary.md](../../standards/glossary.md) — цель опциональной ФТ-6\n  (синхронизация терминов С4).",
+[2026-06-18T11:44:45.337Z] [INFO]         "is_error": false
+[2026-06-18T11:44:45.337Z] [INFO]       }
+[2026-06-18T11:44:45.337Z] [INFO]     ]
+[2026-06-18T11:44:45.337Z] [INFO]   },
+[2026-06-18T11:44:45.337Z] [INFO]   "parent_tool_use_id": null,
+[2026-06-18T11:44:45.337Z] [INFO]   "session_id": "d65e890a-db60-43f7-aea3-691500f7e26c",
+[2026-06-18T11:44:45.337Z] [INFO]   "uuid": "a03b4892-d34d-4714-8edf-5d51c1ef7ad6",
+[2026-06-18T11:44:45.337Z] [INFO]   "timestamp": "2026-06-18T11:44:45.331Z",
+[2026-06-18T11:44:45.337Z] [INFO]   "tool_use_result": {
+[2026-06-18T11:44:45.337Z] [INFO]     "stdout": "| Измерение Вигерса | Эквивалент в mango | ADR mango | Класс | Краткий вывод |\n| --- | --- | --- | --- | --- |\n| **Уровни** Бизнес→Пользователь→Функция (+НФТ) | `Domain→Capability→Feature→Atomic Function` (классификация функциональности) + дерево `BCREQ-NNN.k.m` | [ADR-003](https://github.com/G-Ivan-A/mango_ba_prompts/blob/main/docs/adr/003-ba-ontology.md), [ADR-009](https://github.com/G-Ivan-A/mango_ba_prompts/blob/main/docs/adr/009-bcreq-formation-process.md) | 🔴 | Декомпозиция функциональности ≠ семантическая лестница уровней требования. |\n| **Типы:** Функция / Качество / Ограничение / **Бизнес-правило** | Реестр из 30 артефактов + классификация; качество = ISO 25010; ограничения = «Раздел 6» | [ADR-003](https://github.com/G-Ivan-A/mango_ba_prompts/blob/main/docs/adr/003-ba-ontology.md), [ADR-004](https://github.com/G-Ivan-A/mango_ba_prompts/blob/main/docs/adr/004-operations-taxonomy.md) | 🔴 | **Бизнес-правило как тип (и его 5-категорийная таксономия) отсутствует** в реестре. |\n| **Процессы:** Выявление / Анализ / Спецификация / Проверка + Управление | 13 операций → 6 областей знаний BABOK; конвейер BCREQ П1–П6 | [ADR-004](https://github.com/G-Ivan-A/mango_ba_prompts/blob/main/docs/adr/004-operations-taxonomy.md), [ADR-009](https://github.com/G-Ivan-A/mango_ba_prompts/blob/main/docs/adr/009-bcreq-formation-process.md) | 🟡 | BABOK-операции легитимны и детальнее; нет только crosswalk к Вигерсу. |\n| **Словарь** (Прил. А) | Глоссарий задачи на базе BABOK Glossary + IREB CPRE | [ADR-003](https://github.com/G-Ivan-A/mango_ba_prompts/blob/main/docs/adr/003-ba-ontology.md) (артефакт 7) | 🟢/🟡 | Источники разные; нужна сверка терминов, где определения расходятся. |\n| **SRS** (шаблон, наследие IEEE-830) | ТЗ по ГОСТ 34.602-2020 (артефакт 19), ФТ КК (18) | [ADR-003](https://github.com/G-Ivan-A/mango_ba_prompts/blob/main/docs/adr/003-ba-ontology.md) | 🟢 | Локализация под РФ-рынок оправдана; не велосипед, но можно обогатить. |\n| **Триада** Процесс→Операция→Артефакт | Триада **Операция→Процесс→Артефакт**, расширенная в граф | [ADR-003](https://github.com/G-Ivan-A/mango_ba_prompts/blob/main/docs/adr/003-ba-ontology.md) | 🟢 | Совпадает по сути; направление ребра — деталь нотации. |\n\n## Каталог «велосипедов» и пробелов\n\n### В1 — Уровни требований: декомпозиция функциональности подменяет семантику (🔴)\n\n**Что у Вигерса.** Три уровня — **Бизнес → Пользователь → Функция** — отвечают на\n«зачем → кто/что → как» и образуют **семантическую** лестницу намерения, по которой\nстроится трассировка вверх (функция → бизнес-цель).\n\n**Что в mango.** Две разные конструкции, ни одна из которых не равна лестнице\nуровней:\n\n- `Domain → Capability → Feature → Atomic Function`\n  ([ADR-003](https://github.com/G-Ivan-A/mango_ba_prompts/blob/main/docs/adr/003-ba-ontology.md),\n  классификация функциональности) — это декомпозиция **того, что продукт умеет**, а\n  не уровней требования. Уровни «зачем/кто/как» в ней не выражены.\n- Дерево `BCREQ-NNN.k.m`\n  ([ADR-009](https://github.com/G-Ivan-A/mango_ba_prompts/blob/main/docs/adr/009-bcreq-formation-process.md))\n  — это **структурная глубина** декомпозиции одного требования, тоже не семантика\n  уровня.\n- BABOK даёт лишь дихотомию «требование vs дизайн» (2 градации), а не 3-уровневую\n  лестницу Бизнес/Пользователь/Функция.\n\n**Почему это велосипед/пробел.** Семантика уровней решена неявно и частично, через\nдва других механизма. Из-за этого нельзя однозначно ответить «это бизнес- или\nпользовательское требование», и теряется связь с трассировкой Вигерса.\n\n**Предложение (С1).** Ввести уровень Вигерса как **отдельную ортогональную ось-тег**\n(`requirement_level ∈ {business, user, functional, non-functional}`) поверх\nсуществующей классификации функциональности — **не заменяя** `Domain→…→Atomic\nFunction`. Это даёт семантику без сноса принятой модели (по образцу того, как\n[methodology RFC](methodology-research-and-proposals.md) ввёл ось E0–E4\nортогонально Knowledge Status).\n\n### В2 — Бизнес-правила как тип отсутствуют (🔴, главный пробел)\n\n**Что у Вигерса.** **Бизнес-правило** — самостоятельный тип требования (Гл. 9) с\nтаксономией из 5 категорий: **Факты / Ограничения / Активаторы операций / Выводы /\nВычисления**. Это внешняя норма (политика, закон, формула), которой система обязана\nсоответствовать.\n\n**Что в mango.** В реестре из 30 артефактов\n([ADR-003](https://github.com/G-Ivan-A/mango_ba_prompts/blob/main/docs/adr/003-ba-ontology.md),\n§5) **нет** артефакта `business-rule` и нет эквивалента 5-категорийной таксономии.\nОграничения присутствуют как «Раздел 6» документа, но слиты с НФТ; правила-факты,\nактиваторы, выводы и вычисления отдельно не выделены.\n\n**Почему это важно именно в AI-эру.** Бизнес-правила — **первый кандидат на\nформализацию и автоматическую проверку** ИИ (consistency checking, см. AI-слой\nниже). Без явного типа эту опору не на что положить.\n\n**Предложение (С2).** Добавить в реестр mango тип-артефакт **«Бизнес-правило»** с\n5-категорийной классификацией Вигерса и связью «бизнес-правило → порождает →\nфункцию/ограничение». Это закрытие пробела, а не дубль.\n\n### В3 — Процессы/операции: нужен мост, а не замена (🟡)\n\n**Что у Вигерса.** Разработка требований = **Выявление / Анализ / Спецификация /\nПроверка**, плюс сквозное **Управление требованиями**. Чистая модель 4+1.\n\n**Что в mango.** 13 когнитивных операций, размеченных по 6 областям знаний BABOK\n([ADR-004](https://github.com/G-Ivan-A/mango_ba_prompts/blob/main/docs/adr/004-operations-taxonomy.md)),\nи конвейер BCREQ из 6 подпроцессов\n([ADR-009](https://github.com/G-Ivan-A/mango_ba_prompts/blob/main/docs/adr/009-bcreq-formation-process.md)).\n\n**Почему это НЕ велосипед.** BABOK — легитимный, более гранулярный фреймворк;\nоперации mango покрывают ту же работу детальнее. Проблема лишь в **отсутствии\ncrosswalk**: без него огромный корпус Вигерс-литературы и шаблонов не\nкросс-ссылается на mango.\n\n**Предложение (С3).** Зафиксировать **alias-crosswalk** (без переименований в\nmango — НФТ совместимости mango):\n\n| Процесс Вигерса | Операции mango (ADR-004) | Подпроцесс BCREQ (ADR-009) |\n| --- | --- | --- |\n| Выявление / Elicitation | `ingestion`, `understanding` | П1 |\n| Анализ / Analysis | `modeling`, `research`, `impact_analysis`, `reverse_requirements` | П2, П3 |\n| Спецификация / Specification | `documentation`, `solution_design` | П4 |\n| Проверка / Validation | `validation`, `quality` | П5 |\n| Управление / Management | `governance`, `release_readiness`, `risk_analysis` | П6 |\n\n### В4 — Словарь: разные источники, нужна точечная сверка (🟢/🟡)\n\nГлоссарий mango опирается на BABOK Glossary + IREB CPRE\n([ADR-003](https://github.com/G-Ivan-A/mango_ba_prompts/blob/main/docs/adr/003-ba-ontology.md),\nартефакт 7), словарь Вигерса (Прил. А) — отдельный источник. Это не дубль, но\nопределения местами расходятся (например, «фича/feature» у Вигерса = набор связанных\nфункциональных требований). **Предложение (С4):** при работе над опциональной ФТ-6\n([standards/glossary.md](../../standards/glossary.md)) добавлять термин Вигерса с\nявной пометкой расхождения, если оно есть; не дублировать там, где определения\nсовпадают (Anti-Inflation).\n\n### В5 — SRS vs ТЗ: обоснованная локализация (🟢)\n\nКомплексный документ требований mango — **ТЗ по ГОСТ 34.602-2020** (артефакт 19),\nа не SRS Вигерса (наследие IEEE-830). Это **сознательная локализация** под\nРФ-рынок, не велосипед. **Предложение (С5, опционально):** составить маппинг\nсекций SRS Вигерса (Гл. 10) на разделы ГОСТ ТЗ, чтобы выявить, не теряются ли в ТЗ\nсильные стороны SRS (например, систематизация атрибутов качества) — но **не**\nнавязывать SRS.\n\n## AI-слой: где синхронизация открывает новые возможности\n\nАктуализация на тренд **AI-2026** (детально — в §3.3.3 исследования). Каждое\nутверждение размечено доверием; **ничего из E1–E2 не вносится как стандарт**\n(НФТ Trust & Evidence).\n\n| AI-практика | На что опирается после синхронизации | Доверие |\n| --- | --- | --- |\n| Автоматическая проверка согласованности требований | Профиль аудита mango (9+5 характеристик ISO 29148, [ADR-004](https://github.com/G-Ivan-A/mango_ba_prompts/blob/main/docs/adr/004-operations-taxonomy.md)) + явные **бизнес-правила** (С2) как формализуемая опора. | E2 (Candidate) |\n| AI-трассировка (требование↔код↔тест) | Граф mango (ребро `трассируется`) + ось уровней Вигерса (С1) для трассировки вверх к бизнес-цели. | E1–E2 (Candidate) |\n| AI-ассистированное выявление (суммаризация интервью, черновики US) | Операции `ingestion`/`understanding` + crosswalk «Выявление» (С3). | E1–E2 (Candidate) |\n| **Prompt engineering как новый тип требования** к AI-компоненту | Расширение типологии (В2-подход), но как `Candidate`, не как канон. | E1 (Candidate) |\n\n> 🔒 **Дисциплина доверия.** AI-практики — кандидаты уровня E1–E2. Синхронизация\n> (С1, С2, С3) **создаёт опору** для них, но сами практики становятся нормой только\n> после воспроизводимого подтверждения (Knowledge Status `Candidate` → `Applied`).\n\n## Предложение по синхронизации (сводка)\n\n| # | Рекомендация | Класс | Куда фиксируется | Боль, которую закрывает |\n| --- | --- | --- | --- | --- |\n| С1 | Ось-тег `requirement_level` (Бизнес/Пользователь/Функция/НФТ) поверх классификации функциональности. | 🔴 | issue в `mango_ba_prompts` → ADR-003/стандарт онтологии | Нельзя однозначно определить уровень требования; нет трассировки вверх по Вигерсу. |\n| С2 | Тип-артефакт **«Бизнес-правило»** + 5-категорийная таксономия. | 🔴 | issue в `mango_ba_prompts` → реестр артефактов ADR-003 | Нет опоры для автопроверки правил ИИ; пробел в типологии. |\n| С3 | Alias-crosswalk Вигерс ↔ операции mango ↔ BCREQ (без переименований). | 🟡 | этот RFC (таблица В3) + опц. примечание в таксономии mango | Нет кросс-ссылок с Вигерс-литературой. |\n| С4 | Сверка терминов Вигерса в глоссарии при расхождении определений. | 🟢/🟡 | [standards/glossary.md](../../standards/glossary.md) (ФТ-6, опц.) | Тихие расхождения в терминологии. |\n| С5 | Маппинг секций SRS → разделы ГОСТ ТЗ (диагностика, не замена). | 🟢 | опц. issue/исследование | Возможная потеря сильных сторон SRS в ТЗ. |\n\n> 🧭 **Anti-Inflation.** Приоритет — С1 и С2 (настоящие пробелы под реальную боль).\n> С3 — лёгкий мост (одна таблица). С4/С5 — опциональны и делаются только при\n> возникновении боли. Никаких новых каталогов и «впрок».\n\n## Acceptance Criteria\n\n- Извлечённая система Вигерса сопоставлена с mango-ADR #003–#010 по четырём\n  измерениям (уровни / типы / процессы / артефакты) — таблица «Карта сравнения».\n- «Велосипеды» и пробелы выявлены и **честно классифицированы** (🔴/🟡/🟢), без\n  огульного объявления всего велосипедом.\n- Подтверждён ключевой факт: Вигерс не цитируется ни в одном mango-ADR; основа\n  mango — BABOK + 29148 + 25010 + ГОСТ 34.602-2020.\n- Предложена синхронизация (С1–С5) с привязкой к реальной боли (Anti-Inflation) и\n  указанием, куда фиксируется каждая рекомендация.\n- AI-практики размечены доверием E1–E2 (`Candidate`), ни одна не введена как\n  стандарт (НФТ Trust & Evidence).\n- mango-ADR процитированы по полным URL внешнего репозитория (не редактируются\n  этим RFC); внутренние ссылки разрешимы.\n- Решения accept/reject/синхронизация явно оставлены за человеком.\n\n## Open Decisions\n\n1. **Принять ли С1** (ось `requirement_level`) — и кто инициирует issue в\n   `mango_ba_prompts` (это внешний репозиторий)?\n2. **Принять ли С2** (тип «Бизнес-правило» + 5 категорий) как приоритет №1\n   синхронизации, учитывая ценность для AI-автопроверки?\n3. **Где жить crosswalk С3** — только в этом RFC Хаба, или продублировать\n   примечанием в таксономии mango?\n4. **Делать ли С4/С5 сейчас** или отложить до возникновения конкретной боли\n   (Anti-Inflation)?\n5. **Статус prompt engineering как типа требования** — фиксировать ли его как\n   `Candidate` в Хабе уже сейчас, или ждать воспроизводимых подтверждений?\n6. **Кто владелец синхронизации** между Хабом и `mango_ba_prompts` (репозитории\n   независимы; нужен явный канал)?\n\n## Источники\n\nВнешние стандарты и mango-ADR — по полным URL (mango-ADR в репозитории\n`mango_ba_prompts`, редактируются только там). Первичный источник Вигерса и полный\nразбор измерений — в исследовании\n[research/hub/wigers-requirements-analysis-2026-06.md](../../research/hub/wigers-requirements-analysis-2026-06.md).\n\n- **Первоисточник:** Wiegers, K., Beatty, J. *Software Requirements*, 3rd ed.,\n  Microsoft Press, 2013 (рус. «Разработка требований к ПО», 2020).\n- **mango-ADR (внешний репозиторий `mango_ba_prompts`):**\n  - ADR-003 (онтология БА): <https://github.com/G-Ivan-A/mango_ba_prompts/blob/main/docs/adr/003-ba-ontology.md>\n  - ADR-004 (таксономия операций): <https://github.com/G-Ivan-A/mango_ba_prompts/blob/main/docs/adr/004-operations-taxonomy.md>\n  - ADR-005 (нейминг артефактов): <https://github.com/G-Ivan-A/mango_ba_prompts/blob/main/docs/adr/005-artifact-team-naming.md>\n  - ADR-006 (нейминг промптов): <https://github.com/G-Ivan-A/mango_ba_prompts/blob/main/docs/adr/006-prompt-naming.md>\n  - ADR-007 (стандарт базы знаний): <https://github.com/G-Ivan-A/mango_ba_prompts/blob/main/docs/adr/007-kb-standard.md>\n  - ADR-008 (отраслевые стандарты): <https://github.com/G-Ivan-A/mango_ba_prompts/blob/main/docs/adr/008-industry-standards-standard.md>\n  - ADR-009 (процесс BCREQ): <https://github.com/G-Ivan-A/mango_ba_prompts/blob/main/docs/adr/009-bcreq-formation-process.md>\n  - ADR-010 (UX страниц): <https://github.com/G-Ivan-A/mango_ba_prompts/blob/main/docs/adr/010-pages-ux.md>\n- **Отраслевые стандарты (основа mango):** BABOK Guide v3\n  <https://www.iiba.org/career-resources/a-business-analysis-professionals-foundation-for-success/babok/> ·\n  ISO/IEC/IEEE 29148:2018 <https://www.iso.org/standard/72089.html> ·\n  ISO/IEC 25010 <https://www.iso.org/standard/78176.html> ·\n  ГОСТ 34.602-2020 <https://docs.cntd.ru/document/1200181804>.\n\n## Связанные артефакты\n\n- [research/hub/wigers-requirements-analysis-2026-06.md](../../research/hub/wigers-requirements-analysis-2026-06.md)\n  — независимое извлечение Вигерса (ФТ-1…ФТ-4), доказательная база этого RFC.\n- [governance/rfc/research-memory-source-intelligence.md](research-memory-source-intelligence.md)\n  — PR #242: Knowledge Status (`Candidate`/`Applied`), source intelligence (для\n  разметки AI-практик).\n- [governance/rfc/methodology-research-and-proposals.md](methodology-research-and-proposals.md)\n  — PR #246: 5-слойная модель и ось доверия E0–E4 (использованы для классификации).\n- [AI_GOVERNANCE.md](../../AI_GOVERNANCE.md) — Operating Modes, правило 4 (решения\n  за человеком), Creative-mode.\n- [governance/repo-model.md](../repo-model.md) — Anti-Inflation principle.\n- [standards/glossary.md](../../standards/glossary.md) — цель опциональной ФТ-6\n  (синхронизация терминов С4).",
+[2026-06-18T11:44:45.337Z] [INFO]     "stderr": "",
+[2026-06-18T11:44:45.337Z] [INFO]     "interrupted": false,
+[2026-06-18T11:44:45.337Z] [INFO]     "isImage": false,
+[2026-06-18T11:44:45.337Z] [INFO]     "noOutputExpected": false
+[2026-06-18T11:44:45.337Z] [INFO]   }
+[2026-06-18T11:44:45.337Z] [INFO] }
+[2026-06-18T11:44:45.357Z] [INFO] [log_1eb713] sending request {
+[2026-06-18T11:44:45.359Z] [INFO]   method: "post",
+[2026-06-18T11:44:45.360Z] [INFO]   url: "https://api.anthropic.com/v1/messages?beta=true",
+[2026-06-18T11:44:45.363Z] [INFO]   options: {
+[2026-06-18T11:44:45.364Z] [INFO]     method: "post",
+[2026-06-18T11:44:45.364Z] [INFO]     path: "/v1/messages?beta=true",
+[2026-06-18T11:44:45.365Z] [INFO]     body: {
+[2026-06-18T11:44:45.365Z] [INFO]       model: "claude-opus-4-8",
+[2026-06-18T11:44:45.366Z] [INFO]       messages: [
+[2026-06-18T11:44:45.367Z] [INFO]         [Object ...], [Object ...], [Object ...], [Object ...], [Object ...], [Object ...], [Object ...], [Object ...], [Object ...], [Object ...], [Object ...], [Object ...], [Object ...], [Object ...]
+[2026-06-18T11:44:45.367Z] [INFO]       ],
+[2026-06-18T11:44:45.368Z] [INFO]       system: [
+[2026-06-18T11:44:45.368Z] [INFO]         [Object ...], [Object ...], [Object ...], [Object ...]
+[2026-06-18T11:44:45.370Z] [INFO]       ],
+[2026-06-18T11:44:45.371Z] [INFO]       tools: [
+[2026-06-18T11:44:45.372Z] [INFO]         [Object ...], [Object ...], [Object ...], [Object ...], [Object ...], [Object ...], [Object ...], [Object ...]
+[2026-06-18T11:44:45.372Z] [INFO]       ],
+[2026-06-18T11:44:45.372Z] [INFO]       tool_choice: undefined,
+[2026-06-18T11:44:45.373Z] [INFO]       metadata: [Object ...],
+[2026-06-18T11:44:45.374Z] [INFO]       max_tokens: 128000,
+[2026-06-18T11:44:45.374Z] [INFO]       thinking: [Object ...],
+[2026-06-18T11:44:45.375Z] [INFO]       context_management: [Object ...],
+[2026-06-18T11:44:45.375Z] [INFO]       output_config: [Object ...],
+[2026-06-18T11:44:45.376Z] [INFO]       diagnostics: [Object ...],
+[2026-06-18T11:44:45.376Z] [INFO]       stream: true,
+[2026-06-18T11:44:45.377Z] [INFO]     },
+[2026-06-18T11:44:45.379Z] [INFO]     timeout: 600000,
+[2026-06-18T11:44:45.380Z] [INFO]     signal: AbortSignal {
+[2026-06-18T11:44:45.387Z] [INFO]       [Symbol(events.maxEventTargetListeners)]: 50,
+[2026-06-18T11:44:45.393Z] [INFO]       [Symbol(events.maxEventTargetListenersWarned)]: false,
+[2026-06-18T11:44:45.396Z] [INFO]       aborted: false,
+[2026-06-18T11:44:45.396Z] [INFO]       reason: undefined,
+[2026-06-18T11:44:45.397Z] [INFO]       onabort: null,
+[2026-06-18T11:44:45.397Z] [INFO]       throwIfAborted: [Function: throwIfAborted],
+[2026-06-18T11:44:45.399Z] [INFO]       addEventListener: [Function: addEventListener],
+[2026-06-18T11:44:45.400Z] [INFO]       removeEventListener: [Function: removeEventListener],
+[2026-06-18T11:44:45.401Z] [INFO]       dispatchEvent: [Function: dispatchEvent],
+[2026-06-18T11:44:45.401Z] [INFO]     },
+[2026-06-18T11:44:45.401Z] [INFO]     stream: true,
+[2026-06-18T11:44:45.402Z] [INFO]   },
+[2026-06-18T11:44:45.402Z] [INFO]   headers: {
+[2026-06-18T11:44:45.403Z] [INFO]     accept: "application/json",
+[2026-06-18T11:44:45.405Z] [INFO]     "anthropic-beta": "claude-code-20250219,oauth-2025-04-20,interleaved-thinking-2025-05-14,thinking-token-count-2026-05-13,context-management-2025-06-27,prompt-caching-scope-2026-01-05,mid-conversation-system-2026-04-07,advisor-tool-2026-03-01,advanced-tool-use-2025-11-20,effort-2025-11-24,extended-cache-ttl-2025-04-11,cache-diagnosis-2026-04-07",
+[2026-06-18T11:44:45.406Z] [INFO]     "anthropic-dangerous-direct-browser-access": "true",
+[2026-06-18T11:44:45.407Z] [INFO]     "anthropic-version": "2023-06-01",
+[2026-06-18T11:44:45.407Z] [INFO]     authorization: "***",
+[2026-06-18T11:44:45.408Z] [INFO]     "content-type": "application/json",
+[2026-06-18T11:44:45.408Z] [INFO]     "user-agent": "claude-cli/2.1.181 (external, sdk-cli)",
+[2026-06-18T11:44:45.408Z] [INFO]     "x-app": "cli",
+[2026-06-18T11:44:45.409Z] [INFO]     "x-claude-code-session-id": "d65e890a-db60-43f7-aea3-691500f7e26c",
+[2026-06-18T11:44:45.409Z] [INFO]     "x-client-request-id": "3279d72c-514b-48e5-96b5-aea97a805ae3",
+[2026-06-18T11:44:45.409Z] [INFO]     "x-stainless-arch": "x64",
+[2026-06-18T11:44:45.410Z] [INFO]     "x-stainless-lang": "js",
+[2026-06-18T11:44:45.410Z] [INFO]     "x-stainless-os": "Linux",
+[2026-06-18T11:44:45.411Z] [INFO]     "x-stainless-package-version": "0.94.0",
+[2026-06-18T11:44:45.411Z] [INFO]     "x-stainless-retry-count": "0",
+[2026-06-18T11:44:45.412Z] [INFO]     "x-stainless-runtime": "node",
+[2026-06-18T11:44:45.412Z] [INFO]     "x-stainless-runtime-version": "v24.3.0",
+[2026-06-18T11:44:45.412Z] [INFO]     "x-stainless-timeout": "600",
+[2026-06-18T11:44:45.413Z] [INFO]   },
+[2026-06-18T11:44:45.413Z] [INFO] }
+[2026-06-18T11:44:47.255Z] [INFO] [log_1eb713, request-id: "req_011CcAfh2P8QCzsK6is19P5q"] post https://api.anthropic.com/v1/messages?beta=true succeeded with status 200 in 1899ms
+[2026-06-18T11:44:47.256Z] [INFO] [log_1eb713] response start {
+[2026-06-18T11:44:47.258Z] [INFO]   url: "https://api.anthropic.com/v1/messages?beta=true",
+[2026-06-18T11:44:47.259Z] [INFO]   status: 200,
+[2026-06-18T11:44:47.262Z] [INFO]   headers: {
+[2026-06-18T11:44:47.263Z] [INFO]     "anthropic-organization-id": "ebc2ac93-f86f-4d15-aff3-de8830d8d789",
+[2026-06-18T11:44:47.264Z] [INFO]     "anthropic-ratelimit-unified-5h-reset": "1781787000",
+[2026-06-18T11:44:47.265Z] [INFO]     "anthropic-ratelimit-unified-5h-status": "allowed",
+[2026-06-18T11:44:47.266Z] [INFO]     "anthropic-ratelimit-unified-5h-utilization": "0.33",
+[2026-06-18T11:44:47.268Z] [INFO]     "anthropic-ratelimit-unified-7d-reset": "1782212400",
+[2026-06-18T11:44:47.270Z] [INFO]     "anthropic-ratelimit-unified-7d-status": "allowed",
+[2026-06-18T11:44:47.271Z] [INFO]     "anthropic-ratelimit-unified-7d-utilization": "0.62",
+[2026-06-18T11:44:47.272Z] [INFO]     "anthropic-ratelimit-unified-fallback-percentage": "0.5",
+[2026-06-18T11:44:47.276Z] [INFO]     "anthropic-ratelimit-unified-overage-disabled-reason": "org_level_disabled",
+[2026-06-18T11:44:47.279Z] [INFO]     "anthropic-ratelimit-unified-overage-status": "rejected",
+[2026-06-18T11:44:47.279Z] [INFO]     "anthropic-ratelimit-unified-representative-claim": "five_hour",
+[2026-06-18T11:44:47.282Z] [INFO]     "anthropic-ratelimit-unified-reset": "1781787000",
+[2026-06-18T11:44:47.282Z] [INFO]     "anthropic-ratelimit-unified-status": "allowed",
+[2026-06-18T11:44:47.283Z] [INFO]     "cache-control": "no-cache",
+[2026-06-18T11:44:47.284Z] [INFO]     "cf-cache-status": "DYNAMIC",
+[2026-06-18T11:44:47.284Z] [INFO]     "cf-ray": "a0da0b3b8bf3b19e-FRA",
+[2026-06-18T11:44:47.285Z] [INFO]     connection: "keep-alive",
+[2026-06-18T11:44:47.285Z] [INFO]     "content-encoding": "gzip",
+[2026-06-18T11:44:47.285Z] [INFO]     "content-security-policy": "default-src 'none'; frame-ancestors 'none'",
+[2026-06-18T11:44:47.287Z] [INFO]     "content-type": "text/event-stream; charset=utf-8",
+[2026-06-18T11:44:47.288Z] [INFO]     date: "Thu, 18 Jun 2026 11:44:47 GMT",
+[2026-06-18T11:44:47.288Z] [INFO]     "request-id": "req_011CcAfh2P8QCzsK6is19P5q",
+[2026-06-18T11:44:47.288Z] [INFO]     server: "cloudflare",
+[2026-06-18T11:44:47.289Z] [INFO]     "strict-transport-security": "max-age=31536000; includeSubDomains; preload",
+[2026-06-18T11:44:47.292Z] [INFO]     traceresponse: "00-201c33eeda189030d709d402a2554e0d-2b7e99d730eda5e3-01",
+[2026-06-18T11:44:47.292Z] [INFO]     "transfer-encoding": "chunked",
+[2026-06-18T11:44:47.292Z] [INFO]     vary: "Accept-Encoding",
+[2026-06-18T11:44:47.294Z] [INFO]     "x-robots-tag": "none",
+[2026-06-18T11:44:47.294Z] [INFO]     "set-cookie": "***",
+[2026-06-18T11:44:47.294Z] [INFO]   },
+[2026-06-18T11:44:47.295Z] [INFO]   durationMs: 1899,
+[2026-06-18T11:44:47.296Z] [INFO] }
+[2026-06-18T11:44:47.297Z] [INFO] response 200 https://api.anthropic.com/v1/messages?beta=true Headers {
+[2026-06-18T11:44:47.297Z] [INFO]   "date": "Thu, 18 Jun 2026 11:44:47 GMT",
+[2026-06-18T11:44:47.297Z] [INFO]   "content-type": "text/event-stream; charset=utf-8",
+[2026-06-18T11:44:47.298Z] [INFO]   "transfer-encoding": "chunked",
+[2026-06-18T11:44:47.298Z] [INFO]   "connection": "keep-alive",
+[2026-06-18T11:44:47.298Z] [INFO]   "cache-control": "no-cache",
+[2026-06-18T11:44:47.301Z] [INFO]   "strict-transport-security": "max-age=31536000; includeSubDomains; preload",
+[2026-06-18T11:44:47.302Z] [INFO]   "content-encoding": "gzip",
+[2026-06-18T11:44:47.303Z] [INFO]   "vary": "Accept-Encoding",
+[2026-06-18T11:44:47.303Z] [INFO]   "content-security-policy": "default-src 'none'; frame-ancestors 'none'",
+[2026-06-18T11:44:47.303Z] [INFO]   "set-cookie": [ "_cfuvid=w9N1Z0moCpbbZX9lXgW2OpIX4gZNIu75FRYBSzd1Zvk-1781783085.3659396-1.0.1.1-A_CkcvnpEEyBaS0UDjVLh._HHtmvOt5oQdZ4yy6H_yM; HttpOnly; SameSite=None; Secure; Path=/; Domain=api.anthropic.com" ],
+[2026-06-18T11:44:47.304Z] [INFO]   "anthropic-ratelimit-unified-status": "allowed",
+[2026-06-18T11:44:47.304Z] [INFO]   "anthropic-ratelimit-unified-5h-status": "allowed",
+[2026-06-18T11:44:47.304Z] [INFO]   "anthropic-ratelimit-unified-5h-reset": "1781787000",
+[2026-06-18T11:44:47.304Z] [INFO]   "anthropic-ratelimit-unified-5h-utilization": "0.33",
+[2026-06-18T11:44:47.304Z] [INFO]   "anthropic-ratelimit-unified-7d-status": "allowed",
+[2026-06-18T11:44:47.304Z] [INFO]   "anthropic-ratelimit-unified-7d-reset": "1782212400",
+[2026-06-18T11:44:47.304Z] [INFO]   "anthropic-ratelimit-unified-7d-utilization": "0.62",
+[2026-06-18T11:44:47.305Z] [INFO]   "anthropic-ratelimit-unified-representative-claim": "five_hour",
+[2026-06-18T11:44:47.305Z] [INFO]   "anthropic-ratelimit-unified-fallback-percentage": "0.5",
+[2026-06-18T11:44:47.305Z] [INFO]   "anthropic-ratelimit-unified-reset": "1781787000",
+[2026-06-18T11:44:47.305Z] [INFO]   "anthropic-ratelimit-unified-overage-disabled-reason": "org_level_disabled",
+[2026-06-18T11:44:47.305Z] [INFO]   "anthropic-ratelimit-unified-overage-status": "rejected",
+[2026-06-18T11:44:47.306Z] [INFO]   "request-id": "req_011CcAfh2P8QCzsK6is19P5q",
+[2026-06-18T11:44:47.306Z] [INFO]   "anthropic-organization-id": "ebc2ac93-f86f-4d15-aff3-de8830d8d789",
+[2026-06-18T11:44:47.306Z] [INFO]   "traceresponse": "00-201c33eeda189030d709d402a2554e0d-2b7e99d730eda5e3-01",
+[2026-06-18T11:44:47.307Z] [INFO]   "server": "cloudflare",
+[2026-06-18T11:44:47.307Z] [INFO]   "cf-cache-status": "DYNAMIC",
+[2026-06-18T11:44:47.307Z] [INFO]   "x-robots-tag": "none",
+[2026-06-18T11:44:47.307Z] [INFO]   "cf-ray": "a0da0b3b8bf3b19e-FRA",
+[2026-06-18T11:44:47.307Z] [INFO] } ReadableStream {
+[2026-06-18T11:44:47.308Z] [INFO]   blob: [Function: blob],
+[2026-06-18T11:44:47.308Z] [INFO]   bytes: [Function: bytes],
+[2026-06-18T11:44:47.308Z] [INFO]   cancel: [Function],
+[2026-06-18T11:44:47.309Z] [INFO]   getReader: [Function],
+[2026-06-18T11:44:47.309Z] [INFO]   json: [Function: json],
+[2026-06-18T11:44:47.310Z] [INFO]   locked: [Getter],
+[2026-06-18T11:44:47.310Z] [INFO]   pipeThrough: [Function],
+[2026-06-18T11:44:47.310Z] [INFO]   pipeTo: [Function],
+[2026-06-18T11:44:47.311Z] [INFO]   tee: [Function],
+[2026-06-18T11:44:47.311Z] [INFO]   text: [Function: text],
+[2026-06-18T11:44:47.311Z] [INFO]   values: [Function: values],
+[2026-06-18T11:44:47.311Z] [INFO]   [Symbol(Symbol.asyncIterator)]: [Function: asyncIterator2],
+[2026-06-18T11:44:47.311Z] [INFO] }
+[2026-06-18T11:44:47.312Z] [INFO] [log_1eb713] response parsed {
+[2026-06-18T11:44:47.312Z] [INFO]   url: "https://api.anthropic.com/v1/messages?beta=true",
+[2026-06-18T11:44:47.312Z] [INFO]   status: 200,
+[2026-06-18T11:44:47.313Z] [INFO]   body: sU {
+[2026-06-18T11:44:47.314Z] [INFO]     iterator: [AsyncGeneratorFunction: s],
+[2026-06-18T11:44:47.317Z] [INFO]     controller: AbortController {
+[2026-06-18T11:44:47.317Z] [INFO]       signal: [AbortSignal ...],
+[2026-06-18T11:44:47.318Z] [INFO]       abort: [Function: abort],
+[2026-06-18T11:44:47.322Z] [INFO]     },
+[2026-06-18T11:44:47.322Z] [INFO]     [Symbol(Symbol.asyncIterator)]: [Function],
+[2026-06-18T11:44:47.322Z] [INFO]     tee: [Function: tee],
+[2026-06-18T11:44:47.323Z] [INFO]     toReadableStream: [Function: toReadableStream],
+[2026-06-18T11:44:47.323Z] [INFO]   },
+[2026-06-18T11:44:47.323Z] [INFO]   durationMs: 1899,
+[2026-06-18T11:44:47.323Z] [INFO] }
+[2026-06-18T11:44:48.788Z] [INFO] {
+[2026-06-18T11:44:48.788Z] [INFO]   "type": "system",
+[2026-06-18T11:44:48.788Z] [INFO]   "subtype": "thinking_tokens",
+[2026-06-18T11:44:48.788Z] [INFO]   "estimated_tokens": 50,
+[2026-06-18T11:44:48.788Z] [INFO]   "estimated_tokens_delta": 50,
+[2026-06-18T11:44:48.788Z] [INFO]   "uuid": "e51b2862-5163-4a7c-9a99-832063cc3c5f",
+[2026-06-18T11:44:48.788Z] [INFO]   "session_id": "d65e890a-db60-43f7-aea3-691500f7e26c"
+[2026-06-18T11:44:48.788Z] [INFO] }
+[2026-06-18T11:44:50.098Z] [INFO] {
+[2026-06-18T11:44:50.098Z] [INFO]   "type": "system",
+[2026-06-18T11:44:50.098Z] [INFO]   "subtype": "thinking_tokens",
+[2026-06-18T11:44:50.098Z] [INFO]   "estimated_tokens": 150,
+[2026-06-18T11:44:50.098Z] [INFO]   "estimated_tokens_delta": 100,
+[2026-06-18T11:44:50.098Z] [INFO]   "uuid": "755d340a-08f1-4ee2-861b-03b6a785dea7",
+[2026-06-18T11:44:50.098Z] [INFO]   "session_id": "d65e890a-db60-43f7-aea3-691500f7e26c"
+[2026-06-18T11:44:50.098Z] [INFO] }
+[2026-06-18T11:44:51.969Z] [INFO] {
+[2026-06-18T11:44:51.969Z] [INFO]   "type": "system",
+[2026-06-18T11:44:51.969Z] [INFO]   "subtype": "thinking_tokens",
+[2026-06-18T11:44:51.969Z] [INFO]   "estimated_tokens": 250,
+[2026-06-18T11:44:51.969Z] [INFO]   "estimated_tokens_delta": 100,
+[2026-06-18T11:44:51.969Z] [INFO]   "uuid": "77230d90-4eff-4a85-86f5-4f3d8b5d693c",
+[2026-06-18T11:44:51.969Z] [INFO]   "session_id": "d65e890a-db60-43f7-aea3-691500f7e26c"
+[2026-06-18T11:44:51.969Z] [INFO] }
+[2026-06-18T11:44:53.376Z] [INFO] {
+[2026-06-18T11:44:53.376Z] [INFO]   "type": "system",
+[2026-06-18T11:44:53.376Z] [INFO]   "subtype": "thinking_tokens",
+[2026-06-18T11:44:53.376Z] [INFO]   "estimated_tokens": 346,
+[2026-06-18T11:44:53.376Z] [INFO]   "estimated_tokens_delta": 96,
+[2026-06-18T11:44:53.376Z] [INFO]   "uuid": "82a4e74b-f66c-48e4-a05f-0fe81f4a4a4f",
+[2026-06-18T11:44:53.376Z] [INFO]   "session_id": "d65e890a-db60-43f7-aea3-691500f7e26c"
+[2026-06-18T11:44:53.376Z] [INFO] }
+[2026-06-18T11:44:53.382Z] [INFO] {
+[2026-06-18T11:44:53.382Z] [INFO]   "type": "assistant",
+[2026-06-18T11:44:53.382Z] [INFO]   "message": {
+[2026-06-18T11:44:53.382Z] [INFO]     "model": "claude-opus-4-8",
+[2026-06-18T11:44:53.382Z] [INFO]     "id": "msg_01CeMbPPuQyRq6tqTi6Ccu1g",
+[2026-06-18T11:44:53.382Z] [INFO]     "type": "message",
+[2026-06-18T11:44:53.382Z] [INFO]     "role": "assistant",
+[2026-06-18T11:44:53.382Z] [INFO]     "content": [
+[2026-06-18T11:44:53.382Z] [INFO]       {
+[2026-06-18T11:44:53.382Z] [INFO]         "type": "thinking",
+[2026-06-18T11:44:53.382Z] [INFO]         "thinking": "",
+[2026-06-18T11:44:53.382Z] [INFO]         "signature": "EuIKCmMIDhgCKkAZWrnceAIOqoXq67I/2EhhUBeDP85KsPRtkfrgBpuoOC2loj7b48892rdrdsgjIjyDajpdQ3wBWviyLB/pvaR4Mg9jbGF1ZGUtb3B1cy00LTg4AEIIdGhpbmtpbmcSDB+/FCLTS1Ns2nPVOBoMycycVFU1YJvZAQwUIjAbv3kFGCT1r7DLcEofmsAb9ZsBPWKR5kMp/9c4xu1lhtWFdhNTnmmse8Ncd8y0Yf0qrAnkLcQV/rS6QOgMhKLZUfnZPjTzZvCeOkE6F5KT1Qd5I2t7U4xXjNSKtMSqj8xZGSGXbcKYa7DonA9btiWAom0zCZSNFmCCltivs8FgHgB7sqEb0Phpm4MCx2RCoAfWdd2VaTdx0g8bU/AZbtcw7mBLPRtgMCSl71JNr1KZP1rMCbzXoIEuIbE2jWHHOQc0YOmWE3oYkGRxbG2flbt/PEv6teBXyxbl6fWtJ+i75D2EOhlkM28mGnMNFvOrK9fi4J2kdVoOAwnqZ+20NAxMW+6ikVHPyhZ7EFlaekUO052l18Hpf1nJnIehw5kx4lZZ/Mkuzi2WYQDUVDiOZRN12SQqCAEsP4vPXLmu2AVudipAIeu9KWFKV6/ypaDSW5OSUsQ9XVAPW2BMJr49Xiyr0VHm6zxjZsS4DxhsCyUd7LY68oMG145Ye6AuBadyHnzN10oUmiRxoSqiZOKoa3DV5J0E8SukEcLjg1TfOyShlskXoXHLkA8YjVAw3IQGOPCVu1bc2Rc8K2/5Pgicouxw3jYM/h4F7iCQ4y72qTTLp6r6WZ5iCkCgs10Fx7Rp3Pu/JU2nafOp1maq4biRvuo+XwIR2BJK/dZhWgK6h7XxNTyLHRSLkuAHfzKIbpuNdfr1+bFDgiaXj/wTxadGGKjTY2EIhBxOPPyNWrU6gr8TX+aoG65x1uOzK0nA29UOTMEIN6E+I6YBCICqY+kcveC4n8dhqmGqcGyACWWVaG+kfqWzjau68hUdnqCqXB0sIpRwTYBEWMDCuXvans6G+s7NqprFSA0O3hF59hfVFleehSmGKsYOb0/iqyW7N0GzHTXG655ytiVNe1JTQLFBK/RhCKUK+BdUbHyAb7IrVoHJtlhIzAnmtPk5S6DcjEDKIvP+/zPNXo/9gIZF5VrSyiXZrnXbmTaHdp9RtNhe1S6e7hx3zDg3wdGzkQeo2WVHth+rcVVPGf817zBfQsemN5YhbFn1gHsnE33xNfNJIL59tRJ6otE3migitdrysKuM3ajkUsdHYZJOOnl+bMp/VZGg1dWOyDghwKPxsJ2d9G1mre4nL6qIdw4MEhYLrqCmU+nOV0Qq5RBbUcs7Mz1JxIn4i9fsFgn9IOMUSYOmM0sIAO8oqTjKVJabkJlV/XUyFUB1rhZCiGM19oW9Y/ZygAO3lgO/p/47wfER7N30tcq4g4BrD+fL7+1DIOG3C25dO21W/J5Mb5ywx6i+9G36lJ1HnPeUiUL7jCHZbuBON/35EYZvC2yvgWy5eg1TuEd3DaQ5/esPMmUWDe9Ob+ApQGC4OFr1Uz+HqX4PM0hSmKsWhrteo2DKOS+ew0cQar0lISN2MzfaN9k/hIoPJX4krOudFqdVwknMGop2OVQtmntaLZS/2kBS46aS7IMj/+rNuVIWtiOFjWLkJms61HcDEwgk2UhcnKxvBAlacN7q91CRgzNOGgRjSpSNXZHRuhkiYJmiHRbEQ9VHPlespm244604Pugr74cSRG86pz8pIOz73NIuB2lR76ZrBCUPBDjIJaK9DqkT6IpDgH3HnXsAZYUvcIo+t51vhGPQwCV4ASYNYXQG2VIdNgYJgHhqzdNkORgB"
+[2026-06-18T11:44:53.382Z] [INFO]       }
+[2026-06-18T11:44:53.382Z] [INFO]     ],
+[2026-06-18T11:44:53.382Z] [INFO]     "stop_reason": null,
+[2026-06-18T11:44:53.382Z] [INFO]     "stop_sequence": null,
+[2026-06-18T11:44:53.382Z] [INFO]     "stop_details": null,
+[2026-06-18T11:44:53.382Z] [INFO]     "usage": {
+[2026-06-18T11:44:53.382Z] [INFO]       "input_tokens": 2,
+[2026-06-18T11:44:53.382Z] [INFO]       "cache_creation_input_tokens": 7409,
+[2026-06-18T11:44:53.382Z] [INFO]       "cache_read_input_tokens": 41351,
+[2026-06-18T11:44:53.382Z] [INFO]       "cache_creation": {
+[2026-06-18T11:44:53.382Z] [INFO]         "ephemeral_5m_input_tokens": 0,
+[2026-06-18T11:44:53.382Z] [INFO]         "ephemeral_1h_input_tokens": 7409
+[2026-06-18T11:44:53.382Z] [INFO]       },
+[2026-06-18T11:44:53.382Z] [INFO]       "output_tokens": 3,
+[2026-06-18T11:44:53.382Z] [INFO]       "service_tier": "standard",
+[2026-06-18T11:44:53.382Z] [INFO]       "inference_geo": "not_available"
+[2026-06-18T11:44:53.382Z] [INFO]     },
+[2026-06-18T11:44:53.382Z] [INFO]     "diagnostics": null,
+[2026-06-18T11:44:53.382Z] [INFO]     "context_management": null
+[2026-06-18T11:44:53.382Z] [INFO]   },
+[2026-06-18T11:44:53.382Z] [INFO]   "parent_tool_use_id": null,
+[2026-06-18T11:44:53.382Z] [INFO]   "session_id": "d65e890a-db60-43f7-aea3-691500f7e26c",
+[2026-06-18T11:44:53.382Z] [INFO]   "uuid": "32984e73-1b59-45e4-8a4e-cdad4a266845",
+[2026-06-18T11:44:53.382Z] [INFO]   "request_id": "req_011CcAfh2P8QCzsK6is19P5q"
+[2026-06-18T11:44:53.382Z] [INFO] }
+[2026-06-18T11:44:55.269Z] [INFO] {
+[2026-06-18T11:44:55.269Z] [INFO]   "type": "assistant",
+[2026-06-18T11:44:55.269Z] [INFO]   "message": {
+[2026-06-18T11:44:55.269Z] [INFO]     "model": "claude-opus-4-8",
+[2026-06-18T11:44:55.269Z] [INFO]     "id": "msg_01CeMbPPuQyRq6tqTi6Ccu1g",
+[2026-06-18T11:44:55.269Z] [INFO]     "type": "message",
+[2026-06-18T11:44:55.269Z] [INFO]     "role": "assistant",
+[2026-06-18T11:44:55.269Z] [INFO]     "content": [
+[2026-06-18T11:44:55.269Z] [INFO]       {
+[2026-06-18T11:44:55.269Z] [INFO]         "type": "tool_use",
+[2026-06-18T11:44:55.269Z] [INFO]         "id": "toolu_01RkheqxbjJoMayt3ErCno6n",
+[2026-06-18T11:44:55.269Z] [INFO]         "name": "Bash",
+[2026-06-18T11:44:55.269Z] [INFO]         "input": {
+[2026-06-18T11:44:55.269Z] [INFO]           "command": "echo \"===external insights list===\"; ls research/external-knowledge/external-insights/; echo \"===building-effective-agents head===\"; sed -n '1,40p' research/external-knowledge/external-insights/building-effective-agents-2026-06.md; echo \"===registry grep===\"; grep -iE \"langchain|crewai|autogpt|microsoft|foundry\" research/external-knowledge/external-sources-registry.md | head",
+[2026-06-18T11:44:55.269Z] [INFO]           "description": "Examine external insights and registry"
+[2026-06-18T11:44:55.269Z] [INFO]         },
+[2026-06-18T11:44:55.269Z] [INFO]         "caller": {
+[2026-06-18T11:44:55.269Z] [INFO]           "type": "direct"
+[2026-06-18T11:44:55.269Z] [INFO]         }
+[2026-06-18T11:44:55.269Z] [INFO]       }
+[2026-06-18T11:44:55.269Z] [INFO]     ],
+[2026-06-18T11:44:55.269Z] [INFO]     "stop_reason": null,
+[2026-06-18T11:44:55.269Z] [INFO]     "stop_sequence": null,
+[2026-06-18T11:44:55.269Z] [INFO]     "stop_details": null,
+[2026-06-18T11:44:55.269Z] [INFO]     "usage": {
+[2026-06-18T11:44:55.269Z] [INFO]       "input_tokens": 2,
+[2026-06-18T11:44:55.269Z] [INFO]       "cache_creation_input_tokens": 7409,
+[2026-06-18T11:44:55.269Z] [INFO]       "cache_read_input_tokens": 41351,
+[2026-06-18T11:44:55.269Z] [INFO]       "cache_creation": {
+[2026-06-18T11:44:55.269Z] [INFO]         "ephemeral_5m_input_tokens": 0,
+[2026-06-18T11:44:55.269Z] [INFO]         "ephemeral_1h_input_tokens": 7409
+[2026-06-18T11:44:55.269Z] [INFO]       },
+[2026-06-18T11:44:55.269Z] [INFO]       "output_tokens": 3,
+[2026-06-18T11:44:55.269Z] [INFO]       "service_tier": "standard",
+[2026-06-18T11:44:55.269Z] [INFO]       "inference_geo": "not_available"
+[2026-06-18T11:44:55.269Z] [INFO]     },
+[2026-06-18T11:44:55.269Z] [INFO]     "diagnostics": null,
+[2026-06-18T11:44:55.269Z] [INFO]     "context_management": null
+[2026-06-18T11:44:55.269Z] [INFO]   },
+[2026-06-18T11:44:55.269Z] [INFO]   "parent_tool_use_id": null,
+[2026-06-18T11:44:55.269Z] [INFO]   "session_id": "d65e890a-db60-43f7-aea3-691500f7e26c",
+[2026-06-18T11:44:55.269Z] [INFO]   "uuid": "c7fcb63b-41f2-43ab-8d2f-0c56c5f42029",
+[2026-06-18T11:44:55.269Z] [INFO]   "request_id": "req_011CcAfh2P8QCzsK6is19P5q"
+[2026-06-18T11:44:55.269Z] [INFO] }
+[2026-06-18T11:44:56.264Z] [INFO] {
+[2026-06-18T11:44:56.264Z] [INFO]   "type": "user",
+[2026-06-18T11:44:56.264Z] [INFO]   "message": {
+[2026-06-18T11:44:56.264Z] [INFO]     "role": "user",
+[2026-06-18T11:44:56.264Z] [INFO]     "content": [
+[2026-06-18T11:44:56.264Z] [INFO]       {
+[2026-06-18T11:44:56.264Z] [INFO]         "tool_use_id": "toolu_01RkheqxbjJoMayt3ErCno6n",
+[2026-06-18T11:44:56.264Z] [INFO]         "type": "tool_result",
+[2026-06-18T11:44:56.264Z] [INFO]         "content": "===external insights list===\n12-factor-agents-2026-06.md\nREADME.md\nagent-local-memory-context-2026-06.md\nbuilding-effective-agents-2026-06.md\nspec-driven-development-2026-06.md\nstructured-prompt-driven-development-2026-06.md\n===building-effective-agents head===\n---\nstatus: draft\nversion: 0.1\nupdated: 2026-06-13\ntemperature: 0.1\nai-generated: true\ntype: external-analysis\nsource_id: ext-001\nstage: research\nprojects: [hub, mango, open-ai.ru, clarify-engine-ai]\ncontext: [agents, workflow-patterns, orchestration, hybrid-collaboration]\n---\n\n# Инсайт: простые компонуемые паттерны > монолитные «умные» агенты\n\n**Источник:** `ext-001` —\n[Anthropic: Building Effective Agents](https://www.anthropic.com/engineering/building-effective-agents)\n(см. [реестр](../external-sources-registry.md)).\n\n## Вывод (атомарно)\n\nНадёжные агентные системы строятся не из одного «универсального» агента, а из\nнебольшого набора **компонуемых паттернов**: prompt chaining, routing,\nparallelization, orchestrator-workers, evaluator-optimizer. Сложность вводится\nтолько тогда, когда более простой паттерн (один LLM-вызов с инструментами)\nперестаёт справляться.\n\n## Почему это релевантно экосистеме\n\n- **Прямое совпадение с Anti-Inflation principle** Хаба\n  ([governance/repo-model.md](../../../governance/repo-model.md)): «не добавлять\n  сложность без операционной боли». Источник формулирует тот же принцип для\n  архитектуры агентов.\n- Совпадает с нашим разделением **descriptive vs executable** документов\n  ([standards/executable-documentation-standard.md](../../../standards/executable-documentation-standard.md)):\n  атомарные практики ≈ компонуемые шаги.\n\n## Аргументы за/против\n\n| За | Против / Ограничение |\n===registry grep===\n| `ext-016` | [LangChain — langchain-ai/langchain](https://github.com/langchain-ai/langchain) | `github` | `en` | `repository-architecture, agents, framework, integrations` | `topic: archetypes, topic: prompt-libraries` | `research` | `all` | ✅ [repository-archetypes-template-release.md](../../governance/rfc/repository-archetypes-template-release.md) |\n| `ext-017` | [CrewAI examples](https://github.com/crewAIInc/crewAI-examples) | `github` | `en` | `repository-architecture, examples, agents, templates` | `topic: prompt-libraries, topic: examples` | `research` | `all` | ✅ [repository-archetypes-template-release.md](../../governance/rfc/repository-archetypes-template-release.md) |\n| `ext-018` | [Microsoft Foundry samples](https://github.com/microsoft-foundry/foundry-samples) | `github` | `en` | `repository-architecture, samples, ai-foundry, documentation` | `topic: archetypes, topic: samples` | `research` | `all` | ✅ [repository-archetypes-template-release.md](../../governance/rfc/repository-archetypes-template-release.md) |\n| `ext-019` | [Microsoft Foundry — AI solution templates](https://learn.microsoft.com/en-us/azure/foundry/how-to/develop/ai-template-get-started) | `docs` | `en` | `templates, ai-foundry, quickstart, deployment` | `topic: project-template, topic: production-readiness` | `research` | `all` | ✅ [repository-archetypes-template-release.md](../../governance/rfc/repository-archetypes-template-release.md) |\n| `ext-029` | [Microsoft — Agentic AI adoption maturity model](https://learn.microsoft.com/en-us/agents/adoption-maturity-model/) | `docs` | `en` | `enterprise-intelligence, ai-readiness, maturity-model` | `future-phase: agents` | `research` | `hub, open-ai.ru` | ✅ [methodology-research-and-proposals.md](../../governance/rfc/methodology-research-and-proposals.md) |",
+[2026-06-18T11:44:56.264Z] [INFO]         "is_error": false
+[2026-06-18T11:44:56.264Z] [INFO]       }
+[2026-06-18T11:44:56.264Z] [INFO]     ]
+[2026-06-18T11:44:56.264Z] [INFO]   },
+[2026-06-18T11:44:56.264Z] [INFO]   "parent_tool_use_id": null,
+[2026-06-18T11:44:56.264Z] [INFO]   "session_id": "d65e890a-db60-43f7-aea3-691500f7e26c",
+[2026-06-18T11:44:56.264Z] [INFO]   "uuid": "e4748d84-f052-4699-8283-03b192f3f33e",
+[2026-06-18T11:44:56.264Z] [INFO]   "timestamp": "2026-06-18T11:44:56.261Z",
+[2026-06-18T11:44:56.264Z] [INFO]   "tool_use_result": {
+[2026-06-18T11:44:56.264Z] [INFO]     "stdout": "===external insights list===\n12-factor-agents-2026-06.md\nREADME.md\nagent-local-memory-context-2026-06.md\nbuilding-effective-agents-2026-06.md\nspec-driven-development-2026-06.md\nstructured-prompt-driven-development-2026-06.md\n===building-effective-agents head===\n---\nstatus: draft\nversion: 0.1\nupdated: 2026-06-13\ntemperature: 0.1\nai-generated: true\ntype: external-analysis\nsource_id: ext-001\nstage: research\nprojects: [hub, mango, open-ai.ru, clarify-engine-ai]\ncontext: [agents, workflow-patterns, orchestration, hybrid-collaboration]\n---\n\n# Инсайт: простые компонуемые паттерны > монолитные «умные» агенты\n\n**Источник:** `ext-001` —\n[Anthropic: Building Effective Agents](https://www.anthropic.com/engineering/building-effective-agents)\n(см. [реестр](../external-sources-registry.md)).\n\n## Вывод (атомарно)\n\nНадёжные агентные системы строятся не из одного «универсального» агента, а из\nнебольшого набора **компонуемых паттернов**: prompt chaining, routing,\nparallelization, orchestrator-workers, evaluator-optimizer. Сложность вводится\nтолько тогда, когда более простой паттерн (один LLM-вызов с инструментами)\nперестаёт справляться.\n\n## Почему это релевантно экосистеме\n\n- **Прямое совпадение с Anti-Inflation principle** Хаба\n  ([governance/repo-model.md](../../../governance/repo-model.md)): «не добавлять\n  сложность без операционной боли». Источник формулирует тот же принцип для\n  архитектуры агентов.\n- Совпадает с нашим разделением **descriptive vs executable** документов\n  ([standards/executable-documentation-standard.md](../../../standards/executable-documentation-standard.md)):\n  атомарные практики ≈ компонуемые шаги.\n\n## Аргументы за/против\n\n| За | Против / Ограничение |\n===registry grep===\n| `ext-016` | [LangChain — langchain-ai/langchain](https://github.com/langchain-ai/langchain) | `github` | `en` | `repository-architecture, agents, framework, integrations` | `topic: archetypes, topic: prompt-libraries` | `research` | `all` | ✅ [repository-archetypes-template-release.md](../../governance/rfc/repository-archetypes-template-release.md) |\n| `ext-017` | [CrewAI examples](https://github.com/crewAIInc/crewAI-examples) | `github` | `en` | `repository-architecture, examples, agents, templates` | `topic: prompt-libraries, topic: examples` | `research` | `all` | ✅ [repository-archetypes-template-release.md](../../governance/rfc/repository-archetypes-template-release.md) |\n| `ext-018` | [Microsoft Foundry samples](https://github.com/microsoft-foundry/foundry-samples) | `github` | `en` | `repository-architecture, samples, ai-foundry, documentation` | `topic: archetypes, topic: samples` | `research` | `all` | ✅ [repository-archetypes-template-release.md](../../governance/rfc/repository-archetypes-template-release.md) |\n| `ext-019` | [Microsoft Foundry — AI solution templates](https://learn.microsoft.com/en-us/azure/foundry/how-to/develop/ai-template-get-started) | `docs` | `en` | `templates, ai-foundry, quickstart, deployment` | `topic: project-template, topic: production-readiness` | `research` | `all` | ✅ [repository-archetypes-template-release.md](../../governance/rfc/repository-archetypes-template-release.md) |\n| `ext-029` | [Microsoft — Agentic AI adoption maturity model](https://learn.microsoft.com/en-us/agents/adoption-maturity-model/) | `docs` | `en` | `enterprise-intelligence, ai-readiness, maturity-model` | `future-phase: agents` | `research` | `hub, open-ai.ru` | ✅ [methodology-research-and-proposals.md](../../governance/rfc/methodology-research-and-proposals.md) |",
+[2026-06-18T11:44:56.264Z] [INFO]     "stderr": "",
+[2026-06-18T11:44:56.264Z] [INFO]     "interrupted": false,
+[2026-06-18T11:44:56.264Z] [INFO]     "isImage": false,
+[2026-06-18T11:44:56.264Z] [INFO]     "noOutputExpected": false
+[2026-06-18T11:44:56.264Z] [INFO]   }
+[2026-06-18T11:44:56.264Z] [INFO] }
+[2026-06-18T11:44:56.552Z] [INFO] {
+[2026-06-18T11:44:56.552Z] [INFO]   "type": "assistant",
+[2026-06-18T11:44:56.552Z] [INFO]   "message": {
+[2026-06-18T11:44:56.552Z] [INFO]     "model": "claude-opus-4-8",
+[2026-06-18T11:44:56.552Z] [INFO]     "id": "msg_01CeMbPPuQyRq6tqTi6Ccu1g",
+[2026-06-18T11:44:56.552Z] [INFO]     "type": "message",
+[2026-06-18T11:44:56.552Z] [INFO]     "role": "assistant",
+[2026-06-18T11:44:56.552Z] [INFO]     "content": [
+[2026-06-18T11:44:56.552Z] [INFO]       {
+[2026-06-18T11:44:56.552Z] [INFO]         "type": "tool_use",
+[2026-06-18T11:44:56.552Z] [INFO]         "id": "toolu_01GFb7AMWU8AoL3nQsHQwqhr",
+[2026-06-18T11:44:56.552Z] [INFO]         "name": "Bash",
+[2026-06-18T11:44:56.552Z] [INFO]         "input": {
+[2026-06-18T11:44:56.552Z] [INFO]           "command": "echo \"===validate tools===\"; ls tools/; echo \"=== run frontmatter validator help ===\"; head -30 tools/validate-frontmatter.sh",
+[2026-06-18T11:44:56.552Z] [INFO]           "description": "List tools"
+[2026-06-18T11:44:56.552Z] [INFO]         },
+[2026-06-18T11:44:56.552Z] [INFO]         "caller": {
+[2026-06-18T11:44:56.552Z] [INFO]           "type": "direct"
+[2026-06-18T11:44:56.552Z] [INFO]         }
+[2026-06-18T11:44:56.552Z] [INFO]       }
+[2026-06-18T11:44:56.552Z] [INFO]     ],
+[2026-06-18T11:44:56.552Z] [INFO]     "stop_reason": null,
+[2026-06-18T11:44:56.552Z] [INFO]     "stop_sequence": null,
+[2026-06-18T11:44:56.552Z] [INFO]     "stop_details": null,
+[2026-06-18T11:44:56.552Z] [INFO]     "usage": {
+[2026-06-18T11:44:56.552Z] [INFO]       "input_tokens": 2,
+[2026-06-18T11:44:56.552Z] [INFO]       "cache_creation_input_tokens": 7409,
+[2026-06-18T11:44:56.552Z] [INFO]       "cache_read_input_tokens": 41351,
+[2026-06-18T11:44:56.552Z] [INFO]       "cache_creation": {
+[2026-06-18T11:44:56.552Z] [INFO]         "ephemeral_5m_input_tokens": 0,
+[2026-06-18T11:44:56.552Z] [INFO]         "ephemeral_1h_input_tokens": 7409
+[2026-06-18T11:44:56.552Z] [INFO]       },
+[2026-06-18T11:44:56.552Z] [INFO]       "output_tokens": 3,
+[2026-06-18T11:44:56.552Z] [INFO]       "service_tier": "standard",
+[2026-06-18T11:44:56.552Z] [INFO]       "inference_geo": "not_available"
+[2026-06-18T11:44:56.552Z] [INFO]     },
+[2026-06-18T11:44:56.552Z] [INFO]     "diagnostics": null,
+[2026-06-18T11:44:56.552Z] [INFO]     "context_management": null
+[2026-06-18T11:44:56.552Z] [INFO]   },
+[2026-06-18T11:44:56.552Z] [INFO]   "parent_tool_use_id": null,
+[2026-06-18T11:44:56.552Z] [INFO]   "session_id": "d65e890a-db60-43f7-aea3-691500f7e26c",
+[2026-06-18T11:44:56.552Z] [INFO]   "uuid": "08678877-ce6d-4bdb-b87a-1f99d1041fc6",
+[2026-06-18T11:44:56.552Z] [INFO]   "request_id": "req_011CcAfh2P8QCzsK6is19P5q"
+[2026-06-18T11:44:56.552Z] [INFO] }
+[2026-06-18T11:44:57.728Z] [INFO] {
+[2026-06-18T11:44:57.728Z] [INFO]   "type": "user",
+[2026-06-18T11:44:57.728Z] [INFO]   "message": {
+[2026-06-18T11:44:57.728Z] [INFO]     "role": "user",
+[2026-06-18T11:44:57.728Z] [INFO]     "content": [
+[2026-06-18T11:44:57.728Z] [INFO]       {
+[2026-06-18T11:44:57.728Z] [INFO]         "tool_use_id": "toolu_01GFb7AMWU8AoL3nQsHQwqhr",
+[2026-06-18T11:44:57.728Z] [INFO]         "type": "tool_result",
+[2026-06-18T11:44:57.728Z] [INFO]         "content": "===validate tools===\ngenerate-manifest.py\nsync-from-hub.sh\nvalidate-frontmatter.sh\nvalidate-mkdocs-site.sh\nvalidate-repository-structure.sh\n=== run frontmatter validator help ===\n#!/usr/bin/env bash\nset -euo pipefail\nshopt -s extglob\n\nROOT_DIR=\"$(cd \"$(dirname \"${BASH_SOURCE[0]}\")/..\" && pwd)\"\ncd \"$ROOT_DIR\"\n\nwarnings=0\n\nrequired_fields=(\n  \"status\"\n  \"version\"\n  \"updated\"\n  \"temperature\"\n)\n\noptional_fields=(\n  \"ai-generated\"\n  \"executable\"\n  \"entrypoint\"\n)\n\nwarn() {\n  local path=\"$1\"\n  local line=\"$2\"\n  local message=\"$3\"\n\n  printf '%s:%s: WARN: %s\\n' \"$path\" \"$line\" \"$message\" >&2\n  warnings=$((warnings + 1))\n}",
+[2026-06-18T11:44:57.728Z] [INFO]         "is_error": false
+[2026-06-18T11:44:57.728Z] [INFO]       }
+[2026-06-18T11:44:57.728Z] [INFO]     ]
+[2026-06-18T11:44:57.728Z] [INFO]   },
+[2026-06-18T11:44:57.728Z] [INFO]   "parent_tool_use_id": null,
+[2026-06-18T11:44:57.728Z] [INFO]   "session_id": "d65e890a-db60-43f7-aea3-691500f7e26c",
+[2026-06-18T11:44:57.728Z] [INFO]   "uuid": "f29f957a-d106-4653-9f12-3a34335e8e59",
+[2026-06-18T11:44:57.728Z] [INFO]   "timestamp": "2026-06-18T11:44:57.725Z",
+[2026-06-18T11:44:57.728Z] [INFO]   "tool_use_result": {
+[2026-06-18T11:44:57.728Z] [INFO]     "stdout": "===validate tools===\ngenerate-manifest.py\nsync-from-hub.sh\nvalidate-frontmatter.sh\nvalidate-mkdocs-site.sh\nvalidate-repository-structure.sh\n=== run frontmatter validator help ===\n#!/usr/bin/env bash\nset -euo pipefail\nshopt -s extglob\n\nROOT_DIR=\"$(cd \"$(dirname \"${BASH_SOURCE[0]}\")/..\" && pwd)\"\ncd \"$ROOT_DIR\"\n\nwarnings=0\n\nrequired_fields=(\n  \"status\"\n  \"version\"\n  \"updated\"\n  \"temperature\"\n)\n\noptional_fields=(\n  \"ai-generated\"\n  \"executable\"\n  \"entrypoint\"\n)\n\nwarn() {\n  local path=\"$1\"\n  local line=\"$2\"\n  local message=\"$3\"\n\n  printf '%s:%s: WARN: %s\\n' \"$path\" \"$line\" \"$message\" >&2\n  warnings=$((warnings + 1))\n}",
+[2026-06-18T11:44:57.728Z] [INFO]     "stderr": "",
+[2026-06-18T11:44:57.728Z] [INFO]     "interrupted": false,
+[2026-06-18T11:44:57.728Z] [INFO]     "isImage": false,
+[2026-06-18T11:44:57.728Z] [INFO]     "noOutputExpected": false
+[2026-06-18T11:44:57.728Z] [INFO]   }
+[2026-06-18T11:44:57.728Z] [INFO] }
+[2026-06-18T11:44:57.741Z] [INFO] [log_b62f06] sending request {
+[2026-06-18T11:44:57.744Z] [INFO]   method: "post",
+[2026-06-18T11:44:57.746Z] [INFO]   url: "https://api.anthropic.com/v1/messages?beta=true",
+[2026-06-18T11:44:57.750Z] [INFO]   options: {
+[2026-06-18T11:44:57.755Z] [INFO]     method: "post",
+[2026-06-18T11:44:57.759Z] [INFO]     path: "/v1/messages?beta=true",
+[2026-06-18T11:44:57.761Z] [INFO]     body: {
+[2026-06-18T11:44:57.762Z] [INFO]       model: "claude-opus-4-8",
+[2026-06-18T11:44:57.764Z] [INFO]       messages: [
+[2026-06-18T11:44:57.764Z] [INFO]         [Object ...], [Object ...], [Object ...], [Object ...], [Object ...], [Object ...], [Object ...], [Object ...], [Object ...], [Object ...], [Object ...], [Object ...], [Object ...], [Object ...], [Object ...], [Object ...]
+[2026-06-18T11:44:57.764Z] [INFO]       ],
+[2026-06-18T11:44:57.765Z] [INFO]       system: [
+[2026-06-18T11:44:57.765Z] [INFO]         [Object ...], [Object ...], [Object ...], [Object ...]
+[2026-06-18T11:44:57.765Z] [INFO]       ],
+[2026-06-18T11:44:57.766Z] [INFO]       tools: [
+[2026-06-18T11:44:57.766Z] [INFO]         [Object ...], [Object ...], [Object ...], [Object ...], [Object ...], [Object ...], [Object ...], [Object ...]
+[2026-06-18T11:44:57.767Z] [INFO]       ],
+[2026-06-18T11:44:57.768Z] [INFO]       tool_choice: undefined,
+[2026-06-18T11:44:57.768Z] [INFO]       metadata: [Object ...],
+[2026-06-18T11:44:57.768Z] [INFO]       max_tokens: 128000,
+[2026-06-18T11:44:57.769Z] [INFO]       thinking: [Object ...],
+[2026-06-18T11:44:57.769Z] [INFO]       context_management: [Object ...],
+[2026-06-18T11:44:57.769Z] [INFO]       output_config: [Object ...],
+[2026-06-18T11:44:57.771Z] [INFO]       diagnostics: [Object ...],
+[2026-06-18T11:44:57.773Z] [INFO]       stream: true,
+[2026-06-18T11:44:57.773Z] [INFO]     },
+[2026-06-18T11:44:57.775Z] [INFO]     timeout: 600000,
+[2026-06-18T11:44:57.776Z] [INFO]     signal: AbortSignal {
+[2026-06-18T11:44:57.776Z] [INFO]       [Symbol(events.maxEventTargetListeners)]: 50,
+[2026-06-18T11:44:57.777Z] [INFO]       [Symbol(events.maxEventTargetListenersWarned)]: false,
+[2026-06-18T11:44:57.777Z] [INFO]       aborted: false,
+[2026-06-18T11:44:57.777Z] [INFO]       reason: undefined,
+[2026-06-18T11:44:57.778Z] [INFO]       onabort: null,
+[2026-06-18T11:44:57.778Z] [INFO]       throwIfAborted: [Function: throwIfAborted],
+[2026-06-18T11:44:57.778Z] [INFO]       addEventListener: [Function: addEventListener],
+[2026-06-18T11:44:57.778Z] [INFO]       removeEventListener: [Function: removeEventListener],
+[2026-06-18T11:44:57.779Z] [INFO]       dispatchEvent: [Function: dispatchEvent],
+[2026-06-18T11:44:57.779Z] [INFO]     },
+[2026-06-18T11:44:57.780Z] [INFO]     stream: true,
+[2026-06-18T11:44:57.780Z] [INFO]   },
+[2026-06-18T11:44:57.781Z] [INFO]   headers: {
+[2026-06-18T11:44:57.782Z] [INFO]     accept: "application/json",
+[2026-06-18T11:44:57.783Z] [INFO]     "anthropic-beta": "claude-code-20250219,oauth-2025-04-20,interleaved-thinking-2025-05-14,thinking-token-count-2026-05-13,context-management-2025-06-27,prompt-caching-scope-2026-01-05,mid-conversation-system-2026-04-07,advisor-tool-2026-03-01,advanced-tool-use-2025-11-20,effort-2025-11-24,extended-cache-ttl-2025-04-11,cache-diagnosis-2026-04-07",
+[2026-06-18T11:44:57.783Z] [INFO]     "anthropic-dangerous-direct-browser-access": "true",
+[2026-06-18T11:44:57.783Z] [INFO]     "anthropic-version": "2023-06-01",
+[2026-06-18T11:44:57.784Z] [INFO]     authorization: "***",
+[2026-06-18T11:44:57.785Z] [INFO]     "content-type": "application/json",
+[2026-06-18T11:44:57.785Z] [INFO]     "user-agent": "claude-cli/2.1.181 (external, sdk-cli)",
+[2026-06-18T11:44:57.786Z] [INFO]     "x-app": "cli",
+[2026-06-18T11:44:57.787Z] [INFO]     "x-claude-code-session-id": "d65e890a-db60-43f7-aea3-691500f7e26c",
+[2026-06-18T11:44:57.788Z] [INFO]     "x-client-request-id": "d2dce689-60df-4b05-824f-a6fa1dcac665",
+[2026-06-18T11:44:57.788Z] [INFO]     "x-stainless-arch": "x64",
+[2026-06-18T11:44:57.789Z] [INFO]     "x-stainless-lang": "js",
+[2026-06-18T11:44:57.789Z] [INFO]     "x-stainless-os": "Linux",
+[2026-06-18T11:44:57.790Z] [INFO]     "x-stainless-package-version": "0.94.0",
+[2026-06-18T11:44:57.790Z] [INFO]     "x-stainless-retry-count": "0",
+[2026-06-18T11:44:57.791Z] [INFO]     "x-stainless-runtime": "node",
+[2026-06-18T11:44:57.792Z] [INFO]     "x-stainless-runtime-version": "v24.3.0",
+[2026-06-18T11:44:57.793Z] [INFO]     "x-stainless-timeout": "600",
+[2026-06-18T11:44:57.794Z] [INFO]   },
+[2026-06-18T11:44:57.794Z] [INFO] }
+[2026-06-18T11:44:58.809Z] [INFO] [log_b62f06, request-id: "req_011CcAfhwD72aVaT9nF1UoHQ"] post https://api.anthropic.com/v1/messages?beta=true succeeded with status 200 in 1067ms
+[2026-06-18T11:44:58.810Z] [INFO] [log_b62f06] response start {
+[2026-06-18T11:44:58.810Z] [INFO]   url: "https://api.anthropic.com/v1/messages?beta=true",
+[2026-06-18T11:44:58.811Z] [INFO]   status: 200,
+[2026-06-18T11:44:58.811Z] [INFO]   headers: {
+[2026-06-18T11:44:58.811Z] [INFO]     "anthropic-organization-id": "ebc2ac93-f86f-4d15-aff3-de8830d8d789",
+[2026-06-18T11:44:58.811Z] [INFO]     "anthropic-ratelimit-unified-5h-reset": "1781787000",
+[2026-06-18T11:44:58.811Z] [INFO]     "anthropic-ratelimit-unified-5h-status": "allowed",
+[2026-06-18T11:44:58.811Z] [INFO]     "anthropic-ratelimit-unified-5h-utilization": "0.33",
+[2026-06-18T11:44:58.812Z] [INFO]     "anthropic-ratelimit-unified-7d-reset": "1782212400",
+[2026-06-18T11:44:58.812Z] [INFO]     "anthropic-ratelimit-unified-7d-status": "allowed",
+[2026-06-18T11:44:58.812Z] [INFO]     "anthropic-ratelimit-unified-7d-utilization": "0.62",
+[2026-06-18T11:44:58.812Z] [INFO]     "anthropic-ratelimit-unified-fallback-percentage": "0.5",
+[2026-06-18T11:44:58.812Z] [INFO]     "anthropic-ratelimit-unified-overage-disabled-reason": "org_level_disabled",
+[2026-06-18T11:44:58.812Z] [INFO]     "anthropic-ratelimit-unified-overage-status": "rejected",
+[2026-06-18T11:44:58.812Z] [INFO]     "anthropic-ratelimit-unified-representative-claim": "five_hour",
+[2026-06-18T11:44:58.813Z] [INFO]     "anthropic-ratelimit-unified-reset": "1781787000",
+[2026-06-18T11:44:58.814Z] [INFO]     "anthropic-ratelimit-unified-status": "allowed",
+[2026-06-18T11:44:58.814Z] [INFO]     "cache-control": "no-cache",
+[2026-06-18T11:44:58.815Z] [INFO]     "cf-cache-status": "DYNAMIC",
+[2026-06-18T11:44:58.817Z] [INFO]     "cf-ray": "a0da0b88fd88dc48-FRA",
+[2026-06-18T11:44:58.817Z] [INFO]     connection: "keep-alive",
+[2026-06-18T11:44:58.817Z] [INFO]     "content-encoding": "gzip",
+[2026-06-18T11:44:58.817Z] [INFO]     "content-security-policy": "default-src 'none'; frame-ancestors 'none'",
+[2026-06-18T11:44:58.818Z] [INFO]     "content-type": "text/event-stream; charset=utf-8",
+[2026-06-18T11:44:58.818Z] [INFO]     date: "Thu, 18 Jun 2026 11:44:58 GMT",
+[2026-06-18T11:44:58.818Z] [INFO]     "request-id": "req_011CcAfhwD72aVaT9nF1UoHQ",
+[2026-06-18T11:44:58.819Z] [INFO]     server: "cloudflare",
+[2026-06-18T11:44:58.820Z] [INFO]     "strict-transport-security": "max-age=31536000; includeSubDomains; preload",
+[2026-06-18T11:44:58.821Z] [INFO]     traceresponse: "00-2f32cd3f7f38693dbd7da6d1bf4f8d55-f47faa4684300487-01",
+[2026-06-18T11:44:58.821Z] [INFO]     "transfer-encoding": "chunked",
+[2026-06-18T11:44:58.822Z] [INFO]     vary: "Accept-Encoding",
+[2026-06-18T11:44:58.822Z] [INFO]     "x-robots-tag": "none",
+[2026-06-18T11:44:58.823Z] [INFO]     "set-cookie": "***",
+[2026-06-18T11:44:58.824Z] [INFO]   },
+[2026-06-18T11:44:58.825Z] [INFO]   durationMs: 1067,
+[2026-06-18T11:44:58.825Z] [INFO] }
+[2026-06-18T11:44:58.826Z] [INFO] response 200 https://api.anthropic.com/v1/messages?beta=true Headers {
+[2026-06-18T11:44:58.827Z] [INFO]   "date": "Thu, 18 Jun 2026 11:44:58 GMT",
+[2026-06-18T11:44:58.828Z] [INFO]   "content-type": "text/event-stream; charset=utf-8",
+[2026-06-18T11:44:58.829Z] [INFO]   "transfer-encoding": "chunked",
+[2026-06-18T11:44:58.830Z] [INFO]   "connection": "keep-alive",
+[2026-06-18T11:44:58.831Z] [INFO]   "cache-control": "no-cache",
+[2026-06-18T11:44:58.832Z] [INFO]   "strict-transport-security": "max-age=31536000; includeSubDomains; preload",
+[2026-06-18T11:44:58.833Z] [INFO]   "content-encoding": "gzip",
+[2026-06-18T11:44:58.834Z] [INFO]   "vary": "Accept-Encoding",
+[2026-06-18T11:44:58.834Z] [INFO]   "content-security-policy": "default-src 'none'; frame-ancestors 'none'",
+[2026-06-18T11:44:58.835Z] [INFO]   "set-cookie": [ "_cfuvid=rLU.RiwxP5K9mhHswph6ZAl0DLLWlf6NhbY5i1PBkCs-1781783097.7517204-1.0.1.1-nsY2shyCGaqUNPcIYx58uNlSWmPvyhRpz4PTIFvWptQ; HttpOnly; SameSite=None; Secure; Path=/; Domain=api.anthropic.com" ],
+[2026-06-18T11:44:58.835Z] [INFO]   "anthropic-ratelimit-unified-status": "allowed",
+[2026-06-18T11:44:58.837Z] [INFO]   "anthropic-ratelimit-unified-5h-status": "allowed",
+[2026-06-18T11:44:58.838Z] [INFO]   "anthropic-ratelimit-unified-5h-reset": "1781787000",
+[2026-06-18T11:44:58.839Z] [INFO]   "anthropic-ratelimit-unified-5h-utilization": "0.33",
+[2026-06-18T11:44:58.839Z] [INFO]   "anthropic-ratelimit-unified-7d-status": "allowed",
+[2026-06-18T11:44:58.840Z] [INFO]   "anthropic-ratelimit-unified-7d-reset": "1782212400",
+[2026-06-18T11:44:58.841Z] [INFO]   "anthropic-ratelimit-unified-7d-utilization": "0.62",
+[2026-06-18T11:44:58.841Z] [INFO]   "anthropic-ratelimit-unified-representative-claim": "five_hour",
+[2026-06-18T11:44:58.845Z] [INFO]   "anthropic-ratelimit-unified-fallback-percentage": "0.5",
+[2026-06-18T11:44:58.846Z] [INFO]   "anthropic-ratelimit-unified-reset": "1781787000",
+[2026-06-18T11:44:58.847Z] [INFO]   "anthropic-ratelimit-unified-overage-disabled-reason": "org_level_disabled",
+[2026-06-18T11:44:58.847Z] [INFO]   "anthropic-ratelimit-unified-overage-status": "rejected",
+[2026-06-18T11:44:58.848Z] [INFO]   "request-id": "req_011CcAfhwD72aVaT9nF1UoHQ",
+[2026-06-18T11:44:58.848Z] [INFO]   "anthropic-organization-id": "ebc2ac93-f86f-4d15-aff3-de8830d8d789",
+[2026-06-18T11:44:58.849Z] [INFO]   "traceresponse": "00-2f32cd3f7f38693dbd7da6d1bf4f8d55-f47faa4684300487-01",
+[2026-06-18T11:44:58.849Z] [INFO]   "server": "cloudflare",
+[2026-06-18T11:44:58.850Z] [INFO]   "cf-cache-status": "DYNAMIC",
+[2026-06-18T11:44:58.851Z] [INFO]   "x-robots-tag": "none",
+[2026-06-18T11:44:58.851Z] [INFO]   "cf-ray": "a0da0b88fd88dc48-FRA",
+[2026-06-18T11:44:58.851Z] [INFO] } ReadableStream {
+[2026-06-18T11:44:58.852Z] [INFO]   blob: [Function: blob],
+[2026-06-18T11:44:58.852Z] [INFO]   bytes: [Function: bytes],
+[2026-06-18T11:44:58.852Z] [INFO]   cancel: [Function],
+[2026-06-18T11:44:58.853Z] [INFO]   getReader: [Function],
+[2026-06-18T11:44:58.853Z] [INFO]   json: [Function: json],
+[2026-06-18T11:44:58.853Z] [INFO]   locked: [Getter],
+[2026-06-18T11:44:58.855Z] [INFO]   pipeThrough: [Function],
+[2026-06-18T11:44:58.855Z] [INFO]   pipeTo: [Function],
+[2026-06-18T11:44:58.856Z] [INFO]   tee: [Function],
+[2026-06-18T11:44:58.856Z] [INFO]   text: [Function: text],
+[2026-06-18T11:44:58.856Z] [INFO]   values: [Function: values],
+[2026-06-18T11:44:58.857Z] [INFO]   [Symbol(Symbol.asyncIterator)]: [Function: asyncIterator2],
+[2026-06-18T11:44:58.857Z] [INFO] }
+[2026-06-18T11:44:58.858Z] [INFO] [log_b62f06] response parsed {
+[2026-06-18T11:44:58.858Z] [INFO]   url: "https://api.anthropic.com/v1/messages?beta=true",
+[2026-06-18T11:44:58.858Z] [INFO]   status: 200,
+[2026-06-18T11:44:58.859Z] [INFO]   body: sU {
+[2026-06-18T11:44:58.860Z] [INFO]     iterator: [AsyncGeneratorFunction: s],
+[2026-06-18T11:44:58.860Z] [INFO]     controller: AbortController {
+[2026-06-18T11:44:58.861Z] [INFO]       signal: [AbortSignal ...],
+[2026-06-18T11:44:58.862Z] [INFO]       abort: [Function: abort],
+[2026-06-18T11:44:58.862Z] [INFO]     },
+[2026-06-18T11:44:58.862Z] [INFO]     [Symbol(Symbol.asyncIterator)]: [Function],
+[2026-06-18T11:44:58.863Z] [INFO]     tee: [Function: tee],
+[2026-06-18T11:44:58.863Z] [INFO]     toReadableStream: [Function: toReadableStream],
+[2026-06-18T11:44:58.863Z] [INFO]   },
+[2026-06-18T11:44:58.863Z] [INFO]   durationMs: 1068,
+[2026-06-18T11:44:58.863Z] [INFO] }
+[2026-06-18T11:45:00.247Z] [INFO] {
+[2026-06-18T11:45:00.247Z] [INFO]   "type": "system",
+[2026-06-18T11:45:00.247Z] [INFO]   "subtype": "thinking_tokens",
+[2026-06-18T11:45:00.247Z] [INFO]   "estimated_tokens": 50,
+[2026-06-18T11:45:00.247Z] [INFO]   "estimated_tokens_delta": 50,
+[2026-06-18T11:45:00.247Z] [INFO]   "uuid": "ff018660-0108-4d4e-9860-e6bd522db3f9",
+[2026-06-18T11:45:00.247Z] [INFO]   "session_id": "d65e890a-db60-43f7-aea3-691500f7e26c"
+[2026-06-18T11:45:00.247Z] [INFO] }
+[2026-06-18T11:45:01.665Z] [INFO] {
+[2026-06-18T11:45:01.665Z] [INFO]   "type": "system",
+[2026-06-18T11:45:01.665Z] [INFO]   "subtype": "thinking_tokens",
+[2026-06-18T11:45:01.665Z] [INFO]   "estimated_tokens": 150,
+[2026-06-18T11:45:01.665Z] [INFO]   "estimated_tokens_delta": 100,
+[2026-06-18T11:45:01.665Z] [INFO]   "uuid": "26f42a47-8127-4dc4-9065-e6f9fedb7f02",
+[2026-06-18T11:45:01.665Z] [INFO]   "session_id": "d65e890a-db60-43f7-aea3-691500f7e26c"
+[2026-06-18T11:45:01.665Z] [INFO] }
+[2026-06-18T11:45:03.071Z] [INFO] {
+[2026-06-18T11:45:03.071Z] [INFO]   "type": "system",
+[2026-06-18T11:45:03.071Z] [INFO]   "subtype": "thinking_tokens",
+[2026-06-18T11:45:03.071Z] [INFO]   "estimated_tokens": 250,
+[2026-06-18T11:45:03.071Z] [INFO]   "estimated_tokens_delta": 100,
+[2026-06-18T11:45:03.071Z] [INFO]   "uuid": "4dba0a30-3ca2-4b56-b69a-e4285f3ed3e9",
+[2026-06-18T11:45:03.071Z] [INFO]   "session_id": "d65e890a-db60-43f7-aea3-691500f7e26c"
+[2026-06-18T11:45:03.071Z] [INFO] }
+[2026-06-18T11:45:03.543Z] [INFO] {
+[2026-06-18T11:45:03.543Z] [INFO]   "type": "system",
+[2026-06-18T11:45:03.543Z] [INFO]   "subtype": "thinking_tokens",
+[2026-06-18T11:45:03.543Z] [INFO]   "estimated_tokens": 296,
+[2026-06-18T11:45:03.543Z] [INFO]   "estimated_tokens_delta": 46,
+[2026-06-18T11:45:03.543Z] [INFO]   "uuid": "6028a833-9956-4ef8-affa-5f63223f668a",
+[2026-06-18T11:45:03.543Z] [INFO]   "session_id": "d65e890a-db60-43f7-aea3-691500f7e26c"
+[2026-06-18T11:45:03.543Z] [INFO] }
+[2026-06-18T11:45:03.562Z] [INFO] {
+[2026-06-18T11:45:03.562Z] [INFO]   "type": "assistant",
+[2026-06-18T11:45:03.562Z] [INFO]   "message": {
+[2026-06-18T11:45:03.562Z] [INFO]     "model": "claude-opus-4-8",
+[2026-06-18T11:45:03.562Z] [INFO]     "id": "msg_011y3RztJ2T2Xg6NsvjcyaCM",
+[2026-06-18T11:45:03.562Z] [INFO]     "type": "message",
+[2026-06-18T11:45:03.562Z] [INFO]     "role": "assistant",
+[2026-06-18T11:45:03.562Z] [INFO]     "content": [
+[2026-06-18T11:45:03.562Z] [INFO]       {
+[2026-06-18T11:45:03.562Z] [INFO]         "type": "thinking",
+[2026-06-18T11:45:03.562Z] [INFO]         "thinking": "",
+[2026-06-18T11:45:03.562Z] [INFO]         "signature": "EpgJCmMIDhgCKkDR47yWxh2fQZWtPXjFXCNh46xgMx7QKv5LFXDOcSk7409Q9CzZhCyY+6Enmdw/x0a0/NU5G3OC45T0GdMSvRzWMg9jbGF1ZGUtb3B1cy00LTg4AEIIdGhpbmtpbmcSDIm9xun0xRm/m68egBoMpevMGnYWv/doBZjUIjBuNYzRsYg05uVSr6KMFzloLKlMj6ZXaLZhjTYQiLziOMEw/vzTjDjpxL282LNNreIq4gd7JLSd0N9X3CG9B2COXO2ElX5GIZSh7EGEvLCBAdB3rFa2VZiXzDUKt7hnOI/ZZMYKQF/N3FX29PplNXjDiPDeRrDoGLu8Fs+TkSsNXPqI8MWaneNb5uEd3gfiprbm90keTL+YA2Ei5WR1y7BXzM6InjkTYyE71MtPprYwdBqjjN2vgcwWyjeT1QXY+GZPjohEMTCwC9vh44huxXa/3Ng4b5UejFAKPeUhHk3JlYRAg9Sabyk5/gV/9bBbfPGZ9pJqVRIbRi8FExJ2FH1oy1aj1KBZ9/T/CMWWPOtvGaGwmD80VryI8QLjs6nMSeKu+n3P/9Ht5mxNVjvkUnZxNBaPgOsJwkcl/AWG9RYxNDYT5QjQgC4uPsFlA5p9AV58+aSQqBDF5ch921jPYJMRpoSfOkxZbX7OCYlQ9feqIf24qJmtDcINxjKDO61Xg1PJX1zryzRsbwUqtJ/5XYHP8RoVxEtt8piysOk3rkdn0eAo22a3ItiRimaJoKVNZVl4veTN5WHxVmOt451oSOFcrGTra0cake316qrgtu4IVx7JdaZBxFbOxfBWRRtKljzxqrII7T4vIZgMnBS5AqPgs0AZcnujTI4QaobizTuxA3BJ+l/cuod6c2zA2TN3WkF1I8kcG2a2ETOI/NSiJyAi41ZCydObsl1IUQBb2j5gHXIMljjYeJWZKJP78xQq8xn/76SfBTVPeynTY6ByXtMqU+PYJkRJRIx1UmZ+a9NrNk9+dGQKvMF84LH0TOP19xqCPILLonW2LsJozji+evhgKP5aqCaCyAj1TXALz/9vcB/AcZu35hBsDdzTPgJPtRQ6Dt45eIMJYjJNDVK8KKN4dpfnUb6JvSmaO77f+qpUfk01p8n8ELt3NBhoi4RxYER71jqWarb8DsBnZBufOJwSAlYx2+OiV65fVW3UdEI7My4hAHZQw4ZBLytV8ClGYSiS7GC9Ftl4AzNJRJ4zrFtOM8smSTXplxjckyCHnNW0sxNVIAVOX3s6OEmYaDXhG7A/RmMqTJayMARmk7hPrAykRd9lYBn8+z5RT3QiNRHY0avZARNH2whfqAcwKuxT2aXJSgXNqiH7lRD7DgeNbI7/ep5uDtIbGt9gPyqMTx0rxOWXpgubAL5GamSKeRm4J8Nfta0LF2bOU0iOLF6Ylnlb5C+GdFXUaQU5eDNcxKhyOY85cbY50Ksr5ZbAl/wPcNQ+KNQQd6yRIvbB2I84fVtlC/9Rl3MuqDLQxsjxOlRWK4nYJ6rJw+RqDj840aMvlDLkBn6D9aMfIySxMvoQ+G5eTf6ArQ+/KLno8jVBR4A7mvUiikNLGAE="
+[2026-06-18T11:45:03.562Z] [INFO]       }
+[2026-06-18T11:45:03.562Z] [INFO]     ],
+[2026-06-18T11:45:03.562Z] [INFO]     "stop_reason": null,
+[2026-06-18T11:45:03.562Z] [INFO]     "stop_sequence": null,
+[2026-06-18T11:45:03.562Z] [INFO]     "stop_details": null,
+[2026-06-18T11:45:03.562Z] [INFO]     "usage": {
+[2026-06-18T11:45:03.562Z] [INFO]       "input_tokens": 2,
+[2026-06-18T11:45:03.562Z] [INFO]       "cache_creation_input_tokens": 2575,
+[2026-06-18T11:45:03.562Z] [INFO]       "cache_read_input_tokens": 48760,
+[2026-06-18T11:45:03.562Z] [INFO]       "cache_creation": {
+[2026-06-18T11:45:03.562Z] [INFO]         "ephemeral_5m_input_tokens": 0,
+[2026-06-18T11:45:03.562Z] [INFO]         "ephemeral_1h_input_tokens": 2575
+[2026-06-18T11:45:03.562Z] [INFO]       },
+[2026-06-18T11:45:03.562Z] [INFO]       "output_tokens": 2,
+[2026-06-18T11:45:03.562Z] [INFO]       "service_tier": "standard",
+[2026-06-18T11:45:03.562Z] [INFO]       "inference_geo": "not_available"
+[2026-06-18T11:45:03.562Z] [INFO]     },
+[2026-06-18T11:45:03.562Z] [INFO]     "diagnostics": null,
+[2026-06-18T11:45:03.562Z] [INFO]     "context_management": null
+[2026-06-18T11:45:03.562Z] [INFO]   },
+[2026-06-18T11:45:03.562Z] [INFO]   "parent_tool_use_id": null,
+[2026-06-18T11:45:03.562Z] [INFO]   "session_id": "d65e890a-db60-43f7-aea3-691500f7e26c",
+[2026-06-18T11:45:03.562Z] [INFO]   "uuid": "82e06cbf-710b-4ece-8aca-66133aba113b",
+[2026-06-18T11:45:03.562Z] [INFO]   "request_id": "req_011CcAfhwD72aVaT9nF1UoHQ"
+[2026-06-18T11:45:03.562Z] [INFO] }
+[2026-06-18T11:45:05.898Z] [INFO] {
+[2026-06-18T11:45:05.898Z] [INFO]   "type": "assistant",
+[2026-06-18T11:45:05.898Z] [INFO]   "message": {
+[2026-06-18T11:45:05.898Z] [INFO]     "model": "claude-opus-4-8",
+[2026-06-18T11:45:05.898Z] [INFO]     "id": "msg_011y3RztJ2T2Xg6NsvjcyaCM",
+[2026-06-18T11:45:05.898Z] [INFO]     "type": "message",
+[2026-06-18T11:45:05.898Z] [INFO]     "role": "assistant",
+[2026-06-18T11:45:05.898Z] [INFO]     "content": [
+[2026-06-18T11:45:05.898Z] [INFO]       {
+[2026-06-18T11:45:05.898Z] [INFO]         "type": "tool_use",
+[2026-06-18T11:45:05.898Z] [INFO]         "id": "toolu_01HbZh2YoWcbTreRmEKcydmE",
+[2026-06-18T11:45:05.898Z] [INFO]         "name": "Bash",
+[2026-06-18T11:45:05.898Z] [INFO]         "input": {
+[2026-06-18T11:45:05.898Z] [INFO]           "command": "./tools/validate-frontmatter.sh . 2>&1 | tail -5; echo \"EXIT $?\"; echo \"=== structure ===\"; ./tools/validate-repository-structure.sh 2>&1 | tail -15; echo \"EXIT $?\"",
+[2026-06-18T11:45:05.898Z] [INFO]           "description": "Run validators baseline"
+[2026-06-18T11:45:05.898Z] [INFO]         },
+[2026-06-18T11:45:05.898Z] [INFO]         "caller": {
+[2026-06-18T11:45:05.898Z] [INFO]           "type": "direct"
+[2026-06-18T11:45:05.898Z] [INFO]         }
+[2026-06-18T11:45:05.898Z] [INFO]       }
+[2026-06-18T11:45:05.898Z] [INFO]     ],
+[2026-06-18T11:45:05.898Z] [INFO]     "stop_reason": null,
+[2026-06-18T11:45:05.898Z] [INFO]     "stop_sequence": null,
+[2026-06-18T11:45:05.898Z] [INFO]     "stop_details": null,
+[2026-06-18T11:45:05.898Z] [INFO]     "usage": {
+[2026-06-18T11:45:05.898Z] [INFO]       "input_tokens": 2,
+[2026-06-18T11:45:05.898Z] [INFO]       "cache_creation_input_tokens": 2575,
+[2026-06-18T11:45:05.898Z] [INFO]       "cache_read_input_tokens": 48760,
+[2026-06-18T11:45:05.898Z] [INFO]       "cache_creation": {
+[2026-06-18T11:45:05.898Z] [INFO]         "ephemeral_5m_input_tokens": 0,
+[2026-06-18T11:45:05.898Z] [INFO]         "ephemeral_1h_input_tokens": 2575
+[2026-06-18T11:45:05.898Z] [INFO]       },
+[2026-06-18T11:45:05.898Z] [INFO]       "output_tokens": 2,
+[2026-06-18T11:45:05.898Z] [INFO]       "service_tier": "standard",
+[2026-06-18T11:45:05.898Z] [INFO]       "inference_geo": "not_available"
+[2026-06-18T11:45:05.898Z] [INFO]     },
+[2026-06-18T11:45:05.898Z] [INFO]     "diagnostics": null,
+[2026-06-18T11:45:05.898Z] [INFO]     "context_management": null
+[2026-06-18T11:45:05.898Z] [INFO]   },
+[2026-06-18T11:45:05.898Z] [INFO]   "parent_tool_use_id": null,
+[2026-06-18T11:45:05.898Z] [INFO]   "session_id": "d65e890a-db60-43f7-aea3-691500f7e26c",
+[2026-06-18T11:45:05.898Z] [INFO]   "uuid": "4b565aad-4ff9-4d5f-b4a6-3a4105257cef",
+[2026-06-18T11:45:05.898Z] [INFO]   "request_id": "req_011CcAfhwD72aVaT9nF1UoHQ"
+[2026-06-18T11:45:05.898Z] [INFO] }
+[2026-06-18T11:45:07.317Z] [INFO] {
+[2026-06-18T11:45:07.317Z] [INFO]   "type": "assistant",
+[2026-06-18T11:45:07.317Z] [INFO]   "message": {
+[2026-06-18T11:45:07.317Z] [INFO]     "model": "claude-opus-4-8",
+[2026-06-18T11:45:07.317Z] [INFO]     "id": "msg_011y3RztJ2T2Xg6NsvjcyaCM",
+[2026-06-18T11:45:07.317Z] [INFO]     "type": "message",
+[2026-06-18T11:45:07.317Z] [INFO]     "role": "assistant",
+[2026-06-18T11:45:07.317Z] [INFO]     "content": [
+[2026-06-18T11:45:07.317Z] [INFO]       {
+[2026-06-18T11:45:07.317Z] [INFO]         "type": "tool_use",
+[2026-06-18T11:45:07.317Z] [INFO]         "id": "toolu_01WZRV9hZebM5NroYs5WzWVE",
+[2026-06-18T11:45:07.317Z] [INFO]         "name": "Bash",
+[2026-06-18T11:45:07.317Z] [INFO]         "input": {
+[2026-06-18T11:45:07.317Z] [INFO]           "command": "grep -iE \"autogpt|significant-gravitas\" research/external-knowledge/external-sources-registry.md | head; echo \"---tail of registry to find next id---\"; grep -oE 'ext-[0-9]+' research/external-knowledge/external-sources-registry.md | sort -u | tail -5",
+[2026-06-18T11:45:07.317Z] [INFO]           "description": "Check AutoGPT in registry and last id"
+[2026-06-18T11:45:07.317Z] [INFO]         },
+[2026-06-18T11:45:07.317Z] [INFO]         "caller": {
+[2026-06-18T11:45:07.317Z] [INFO]           "type": "direct"
+[2026-06-18T11:45:07.317Z] [INFO]         }
+[2026-06-18T11:45:07.317Z] [INFO]       }
+[2026-06-18T11:45:07.317Z] [INFO]     ],
+[2026-06-18T11:45:07.317Z] [INFO]     "stop_reason": null,
+[2026-06-18T11:45:07.317Z] [INFO]     "stop_sequence": null,
+[2026-06-18T11:45:07.317Z] [INFO]     "stop_details": null,
+[2026-06-18T11:45:07.317Z] [INFO]     "usage": {
+[2026-06-18T11:45:07.317Z] [INFO]       "input_tokens": 2,
+[2026-06-18T11:45:07.317Z] [INFO]       "cache_creation_input_tokens": 2575,
+[2026-06-18T11:45:07.317Z] [INFO]       "cache_read_input_tokens": 48760,
+[2026-06-18T11:45:07.317Z] [INFO]       "cache_creation": {
+[2026-06-18T11:45:07.317Z] [INFO]         "ephemeral_5m_input_tokens": 0,
+[2026-06-18T11:45:07.317Z] [INFO]         "ephemeral_1h_input_tokens": 2575
+[2026-06-18T11:45:07.317Z] [INFO]       },
+[2026-06-18T11:45:07.317Z] [INFO]       "output_tokens": 2,
+[2026-06-18T11:45:07.317Z] [INFO]       "service_tier": "standard",
+[2026-06-18T11:45:07.317Z] [INFO]       "inference_geo": "not_available"
+[2026-06-18T11:45:07.317Z] [INFO]     },
+[2026-06-18T11:45:07.317Z] [INFO]     "diagnostics": null,
+[2026-06-18T11:45:07.317Z] [INFO]     "context_management": null
+[2026-06-18T11:45:07.317Z] [INFO]   },
+[2026-06-18T11:45:07.317Z] [INFO]   "parent_tool_use_id": null,
+[2026-06-18T11:45:07.317Z] [INFO]   "session_id": "d65e890a-db60-43f7-aea3-691500f7e26c",
+[2026-06-18T11:45:07.317Z] [INFO]   "uuid": "bc0cf069-e172-4140-b9e8-e3c5b755aee9",
+[2026-06-18T11:45:07.317Z] [INFO]   "request_id": "req_011CcAfhwD72aVaT9nF1UoHQ"
+[2026-06-18T11:45:07.317Z] [INFO] }
+[2026-06-18T11:45:09.004Z] [INFO] {
+[2026-06-18T11:45:09.004Z] [INFO]   "type": "system",
+[2026-06-18T11:45:09.004Z] [INFO]   "subtype": "task_started",
+[2026-06-18T11:45:09.004Z] [INFO]   "task_id": "bw03bs75t",
+[2026-06-18T11:45:09.004Z] [INFO]   "tool_use_id": "toolu_01HbZh2YoWcbTreRmEKcydmE",
+[2026-06-18T11:45:09.004Z] [INFO]   "description": "Run validators baseline",
+[2026-06-18T11:45:09.004Z] [INFO]   "task_type": "local_bash",
+[2026-06-18T11:45:09.004Z] [INFO]   "uuid": "3f2a49ec-bc5e-4e23-a3e5-1bf133841d8b",
+[2026-06-18T11:45:09.004Z] [INFO]   "session_id": "d65e890a-db60-43f7-aea3-691500f7e26c"
+[2026-06-18T11:45:09.004Z] [INFO] }
+[2026-06-18T11:45:15.499Z] [INFO] {
+[2026-06-18T11:45:15.499Z] [INFO]   "type": "system",
+[2026-06-18T11:45:15.499Z] [INFO]   "subtype": "task_notification",
+[2026-06-18T11:45:15.499Z] [INFO]   "task_id": "bw03bs75t",
+[2026-06-18T11:45:15.499Z] [INFO]   "tool_use_id": "toolu_01HbZh2YoWcbTreRmEKcydmE",
+[2026-06-18T11:45:15.499Z] [INFO]   "status": "completed",
+[2026-06-18T11:45:15.499Z] [INFO]   "output_file": "",
+[2026-06-18T11:45:15.499Z] [INFO]   "summary": "Run validators baseline",
+[2026-06-18T11:45:15.499Z] [INFO]   "uuid": "b108555b-8573-4a08-bfac-3e811f5f14d0",
+[2026-06-18T11:45:15.499Z] [INFO]   "session_id": "d65e890a-db60-43f7-aea3-691500f7e26c"
+[2026-06-18T11:45:15.499Z] [INFO] }
+[2026-06-18T11:45:15.516Z] [INFO] {
+[2026-06-18T11:45:15.516Z] [INFO]   "type": "user",
+[2026-06-18T11:45:15.516Z] [INFO]   "message": {
+[2026-06-18T11:45:15.516Z] [INFO]     "role": "user",
+[2026-06-18T11:45:15.516Z] [INFO]     "content": [
+[2026-06-18T11:45:15.516Z] [INFO]       {
+[2026-06-18T11:45:15.516Z] [INFO]         "tool_use_id": "toolu_01HbZh2YoWcbTreRmEKcydmE",
+[2026-06-18T11:45:15.516Z] [INFO]         "type": "tool_result",
+[2026-06-18T11:45:15.516Z] [INFO]         "content": "Frontmatter validation passed.\nEXIT 0\n=== structure ===\nRepository structure validation passed.\nEXIT 0",
+[2026-06-18T11:45:15.516Z] [INFO]         "is_error": false
+[2026-06-18T11:45:15.516Z] [INFO]       }
+[2026-06-18T11:45:15.516Z] [INFO]     ]
+[2026-06-18T11:45:15.516Z] [INFO]   },
+[2026-06-18T11:45:15.516Z] [INFO]   "parent_tool_use_id": null,
+[2026-06-18T11:45:15.516Z] [INFO]   "session_id": "d65e890a-db60-43f7-aea3-691500f7e26c",
+[2026-06-18T11:45:15.516Z] [INFO]   "uuid": "a1be496a-2b2a-40d9-88f7-947cdc77a678",
+[2026-06-18T11:45:15.516Z] [INFO]   "timestamp": "2026-06-18T11:45:15.501Z",
+[2026-06-18T11:45:15.516Z] [INFO]   "tool_use_result": {
+[2026-06-18T11:45:15.516Z] [INFO]     "stdout": "Frontmatter validation passed.\nEXIT 0\n=== structure ===\nRepository structure validation passed.\nEXIT 0",
+[2026-06-18T11:45:15.516Z] [INFO]     "stderr": "",
+[2026-06-18T11:45:15.516Z] [INFO]     "interrupted": false,
+[2026-06-18T11:45:15.516Z] [INFO]     "isImage": false,
+[2026-06-18T11:45:15.516Z] [INFO]     "noOutputExpected": false
+[2026-06-18T11:45:15.516Z] [INFO]   }
+[2026-06-18T11:45:15.516Z] [INFO] }
+[2026-06-18T11:45:16.676Z] [INFO] {
+[2026-06-18T11:45:16.676Z] [INFO]   "type": "user",
+[2026-06-18T11:45:16.676Z] [INFO]   "message": {
+[2026-06-18T11:45:16.676Z] [INFO]     "role": "user",
+[2026-06-18T11:45:16.676Z] [INFO]     "content": [
+[2026-06-18T11:45:16.676Z] [INFO]       {
+[2026-06-18T11:45:16.676Z] [INFO]         "tool_use_id": "toolu_01WZRV9hZebM5NroYs5WzWVE",
+[2026-06-18T11:45:16.676Z] [INFO]         "type": "tool_result",
+[2026-06-18T11:45:16.676Z] [INFO]         "content": "---tail of registry to find next id---\next-045\next-046\next-047\next-048\next-2026",
+[2026-06-18T11:45:16.676Z] [INFO]         "is_error": false
+[2026-06-18T11:45:16.676Z] [INFO]       }
+[2026-06-18T11:45:16.676Z] [INFO]     ]
+[2026-06-18T11:45:16.676Z] [INFO]   },
+[2026-06-18T11:45:16.676Z] [INFO]   "parent_tool_use_id": null,
+[2026-06-18T11:45:16.676Z] [INFO]   "session_id": "d65e890a-db60-43f7-aea3-691500f7e26c",
+[2026-06-18T11:45:16.676Z] [INFO]   "uuid": "ac8253ae-d4f1-4fd0-bb81-03d4368fd7cc",
+[2026-06-18T11:45:16.676Z] [INFO]   "timestamp": "2026-06-18T11:45:16.674Z",
+[2026-06-18T11:45:16.676Z] [INFO]   "tool_use_result": {
+[2026-06-18T11:45:16.676Z] [INFO]     "stdout": "---tail of registry to find next id---\next-045\next-046\next-047\next-048\next-2026",
+[2026-06-18T11:45:16.676Z] [INFO]     "stderr": "",
+[2026-06-18T11:45:16.676Z] [INFO]     "interrupted": false,
+[2026-06-18T11:45:16.676Z] [INFO]     "isImage": false,
+[2026-06-18T11:45:16.676Z] [INFO]     "noOutputExpected": false
+[2026-06-18T11:45:16.676Z] [INFO]   }
+[2026-06-18T11:45:16.676Z] [INFO] }
+[2026-06-18T11:45:16.686Z] [INFO] [log_192e42] sending request {
+[2026-06-18T11:45:16.688Z] [INFO]   method: "post",
+[2026-06-18T11:45:16.688Z] [INFO]   url: "https://api.anthropic.com/v1/messages?beta=true",
+[2026-06-18T11:45:16.689Z] [INFO]   options: {
+[2026-06-18T11:45:16.689Z] [INFO]     method: "post",
+[2026-06-18T11:45:16.690Z] [INFO]     path: "/v1/messages?beta=true",
+[2026-06-18T11:45:16.690Z] [INFO]     body: {
+[2026-06-18T11:45:16.690Z] [INFO]       model: "claude-opus-4-8",
+[2026-06-18T11:45:16.691Z] [INFO]       messages: [
+[2026-06-18T11:45:16.691Z] [INFO]         [Object ...], [Object ...], [Object ...], [Object ...], [Object ...], [Object ...], [Object ...], [Object ...], [Object ...], [Object ...], [Object ...], [Object ...], [Object ...], [Object ...], [Object ...], [Object ...], [Object ...], [Object ...]
+[2026-06-18T11:45:16.691Z] [INFO]       ],
+[2026-06-18T11:45:16.692Z] [INFO]       system: [
+[2026-06-18T11:45:16.692Z] [INFO]         [Object ...], [Object ...], [Object ...], [Object ...]
+[2026-06-18T11:45:16.694Z] [INFO]       ],
+[2026-06-18T11:45:16.695Z] [INFO]       tools: [
+[2026-06-18T11:45:16.696Z] [INFO]         [Object ...], [Object ...], [Object ...], [Object ...], [Object ...], [Object ...], [Object ...], [Object ...]
+[2026-06-18T11:45:16.696Z] [INFO]       ],
+[2026-06-18T11:45:16.697Z] [INFO]       tool_choice: undefined,
+[2026-06-18T11:45:16.698Z] [INFO]       metadata: [Object ...],
+[2026-06-18T11:45:16.698Z] [INFO]       max_tokens: 128000,
+[2026-06-18T11:45:16.698Z] [INFO]       thinking: [Object ...],
+[2026-06-18T11:45:16.699Z] [INFO]       context_management: [Object ...],
+[2026-06-18T11:45:16.699Z] [INFO]       output_config: [Object ...],
+[2026-06-18T11:45:16.699Z] [INFO]       diagnostics: [Object ...],
+[2026-06-18T11:45:16.699Z] [INFO]       stream: true,
+[2026-06-18T11:45:16.700Z] [INFO]     },
+[2026-06-18T11:45:16.700Z] [INFO]     timeout: 600000,
+[2026-06-18T11:45:16.700Z] [INFO]     signal: AbortSignal {
+[2026-06-18T11:45:16.701Z] [INFO]       [Symbol(events.maxEventTargetListeners)]: 50,
+[2026-06-18T11:45:16.701Z] [INFO]       [Symbol(events.maxEventTargetListenersWarned)]: false,
+[2026-06-18T11:45:16.702Z] [INFO]       aborted: false,
+[2026-06-18T11:45:16.703Z] [INFO]       reason: undefined,
+[2026-06-18T11:45:16.703Z] [INFO]       onabort: null,
+[2026-06-18T11:45:16.704Z] [INFO]       throwIfAborted: [Function: throwIfAborted],
+[2026-06-18T11:45:16.705Z] [INFO]       addEventListener: [Function: addEventListener],
+[2026-06-18T11:45:16.705Z] [INFO]       removeEventListener: [Function: removeEventListener],
+[2026-06-18T11:45:16.706Z] [INFO]       dispatchEvent: [Function: dispatchEvent],
+[2026-06-18T11:45:16.706Z] [INFO]     },
+[2026-06-18T11:45:16.707Z] [INFO]     stream: true,
+[2026-06-18T11:45:16.707Z] [INFO]   },
+[2026-06-18T11:45:16.707Z] [INFO]   headers: {
+[2026-06-18T11:45:16.707Z] [INFO]     accept: "application/json",
+[2026-06-18T11:45:16.708Z] [INFO]     "anthropic-beta": "claude-code-20250219,oauth-2025-04-20,interleaved-thinking-2025-05-14,thinking-token-count-2026-05-13,context-management-2025-06-27,prompt-caching-scope-2026-01-05,mid-conversation-system-2026-04-07,advisor-tool-2026-03-01,advanced-tool-use-2025-11-20,effort-2025-11-24,extended-cache-ttl-2025-04-11,cache-diagnosis-2026-04-07",
+[2026-06-18T11:45:16.708Z] [INFO]     "anthropic-dangerous-direct-browser-access": "true",
+[2026-06-18T11:45:16.709Z] [INFO]     "anthropic-version": "2023-06-01",
+[2026-06-18T11:45:16.709Z] [INFO]     authorization: "***",
+[2026-06-18T11:45:16.709Z] [INFO]     "content-type": "application/json",
+[2026-06-18T11:45:16.710Z] [INFO]     "user-agent": "claude-cli/2.1.181 (external, sdk-cli)",
+[2026-06-18T11:45:16.710Z] [INFO]     "x-app": "cli",
+[2026-06-18T11:45:16.711Z] [INFO]     "x-claude-code-session-id": "d65e890a-db60-43f7-aea3-691500f7e26c",
+[2026-06-18T11:45:16.712Z] [INFO]     "x-client-request-id": "fecb7443-9a06-4371-9ee7-86a64bf4e824",
+[2026-06-18T11:45:16.714Z] [INFO]     "x-stainless-arch": "x64",
+[2026-06-18T11:45:16.715Z] [INFO]     "x-stainless-lang": "js",
+[2026-06-18T11:45:16.715Z] [INFO]     "x-stainless-os": "Linux",
+[2026-06-18T11:45:16.715Z] [INFO]     "x-stainless-package-version": "0.94.0",
+[2026-06-18T11:45:16.715Z] [INFO]     "x-stainless-retry-count": "0",
+[2026-06-18T11:45:16.716Z] [INFO]     "x-stainless-runtime": "node",
+[2026-06-18T11:45:16.716Z] [INFO]     "x-stainless-runtime-version": "v24.3.0",
+[2026-06-18T11:45:16.716Z] [INFO]     "x-stainless-timeout": "600",
+[2026-06-18T11:45:16.717Z] [INFO]   },
+[2026-06-18T11:45:16.717Z] [INFO] }
+[2026-06-18T11:45:18.789Z] [INFO] [log_192e42, request-id: "req_011CcAfjLw9jLwrZWK31syr2"] post https://api.anthropic.com/v1/messages?beta=true succeeded with status 200 in 2103ms
+[2026-06-18T11:45:18.790Z] [INFO] [log_192e42] response start {
+[2026-06-18T11:45:18.790Z] [INFO]   url: "https://api.anthropic.com/v1/messages?beta=true",
+[2026-06-18T11:45:18.791Z] [INFO]   status: 200,
+[2026-06-18T11:45:18.793Z] [INFO]   headers: {
+[2026-06-18T11:45:18.794Z] [INFO]     "anthropic-organization-id": "ebc2ac93-f86f-4d15-aff3-de8830d8d789",
+[2026-06-18T11:45:18.794Z] [INFO]     "anthropic-ratelimit-unified-5h-reset": "1781787000",
+[2026-06-18T11:45:18.795Z] [INFO]     "anthropic-ratelimit-unified-5h-status": "allowed",
+[2026-06-18T11:45:18.795Z] [INFO]     "anthropic-ratelimit-unified-5h-utilization": "0.33",
+[2026-06-18T11:45:18.795Z] [INFO]     "anthropic-ratelimit-unified-7d-reset": "1782212400",
+[2026-06-18T11:45:18.796Z] [INFO]     "anthropic-ratelimit-unified-7d-status": "allowed",
+[2026-06-18T11:45:18.797Z] [INFO]     "anthropic-ratelimit-unified-7d-utilization": "0.62",
+[2026-06-18T11:45:18.797Z] [INFO]     "anthropic-ratelimit-unified-fallback-percentage": "0.5",
+[2026-06-18T11:45:18.798Z] [INFO]     "anthropic-ratelimit-unified-overage-disabled-reason": "org_level_disabled",
+[2026-06-18T11:45:18.800Z] [INFO]     "anthropic-ratelimit-unified-overage-status": "rejected",
+[2026-06-18T11:45:18.801Z] [INFO]     "anthropic-ratelimit-unified-representative-claim": "five_hour",
+[2026-06-18T11:45:18.802Z] [INFO]     "anthropic-ratelimit-unified-reset": "1781787000",
+[2026-06-18T11:45:18.803Z] [INFO]     "anthropic-ratelimit-unified-status": "allowed",
+[2026-06-18T11:45:18.803Z] [INFO]     "cache-control": "no-cache",
+[2026-06-18T11:45:18.803Z] [INFO]     "cf-cache-status": "DYNAMIC",
+[2026-06-18T11:45:18.804Z] [INFO]     "cf-ray": "a0da0bff5f02b19e-FRA",
+[2026-06-18T11:45:18.804Z] [INFO]     connection: "keep-alive",
+[2026-06-18T11:45:18.804Z] [INFO]     "content-encoding": "gzip",
+[2026-06-18T11:45:18.805Z] [INFO]     "content-security-policy": "default-src 'none'; frame-ancestors 'none'",
+[2026-06-18T11:45:18.805Z] [INFO]     "content-type": "text/event-stream; charset=utf-8",
+[2026-06-18T11:45:18.805Z] [INFO]     date: "Thu, 18 Jun 2026 11:45:18 GMT",
+[2026-06-18T11:45:18.806Z] [INFO]     "request-id": "req_011CcAfjLw9jLwrZWK31syr2",
+[2026-06-18T11:45:18.807Z] [INFO]     server: "cloudflare",
+[2026-06-18T11:45:18.807Z] [INFO]     "strict-transport-security": "max-age=31536000; includeSubDomains; preload",
+[2026-06-18T11:45:18.811Z] [INFO]     traceresponse: "00-6125447b08c43c4fdd1446cf8d4e336e-807774628647e561-01",
+[2026-06-18T11:45:18.812Z] [INFO]     "transfer-encoding": "chunked",
+[2026-06-18T11:45:18.814Z] [INFO]     vary: "Accept-Encoding",
+[2026-06-18T11:45:18.815Z] [INFO]     "x-robots-tag": "none",
+[2026-06-18T11:45:18.816Z] [INFO]     "set-cookie": "***",
+[2026-06-18T11:45:18.817Z] [INFO]   },
+[2026-06-18T11:45:18.819Z] [INFO]   durationMs: 2103,
+[2026-06-18T11:45:18.819Z] [INFO] }
+[2026-06-18T11:45:18.821Z] [INFO] response 200 https://api.anthropic.com/v1/messages?beta=true Headers {
+[2026-06-18T11:45:18.822Z] [INFO]   "date": "Thu, 18 Jun 2026 11:45:18 GMT",
+[2026-06-18T11:45:18.823Z] [INFO]   "content-type": "text/event-stream; charset=utf-8",
+[2026-06-18T11:45:18.823Z] [INFO]   "transfer-encoding": "chunked",
+[2026-06-18T11:45:18.824Z] [INFO]   "connection": "keep-alive",
+[2026-06-18T11:45:18.824Z] [INFO]   "cache-control": "no-cache",
+[2026-06-18T11:45:18.825Z] [INFO]   "strict-transport-security": "max-age=31536000; includeSubDomains; preload",
+[2026-06-18T11:45:18.825Z] [INFO]   "content-encoding": "gzip",
+[2026-06-18T11:45:18.826Z] [INFO]   "vary": "Accept-Encoding",
+[2026-06-18T11:45:18.826Z] [INFO]   "content-security-policy": "default-src 'none'; frame-ancestors 'none'",
+[2026-06-18T11:45:18.826Z] [INFO]   "set-cookie": [ "_cfuvid=i.p4cmPYZmgjrqaeUkVxVGUuIU7iAmId8Ci9FQlPkQ4-1781783116.693054-1.0.1.1-.NUeTbYPsA9wydS_7UaECUG.URaqldhP0z6fXFqkWxI; HttpOnly; SameSite=None; Secure; Path=/; Domain=api.anthropic.com" ],
+[2026-06-18T11:45:18.826Z] [INFO]   "anthropic-ratelimit-unified-status": "allowed",
+[2026-06-18T11:45:18.827Z] [INFO]   "anthropic-ratelimit-unified-5h-status": "allowed",
+[2026-06-18T11:45:18.827Z] [INFO]   "anthropic-ratelimit-unified-5h-reset": "1781787000",
+[2026-06-18T11:45:18.828Z] [INFO]   "anthropic-ratelimit-unified-5h-utilization": "0.33",
+[2026-06-18T11:45:18.828Z] [INFO]   "anthropic-ratelimit-unified-7d-status": "allowed",
+[2026-06-18T11:45:18.830Z] [INFO]   "anthropic-ratelimit-unified-7d-reset": "1782212400",
+[2026-06-18T11:45:18.831Z] [INFO]   "anthropic-ratelimit-unified-7d-utilization": "0.62",
+[2026-06-18T11:45:18.831Z] [INFO]   "anthropic-ratelimit-unified-representative-claim": "five_hour",
+[2026-06-18T11:45:18.832Z] [INFO]   "anthropic-ratelimit-unified-fallback-percentage": "0.5",
+[2026-06-18T11:45:18.834Z] [INFO]   "anthropic-ratelimit-unified-reset": "1781787000",
+[2026-06-18T11:45:18.835Z] [INFO]   "anthropic-ratelimit-unified-overage-disabled-reason": "org_level_disabled",
+[2026-06-18T11:45:18.836Z] [INFO]   "anthropic-ratelimit-unified-overage-status": "rejected",
+[2026-06-18T11:45:18.837Z] [INFO]   "request-id": "req_011CcAfjLw9jLwrZWK31syr2",
+[2026-06-18T11:45:18.838Z] [INFO]   "anthropic-organization-id": "ebc2ac93-f86f-4d15-aff3-de8830d8d789",
+[2026-06-18T11:45:18.838Z] [INFO]   "traceresponse": "00-6125447b08c43c4fdd1446cf8d4e336e-807774628647e561-01",
+[2026-06-18T11:45:18.839Z] [INFO]   "server": "cloudflare",
+[2026-06-18T11:45:18.840Z] [INFO]   "cf-cache-status": "DYNAMIC",
+[2026-06-18T11:45:18.840Z] [INFO]   "x-robots-tag": "none",
+[2026-06-18T11:45:18.840Z] [INFO]   "cf-ray": "a0da0bff5f02b19e-FRA",
+[2026-06-18T11:45:18.841Z] [INFO] } ReadableStream {
+[2026-06-18T11:45:18.841Z] [INFO]   blob: [Function: blob],
+[2026-06-18T11:45:18.842Z] [INFO]   bytes: [Function: bytes],
+[2026-06-18T11:45:18.842Z] [INFO]   cancel: [Function],
+[2026-06-18T11:45:18.844Z] [INFO]   getReader: [Function],
+[2026-06-18T11:45:18.845Z] [INFO]   json: [Function: json],
+[2026-06-18T11:45:18.846Z] [INFO]   locked: [Getter],
+[2026-06-18T11:45:18.846Z] [INFO]   pipeThrough: [Function],
+[2026-06-18T11:45:18.847Z] [INFO]   pipeTo: [Function],
+[2026-06-18T11:45:18.849Z] [INFO]   tee: [Function],
+[2026-06-18T11:45:18.850Z] [INFO]   text: [Function: text],
+[2026-06-18T11:45:18.851Z] [INFO]   values: [Function: values],
+[2026-06-18T11:45:18.853Z] [INFO]   [Symbol(Symbol.asyncIterator)]: [Function: asyncIterator2],
+[2026-06-18T11:45:18.855Z] [INFO] }
+[2026-06-18T11:45:18.857Z] [INFO] [log_192e42] response parsed {
+[2026-06-18T11:45:18.858Z] [INFO]   url: "https://api.anthropic.com/v1/messages?beta=true",
+[2026-06-18T11:45:18.860Z] [INFO]   status: 200,
+[2026-06-18T11:45:18.860Z] [INFO]   body: sU {
+[2026-06-18T11:45:18.861Z] [INFO]     iterator: [AsyncGeneratorFunction: s],
+[2026-06-18T11:45:18.863Z] [INFO]     controller: AbortController {
+[2026-06-18T11:45:18.864Z] [INFO]       signal: [AbortSignal ...],
+[2026-06-18T11:45:18.865Z] [INFO]       abort: [Function: abort],
+[2026-06-18T11:45:18.867Z] [INFO]     },
+[2026-06-18T11:45:18.869Z] [INFO]     [Symbol(Symbol.asyncIterator)]: [Function],
+[2026-06-18T11:45:18.870Z] [INFO]     tee: [Function: tee],
+[2026-06-18T11:45:18.871Z] [INFO]     toReadableStream: [Function: toReadableStream],
+[2026-06-18T11:45:18.872Z] [INFO]   },
+[2026-06-18T11:45:18.872Z] [INFO]   durationMs: 2103,
+[2026-06-18T11:45:18.873Z] [INFO] }
+[2026-06-18T11:45:20.217Z] [INFO] {
+[2026-06-18T11:45:20.217Z] [INFO]   "type": "system",
+[2026-06-18T11:45:20.217Z] [INFO]   "subtype": "thinking_tokens",
+[2026-06-18T11:45:20.217Z] [INFO]   "estimated_tokens": 50,
+[2026-06-18T11:45:20.217Z] [INFO]   "estimated_tokens_delta": 50,
+[2026-06-18T11:45:20.217Z] [INFO]   "uuid": "f4d64a9c-969f-46dd-a47a-5717d1730ced",
+[2026-06-18T11:45:20.217Z] [INFO]   "session_id": "d65e890a-db60-43f7-aea3-691500f7e26c"
+[2026-06-18T11:45:20.217Z] [INFO] }
+[2026-06-18T11:45:21.628Z] [INFO] {
+[2026-06-18T11:45:21.628Z] [INFO]   "type": "system",
+[2026-06-18T11:45:21.628Z] [INFO]   "subtype": "thinking_tokens",
+[2026-06-18T11:45:21.628Z] [INFO]   "estimated_tokens": 150,
+[2026-06-18T11:45:21.628Z] [INFO]   "estimated_tokens_delta": 100,
+[2026-06-18T11:45:21.628Z] [INFO]   "uuid": "d9c99871-d8e8-428a-851e-3bac2e3c4d09",
+[2026-06-18T11:45:21.628Z] [INFO]   "session_id": "d65e890a-db60-43f7-aea3-691500f7e26c"
+[2026-06-18T11:45:21.628Z] [INFO] }
+[2026-06-18T11:45:22.101Z] [INFO] {
+[2026-06-18T11:45:22.101Z] [INFO]   "type": "system",
+[2026-06-18T11:45:22.101Z] [INFO]   "subtype": "thinking_tokens",
+[2026-06-18T11:45:22.101Z] [INFO]   "estimated_tokens": 219,
+[2026-06-18T11:45:22.101Z] [INFO]   "estimated_tokens_delta": 69,
+[2026-06-18T11:45:22.101Z] [INFO]   "uuid": "e8fa36fc-a855-44a1-a733-f9156311ab0f",
+[2026-06-18T11:45:22.101Z] [INFO]   "session_id": "d65e890a-db60-43f7-aea3-691500f7e26c"
+[2026-06-18T11:45:22.101Z] [INFO] }
+[2026-06-18T11:45:22.104Z] [INFO] {
+[2026-06-18T11:45:22.104Z] [INFO]   "type": "assistant",
+[2026-06-18T11:45:22.104Z] [INFO]   "message": {
+[2026-06-18T11:45:22.104Z] [INFO]     "model": "claude-opus-4-8",
+[2026-06-18T11:45:22.104Z] [INFO]     "id": "msg_01JCzumVv5qk4mpVVmTjZZj4",
+[2026-06-18T11:45:22.104Z] [INFO]     "type": "message",
+[2026-06-18T11:45:22.104Z] [INFO]     "role": "assistant",
+[2026-06-18T11:45:22.104Z] [INFO]     "content": [
+[2026-06-18T11:45:22.104Z] [INFO]       {
+[2026-06-18T11:45:22.104Z] [INFO]         "type": "thinking",
+[2026-06-18T11:45:22.104Z] [INFO]         "thinking": "",
+[2026-06-18T11:45:22.104Z] [INFO]         "signature": "EuYGCmMIDhgCKkAUu+5DTkjzE0U5/IMcjOFi3srn0X5drY4khAqig/tPE75PsL3hdbtueK2mClV44X5lrGBxGcLkMf76o+fvd2LwMg9jbGF1ZGUtb3B1cy00LTg4AEIIdGhpbmtpbmcSDFWCUYrV8AJd8pA++hoM/I65cEL+JKpVIf36IjDexysoFIaYqEhaQpIjPsgwhK1Tjh/XwufNaCPI8Y31gfVRJIboFMvGF0vRcojFmPMqsAWcqGKwFnS6PWr1L7+vIDi9JEniycgINM/VfX1y5nfi0hKic6cpO8puyhAyKLNi37Vr0COdNUJKAP+2TFtm4EIzaQuyx235JhTIXZVcZGHgFKCl4WW2tTkCq7rI/byBkrIcl3QerDbrJI2ck9ki08Z0Y4miR3d6JcswvpbMQLgL4t79nPDJ/N21ppzZybr4daaTSM37/2soL5t5rJXjGQCYT5QuybJ/FxQ3hxZehLRiU2Pfb1t2aPEyytAaxNFH74SLKqo5vFTI8BT44qmBqCQEmqrAJDr6rb0z1GlBnn02h6Z/auFgKjk8OAE+KIuYq1Kd6txDcmUAYenYW7S9jwmcl2b5FZKex2IlxpYe7KuR5Z57qO9cMdmJxdzpFA7hQ2qjQlDmvDUkWoBQ1FmRRoGRpFjGsYDgCpKQ5yaoGpfbicHC5HeLkEY7wqajzDL0zq4LVvgXlJJ0bCfCQmdzepcyqsXD58ezKBP23W/90V6lHwGJQySQ0fPse+54/44N1lohIxCPgvVKOwBN96THbDdYM7PSvLx2u3WngJYzLfUTpWCOuoC0RRI4zpBpYMl8dJR+/ha8V/NM9LXxh/fK9lkwlQAF12Ody/j2mRX7iqArsGMsQC5vauNdz6VpkHEN1l42NfnOddniX9ZKxx6CFimSIQZBmEhnWkbAo7/DsxVdbMBs2nfCehZEan8nJiHQCKKuKIeHgxabRYEXRyfAuVQHy9huAOqDPE6WMhc1P00xDdqSyFDEXmLtTP+fn+ZKw20fT5gNxFNs03KSbr74Xy5cTMKw/mpO/S+AqRuJd2lpXaKlLRbpsRm6MZGVZ8s1aem42RFqAWfwUHqSPePFcATfFF/FQ/mIwMQ+HvO0vXzvSkkQxV7YJgOLg5ooODnLP6eUaff0QzDbLZvALIWz/ZKZGAE="
+[2026-06-18T11:45:22.104Z] [INFO]       }
+[2026-06-18T11:45:22.104Z] [INFO]     ],
+[2026-06-18T11:45:22.104Z] [INFO]     "stop_reason": null,
+[2026-06-18T11:45:22.104Z] [INFO]     "stop_sequence": null,
+[2026-06-18T11:45:22.104Z] [INFO]     "stop_details": null,
+[2026-06-18T11:45:22.104Z] [INFO]     "usage": {
+[2026-06-18T11:45:22.104Z] [INFO]       "input_tokens": 2,
+[2026-06-18T11:45:22.104Z] [INFO]       "cache_creation_input_tokens": 793,
+[2026-06-18T11:45:22.104Z] [INFO]       "cache_read_input_tokens": 51335,
+[2026-06-18T11:45:22.104Z] [INFO]       "cache_creation": {
+[2026-06-18T11:45:22.104Z] [INFO]         "ephemeral_5m_input_tokens": 0,
+[2026-06-18T11:45:22.104Z] [INFO]         "ephemeral_1h_input_tokens": 793
+[2026-06-18T11:45:22.104Z] [INFO]       },
+[2026-06-18T11:45:22.104Z] [INFO]       "output_tokens": 3,
+[2026-06-18T11:45:22.104Z] [INFO]       "service_tier": "standard",
+[2026-06-18T11:45:22.104Z] [INFO]       "inference_geo": "not_available"
+[2026-06-18T11:45:22.104Z] [INFO]     },
+[2026-06-18T11:45:22.104Z] [INFO]     "diagnostics": null,
+[2026-06-18T11:45:22.104Z] [INFO]     "context_management": null
+[2026-06-18T11:45:22.104Z] [INFO]   },
+[2026-06-18T11:45:22.104Z] [INFO]   "parent_tool_use_id": null,
+[2026-06-18T11:45:22.104Z] [INFO]   "session_id": "d65e890a-db60-43f7-aea3-691500f7e26c",
+[2026-06-18T11:45:22.104Z] [INFO]   "uuid": "a96df312-6677-40e1-82bc-47e5ba1852f7",
+[2026-06-18T11:45:22.104Z] [INFO]   "request_id": "req_011CcAfjLw9jLwrZWK31syr2"
+[2026-06-18T11:45:22.104Z] [INFO] }
+[2026-06-18T11:45:22.576Z] [INFO] {
+[2026-06-18T11:45:22.576Z] [INFO]   "type": "assistant",
+[2026-06-18T11:45:22.576Z] [INFO]   "message": {
+[2026-06-18T11:45:22.576Z] [INFO]     "model": "claude-opus-4-8",
+[2026-06-18T11:45:22.576Z] [INFO]     "id": "msg_01JCzumVv5qk4mpVVmTjZZj4",
+[2026-06-18T11:45:22.576Z] [INFO]     "type": "message",
+[2026-06-18T11:45:22.576Z] [INFO]     "role": "assistant",
+[2026-06-18T11:45:22.576Z] [INFO]     "content": [
+[2026-06-18T11:45:22.576Z] [INFO]       {
+[2026-06-18T11:45:22.576Z] [INFO]         "type": "text",
+[2026-06-18T11:45:22.576Z] [INFO]         "text": "Validators pass at baseline. Let me set up tasks and check the manifest mechanism, then write the document."
+[2026-06-18T11:45:22.576Z] [INFO]       }
+[2026-06-18T11:45:22.576Z] [INFO]     ],
+[2026-06-18T11:45:22.576Z] [INFO]     "stop_reason": null,
+[2026-06-18T11:45:22.576Z] [INFO]     "stop_sequence": null,
+[2026-06-18T11:45:22.576Z] [INFO]     "stop_details": null,
+[2026-06-18T11:45:22.576Z] [INFO]     "usage": {
+[2026-06-18T11:45:22.576Z] [INFO]       "input_tokens": 2,
+[2026-06-18T11:45:22.576Z] [INFO]       "cache_creation_input_tokens": 793,
+[2026-06-18T11:45:22.576Z] [INFO]       "cache_read_input_tokens": 51335,
+[2026-06-18T11:45:22.576Z] [INFO]       "cache_creation": {
+[2026-06-18T11:45:22.576Z] [INFO]         "ephemeral_5m_input_tokens": 0,
+[2026-06-18T11:45:22.576Z] [INFO]         "ephemeral_1h_input_tokens": 793
+[2026-06-18T11:45:22.576Z] [INFO]       },
+[2026-06-18T11:45:22.576Z] [INFO]       "output_tokens": 3,
+[2026-06-18T11:45:22.576Z] [INFO]       "service_tier": "standard",
+[2026-06-18T11:45:22.576Z] [INFO]       "inference_geo": "not_available"
+[2026-06-18T11:45:22.576Z] [INFO]     },
+[2026-06-18T11:45:22.576Z] [INFO]     "diagnostics": null,
+[2026-06-18T11:45:22.576Z] [INFO]     "context_management": null
+[2026-06-18T11:45:22.576Z] [INFO]   },
+[2026-06-18T11:45:22.576Z] [INFO]   "parent_tool_use_id": null,
+[2026-06-18T11:45:22.576Z] [INFO]   "session_id": "d65e890a-db60-43f7-aea3-691500f7e26c",
+[2026-06-18T11:45:22.576Z] [INFO]   "uuid": "5b96dd8f-2903-4db9-810d-d9fb4c8e78f7",
+[2026-06-18T11:45:22.576Z] [INFO]   "request_id": "req_011CcAfjLw9jLwrZWK31syr2"
+[2026-06-18T11:45:22.576Z] [INFO] }
+[2026-06-18T11:45:23.518Z] [INFO] {
+[2026-06-18T11:45:23.518Z] [INFO]   "type": "assistant",
+[2026-06-18T11:45:23.518Z] [INFO]   "message": {
+[2026-06-18T11:45:23.518Z] [INFO]     "model": "claude-opus-4-8",
+[2026-06-18T11:45:23.518Z] [INFO]     "id": "msg_01JCzumVv5qk4mpVVmTjZZj4",
+[2026-06-18T11:45:23.518Z] [INFO]     "type": "message",
+[2026-06-18T11:45:23.518Z] [INFO]     "role": "assistant",
+[2026-06-18T11:45:23.518Z] [INFO]     "content": [
+[2026-06-18T11:45:23.518Z] [INFO]       {
+[2026-06-18T11:45:23.518Z] [INFO]         "type": "tool_use",
+[2026-06-18T11:45:23.518Z] [INFO]         "id": "toolu_01TjpNXJfxPDgb6eb4KF567J",
+[2026-06-18T11:45:23.518Z] [INFO]         "name": "ToolSearch",
+[2026-06-18T11:45:23.518Z] [INFO]         "input": {
+[2026-06-18T11:45:23.518Z] [INFO]           "query": "select:TaskCreate,TaskUpdate",
+[2026-06-18T11:45:23.518Z] [INFO]           "max_results": 5
+[2026-06-18T11:45:23.518Z] [INFO]         },
+[2026-06-18T11:45:23.518Z] [INFO]         "caller": {
+[2026-06-18T11:45:23.518Z] [INFO]           "type": "direct"
+[2026-06-18T11:45:23.518Z] [INFO]         }
+[2026-06-18T11:45:23.518Z] [INFO]       }
+[2026-06-18T11:45:23.518Z] [INFO]     ],
+[2026-06-18T11:45:23.518Z] [INFO]     "stop_reason": null,
+[2026-06-18T11:45:23.518Z] [INFO]     "stop_sequence": null,
+[2026-06-18T11:45:23.518Z] [INFO]     "stop_details": null,
+[2026-06-18T11:45:23.518Z] [INFO]     "usage": {
+[2026-06-18T11:45:23.518Z] [INFO]       "input_tokens": 2,
+[2026-06-18T11:45:23.518Z] [INFO]       "cache_creation_input_tokens": 793,
+[2026-06-18T11:45:23.518Z] [INFO]       "cache_read_input_tokens": 51335,
+[2026-06-18T11:45:23.518Z] [INFO]       "cache_creation": {
+[2026-06-18T11:45:23.518Z] [INFO]         "ephemeral_5m_input_tokens": 0,
+[2026-06-18T11:45:23.518Z] [INFO]         "ephemeral_1h_input_tokens": 793
+[2026-06-18T11:45:23.518Z] [INFO]       },
+[2026-06-18T11:45:23.518Z] [INFO]       "output_tokens": 3,
+[2026-06-18T11:45:23.518Z] [INFO]       "service_tier": "standard",
+[2026-06-18T11:45:23.518Z] [INFO]       "inference_geo": "not_available"
+[2026-06-18T11:45:23.518Z] [INFO]     },
+[2026-06-18T11:45:23.518Z] [INFO]     "diagnostics": null,
+[2026-06-18T11:45:23.518Z] [INFO]     "context_management": null
+[2026-06-18T11:45:23.518Z] [INFO]   },
+[2026-06-18T11:45:23.518Z] [INFO]   "parent_tool_use_id": null,
+[2026-06-18T11:45:23.518Z] [INFO]   "session_id": "d65e890a-db60-43f7-aea3-691500f7e26c",
+[2026-06-18T11:45:23.518Z] [INFO]   "uuid": "7bebea3f-65cb-4ad7-af03-021450acea50",
+[2026-06-18T11:45:23.518Z] [INFO]   "request_id": "req_011CcAfjLw9jLwrZWK31syr2"
+[2026-06-18T11:45:23.518Z] [INFO] }
+[2026-06-18T11:45:23.524Z] [INFO] {
+[2026-06-18T11:45:23.524Z] [INFO]   "type": "user",
+[2026-06-18T11:45:23.524Z] [INFO]   "message": {
+[2026-06-18T11:45:23.524Z] [INFO]     "role": "user",
+[2026-06-18T11:45:23.524Z] [INFO]     "content": [
+[2026-06-18T11:45:23.524Z] [INFO]       {
+[2026-06-18T11:45:23.524Z] [INFO]         "type": "tool_result",
+[2026-06-18T11:45:23.524Z] [INFO]         "tool_use_id": "toolu_01TjpNXJfxPDgb6eb4KF567J",
+[2026-06-18T11:45:23.524Z] [INFO]         "content": [
+[2026-06-18T11:45:23.524Z] [INFO]           {
+[2026-06-18T11:45:23.524Z] [INFO]             "type": "tool_reference",
+[2026-06-18T11:45:23.524Z] [INFO]             "tool_name": "TaskCreate"
+[2026-06-18T11:45:23.524Z] [INFO]           },
+[2026-06-18T11:45:23.524Z] [INFO]           {
+[2026-06-18T11:45:23.524Z] [INFO]             "type": "tool_reference",
+[2026-06-18T11:45:23.524Z] [INFO]             "tool_name": "TaskUpdate"
+[2026-06-18T11:45:23.524Z] [INFO]           }
+[2026-06-18T11:45:23.524Z] [INFO]         ]
+[2026-06-18T11:45:23.524Z] [INFO]       }
+[2026-06-18T11:45:23.524Z] [INFO]     ]
+[2026-06-18T11:45:23.524Z] [INFO]   },
+[2026-06-18T11:45:23.524Z] [INFO]   "parent_tool_use_id": null,
+[2026-06-18T11:45:23.524Z] [INFO]   "session_id": "d65e890a-db60-43f7-aea3-691500f7e26c",
+[2026-06-18T11:45:23.524Z] [INFO]   "uuid": "914b2ffc-8135-47fa-859a-3a1849bbb1ce",
+[2026-06-18T11:45:23.524Z] [INFO]   "timestamp": "2026-06-18T11:45:23.522Z",
+[2026-06-18T11:45:23.524Z] [INFO]   "tool_use_result": {
+[2026-06-18T11:45:23.524Z] [INFO]     "matches": [
+[2026-06-18T11:45:23.524Z] [INFO]       "TaskCreate",
+[2026-06-18T11:45:23.524Z] [INFO]       "TaskUpdate"
+[2026-06-18T11:45:23.524Z] [INFO]     ],
+[2026-06-18T11:45:23.524Z] [INFO]     "query": "select:TaskCreate,TaskUpdate",
+[2026-06-18T11:45:23.524Z] [INFO]     "total_deferred_tools": 32
+[2026-06-18T11:45:23.524Z] [INFO]   }
+[2026-06-18T11:45:23.524Z] [INFO] }
+[2026-06-18T11:45:24.788Z] [INFO] {
+[2026-06-18T11:45:24.788Z] [INFO]   "type": "assistant",
+[2026-06-18T11:45:24.788Z] [INFO]   "message": {
+[2026-06-18T11:45:24.788Z] [INFO]     "model": "claude-opus-4-8",
+[2026-06-18T11:45:24.788Z] [INFO]     "id": "msg_01JCzumVv5qk4mpVVmTjZZj4",
+[2026-06-18T11:45:24.788Z] [INFO]     "type": "message",
+[2026-06-18T11:45:24.788Z] [INFO]     "role": "assistant",
+[2026-06-18T11:45:24.788Z] [INFO]     "content": [
+[2026-06-18T11:45:24.788Z] [INFO]       {
+[2026-06-18T11:45:24.788Z] [INFO]         "type": "tool_use",
+[2026-06-18T11:45:24.788Z] [INFO]         "id": "toolu_01Jok99MJVK11ncBvKP3YCgM",
+[2026-06-18T11:45:24.788Z] [INFO]         "name": "Bash",
+[2026-06-18T11:45:24.788Z] [INFO]         "input": {
+[2026-06-18T11:45:24.788Z] [INFO]           "command": "python3 tools/generate-manifest.py --check 2>&1 | tail -5; echo \"EXIT $?\"; echo \"=== where is manifest / artifact-map ===\"; ls governance/ | head; grep -rl \"requirements-engineering-ai-era\" governance/ docs/ mkdocs.yml 2>/dev/null",
+[2026-06-18T11:45:24.788Z] [INFO]           "description": "Check manifest and references"
+[2026-06-18T11:45:24.788Z] [INFO]         },
+[2026-06-18T11:45:24.788Z] [INFO]         "caller": {
+[2026-06-18T11:45:24.788Z] [INFO]           "type": "direct"
+[2026-06-18T11:45:24.788Z] [INFO]         }
+[2026-06-18T11:45:24.788Z] [INFO]       }
+[2026-06-18T11:45:24.788Z] [INFO]     ],
+[2026-06-18T11:45:24.788Z] [INFO]     "stop_reason": null,
+[2026-06-18T11:45:24.788Z] [INFO]     "stop_sequence": null,
+[2026-06-18T11:45:24.788Z] [INFO]     "stop_details": null,
+[2026-06-18T11:45:24.788Z] [INFO]     "usage": {
+[2026-06-18T11:45:24.788Z] [INFO]       "input_tokens": 2,
+[2026-06-18T11:45:24.788Z] [INFO]       "cache_creation_input_tokens": 793,
+[2026-06-18T11:45:24.788Z] [INFO]       "cache_read_input_tokens": 51335,
+[2026-06-18T11:45:24.788Z] [INFO]       "cache_creation": {
+[2026-06-18T11:45:24.788Z] [INFO]         "ephemeral_5m_input_tokens": 0,
+[2026-06-18T11:45:24.788Z] [INFO]         "ephemeral_1h_input_tokens": 793
+[2026-06-18T11:45:24.788Z] [INFO]       },
+[2026-06-18T11:45:24.788Z] [INFO]       "output_tokens": 3,
+[2026-06-18T11:45:24.788Z] [INFO]       "service_tier": "standard",
+[2026-06-18T11:45:24.788Z] [INFO]       "inference_geo": "not_available"
+[2026-06-18T11:45:24.788Z] [INFO]     },
+[2026-06-18T11:45:24.788Z] [INFO]     "diagnostics": null,
+[2026-06-18T11:45:24.788Z] [INFO]     "context_management": null
+[2026-06-18T11:45:24.788Z] [INFO]   },
+[2026-06-18T11:45:24.788Z] [INFO]   "parent_tool_use_id": null,
+[2026-06-18T11:45:24.788Z] [INFO]   "session_id": "d65e890a-db60-43f7-aea3-691500f7e26c",
+[2026-06-18T11:45:24.788Z] [INFO]   "uuid": "58a2c6b0-3e84-4d7d-99c7-29a5400650d3",
+[2026-06-18T11:45:24.788Z] [INFO]   "request_id": "req_011CcAfjLw9jLwrZWK31syr2"
+[2026-06-18T11:45:24.788Z] [INFO] }
+[2026-06-18T11:45:25.947Z] [INFO] {
+[2026-06-18T11:45:25.947Z] [INFO]   "type": "user",
+[2026-06-18T11:45:25.947Z] [INFO]   "message": {
+[2026-06-18T11:45:25.947Z] [INFO]     "role": "user",
+[2026-06-18T11:45:25.947Z] [INFO]     "content": [
+[2026-06-18T11:45:25.947Z] [INFO]       {
+[2026-06-18T11:45:25.947Z] [INFO]         "tool_use_id": "toolu_01Jok99MJVK11ncBvKP3YCgM",
+[2026-06-18T11:45:25.947Z] [INFO]         "type": "tool_result",
+[2026-06-18T11:45:25.947Z] [INFO]         "content": "manifest.json is up to date.\nEXIT 0\n=== where is manifest / artifact-map ===\nagent-onboarding-protocol.md\nartifact-map.md\nbacklog.md\nexecutable-documents-issues.md\nrepo-model.md\nrfc\nsession-digests.md\ngovernance/artifact-map.md\ngovernance/rfc/README.md",
+[2026-06-18T11:45:25.947Z] [INFO]         "is_error": false
+[2026-06-18T11:45:25.947Z] [INFO]       }
+[2026-06-18T11:45:25.947Z] [INFO]     ]
+[2026-06-18T11:45:25.947Z] [INFO]   },
+[2026-06-18T11:45:25.947Z] [INFO]   "parent_tool_use_id": null,
+[2026-06-18T11:45:25.947Z] [INFO]   "session_id": "d65e890a-db60-43f7-aea3-691500f7e26c",
+[2026-06-18T11:45:25.947Z] [INFO]   "uuid": "4ba8f601-ef09-48dc-af8c-aafc3acd7303",
+[2026-06-18T11:45:25.947Z] [INFO]   "timestamp": "2026-06-18T11:45:25.944Z",
+[2026-06-18T11:45:25.947Z] [INFO]   "tool_use_result": {
+[2026-06-18T11:45:25.947Z] [INFO]     "stdout": "manifest.json is up to date.\nEXIT 0\n=== where is manifest / artifact-map ===\nagent-onboarding-protocol.md\nartifact-map.md\nbacklog.md\nexecutable-documents-issues.md\nrepo-model.md\nrfc\nsession-digests.md\ngovernance/artifact-map.md\ngovernance/rfc/README.md",
+[2026-06-18T11:45:25.947Z] [INFO]     "stderr": "",
+[2026-06-18T11:45:25.947Z] [INFO]     "interrupted": false,
+[2026-06-18T11:45:25.947Z] [INFO]     "isImage": false,
+[2026-06-18T11:45:25.947Z] [INFO]     "noOutputExpected": false
+[2026-06-18T11:45:25.947Z] [INFO]   }
+[2026-06-18T11:45:25.947Z] [INFO] }
+[2026-06-18T11:45:25.958Z] [INFO] [log_366b51] sending request {
+[2026-06-18T11:45:25.959Z] [INFO]   method: "post",
+[2026-06-18T11:45:25.960Z] [INFO]   url: "https://api.anthropic.com/v1/messages?beta=true",
+[2026-06-18T11:45:25.962Z] [INFO]   options: {
+[2026-06-18T11:45:25.963Z] [INFO]     method: "post",
+[2026-06-18T11:45:25.963Z] [INFO]     path: "/v1/messages?beta=true",
+[2026-06-18T11:45:25.964Z] [INFO]     body: {
+[2026-06-18T11:45:25.964Z] [INFO]       model: "claude-opus-4-8",
+[2026-06-18T11:45:25.964Z] [INFO]       messages: [
+[2026-06-18T11:45:25.965Z] [INFO]         [Object ...], [Object ...], [Object ...], [Object ...], [Object ...], [Object ...], [Object ...], [Object ...], [Object ...], [Object ...], [Object ...], [Object ...], [Object ...], [Object ...], [Object ...], [Object ...], [Object ...], [Object ...], [Object ...], [Object ...]
+[2026-06-18T11:45:25.965Z] [INFO]       ],
+[2026-06-18T11:45:25.965Z] [INFO]       system: [
+[2026-06-18T11:45:25.966Z] [INFO]         [Object ...], [Object ...], [Object ...], [Object ...]
+[2026-06-18T11:45:25.967Z] [INFO]       ],
+[2026-06-18T11:45:25.968Z] [INFO]       tools: [
+[2026-06-18T11:45:25.969Z] [INFO]         [Object ...], [Object ...], [Object ...], [Object ...], [Object ...], [Object ...], [Object ...], [Object ...], [Object ...], [Object ...]
+[2026-06-18T11:45:25.969Z] [INFO]       ],
+[2026-06-18T11:45:25.970Z] [INFO]       tool_choice: undefined,
+[2026-06-18T11:45:25.970Z] [INFO]       metadata: [Object ...],
+[2026-06-18T11:45:25.971Z] [INFO]       max_tokens: 128000,
+[2026-06-18T11:45:25.971Z] [INFO]       thinking: [Object ...],
+[2026-06-18T11:45:25.972Z] [INFO]       context_management: [Object ...],
+[2026-06-18T11:45:25.972Z] [INFO]       output_config: [Object ...],
+[2026-06-18T11:45:25.972Z] [INFO]       diagnostics: [Object ...],
+[2026-06-18T11:45:25.973Z] [INFO]       stream: true,
+[2026-06-18T11:45:25.974Z] [INFO]     },
+[2026-06-18T11:45:25.975Z] [INFO]     timeout: 600000,
+[2026-06-18T11:45:25.976Z] [INFO]     signal: AbortSignal {
+[2026-06-18T11:45:25.977Z] [INFO]       [Symbol(events.maxEventTargetListeners)]: 50,
+[2026-06-18T11:45:25.977Z] [INFO]       [Symbol(events.maxEventTargetListenersWarned)]: false,
+[2026-06-18T11:45:25.978Z] [INFO]       aborted: false,
+[2026-06-18T11:45:25.979Z] [INFO]       reason: undefined,
+[2026-06-18T11:45:25.981Z] [INFO]       onabort: null,
+[2026-06-18T11:45:25.982Z] [INFO]       throwIfAborted: [Function: throwIfAborted],
+[2026-06-18T11:45:25.982Z] [INFO]       addEventListener: [Function: addEventListener],
+[2026-06-18T11:45:25.983Z] [INFO]       removeEventListener: [Function: removeEventListener],
+[2026-06-18T11:45:25.985Z] [INFO]       dispatchEvent: [Function: dispatchEvent],
+[2026-06-18T11:45:25.986Z] [INFO]     },
+[2026-06-18T11:45:25.988Z] [INFO]     stream: true,
+[2026-06-18T11:45:25.988Z] [INFO]   },
+[2026-06-18T11:45:25.988Z] [INFO]   headers: {
+[2026-06-18T11:45:25.989Z] [INFO]     accept: "application/json",
+[2026-06-18T11:45:25.989Z] [INFO]     "anthropic-beta": "claude-code-20250219,oauth-2025-04-20,interleaved-thinking-2025-05-14,thinking-token-count-2026-05-13,context-management-2025-06-27,prompt-caching-scope-2026-01-05,mid-conversation-system-2026-04-07,advisor-tool-2026-03-01,advanced-tool-use-2025-11-20,effort-2025-11-24,extended-cache-ttl-2025-04-11,cache-diagnosis-2026-04-07",
+[2026-06-18T11:45:25.990Z] [INFO]     "anthropic-dangerous-direct-browser-access": "true",
+[2026-06-18T11:45:25.991Z] [INFO]     "anthropic-version": "2023-06-01",
+[2026-06-18T11:45:25.996Z] [INFO]     authorization: "***",
+[2026-06-18T11:45:25.997Z] [INFO]     "content-type": "application/json",
+[2026-06-18T11:45:25.999Z] [INFO]     "user-agent": "claude-cli/2.1.181 (external, sdk-cli)",
+[2026-06-18T11:45:26.000Z] [INFO]     "x-app": "cli",
+[2026-06-18T11:45:26.002Z] [INFO]     "x-claude-code-session-id": "d65e890a-db60-43f7-aea3-691500f7e26c",
+[2026-06-18T11:45:26.004Z] [INFO]     "x-client-request-id": "5725bfab-47ce-43fa-a411-585b3bc0ae0d",
+[2026-06-18T11:45:26.006Z] [INFO]     "x-stainless-arch": "x64",
+[2026-06-18T11:45:26.007Z] [INFO]     "x-stainless-lang": "js",
+[2026-06-18T11:45:26.008Z] [INFO]     "x-stainless-os": "Linux",
+[2026-06-18T11:45:26.010Z] [INFO]     "x-stainless-package-version": "0.94.0",
+[2026-06-18T11:45:26.011Z] [INFO]     "x-stainless-retry-count": "0",
+[2026-06-18T11:45:26.012Z] [INFO]     "x-stainless-runtime": "node",
+[2026-06-18T11:45:26.012Z] [INFO]     "x-stainless-runtime-version": "v24.3.0",
+[2026-06-18T11:45:26.013Z] [INFO]     "x-stainless-timeout": "600",
+[2026-06-18T11:45:26.014Z] [INFO]   },
+[2026-06-18T11:45:26.014Z] [INFO] }
+[2026-06-18T11:45:27.332Z] [INFO] [log_366b51, request-id: "req_011CcAfk1qUMG74ajagQUBYn"] post https://api.anthropic.com/v1/messages?beta=true succeeded with status 200 in 1374ms
+[2026-06-18T11:45:27.333Z] [INFO] [log_366b51] response start {
+[2026-06-18T11:45:27.337Z] [INFO]   url: "https://api.anthropic.com/v1/messages?beta=true",
+[2026-06-18T11:45:27.339Z] [INFO]   status: 200,
+[2026-06-18T11:45:27.341Z] [INFO]   headers: {
+[2026-06-18T11:45:27.344Z] [INFO]     "anthropic-organization-id": "ebc2ac93-f86f-4d15-aff3-de8830d8d789",
+[2026-06-18T11:45:27.346Z] [INFO]     "anthropic-ratelimit-unified-5h-reset": "1781787000",
+[2026-06-18T11:45:27.348Z] [INFO]     "anthropic-ratelimit-unified-5h-status": "allowed",
+[2026-06-18T11:45:27.350Z] [INFO]     "anthropic-ratelimit-unified-5h-utilization": "0.33",
+[2026-06-18T11:45:27.351Z] [INFO]     "anthropic-ratelimit-unified-7d-reset": "1782212400",
+[2026-06-18T11:45:27.352Z] [INFO]     "anthropic-ratelimit-unified-7d-status": "allowed",
+[2026-06-18T11:45:27.352Z] [INFO]     "anthropic-ratelimit-unified-7d-utilization": "0.62",
+[2026-06-18T11:45:27.353Z] [INFO]     "anthropic-ratelimit-unified-fallback-percentage": "0.5",
+[2026-06-18T11:45:27.353Z] [INFO]     "anthropic-ratelimit-unified-overage-disabled-reason": "org_level_disabled",
+[2026-06-18T11:45:27.354Z] [INFO]     "anthropic-ratelimit-unified-overage-status": "rejected",
+[2026-06-18T11:45:27.354Z] [INFO]     "anthropic-ratelimit-unified-representative-claim": "five_hour",
+[2026-06-18T11:45:27.355Z] [INFO]     "anthropic-ratelimit-unified-reset": "1781787000",
+[2026-06-18T11:45:27.355Z] [INFO]     "anthropic-ratelimit-unified-status": "allowed",
+[2026-06-18T11:45:27.355Z] [INFO]     "cache-control": "no-cache",
+[2026-06-18T11:45:27.356Z] [INFO]     "cf-cache-status": "DYNAMIC",
+[2026-06-18T11:45:27.357Z] [INFO]     "cf-ray": "a0da0c394eceb19e-FRA",
+[2026-06-18T11:45:27.357Z] [INFO]     connection: "keep-alive",
+[2026-06-18T11:45:27.358Z] [INFO]     "content-encoding": "gzip",
+[2026-06-18T11:45:27.358Z] [INFO]     "content-security-policy": "default-src 'none'; frame-ancestors 'none'",
+[2026-06-18T11:45:27.358Z] [INFO]     "content-type": "text/event-stream; charset=utf-8",
+[2026-06-18T11:45:27.359Z] [INFO]     date: "Thu, 18 Jun 2026 11:45:27 GMT",
+[2026-06-18T11:45:27.359Z] [INFO]     "request-id": "req_011CcAfk1qUMG74ajagQUBYn",
+[2026-06-18T11:45:27.360Z] [INFO]     server: "cloudflare",
+[2026-06-18T11:45:27.360Z] [INFO]     "strict-transport-security": "max-age=31536000; includeSubDomains; preload",
+[2026-06-18T11:45:27.361Z] [INFO]     traceresponse: "00-0b63b5ebe9634c53ba1f2ce1087f8bbb-e9ea2f1680ae9543-01",
+[2026-06-18T11:45:27.361Z] [INFO]     "transfer-encoding": "chunked",
+[2026-06-18T11:45:27.362Z] [INFO]     vary: "Accept-Encoding",
+[2026-06-18T11:45:27.363Z] [INFO]     "x-robots-tag": "none",
+[2026-06-18T11:45:27.365Z] [INFO]     "set-cookie": "***",
+[2026-06-18T11:45:27.367Z] [INFO]   },
+[2026-06-18T11:45:27.368Z] [INFO]   durationMs: 1374,
+[2026-06-18T11:45:27.372Z] [INFO] }
+[2026-06-18T11:45:27.372Z] [INFO] response 200 https://api.anthropic.com/v1/messages?beta=true Headers {
+[2026-06-18T11:45:27.373Z] [INFO]   "date": "Thu, 18 Jun 2026 11:45:27 GMT",
+[2026-06-18T11:45:27.374Z] [INFO]   "content-type": "text/event-stream; charset=utf-8",
+[2026-06-18T11:45:27.374Z] [INFO]   "transfer-encoding": "chunked",
+[2026-06-18T11:45:27.374Z] [INFO]   "connection": "keep-alive",
+[2026-06-18T11:45:27.374Z] [INFO]   "cache-control": "no-cache",
+[2026-06-18T11:45:27.375Z] [INFO]   "strict-transport-security": "max-age=31536000; includeSubDomains; preload",
+[2026-06-18T11:45:27.376Z] [INFO]   "content-encoding": "gzip",
+[2026-06-18T11:45:27.376Z] [INFO]   "vary": "Accept-Encoding",
+[2026-06-18T11:45:27.376Z] [INFO]   "content-security-policy": "default-src 'none'; frame-ancestors 'none'",
+[2026-06-18T11:45:27.376Z] [INFO]   "set-cookie": [ "_cfuvid=dOcC_EZ9HU6n39sG.HoZgT5m9_eOp_c.bcsmcWfO9lI-1781783125.9670985-1.0.1.1-HLG0NAWUDBZi4uIobSemheQLFyu4iycZtLbzofepwmw; HttpOnly; SameSite=None; Secure; Path=/; Domain=api.anthropic.com" ],
+[2026-06-18T11:45:27.376Z] [INFO]   "anthropic-ratelimit-unified-status": "allowed",
+[2026-06-18T11:45:27.376Z] [INFO]   "anthropic-ratelimit-unified-5h-status": "allowed",
+[2026-06-18T11:45:27.377Z] [INFO]   "anthropic-ratelimit-unified-5h-reset": "1781787000",
+[2026-06-18T11:45:27.377Z] [INFO]   "anthropic-ratelimit-unified-5h-utilization": "0.33",
+[2026-06-18T11:45:27.377Z] [INFO]   "anthropic-ratelimit-unified-7d-status": "allowed",
+[2026-06-18T11:45:27.377Z] [INFO]   "anthropic-ratelimit-unified-7d-reset": "1782212400",
+[2026-06-18T11:45:27.378Z] [INFO]   "anthropic-ratelimit-unified-7d-utilization": "0.62",
+[2026-06-18T11:45:27.378Z] [INFO]   "anthropic-ratelimit-unified-representative-claim": "five_hour",
+[2026-06-18T11:45:27.378Z] [INFO]   "anthropic-ratelimit-unified-fallback-percentage": "0.5",
+[2026-06-18T11:45:27.379Z] [INFO]   "anthropic-ratelimit-unified-reset": "1781787000",
+[2026-06-18T11:45:27.379Z] [INFO]   "anthropic-ratelimit-unified-overage-disabled-reason": "org_level_disabled",
+[2026-06-18T11:45:27.380Z] [INFO]   "anthropic-ratelimit-unified-overage-status": "rejected",
+[2026-06-18T11:45:27.381Z] [INFO]   "request-id": "req_011CcAfk1qUMG74ajagQUBYn",
+[2026-06-18T11:45:27.382Z] [INFO]   "anthropic-organization-id": "ebc2ac93-f86f-4d15-aff3-de8830d8d789",
+[2026-06-18T11:45:27.383Z] [INFO]   "traceresponse": "00-0b63b5ebe9634c53ba1f2ce1087f8bbb-e9ea2f1680ae9543-01",
+[2026-06-18T11:45:27.384Z] [INFO]   "server": "cloudflare",
+[2026-06-18T11:45:27.384Z] [INFO]   "cf-cache-status": "DYNAMIC",
+[2026-06-18T11:45:27.384Z] [INFO]   "x-robots-tag": "none",
+[2026-06-18T11:45:27.384Z] [INFO]   "cf-ray": "a0da0c394eceb19e-FRA",
+[2026-06-18T11:45:27.385Z] [INFO] } ReadableStream {
+[2026-06-18T11:45:27.385Z] [INFO]   blob: [Function: blob],
+[2026-06-18T11:45:27.385Z] [INFO]   bytes: [Function: bytes],
+[2026-06-18T11:45:27.386Z] [INFO]   cancel: [Function],
+[2026-06-18T11:45:27.386Z] [INFO]   getReader: [Function],
+[2026-06-18T11:45:27.387Z] [INFO]   json: [Function: json],
+[2026-06-18T11:45:27.387Z] [INFO]   locked: [Getter],
+[2026-06-18T11:45:27.388Z] [INFO]   pipeThrough: [Function],
+[2026-06-18T11:45:27.388Z] [INFO]   pipeTo: [Function],
+[2026-06-18T11:45:27.390Z] [INFO]   tee: [Function],
+[2026-06-18T11:45:27.390Z] [INFO]   text: [Function: text],
+[2026-06-18T11:45:27.392Z] [INFO]   values: [Function: values],
+[2026-06-18T11:45:27.392Z] [INFO]   [Symbol(Symbol.asyncIterator)]: [Function: asyncIterator2],
+[2026-06-18T11:45:27.393Z] [INFO] }
+[2026-06-18T11:45:27.393Z] [INFO] [log_366b51] response parsed {
+[2026-06-18T11:45:27.394Z] [INFO]   url: "https://api.anthropic.com/v1/messages?beta=true",
+[2026-06-18T11:45:27.395Z] [INFO]   status: 200,
+[2026-06-18T11:45:27.395Z] [INFO]   body: sU {
+[2026-06-18T11:45:27.396Z] [INFO]     iterator: [AsyncGeneratorFunction: s],
+[2026-06-18T11:45:27.398Z] [INFO]     controller: AbortController {
+[2026-06-18T11:45:27.399Z] [INFO]       signal: [AbortSignal ...],
+[2026-06-18T11:45:27.399Z] [INFO]       abort: [Function: abort],
+[2026-06-18T11:45:27.400Z] [INFO]     },
+[2026-06-18T11:45:27.401Z] [INFO]     [Symbol(Symbol.asyncIterator)]: [Function],
+[2026-06-18T11:45:27.401Z] [INFO]     tee: [Function: tee],
+[2026-06-18T11:45:27.402Z] [INFO]     toReadableStream: [Function: toReadableStream],
+[2026-06-18T11:45:27.402Z] [INFO]   },
+[2026-06-18T11:45:27.404Z] [INFO]   durationMs: 1375,
+[2026-06-18T11:45:27.404Z] [INFO] }
+[2026-06-18T11:45:28.384Z] [INFO] {
+[2026-06-18T11:45:28.384Z] [INFO]   "type": "system",
+[2026-06-18T11:45:28.384Z] [INFO]   "subtype": "thinking_tokens",
+[2026-06-18T11:45:28.384Z] [INFO]   "estimated_tokens": 50,
+[2026-06-18T11:45:28.384Z] [INFO]   "estimated_tokens_delta": 50,
+[2026-06-18T11:45:28.384Z] [INFO]   "uuid": "b86b135a-e7b7-484f-9d51-2acf97467617",
+[2026-06-18T11:45:28.384Z] [INFO]   "session_id": "d65e890a-db60-43f7-aea3-691500f7e26c"
+[2026-06-18T11:45:28.384Z] [INFO] }
+[2026-06-18T11:45:28.386Z] [INFO] {
+[2026-06-18T11:45:28.386Z] [INFO]   "type": "system",
+[2026-06-18T11:45:28.386Z] [INFO]   "subtype": "thinking_tokens",
+[2026-06-18T11:45:28.386Z] [INFO]   "estimated_tokens": 105,
+[2026-06-18T11:45:28.386Z] [INFO]   "estimated_tokens_delta": 55,
+[2026-06-18T11:45:28.386Z] [INFO]   "uuid": "7fb7f60d-4584-4222-b5fc-e8ebfeda2a59",
+[2026-06-18T11:45:28.386Z] [INFO]   "session_id": "d65e890a-db60-43f7-aea3-691500f7e26c"
+[2026-06-18T11:45:28.386Z] [INFO] }
+[2026-06-18T11:45:28.388Z] [INFO] {
+[2026-06-18T11:45:28.388Z] [INFO]   "type": "assistant",
+[2026-06-18T11:45:28.388Z] [INFO]   "message": {
+[2026-06-18T11:45:28.388Z] [INFO]     "model": "claude-opus-4-8",
+[2026-06-18T11:45:28.388Z] [INFO]     "id": "msg_01CohTBzjMDqBUkjf7me3U4D",
+[2026-06-18T11:45:28.388Z] [INFO]     "type": "message",
+[2026-06-18T11:45:28.388Z] [INFO]     "role": "assistant",
+[2026-06-18T11:45:28.388Z] [INFO]     "content": [
+[2026-06-18T11:45:28.388Z] [INFO]       {
+[2026-06-18T11:45:28.388Z] [INFO]         "type": "thinking",
+[2026-06-18T11:45:28.388Z] [INFO]         "thinking": "",
+[2026-06-18T11:45:28.388Z] [INFO]         "signature": "EpsDCmMIDhgCKkC8HL0YKf270xza6PljnxuEQiOYChsNh8RedlWxoQ8pxSPVY58M0BhkEYcME5XBiCQThA7DoTsr1c1xUZCpl/pTMg9jbGF1ZGUtb3B1cy00LTg4AEIIdGhpbmtpbmcSDJ88kd+cEeaScL8IHBoMazo8+JZfB3ZdmqOoIjDPqSYNs298R11UEJoaXe+HKt6Tccm6EHAbaIx6+ys3Qm7/muiCr3TrT+4CWqssvN4q5QHKvcC0XOsUob/m66t4x7UcnP9g7K3nxCpfmcVpp+5C1KDer5jN4LCZg/Wte31UySNru0dkmSsDtGiBpnzl0R69XdKCPg84sXK+tVJmTeo5uM+YhtVgLoh7Vb9S/3Y6mVDQxugKNU8BQ7WxPZumakhdBPOKdjr2jRaXTSGZxLv9BC20y2ieAkEROyyxwVEilzqOvr47ff+pwrC94d2FF3gckLK94UTfYmoVk3CXVXhXh/jBFUtq/mqI03VNvtD4G8UOzxdKGkfZs2KebdOjoAbZf9+UHlYH4hlRw2gJJY5907xIFTF6GAE="
+[2026-06-18T11:45:28.388Z] [INFO]       }
+[2026-06-18T11:45:28.388Z] [INFO]     ],
+[2026-06-18T11:45:28.388Z] [INFO]     "stop_reason": null,
+[2026-06-18T11:45:28.388Z] [INFO]     "stop_sequence": null,
+[2026-06-18T11:45:28.388Z] [INFO]     "stop_details": null,
+[2026-06-18T11:45:28.388Z] [INFO]     "usage": {
+[2026-06-18T11:45:28.388Z] [INFO]       "input_tokens": 2,
+[2026-06-18T11:45:28.388Z] [INFO]       "cache_creation_input_tokens": 42592,
+[2026-06-18T11:45:28.388Z] [INFO]       "cache_read_input_tokens": 12765,
+[2026-06-18T11:45:28.388Z] [INFO]       "cache_creation": {
+[2026-06-18T11:45:28.388Z] [INFO]         "ephemeral_5m_input_tokens": 0,
+[2026-06-18T11:45:28.388Z] [INFO]         "ephemeral_1h_input_tokens": 42592
+[2026-06-18T11:45:28.388Z] [INFO]       },
+[2026-06-18T11:45:28.388Z] [INFO]       "output_tokens": 7,
+[2026-06-18T11:45:28.388Z] [INFO]       "service_tier": "standard",
+[2026-06-18T11:45:28.388Z] [INFO]       "inference_geo": "not_available"
+[2026-06-18T11:45:28.388Z] [INFO]     },
+[2026-06-18T11:45:28.388Z] [INFO]     "diagnostics": {
+[2026-06-18T11:45:28.388Z] [INFO]       "cache_miss_reason": {
+[2026-06-18T11:45:28.388Z] [INFO]         "type": "tools_changed",
+[2026-06-18T11:45:28.388Z] [INFO]         "cache_missed_input_tokens": 51749
+[2026-06-18T11:45:28.388Z] [INFO]       }
+[2026-06-18T11:45:28.388Z] [INFO]     },
+[2026-06-18T11:45:28.388Z] [INFO]     "context_management": null
+[2026-06-18T11:45:28.388Z] [INFO]   },
+[2026-06-18T11:45:28.388Z] [INFO]   "parent_tool_use_id": null,
+[2026-06-18T11:45:28.388Z] [INFO]   "session_id": "d65e890a-db60-43f7-aea3-691500f7e26c",
+[2026-06-18T11:45:28.388Z] [INFO]   "uuid": "2eaf28df-ae61-4532-9988-b60b4a99c53f",
+[2026-06-18T11:45:28.388Z] [INFO]   "request_id": "req_011CcAfk1qUMG74ajagQUBYn"
+[2026-06-18T11:45:28.388Z] [INFO] }
+[2026-06-18T11:45:29.776Z] [INFO] {
+[2026-06-18T11:45:29.776Z] [INFO]   "type": "assistant",
+[2026-06-18T11:45:29.776Z] [INFO]   "message": {
+[2026-06-18T11:45:29.776Z] [INFO]     "model": "claude-opus-4-8",
+[2026-06-18T11:45:29.776Z] [INFO]     "id": "msg_01CohTBzjMDqBUkjf7me3U4D",
+[2026-06-18T11:45:29.776Z] [INFO]     "type": "message",
+[2026-06-18T11:45:29.776Z] [INFO]     "role": "assistant",
+[2026-06-18T11:45:29.776Z] [INFO]     "content": [
+[2026-06-18T11:45:29.776Z] [INFO]       {
+[2026-06-18T11:45:29.776Z] [INFO]         "type": "tool_use",
+[2026-06-18T11:45:29.776Z] [INFO]         "id": "toolu_01RnKFB2AryMW1Mg4FqVWkLW",
+[2026-06-18T11:45:29.776Z] [INFO]         "name": "Bash",
+[2026-06-18T11:45:29.776Z] [INFO]         "input": {
+[2026-06-18T11:45:29.776Z] [INFO]           "command": "grep -n \"research/mango\" governance/artifact-map.md | head; echo \"=== manifest? ===\"; find . -name manifest.json -not -path '*/.git/*'; grep -c \"research/mango\" $(find . -name manifest.json -not -path '*/.git/*' | head -1)",
+[2026-06-18T11:45:29.776Z] [INFO]           "description": "Check artifact-map and manifest references"
+[2026-06-18T11:45:29.776Z] [INFO]         },
+[2026-06-18T11:45:29.776Z] [INFO]         "caller": {
+[2026-06-18T11:45:29.776Z] [INFO]           "type": "direct"
+[2026-06-18T11:45:29.776Z] [INFO]         }
+[2026-06-18T11:45:29.776Z] [INFO]       }
+[2026-06-18T11:45:29.776Z] [INFO]     ],
+[2026-06-18T11:45:29.776Z] [INFO]     "stop_reason": null,
+[2026-06-18T11:45:29.776Z] [INFO]     "stop_sequence": null,
+[2026-06-18T11:45:29.776Z] [INFO]     "stop_details": null,
+[2026-06-18T11:45:29.776Z] [INFO]     "usage": {
+[2026-06-18T11:45:29.776Z] [INFO]       "input_tokens": 2,
+[2026-06-18T11:45:29.776Z] [INFO]       "cache_creation_input_tokens": 42592,
+[2026-06-18T11:45:29.776Z] [INFO]       "cache_read_input_tokens": 12765,
+[2026-06-18T11:45:29.776Z] [INFO]       "cache_creation": {
+[2026-06-18T11:45:29.776Z] [INFO]         "ephemeral_5m_input_tokens": 0,
+[2026-06-18T11:45:29.776Z] [INFO]         "ephemeral_1h_input_tokens": 42592
+[2026-06-18T11:45:29.776Z] [INFO]       },
+[2026-06-18T11:45:29.776Z] [INFO]       "output_tokens": 7,
+[2026-06-18T11:45:29.776Z] [INFO]       "service_tier": "standard",
+[2026-06-18T11:45:29.776Z] [INFO]       "inference_geo": "not_available"
+[2026-06-18T11:45:29.776Z] [INFO]     },
+[2026-06-18T11:45:29.776Z] [INFO]     "diagnostics": {
+[2026-06-18T11:45:29.776Z] [INFO]       "cache_miss_reason": {
+[2026-06-18T11:45:29.776Z] [INFO]         "type": "tools_changed",
+[2026-06-18T11:45:29.776Z] [INFO]         "cache_missed_input_tokens": 51749
+[2026-06-18T11:45:29.776Z] [INFO]       }
+[2026-06-18T11:45:29.776Z] [INFO]     },
+[2026-06-18T11:45:29.776Z] [INFO]     "context_management": null
+[2026-06-18T11:45:29.776Z] [INFO]   },
+[2026-06-18T11:45:29.776Z] [INFO]   "parent_tool_use_id": null,
+[2026-06-18T11:45:29.776Z] [INFO]   "session_id": "d65e890a-db60-43f7-aea3-691500f7e26c",
+[2026-06-18T11:45:29.776Z] [INFO]   "uuid": "454d7ec0-7665-45cc-bf94-f34aaf07d723",
+[2026-06-18T11:45:29.776Z] [INFO]   "request_id": "req_011CcAfk1qUMG74ajagQUBYn"
+[2026-06-18T11:45:29.776Z] [INFO] }
+[2026-06-18T11:45:30.751Z] [INFO] {
+[2026-06-18T11:45:30.751Z] [INFO]   "type": "user",
+[2026-06-18T11:45:30.751Z] [INFO]   "message": {
+[2026-06-18T11:45:30.751Z] [INFO]     "role": "user",
+[2026-06-18T11:45:30.751Z] [INFO]     "content": [
+[2026-06-18T11:45:30.751Z] [INFO]       {
+[2026-06-18T11:45:30.751Z] [INFO]         "tool_use_id": "toolu_01RnKFB2AryMW1Mg4FqVWkLW",
+[2026-06-18T11:45:30.751Z] [INFO]         "type": "tool_result",
+[2026-06-18T11:45:30.751Z] [INFO]         "content": "94:| `/governance/rfc/draft-triage-and-exit-plan.md` | RFC | справка | Canonical RFC триажа 20 draft-документов категории \"К доработке\": группировка template/hub/Mango/education, exit plans, placeholder strategy, draft lifecycle rule, phased cleanup и утверждённые Anti-Bureaucracy правила Phase 1. | ⚠️ По необходимости | `governance/rfc/repository-quality-improvement-plan.md`, `templates/htom/README.md`, `research/governance/README.md`, `research/hub/prompts-classification-standard-2026-05.md`, `research/mango/taxonomy-concept-2026-05.md`, `projects/education-ba-prompt/README.md` |\n152:| `/research/mango/taxonomy-concept-2026-05.md` | концепция | — | Draft-концепция Unified Capability Taxonomy для Mango: мета-модель, mapping фич, процесс нормализации, интерфейс команд, метрики, пилот и риски. | ⚠️ По необходимости | `research/mango/classification.md`, `research/mango/classification-tz.md`, `research/mango/requirements-flow.md`, `mango_ba_prompts`, `standards/glossary.md`, `governance/repo-model.md` |\n153:| `/research/mango/requirements-lifecycle-uncertainty-2026-05.md` | исследование | — | Жизненный цикл требования на доработку Mango: бенчмарк международной практики, моделирование кейсов (`0 → 1`), обработка неопределенности, декомпозиция и рекомендации для стандарта процесса БА. | ⚠️ По необходимости | `research/mango/requirements-flow.md`, `research/mango/taxonomy-concept-2026-05.md`, `research/mango/classification.md`, `mango_ba_prompts`, `standards/glossary.md` |\n154:| `/research/mango/rag-mapping-roadmap-2026-05.md` | исследование | — | Маппинг продуктов/фич Mango как RAG-навигатор: структура `kb/product-matrix.md`, оценка источников документации, roadmap автоматизации БА и карта PlantUML-диаграмм. | ⚠️ По необходимости | `research/mango/taxonomy-concept-2026-05.md`, `research/mango/requirements-lifecycle-uncertainty-2026-05.md`, `mango_ba_prompts`, `standards/research-profile.md` |\n155:| `/research/mango/capability-decomposition-2026-05.md` | исследование | — | Справочник атомарных функций пилотных доменов Mango (`voice-ucaas`, `contact-center`, `digital-channels`): параметры, международные источники, примеры ТЗ, критерии атомарности и связь с НФТ-классами. | ⚠️ По необходимости | `research/mango/classification.md`, `research/mango/classification-tz.md`, `research/mango/rag-mapping-roadmap-2026-05.md`, `mango_ba_prompts/standards/GLOSSARY.md` |\n156:| `/research/hub/project-context-and-bootstrap-patterns-2026-05.md` | исследование | — | Паттерны передачи контекста, предсказуемого project bootstrap и маршрута \"рекомендация -> задача\" на опыте Mango. Scope: repo-wide. | ⚠️ По необходимости | `mango_ba_prompts`, `research/mango/`, `standards/project-structure-inheritance.md` |\n192:| `/research/external-knowledge/external-insights/spec-driven-development-2026-06.md` | исследование | — | Инсайт `ext-003`: spec-driven development как кандидат для уточнения требований (Mango/clarify-engine-ai). Stage: hypothesis. | ⚠️ По необходимости | `research/external-knowledge/external-sources-registry.md`, `research/mango/requirements-flow.md`, `governance/rfc/knowledge-lifecycle-proposal.md` |\n196:| `https://github.com/G-Ivan-A/mango_ba_prompts` | каталог | — | Внешний spoke-репозиторий Mango: рабочие prompt assets, эксперименты, `standards/GLOSSARY.md` и migration manifest. | ⚠️ По необходимости | `projects/README.md`, `research/mango/README.md` |\n205:| `/research/mango/README.md` | навигация | — | Индекс активных исследований MANGO OFFICE; HTML генерируется через MkDocs/GitHub Pages и не хранится в репозитории. | ✅ Да | `research/README.md`, `mango_ba_prompts` |\n206:| `/research/mango/classification.md` | исследование | — | Классификация IT/Telecom SaaS-продуктов MANGO OFFICE. | ✅ Да | `research/mango/README.md`, `standards/research-profile.md` |\n=== manifest? ===\n./templates/manifest.json\n0",
+[2026-06-18T11:45:30.751Z] [INFO]         "is_error": false
+[2026-06-18T11:45:30.751Z] [INFO]       }
+[2026-06-18T11:45:30.751Z] [INFO]     ]
+[2026-06-18T11:45:30.751Z] [INFO]   },
+[2026-06-18T11:45:30.751Z] [INFO]   "parent_tool_use_id": null,
+[2026-06-18T11:45:30.751Z] [INFO]   "session_id": "d65e890a-db60-43f7-aea3-691500f7e26c",
+[2026-06-18T11:45:30.751Z] [INFO]   "uuid": "c5baaf80-d7a2-4a90-b016-412a7cfd41bb",
+[2026-06-18T11:45:30.751Z] [INFO]   "timestamp": "2026-06-18T11:45:30.747Z",
+[2026-06-18T11:45:30.751Z] [INFO]   "tool_use_result": {
+[2026-06-18T11:45:30.751Z] [INFO]     "stdout": "94:| `/governance/rfc/draft-triage-and-exit-plan.md` | RFC | справка | Canonical RFC триажа 20 draft-документов категории \"К доработке\": группировка template/hub/Mango/education, exit plans, placeholder strategy, draft lifecycle rule, phased cleanup и утверждённые Anti-Bureaucracy правила Phase 1. | ⚠️ По необходимости | `governance/rfc/repository-quality-improvement-plan.md`, `templates/htom/README.md`, `research/governance/README.md`, `research/hub/prompts-classification-standard-2026-05.md`, `research/mango/taxonomy-concept-2026-05.md`, `projects/education-ba-prompt/README.md` |\n152:| `/research/mango/taxonomy-concept-2026-05.md` | концепция | — | Draft-концепция Unified Capability Taxonomy для Mango: мета-модель, mapping фич, процесс нормализации, интерфейс команд, метрики, пилот и риски. | ⚠️ По необходимости | `research/mango/classification.md`, `research/mango/classification-tz.md`, `research/mango/requirements-flow.md`, `mango_ba_prompts`, `standards/glossary.md`, `governance/repo-model.md` |\n153:| `/research/mango/requirements-lifecycle-uncertainty-2026-05.md` | исследование | — | Жизненный цикл требования на доработку Mango: бенчмарк международной практики, моделирование кейсов (`0 → 1`), обработка неопределенности, декомпозиция и рекомендации для стандарта процесса БА. | ⚠️ По необходимости | `research/mango/requirements-flow.md`, `research/mango/taxonomy-concept-2026-05.md`, `research/mango/classification.md`, `mango_ba_prompts`, `standards/glossary.md` |\n154:| `/research/mango/rag-mapping-roadmap-2026-05.md` | исследование | — | Маппинг продуктов/фич Mango как RAG-навигатор: структура `kb/product-matrix.md`, оценка источников документации, roadmap автоматизации БА и карта PlantUML-диаграмм. | ⚠️ По необходимости | `research/mango/taxonomy-concept-2026-05.md`, `research/mango/requirements-lifecycle-uncertainty-2026-05.md`, `mango_ba_prompts`, `standards/research-profile.md` |\n155:| `/research/mango/capability-decomposition-2026-05.md` | исследование | — | Справочник атомарных функций пилотных доменов Mango (`voice-ucaas`, `contact-center`, `digital-channels`): параметры, международные источники, примеры ТЗ, критерии атомарности и связь с НФТ-классами. | ⚠️ По необходимости | `research/mango/classification.md`, `research/mango/classification-tz.md`, `research/mango/rag-mapping-roadmap-2026-05.md`, `mango_ba_prompts/standards/GLOSSARY.md` |\n156:| `/research/hub/project-context-and-bootstrap-patterns-2026-05.md` | исследование | — | Паттерны передачи контекста, предсказуемого project bootstrap и маршрута \"рекомендация -> задача\" на опыте Mango. Scope: repo-wide. | ⚠️ По необходимости | `mango_ba_prompts`, `research/mango/`, `standards/project-structure-inheritance.md` |\n192:| `/research/external-knowledge/external-insights/spec-driven-development-2026-06.md` | исследование | — | Инсайт `ext-003`: spec-driven development как кандидат для уточнения требований (Mango/clarify-engine-ai). Stage: hypothesis. | ⚠️ По необходимости | `research/external-knowledge/external-sources-registry.md`, `research/mango/requirements-flow.md`, `governance/rfc/knowledge-lifecycle-proposal.md` |\n196:| `https://github.com/G-Ivan-A/mango_ba_prompts` | каталог | — | Внешний spoke-репозиторий Mango: рабочие prompt assets, эксперименты, `standards/GLOSSARY.md` и migration manifest. | ⚠️ По необходимости | `projects/README.md`, `research/mango/README.md` |\n205:| `/research/mango/README.md` | навигация | — | Индекс активных исследований MANGO OFFICE; HTML генерируется через MkDocs/GitHub Pages и не хранится в репозитории. | ✅ Да | `research/README.md`, `mango_ba_prompts` |\n206:| `/research/mango/classification.md` | исследование | — | Классификация IT/Telecom SaaS-продуктов MANGO OFFICE. | ✅ Да | `research/mango/README.md`, `standards/research-profile.md` |\n=== manifest? ===\n./templates/manifest.json\n0",
+[2026-06-18T11:45:30.751Z] [INFO]     "stderr": "",
+[2026-06-18T11:45:30.751Z] [INFO]     "interrupted": false,
+[2026-06-18T11:45:30.751Z] [INFO]     "isImage": false,
+[2026-06-18T11:45:30.751Z] [INFO]     "returnCodeInterpretation": "No matches found",
+[2026-06-18T11:45:30.751Z] [INFO]     "noOutputExpected": false
+[2026-06-18T11:45:30.751Z] [INFO]   }
+[2026-06-18T11:45:30.751Z] [INFO] }
+[2026-06-18T11:45:30.762Z] [INFO] [log_1ec4d3] sending request {
+[2026-06-18T11:45:30.764Z] [INFO]   method: "post",
+[2026-06-18T11:45:30.766Z] [INFO]   url: "https://api.anthropic.com/v1/messages?beta=true",
+[2026-06-18T11:45:30.767Z] [INFO]   options: {
+[2026-06-18T11:45:30.767Z] [INFO]     method: "post",
+[2026-06-18T11:45:30.769Z] [INFO]     path: "/v1/messages?beta=true",
+[2026-06-18T11:45:30.769Z] [INFO]     body: {
+[2026-06-18T11:45:30.770Z] [INFO]       model: "claude-opus-4-8",
+[2026-06-18T11:45:30.771Z] [INFO]       messages: [
+[2026-06-18T11:45:30.772Z] [INFO]         [Object ...], [Object ...], [Object ...], [Object ...], [Object ...], [Object ...], [Object ...], [Object ...], [Object ...], [Object ...], [Object ...], [Object ...], [Object ...], [Object ...], [Object ...], [Object ...], [Object ...], [Object ...], [Object ...], [Object ...], [Object ...], [Object ...]
+[2026-06-18T11:45:30.773Z] [INFO]       ],
+[2026-06-18T11:45:30.774Z] [INFO]       system: [
+[2026-06-18T11:45:30.775Z] [INFO]         [Object ...], [Object ...], [Object ...], [Object ...]
+[2026-06-18T11:45:30.776Z] [INFO]       ],
+[2026-06-18T11:45:30.777Z] [INFO]       tools: [
+[2026-06-18T11:45:30.777Z] [INFO]         [Object ...], [Object ...], [Object ...], [Object ...], [Object ...], [Object ...], [Object ...], [Object ...], [Object ...], [Object ...]
+[2026-06-18T11:45:30.778Z] [INFO]       ],
+[2026-06-18T11:45:30.779Z] [INFO]       tool_choice: undefined,
+[2026-06-18T11:45:30.780Z] [INFO]       metadata: [Object ...],
+[2026-06-18T11:45:30.782Z] [INFO]       max_tokens: 128000,
+[2026-06-18T11:45:30.783Z] [INFO]       thinking: [Object ...],
+[2026-06-18T11:45:30.783Z] [INFO]       context_management: [Object ...],
+[2026-06-18T11:45:30.784Z] [INFO]       output_config: [Object ...],
+[2026-06-18T11:45:30.784Z] [INFO]       diagnostics: [Object ...],
+[2026-06-18T11:45:30.784Z] [INFO]       stream: true,
+[2026-06-18T11:45:30.785Z] [INFO]     },
+[2026-06-18T11:45:30.785Z] [INFO]     timeout: 600000,
+[2026-06-18T11:45:30.786Z] [INFO]     signal: AbortSignal {
+[2026-06-18T11:45:30.786Z] [INFO]       [Symbol(events.maxEventTargetListeners)]: 50,
+[2026-06-18T11:45:30.787Z] [INFO]       [Symbol(events.maxEventTargetListenersWarned)]: false,
+[2026-06-18T11:45:30.788Z] [INFO]       aborted: false,
+[2026-06-18T11:45:30.788Z] [INFO]       reason: undefined,
+[2026-06-18T11:45:30.790Z] [INFO]       onabort: null,
+[2026-06-18T11:45:30.790Z] [INFO]       throwIfAborted: [Function: throwIfAborted],
+[2026-06-18T11:45:30.791Z] [INFO]       addEventListener: [Function: addEventListener],
+[2026-06-18T11:45:30.792Z] [INFO]       removeEventListener: [Function: removeEventListener],
+[2026-06-18T11:45:30.793Z] [INFO]       dispatchEvent: [Function: dispatchEvent],
+[2026-06-18T11:45:30.793Z] [INFO]     },
+[2026-06-18T11:45:30.793Z] [INFO]     stream: true,
+[2026-06-18T11:45:30.794Z] [INFO]   },
+[2026-06-18T11:45:30.794Z] [INFO]   headers: {
+[2026-06-18T11:45:30.795Z] [INFO]     accept: "application/json",
+[2026-06-18T11:45:30.795Z] [INFO]     "anthropic-beta": "claude-code-20250219,oauth-2025-04-20,interleaved-thinking-2025-05-14,thinking-token-count-2026-05-13,context-management-2025-06-27,prompt-caching-scope-2026-01-05,mid-conversation-system-2026-04-07,advisor-tool-2026-03-01,advanced-tool-use-2025-11-20,effort-2025-11-24,extended-cache-ttl-2025-04-11,cache-diagnosis-2026-04-07",
+[2026-06-18T11:45:30.795Z] [INFO]     "anthropic-dangerous-direct-browser-access": "true",
+[2026-06-18T11:45:30.796Z] [INFO]     "anthropic-version": "2023-06-01",
+[2026-06-18T11:45:30.796Z] [INFO]     authorization: "***",
+[2026-06-18T11:45:30.796Z] [INFO]     "content-type": "application/json",
+[2026-06-18T11:45:30.797Z] [INFO]     "user-agent": "claude-cli/2.1.181 (external, sdk-cli)",
+[2026-06-18T11:45:30.797Z] [INFO]     "x-app": "cli",
+[2026-06-18T11:45:30.797Z] [INFO]     "x-claude-code-session-id": "d65e890a-db60-43f7-aea3-691500f7e26c",
+[2026-06-18T11:45:30.798Z] [INFO]     "x-client-request-id": "2c788b36-b0a3-4df0-aedc-7f30d93a24a8",
+[2026-06-18T11:45:30.798Z] [INFO]     "x-stainless-arch": "x64",
+[2026-06-18T11:45:30.798Z] [INFO]     "x-stainless-lang": "js",
+[2026-06-18T11:45:30.798Z] [INFO]     "x-stainless-os": "Linux",
+[2026-06-18T11:45:30.799Z] [INFO]     "x-stainless-package-version": "0.94.0",
+[2026-06-18T11:45:30.799Z] [INFO]     "x-stainless-retry-count": "0",
+[2026-06-18T11:45:30.799Z] [INFO]     "x-stainless-runtime": "node",
+[2026-06-18T11:45:30.800Z] [INFO]     "x-stainless-runtime-version": "v24.3.0",
+[2026-06-18T11:45:30.800Z] [INFO]     "x-stainless-timeout": "600",
+[2026-06-18T11:45:30.800Z] [INFO]   },
+[2026-06-18T11:45:30.800Z] [INFO] }
+[2026-06-18T11:45:32.057Z] [INFO] [log_1ec4d3, request-id: "req_011CcAfkNRUKQ91nv2HMT7AS"] post https://api.anthropic.com/v1/messages?beta=true succeeded with status 200 in 1295ms
+[2026-06-18T11:45:32.057Z] [INFO] [log_1ec4d3] response start {
+[2026-06-18T11:45:32.058Z] [INFO]   url: "https://api.anthropic.com/v1/messages?beta=true",
+[2026-06-18T11:45:32.059Z] [INFO]   status: 200,
+[2026-06-18T11:45:32.060Z] [INFO]   headers: {
+[2026-06-18T11:45:32.060Z] [INFO]     "anthropic-organization-id": "ebc2ac93-f86f-4d15-aff3-de8830d8d789",
+[2026-06-18T11:45:32.061Z] [INFO]     "anthropic-ratelimit-unified-5h-reset": "1781787000",
+[2026-06-18T11:45:32.062Z] [INFO]     "anthropic-ratelimit-unified-5h-status": "allowed",
+[2026-06-18T11:45:32.062Z] [INFO]     "anthropic-ratelimit-unified-5h-utilization": "0.33",
+[2026-06-18T11:45:32.062Z] [INFO]     "anthropic-ratelimit-unified-7d-reset": "1782212400",
+[2026-06-18T11:45:32.063Z] [INFO]     "anthropic-ratelimit-unified-7d-status": "allowed",
+[2026-06-18T11:45:32.063Z] [INFO]     "anthropic-ratelimit-unified-7d-utilization": "0.62",
+[2026-06-18T11:45:32.064Z] [INFO]     "anthropic-ratelimit-unified-fallback-percentage": "0.5",
+[2026-06-18T11:45:32.065Z] [INFO]     "anthropic-ratelimit-unified-overage-disabled-reason": "org_level_disabled",
+[2026-06-18T11:45:32.066Z] [INFO]     "anthropic-ratelimit-unified-overage-status": "rejected",
+[2026-06-18T11:45:32.066Z] [INFO]     "anthropic-ratelimit-unified-representative-claim": "five_hour",
+[2026-06-18T11:45:32.066Z] [INFO]     "anthropic-ratelimit-unified-reset": "1781787000",
+[2026-06-18T11:45:32.067Z] [INFO]     "anthropic-ratelimit-unified-status": "allowed",
+[2026-06-18T11:45:32.068Z] [INFO]     "cache-control": "no-cache",
+[2026-06-18T11:45:32.069Z] [INFO]     "cf-cache-status": "DYNAMIC",
+[2026-06-18T11:45:32.069Z] [INFO]     "cf-ray": "a0da0c575d6adc48-FRA",
+[2026-06-18T11:45:32.070Z] [INFO]     connection: "keep-alive",
+[2026-06-18T11:45:32.071Z] [INFO]     "content-encoding": "gzip",
+[2026-06-18T11:45:32.071Z] [INFO]     "content-security-policy": "default-src 'none'; frame-ancestors 'none'",
+[2026-06-18T11:45:32.071Z] [INFO]     "content-type": "text/event-stream; charset=utf-8",
+[2026-06-18T11:45:32.072Z] [INFO]     date: "Thu, 18 Jun 2026 11:45:32 GMT",
+[2026-06-18T11:45:32.072Z] [INFO]     "request-id": "req_011CcAfkNRUKQ91nv2HMT7AS",
+[2026-06-18T11:45:32.072Z] [INFO]     server: "cloudflare",
+[2026-06-18T11:45:32.072Z] [INFO]     "strict-transport-security": "max-age=31536000; includeSubDomains; preload",
+[2026-06-18T11:45:32.072Z] [INFO]     traceresponse: "00-54e8f488e0b9dd3fa06786f93eac880c-d718b76b1b601a42-01",
+[2026-06-18T11:45:32.073Z] [INFO]     "transfer-encoding": "chunked",
+[2026-06-18T11:45:32.073Z] [INFO]     vary: "Accept-Encoding",
+[2026-06-18T11:45:32.073Z] [INFO]     "x-robots-tag": "none",
+[2026-06-18T11:45:32.074Z] [INFO]     "set-cookie": "***",
+[2026-06-18T11:45:32.074Z] [INFO]   },
+[2026-06-18T11:45:32.074Z] [INFO]   durationMs: 1295,
+[2026-06-18T11:45:32.075Z] [INFO] }
+[2026-06-18T11:45:32.075Z] [INFO] response 200 https://api.anthropic.com/v1/messages?beta=true Headers {
+[2026-06-18T11:45:32.075Z] [INFO]   "date": "Thu, 18 Jun 2026 11:45:32 GMT",
+[2026-06-18T11:45:32.075Z] [INFO]   "content-type": "text/event-stream; charset=utf-8",
+[2026-06-18T11:45:32.075Z] [INFO]   "transfer-encoding": "chunked",
+[2026-06-18T11:45:32.075Z] [INFO]   "connection": "keep-alive",
+[2026-06-18T11:45:32.076Z] [INFO]   "cache-control": "no-cache",
+[2026-06-18T11:45:32.076Z] [INFO]   "strict-transport-security": "max-age=31536000; includeSubDomains; preload",
+[2026-06-18T11:45:32.076Z] [INFO]   "content-encoding": "gzip",
+[2026-06-18T11:45:32.076Z] [INFO]   "vary": "Accept-Encoding",
+[2026-06-18T11:45:32.076Z] [INFO]   "content-security-policy": "default-src 'none'; frame-ancestors 'none'",
+[2026-06-18T11:45:32.077Z] [INFO]   "set-cookie": [ "_cfuvid=1eTHzU7j1614dJlC0NvpygwKSH2RvLLmv4C4jxIqkgI-1781783130.774097-1.0.1.1-yqHoaYHjRKTO.Qpj7Jj83DFlzNDSLDIEr4NxkH1BzBU; HttpOnly; SameSite=None; Secure; Path=/; Domain=api.anthropic.com" ],
+[2026-06-18T11:45:32.077Z] [INFO]   "anthropic-ratelimit-unified-status": "allowed",
+[2026-06-18T11:45:32.078Z] [INFO]   "anthropic-ratelimit-unified-5h-status": "allowed",
+[2026-06-18T11:45:32.078Z] [INFO]   "anthropic-ratelimit-unified-5h-reset": "1781787000",
+[2026-06-18T11:45:32.078Z] [INFO]   "anthropic-ratelimit-unified-5h-utilization": "0.33",
+[2026-06-18T11:45:32.079Z] [INFO]   "anthropic-ratelimit-unified-7d-status": "allowed",
+[2026-06-18T11:45:32.079Z] [INFO]   "anthropic-ratelimit-unified-7d-reset": "1782212400",
+[2026-06-18T11:45:32.080Z] [INFO]   "anthropic-ratelimit-unified-7d-utilization": "0.62",
+[2026-06-18T11:45:32.081Z] [INFO]   "anthropic-ratelimit-unified-representative-claim": "five_hour",
+[2026-06-18T11:45:32.082Z] [INFO]   "anthropic-ratelimit-unified-fallback-percentage": "0.5",
+[2026-06-18T11:45:32.082Z] [INFO]   "anthropic-ratelimit-unified-reset": "1781787000",
+[2026-06-18T11:45:32.083Z] [INFO]   "anthropic-ratelimit-unified-overage-disabled-reason": "org_level_disabled",
+[2026-06-18T11:45:32.084Z] [INFO]   "anthropic-ratelimit-unified-overage-status": "rejected",
+[2026-06-18T11:45:32.084Z] [INFO]   "request-id": "req_011CcAfkNRUKQ91nv2HMT7AS",
+[2026-06-18T11:45:32.084Z] [INFO]   "anthropic-organization-id": "ebc2ac93-f86f-4d15-aff3-de8830d8d789",
+[2026-06-18T11:45:32.084Z] [INFO]   "traceresponse": "00-54e8f488e0b9dd3fa06786f93eac880c-d718b76b1b601a42-01",
+[2026-06-18T11:45:32.084Z] [INFO]   "server": "cloudflare",
+[2026-06-18T11:45:32.085Z] [INFO]   "cf-cache-status": "DYNAMIC",
+[2026-06-18T11:45:32.085Z] [INFO]   "x-robots-tag": "none",
+[2026-06-18T11:45:32.085Z] [INFO]   "cf-ray": "a0da0c575d6adc48-FRA",
+[2026-06-18T11:45:32.085Z] [INFO] } ReadableStream {
+[2026-06-18T11:45:32.086Z] [INFO]   blob: [Function: blob],
+[2026-06-18T11:45:32.086Z] [INFO]   bytes: [Function: bytes],
+[2026-06-18T11:45:32.086Z] [INFO]   cancel: [Function],
+[2026-06-18T11:45:32.086Z] [INFO]   getReader: [Function],
+[2026-06-18T11:45:32.088Z] [INFO]   json: [Function: json],
+[2026-06-18T11:45:32.089Z] [INFO]   locked: [Getter],
+[2026-06-18T11:45:32.089Z] [INFO]   pipeThrough: [Function],
+[2026-06-18T11:45:32.089Z] [INFO]   pipeTo: [Function],
+[2026-06-18T11:45:32.090Z] [INFO]   tee: [Function],
+[2026-06-18T11:45:32.090Z] [INFO]   text: [Function: text],
+[2026-06-18T11:45:32.091Z] [INFO]   values: [Function: values],
+[2026-06-18T11:45:32.091Z] [INFO]   [Symbol(Symbol.asyncIterator)]: [Function: asyncIterator2],
+[2026-06-18T11:45:32.095Z] [INFO] }
+[2026-06-18T11:45:32.095Z] [INFO] [log_1ec4d3] response parsed {
+[2026-06-18T11:45:32.096Z] [INFO]   url: "https://api.anthropic.com/v1/messages?beta=true",
+[2026-06-18T11:45:32.096Z] [INFO]   status: 200,
+[2026-06-18T11:45:32.096Z] [INFO]   body: sU {
+[2026-06-18T11:45:32.096Z] [INFO]     iterator: [AsyncGeneratorFunction: s],
+[2026-06-18T11:45:32.096Z] [INFO]     controller: AbortController {
+[2026-06-18T11:45:32.096Z] [INFO]       signal: [AbortSignal ...],
+[2026-06-18T11:45:32.097Z] [INFO]       abort: [Function: abort],
+[2026-06-18T11:45:32.097Z] [INFO]     },
+[2026-06-18T11:45:32.097Z] [INFO]     [Symbol(Symbol.asyncIterator)]: [Function],
+[2026-06-18T11:45:32.098Z] [INFO]     tee: [Function: tee],
+[2026-06-18T11:45:32.098Z] [INFO]     toReadableStream: [Function: toReadableStream],
+[2026-06-18T11:45:32.098Z] [INFO]   },
+[2026-06-18T11:45:32.098Z] [INFO]   durationMs: 1295,
+[2026-06-18T11:45:32.099Z] [INFO] }
+[2026-06-18T11:45:33.412Z] [INFO] {
+[2026-06-18T11:45:33.412Z] [INFO]   "type": "system",
+[2026-06-18T11:45:33.412Z] [INFO]   "subtype": "thinking_tokens",
+[2026-06-18T11:45:33.412Z] [INFO]   "estimated_tokens": 50,
+[2026-06-18T11:45:33.412Z] [INFO]   "estimated_tokens_delta": 50,
+[2026-06-18T11:45:33.412Z] [INFO]   "uuid": "772a6708-3179-43fb-bb68-2335983e803d",
+[2026-06-18T11:45:33.412Z] [INFO]   "session_id": "d65e890a-db60-43f7-aea3-691500f7e26c"
+[2026-06-18T11:45:33.412Z] [INFO] }
+[2026-06-18T11:45:35.301Z] [INFO] {
+[2026-06-18T11:45:35.301Z] [INFO]   "type": "system",
+[2026-06-18T11:45:35.301Z] [INFO]   "subtype": "thinking_tokens",
+[2026-06-18T11:45:35.301Z] [INFO]   "estimated_tokens": 200,
+[2026-06-18T11:45:35.301Z] [INFO]   "estimated_tokens_delta": 150,
+[2026-06-18T11:45:35.301Z] [INFO]   "uuid": "c33dc924-88ba-467c-a89e-11c1eadcffc8",
+[2026-06-18T11:45:35.301Z] [INFO]   "session_id": "d65e890a-db60-43f7-aea3-691500f7e26c"
+[2026-06-18T11:45:35.301Z] [INFO] }
+[2026-06-18T11:45:36.767Z] [INFO] {
+[2026-06-18T11:45:36.767Z] [INFO]   "type": "system",
+[2026-06-18T11:45:36.767Z] [INFO]   "subtype": "thinking_tokens",
+[2026-06-18T11:45:36.767Z] [INFO]   "estimated_tokens": 300,
+[2026-06-18T11:45:36.767Z] [INFO]   "estimated_tokens_delta": 100,
+[2026-06-18T11:45:36.767Z] [INFO]   "uuid": "b05e86dd-21ed-47b5-bfab-2942979996cb",
+[2026-06-18T11:45:36.767Z] [INFO]   "session_id": "d65e890a-db60-43f7-aea3-691500f7e26c"
+[2026-06-18T11:45:36.767Z] [INFO] }
+[2026-06-18T11:45:37.718Z] [INFO] {
+[2026-06-18T11:45:37.718Z] [INFO]   "type": "system",
+[2026-06-18T11:45:37.718Z] [INFO]   "subtype": "thinking_tokens",
+[2026-06-18T11:45:37.718Z] [INFO]   "estimated_tokens": 313,
+[2026-06-18T11:45:37.718Z] [INFO]   "estimated_tokens_delta": 13,
+[2026-06-18T11:45:37.718Z] [INFO]   "uuid": "6231c7fd-e24f-4ef1-ac0e-686cefb0d220",
+[2026-06-18T11:45:37.718Z] [INFO]   "session_id": "d65e890a-db60-43f7-aea3-691500f7e26c"
+[2026-06-18T11:45:37.718Z] [INFO] }
+[2026-06-18T11:45:37.720Z] [INFO] {
+[2026-06-18T11:45:37.720Z] [INFO]   "type": "assistant",
+[2026-06-18T11:45:37.720Z] [INFO]   "message": {
+[2026-06-18T11:45:37.720Z] [INFO]     "model": "claude-opus-4-8",
+[2026-06-18T11:45:37.720Z] [INFO]     "id": "msg_013XwsRHWe9Qn1KZgMne9zDj",
+[2026-06-18T11:45:37.720Z] [INFO]     "type": "message",
+[2026-06-18T11:45:37.720Z] [INFO]     "role": "assistant",
+[2026-06-18T11:45:37.720Z] [INFO]     "content": [
+[2026-06-18T11:45:37.720Z] [INFO]       {
+[2026-06-18T11:45:37.720Z] [INFO]         "type": "thinking",
+[2026-06-18T11:45:37.720Z] [INFO]         "thinking": "",
+[2026-06-18T11:45:37.720Z] [INFO]         "signature": "Et0JCmMIDhgCKkB4BZVcj4u9CHSkEXvSd5a+9b+/AUdxd0fhgwLUGz1ch45F4/uiC3BDv0AQJL4aAduyrVVaVZawZkq3lgjxGAIwMg9jbGF1ZGUtb3B1cy00LTg4AEIIdGhpbmtpbmcSDKsddcdbH3Awu1oAqxoMjf+EDYScsM23jZOQIjDhBpA7TINKJ7LYywo7J5zmATPMX5mG6VAAiV/lqpTskqVKOZlr41og6t4PQ7kk39gqpwjZQr8xg8iJZ0vW9TusELRglyBgm9SlgdfYmftOjG32UsGP0vv69fc1XX/Dj3TX9hibjMPYXHMab4TkwZzDxrRsJE2AO2MCskXqYXYAGZ/XCJ/hUOjsj5t6D0K53QIxMT7TI0x3xGEnxJA97Hv/Ocj9jXfy6w5yhC9Faw7dytNwyJilb7vWVqQDKpBG8zL3DmN5Zkstr4vt0QEL+MKYiIPeMQKUA5DeOj0yaepoL1qyg4S9SSd3V91Xz/gxV2gMjEufO8tffTGaQRhxqjXYvFzmkxI1qJ/HvHt6ELzqIt2T1b3wpoc8+1OVAFLHBgoui+HhCkBf0B0J2toMHOvDC5pjWO4ftSwRMENMVvjyC119xG6kwBOGifSap7fYJWFZ/Ax5ljYgfT18sfG6f2sZr5s43Xng/EnRlMsAMP0YfMP6rJqNBRFvT/I8Dd4U6qzFNVJAtTq6B8iQXPM38KNJhr9EWUQ8jgN+ARSOvvtpcwhinakQJ0dWapnrWFcleQ4ypLLxvlcxwtzcPeDZLN2jHHVRse1ENWgW0O/gx3AqWjEpCgzLnWl4qK0CI/wLkbzQ+22aWo9WitrOKkJGzRBW+fN7LAaRhe1fw89nd0wgjIRRyVtmznLb7DftxzRtwHUNcbXBH1PqVw/3WwPlPktZznpTuwyjRlB5W+M1l62usEZWvCBhk/3fy0qzQxF0XlmAlwXXpMbogt/4kpwk74uguIYusVnY2badWVwL/SiLqVmUXeGt2l9L2v2nMsxZl3zycB0Iczn9ptLTrOomvuRUoo/jvXlDSkG8PuQ8zNxRgP2g1L02MoPfeEG+j6SPhlol/SlZ8wbEvTyySp5mhKtVRfZlESJOA27uzvKNt4dMG8Cd2kBwspIrH7ZC3IbbnH3ZkhshuXEHiS8xGxJOE/SPwv5AYnfP414TFOAXC9GJ03ylmVRXpygzFL7M+eHI/7XrPgY7RTwbC5NTZsn++/bbBYVhjTEmAb6OHthgQBYVadwk4Ti/HL0I8fFSV1EgjF4aQfE5v8OJVtHXjytxdl7ZQmpyoYM814FulnMHlF8m6+HbxM4qU9TnfYZUQwODtYdBR0DRx1VnPiCeHV28kCp29dvUte70s8nKh+XBv+8+gmsg5TfWJ0U8+md3DIss1MQds1PbzEITOgjdnGVo19IcJBITxsZjnR7NrO9NIm0us88UWzlUaq5c/dllMf6xsCddLroAvtn9AokTzYoqtLLhlrPBDorVQoqy3lxH9wks5EsIVlPLJOvVPTl47hASrDJe7ilNz9oKXP/bnSuA4UrEEntn6a28vqG2PTSljM8vIckkggaWiqtJ5b7mj3DX+OjpWkOBYSKTwlhYc0d8DLx0Lk+xsbZERdIMRNpaq2lqLhIuYrCn2A8BB4qC5uqblATFpiYc1IBKNiGBGAE="
+[2026-06-18T11:45:37.720Z] [INFO]       }
+[2026-06-18T11:45:37.720Z] [INFO]     ],
+[2026-06-18T11:45:37.720Z] [INFO]     "stop_reason": null,
+[2026-06-18T11:45:37.720Z] [INFO]     "stop_sequence": null,
+[2026-06-18T11:45:37.720Z] [INFO]     "stop_details": null,
+[2026-06-18T11:45:37.720Z] [INFO]     "usage": {
+[2026-06-18T11:45:37.720Z] [INFO]       "input_tokens": 2,
+[2026-06-18T11:45:37.720Z] [INFO]       "cache_creation_input_tokens": 1958,
+[2026-06-18T11:45:37.720Z] [INFO]       "cache_read_input_tokens": 55357,
+[2026-06-18T11:45:37.720Z] [INFO]       "cache_creation": {
+[2026-06-18T11:45:37.720Z] [INFO]         "ephemeral_5m_input_tokens": 0,
+[2026-06-18T11:45:37.720Z] [INFO]         "ephemeral_1h_input_tokens": 1958
+[2026-06-18T11:45:37.720Z] [INFO]       },
+[2026-06-18T11:45:37.720Z] [INFO]       "output_tokens": 8,
+[2026-06-18T11:45:37.720Z] [INFO]       "service_tier": "standard",
+[2026-06-18T11:45:37.720Z] [INFO]       "inference_geo": "not_available"
+[2026-06-18T11:45:37.720Z] [INFO]     },
+[2026-06-18T11:45:37.720Z] [INFO]     "diagnostics": null,
+[2026-06-18T11:45:37.720Z] [INFO]     "context_management": null
+[2026-06-18T11:45:37.720Z] [INFO]   },
+[2026-06-18T11:45:37.720Z] [INFO]   "parent_tool_use_id": null,
+[2026-06-18T11:45:37.720Z] [INFO]   "session_id": "d65e890a-db60-43f7-aea3-691500f7e26c",
+[2026-06-18T11:45:37.720Z] [INFO]   "uuid": "533204cd-a4b7-43e9-bb4b-c4180430dc46",
+[2026-06-18T11:45:37.720Z] [INFO]   "request_id": "req_011CcAfkNRUKQ91nv2HMT7AS"
+[2026-06-18T11:45:37.720Z] [INFO] }
+[2026-06-18T11:45:39.163Z] [INFO] {
+[2026-06-18T11:45:39.163Z] [INFO]   "type": "assistant",
+[2026-06-18T11:45:39.163Z] [INFO]   "message": {
+[2026-06-18T11:45:39.163Z] [INFO]     "model": "claude-opus-4-8",
+[2026-06-18T11:45:39.163Z] [INFO]     "id": "msg_013XwsRHWe9Qn1KZgMne9zDj",
+[2026-06-18T11:45:39.163Z] [INFO]     "type": "message",
+[2026-06-18T11:45:39.163Z] [INFO]     "role": "assistant",
+[2026-06-18T11:45:39.163Z] [INFO]     "content": [
+[2026-06-18T11:45:39.163Z] [INFO]       {
+[2026-06-18T11:45:39.163Z] [INFO]         "type": "tool_use",
+[2026-06-18T11:45:39.163Z] [INFO]         "id": "toolu_01CYosBQifkrBGw8DQ9eY4f9",
+[2026-06-18T11:45:39.163Z] [INFO]         "name": "TaskCreate",
+[2026-06-18T11:45:39.163Z] [INFO]         "input": {
+[2026-06-18T11:45:39.163Z] [INFO]           "subject": "Write ai-classifications-formalization doc",
+[2026-06-18T11:45:39.163Z] [INFO]           "description": "Create research/mango/ai-classifications-formalization-2026-06.md with 4 AI subprocesses, Mango roadmap evolution, C1/C2/C3 sync prep, examples, bilingual terms, open questions.",
+[2026-06-18T11:45:39.163Z] [INFO]           "activeForm": "Writing formalization document"
+[2026-06-18T11:45:39.163Z] [INFO]         },
+[2026-06-18T11:45:39.163Z] [INFO]         "caller": {
+[2026-06-18T11:45:39.163Z] [INFO]           "type": "direct"
+[2026-06-18T11:45:39.163Z] [INFO]         }
+[2026-06-18T11:45:39.163Z] [INFO]       }
+[2026-06-18T11:45:39.163Z] [INFO]     ],
+[2026-06-18T11:45:39.163Z] [INFO]     "stop_reason": null,
+[2026-06-18T11:45:39.163Z] [INFO]     "stop_sequence": null,
+[2026-06-18T11:45:39.163Z] [INFO]     "stop_details": null,
+[2026-06-18T11:45:39.163Z] [INFO]     "usage": {
+[2026-06-18T11:45:39.163Z] [INFO]       "input_tokens": 2,
+[2026-06-18T11:45:39.163Z] [INFO]       "cache_creation_input_tokens": 1958,
+[2026-06-18T11:45:39.163Z] [INFO]       "cache_read_input_tokens": 55357,
+[2026-06-18T11:45:39.163Z] [INFO]       "cache_creation": {
+[2026-06-18T11:45:39.163Z] [INFO]         "ephemeral_5m_input_tokens": 0,
+[2026-06-18T11:45:39.163Z] [INFO]         "ephemeral_1h_input_tokens": 1958
+[2026-06-18T11:45:39.163Z] [INFO]       },
+[2026-06-18T11:45:39.163Z] [INFO]       "output_tokens": 8,
+[2026-06-18T11:45:39.163Z] [INFO]       "service_tier": "standard",
+[2026-06-18T11:45:39.163Z] [INFO]       "inference_geo": "not_available"
+[2026-06-18T11:45:39.163Z] [INFO]     },
+[2026-06-18T11:45:39.163Z] [INFO]     "diagnostics": null,
+[2026-06-18T11:45:39.163Z] [INFO]     "context_management": null
+[2026-06-18T11:45:39.163Z] [INFO]   },
+[2026-06-18T11:45:39.163Z] [INFO]   "parent_tool_use_id": null,
+[2026-06-18T11:45:39.163Z] [INFO]   "session_id": "d65e890a-db60-43f7-aea3-691500f7e26c",
+[2026-06-18T11:45:39.163Z] [INFO]   "uuid": "faf4a248-d443-4ab3-9fe2-d0e0fd520606",
+[2026-06-18T11:45:39.163Z] [INFO]   "request_id": "req_011CcAfkNRUKQ91nv2HMT7AS"
+[2026-06-18T11:45:39.163Z] [INFO] }
+[2026-06-18T11:45:39.173Z] [INFO] {
+[2026-06-18T11:45:39.173Z] [INFO]   "type": "user",
+[2026-06-18T11:45:39.173Z] [INFO]   "message": {
+[2026-06-18T11:45:39.173Z] [INFO]     "role": "user",
+[2026-06-18T11:45:39.173Z] [INFO]     "content": [
+[2026-06-18T11:45:39.173Z] [INFO]       {
+[2026-06-18T11:45:39.173Z] [INFO]         "tool_use_id": "toolu_01CYosBQifkrBGw8DQ9eY4f9",
+[2026-06-18T11:45:39.173Z] [INFO]         "type": "tool_result",
+[2026-06-18T11:45:39.173Z] [INFO]         "content": "Task #1 created successfully: Write ai-classifications-formalization doc"
+[2026-06-18T11:45:39.173Z] [INFO]       }
+[2026-06-18T11:45:39.173Z] [INFO]     ]
+[2026-06-18T11:45:39.173Z] [INFO]   },
+[2026-06-18T11:45:39.173Z] [INFO]   "parent_tool_use_id": null,
+[2026-06-18T11:45:39.173Z] [INFO]   "session_id": "d65e890a-db60-43f7-aea3-691500f7e26c",
+[2026-06-18T11:45:39.173Z] [INFO]   "uuid": "40f0246c-a1a8-473d-9f17-cbe5c7b478af",
+[2026-06-18T11:45:39.173Z] [INFO]   "timestamp": "2026-06-18T11:45:39.171Z",
+[2026-06-18T11:45:39.173Z] [INFO]   "tool_use_result": {
+[2026-06-18T11:45:39.173Z] [INFO]     "task": {
+[2026-06-18T11:45:39.173Z] [INFO]       "id": "1",
+[2026-06-18T11:45:39.173Z] [INFO]       "subject": "Write ai-classifications-formalization doc"
+[2026-06-18T11:45:39.173Z] [INFO]     }
+[2026-06-18T11:45:39.173Z] [INFO]   }
+[2026-06-18T11:45:39.173Z] [INFO] }
+[2026-06-18T11:45:40.104Z] [INFO] {
+[2026-06-18T11:45:40.104Z] [INFO]   "type": "assistant",
+[2026-06-18T11:45:40.104Z] [INFO]   "message": {
+[2026-06-18T11:45:40.104Z] [INFO]     "model": "claude-opus-4-8",
+[2026-06-18T11:45:40.104Z] [INFO]     "id": "msg_013XwsRHWe9Qn1KZgMne9zDj",
+[2026-06-18T11:45:40.104Z] [INFO]     "type": "message",
+[2026-06-18T11:45:40.104Z] [INFO]     "role": "assistant",
+[2026-06-18T11:45:40.104Z] [INFO]     "content": [
+[2026-06-18T11:45:40.104Z] [INFO]       {
+[2026-06-18T11:45:40.104Z] [INFO]         "type": "tool_use",
+[2026-06-18T11:45:40.104Z] [INFO]         "id": "toolu_01EwMDJxrsoHkLgaS7fypr6A",
+[2026-06-18T11:45:40.104Z] [INFO]         "name": "TaskCreate",
+[2026-06-18T11:45:40.104Z] [INFO]         "input": {
+[2026-06-18T11:45:40.104Z] [INFO]           "subject": "Update navigation and artifact-map",
+[2026-06-18T11:45:40.104Z] [INFO]           "description": "Add new doc to research/mango/README.md and governance/artifact-map.md.",
+[2026-06-18T11:45:40.104Z] [INFO]           "activeForm": "Updating navigation"
+[2026-06-18T11:45:40.104Z] [INFO]         },
+[2026-06-18T11:45:40.104Z] [INFO]         "caller": {
+[2026-06-18T11:45:40.104Z] [INFO]           "type": "direct"
+[2026-06-18T11:45:40.104Z] [INFO]         }
+[2026-06-18T11:45:40.104Z] [INFO]       }
+[2026-06-18T11:45:40.104Z] [INFO]     ],
+[2026-06-18T11:45:40.104Z] [INFO]     "stop_reason": null,
+[2026-06-18T11:45:40.104Z] [INFO]     "stop_sequence": null,
+[2026-06-18T11:45:40.104Z] [INFO]     "stop_details": null,
+[2026-06-18T11:45:40.104Z] [INFO]     "usage": {
+[2026-06-18T11:45:40.104Z] [INFO]       "input_tokens": 2,
+[2026-06-18T11:45:40.104Z] [INFO]       "cache_creation_input_tokens": 1958,
+[2026-06-18T11:45:40.104Z] [INFO]       "cache_read_input_tokens": 55357,
+[2026-06-18T11:45:40.104Z] [INFO]       "cache_creation": {
+[2026-06-18T11:45:40.104Z] [INFO]         "ephemeral_5m_input_tokens": 0,
+[2026-06-18T11:45:40.104Z] [INFO]         "ephemeral_1h_input_tokens": 1958
+[2026-06-18T11:45:40.104Z] [INFO]       },
+[2026-06-18T11:45:40.104Z] [INFO]       "output_tokens": 8,
+[2026-06-18T11:45:40.104Z] [INFO]       "service_tier": "standard",
+[2026-06-18T11:45:40.104Z] [INFO]       "inference_geo": "not_available"
+[2026-06-18T11:45:40.104Z] [INFO]     },
+[2026-06-18T11:45:40.104Z] [INFO]     "diagnostics": null,
+[2026-06-18T11:45:40.104Z] [INFO]     "context_management": null
+[2026-06-18T11:45:40.104Z] [INFO]   },
+[2026-06-18T11:45:40.104Z] [INFO]   "parent_tool_use_id": null,
+[2026-06-18T11:45:40.104Z] [INFO]   "session_id": "d65e890a-db60-43f7-aea3-691500f7e26c",
+[2026-06-18T11:45:40.104Z] [INFO]   "uuid": "802550e5-9ba0-4660-9bf0-62276b897e47",
+[2026-06-18T11:45:40.104Z] [INFO]   "request_id": "req_011CcAfkNRUKQ91nv2HMT7AS"
+[2026-06-18T11:45:40.104Z] [INFO] }
+[2026-06-18T11:45:40.120Z] [INFO] {
+[2026-06-18T11:45:40.120Z] [INFO]   "type": "user",
+[2026-06-18T11:45:40.120Z] [INFO]   "message": {
+[2026-06-18T11:45:40.120Z] [INFO]     "role": "user",
+[2026-06-18T11:45:40.120Z] [INFO]     "content": [
+[2026-06-18T11:45:40.120Z] [INFO]       {
+[2026-06-18T11:45:40.120Z] [INFO]         "tool_use_id": "toolu_01EwMDJxrsoHkLgaS7fypr6A",
+[2026-06-18T11:45:40.120Z] [INFO]         "type": "tool_result",
+[2026-06-18T11:45:40.120Z] [INFO]         "content": "Task #2 created successfully: Update navigation and artifact-map"
+[2026-06-18T11:45:40.120Z] [INFO]       }
+[2026-06-18T11:45:40.120Z] [INFO]     ]
+[2026-06-18T11:45:40.120Z] [INFO]   },
+[2026-06-18T11:45:40.120Z] [INFO]   "parent_tool_use_id": null,
+[2026-06-18T11:45:40.120Z] [INFO]   "session_id": "d65e890a-db60-43f7-aea3-691500f7e26c",
+[2026-06-18T11:45:40.120Z] [INFO]   "uuid": "feb7bf89-7405-404c-9784-5cf231dec933",
+[2026-06-18T11:45:40.120Z] [INFO]   "timestamp": "2026-06-18T11:45:40.116Z",
+[2026-06-18T11:45:40.120Z] [INFO]   "tool_use_result": {
+[2026-06-18T11:45:40.120Z] [INFO]     "task": {
+[2026-06-18T11:45:40.120Z] [INFO]       "id": "2",
+[2026-06-18T11:45:40.120Z] [INFO]       "subject": "Update navigation and artifact-map"
+[2026-06-18T11:45:40.120Z] [INFO]     }
+[2026-06-18T11:45:40.120Z] [INFO]   }
+[2026-06-18T11:45:40.120Z] [INFO] }
+[2026-06-18T11:45:41.188Z] [INFO] {
+[2026-06-18T11:45:41.188Z] [INFO]   "type": "assistant",
+[2026-06-18T11:45:41.188Z] [INFO]   "message": {
+[2026-06-18T11:45:41.188Z] [INFO]     "model": "claude-opus-4-8",
+[2026-06-18T11:45:41.188Z] [INFO]     "id": "msg_013XwsRHWe9Qn1KZgMne9zDj",
+[2026-06-18T11:45:41.188Z] [INFO]     "type": "message",
+[2026-06-18T11:45:41.188Z] [INFO]     "role": "assistant",
+[2026-06-18T11:45:41.188Z] [INFO]     "content": [
+[2026-06-18T11:45:41.188Z] [INFO]       {
+[2026-06-18T11:45:41.188Z] [INFO]         "type": "tool_use",
+[2026-06-18T11:45:41.188Z] [INFO]         "id": "toolu_0158Vwa4WRYN8NbN9FNezdjY",
+[2026-06-18T11:45:41.188Z] [INFO]         "name": "TaskCreate",
+[2026-06-18T11:45:41.188Z] [INFO]         "input": {
+[2026-06-18T11:45:41.188Z] [INFO]           "subject": "Validate, commit, update PR",
+[2026-06-18T11:45:41.188Z] [INFO]           "description": "Run validators, commit with required message, push, update PR description, mark ready.",
+[2026-06-18T11:45:41.188Z] [INFO]           "activeForm": "Validating and finalizing"
+[2026-06-18T11:45:41.188Z] [INFO]         },
+[2026-06-18T11:45:41.188Z] [INFO]         "caller": {
+[2026-06-18T11:45:41.188Z] [INFO]           "type": "direct"
+[2026-06-18T11:45:41.188Z] [INFO]         }
+[2026-06-18T11:45:41.188Z] [INFO]       }
+[2026-06-18T11:45:41.188Z] [INFO]     ],
+[2026-06-18T11:45:41.188Z] [INFO]     "stop_reason": null,
+[2026-06-18T11:45:41.188Z] [INFO]     "stop_sequence": null,
+[2026-06-18T11:45:41.188Z] [INFO]     "stop_details": null,
+[2026-06-18T11:45:41.188Z] [INFO]     "usage": {
+[2026-06-18T11:45:41.188Z] [INFO]       "input_tokens": 2,
+[2026-06-18T11:45:41.188Z] [INFO]       "cache_creation_input_tokens": 1958,
+[2026-06-18T11:45:41.188Z] [INFO]       "cache_read_input_tokens": 55357,
+[2026-06-18T11:45:41.188Z] [INFO]       "cache_creation": {
+[2026-06-18T11:45:41.188Z] [INFO]         "ephemeral_5m_input_tokens": 0,
+[2026-06-18T11:45:41.188Z] [INFO]         "ephemeral_1h_input_tokens": 1958
+[2026-06-18T11:45:41.188Z] [INFO]       },
+[2026-06-18T11:45:41.188Z] [INFO]       "output_tokens": 8,
+[2026-06-18T11:45:41.188Z] [INFO]       "service_tier": "standard",
+[2026-06-18T11:45:41.188Z] [INFO]       "inference_geo": "not_available"
+[2026-06-18T11:45:41.188Z] [INFO]     },
+[2026-06-18T11:45:41.188Z] [INFO]     "diagnostics": null,
+[2026-06-18T11:45:41.188Z] [INFO]     "context_management": null
+[2026-06-18T11:45:41.188Z] [INFO]   },
+[2026-06-18T11:45:41.188Z] [INFO]   "parent_tool_use_id": null,
+[2026-06-18T11:45:41.188Z] [INFO]   "session_id": "d65e890a-db60-43f7-aea3-691500f7e26c",
+[2026-06-18T11:45:41.188Z] [INFO]   "uuid": "4cb223d7-0883-49cf-8e8a-577cc2d51126",
+[2026-06-18T11:45:41.188Z] [INFO]   "request_id": "req_011CcAfkNRUKQ91nv2HMT7AS"
+[2026-06-18T11:45:41.188Z] [INFO] }
+[2026-06-18T11:45:41.193Z] [INFO] {
+[2026-06-18T11:45:41.193Z] [INFO]   "type": "user",
+[2026-06-18T11:45:41.193Z] [INFO]   "message": {
+[2026-06-18T11:45:41.193Z] [INFO]     "role": "user",
+[2026-06-18T11:45:41.193Z] [INFO]     "content": [
+[2026-06-18T11:45:41.193Z] [INFO]       {
+[2026-06-18T11:45:41.193Z] [INFO]         "tool_use_id": "toolu_0158Vwa4WRYN8NbN9FNezdjY",
+[2026-06-18T11:45:41.193Z] [INFO]         "type": "tool_result",
+[2026-06-18T11:45:41.193Z] [INFO]         "content": "Task #3 created successfully: Validate, commit, update PR"
+[2026-06-18T11:45:41.193Z] [INFO]       }
+[2026-06-18T11:45:41.193Z] [INFO]     ]
+[2026-06-18T11:45:41.193Z] [INFO]   },
+[2026-06-18T11:45:41.193Z] [INFO]   "parent_tool_use_id": null,
+[2026-06-18T11:45:41.193Z] [INFO]   "session_id": "d65e890a-db60-43f7-aea3-691500f7e26c",
+[2026-06-18T11:45:41.193Z] [INFO]   "uuid": "a98c82b7-f157-4224-b31e-b39accc27b79",
+[2026-06-18T11:45:41.193Z] [INFO]   "timestamp": "2026-06-18T11:45:41.191Z",
+[2026-06-18T11:45:41.193Z] [INFO]   "tool_use_result": {
+[2026-06-18T11:45:41.193Z] [INFO]     "task": {
+[2026-06-18T11:45:41.193Z] [INFO]       "id": "3",
+[2026-06-18T11:45:41.193Z] [INFO]       "subject": "Validate, commit, update PR"
+[2026-06-18T11:45:41.193Z] [INFO]     }
+[2026-06-18T11:45:41.193Z] [INFO]   }
+[2026-06-18T11:45:41.193Z] [INFO] }
+[2026-06-18T11:45:41.304Z] [INFO] [log_4c0f52] sending request {
+[2026-06-18T11:45:41.304Z] [INFO]   method: "post",
+[2026-06-18T11:45:41.305Z] [INFO]   url: "https://api.anthropic.com/v1/messages?beta=true",
+[2026-06-18T11:45:41.305Z] [INFO]   options: {
+[2026-06-18T11:45:41.305Z] [INFO]     method: "post",
+[2026-06-18T11:45:41.306Z] [INFO]     path: "/v1/messages?beta=true",
+[2026-06-18T11:45:41.306Z] [INFO]     body: {
+[2026-06-18T11:45:41.307Z] [INFO]       model: "claude-opus-4-8",
+[2026-06-18T11:45:41.307Z] [INFO]       messages: [
+[2026-06-18T11:45:41.308Z] [INFO]         [Object ...], [Object ...], [Object ...], [Object ...], [Object ...], [Object ...], [Object ...], [Object ...], [Object ...], [Object ...], [Object ...], [Object ...], [Object ...], [Object ...], [Object ...], [Object ...], [Object ...], [Object ...], [Object ...], [Object ...], [Object ...], [Object ...], [Object ...], [Object ...]
+[2026-06-18T11:45:41.308Z] [INFO]       ],
+[2026-06-18T11:45:41.308Z] [INFO]       system: [
+[2026-06-18T11:45:41.309Z] [INFO]         [Object ...], [Object ...], [Object ...], [Object ...]
+[2026-06-18T11:45:41.309Z] [INFO]       ],
+[2026-06-18T11:45:41.309Z] [INFO]       tools: [
+[2026-06-18T11:45:41.310Z] [INFO]         [Object ...], [Object ...], [Object ...], [Object ...], [Object ...], [Object ...], [Object ...], [Object ...], [Object ...], [Object ...]
+[2026-06-18T11:45:41.310Z] [INFO]       ],
+[2026-06-18T11:45:41.311Z] [INFO]       tool_choice: undefined,
+[2026-06-18T11:45:41.311Z] [INFO]       metadata: [Object ...],
+[2026-06-18T11:45:41.312Z] [INFO]       max_tokens: 128000,
+[2026-06-18T11:45:41.313Z] [INFO]       thinking: [Object ...],
+[2026-06-18T11:45:41.313Z] [INFO]       context_management: [Object ...],
+[2026-06-18T11:45:41.313Z] [INFO]       output_config: [Object ...],
+[2026-06-18T11:45:41.314Z] [INFO]       diagnostics: [Object ...],
+[2026-06-18T11:45:41.314Z] [INFO]       stream: true,
+[2026-06-18T11:45:41.315Z] [INFO]     },
+[2026-06-18T11:45:41.315Z] [INFO]     timeout: 600000,
+[2026-06-18T11:45:41.316Z] [INFO]     signal: AbortSignal {
+[2026-06-18T11:45:41.318Z] [INFO]       [Symbol(events.maxEventTargetListeners)]: 50,
+[2026-06-18T11:45:41.319Z] [INFO]       [Symbol(events.maxEventTargetListenersWarned)]: false,
+[2026-06-18T11:45:41.320Z] [INFO]       aborted: false,
+[2026-06-18T11:45:41.320Z] [INFO]       reason: undefined,
+[2026-06-18T11:45:41.322Z] [INFO]       onabort: null,
+[2026-06-18T11:45:41.323Z] [INFO]       throwIfAborted: [Function: throwIfAborted],
+[2026-06-18T11:45:41.323Z] [INFO]       addEventListener: [Function: addEventListener],
+[2026-06-18T11:45:41.323Z] [INFO]       removeEventListener: [Function: removeEventListener],
+[2026-06-18T11:45:41.323Z] [INFO]       dispatchEvent: [Function: dispatchEvent],
+[2026-06-18T11:45:41.324Z] [INFO]     },
+[2026-06-18T11:45:41.324Z] [INFO]     stream: true,
+[2026-06-18T11:45:41.324Z] [INFO]   },
+[2026-06-18T11:45:41.324Z] [INFO]   headers: {
+[2026-06-18T11:45:41.325Z] [INFO]     accept: "application/json",
+[2026-06-18T11:45:41.325Z] [INFO]     "anthropic-beta": "claude-code-20250219,oauth-2025-04-20,interleaved-thinking-2025-05-14,thinking-token-count-2026-05-13,context-management-2025-06-27,prompt-caching-scope-2026-01-05,mid-conversation-system-2026-04-07,advisor-tool-2026-03-01,advanced-tool-use-2025-11-20,effort-2025-11-24,extended-cache-ttl-2025-04-11,cache-diagnosis-2026-04-07",
+[2026-06-18T11:45:41.325Z] [INFO]     "anthropic-dangerous-direct-browser-access": "true",
+[2026-06-18T11:45:41.325Z] [INFO]     "anthropic-version": "2023-06-01",
+[2026-06-18T11:45:41.326Z] [INFO]     authorization: "***",
+[2026-06-18T11:45:41.326Z] [INFO]     "content-type": "application/json",
+[2026-06-18T11:45:41.327Z] [INFO]     "user-agent": "claude-cli/2.1.181 (external, sdk-cli)",
+[2026-06-18T11:45:41.327Z] [INFO]     "x-app": "cli",
+[2026-06-18T11:45:41.327Z] [INFO]     "x-claude-code-session-id": "d65e890a-db60-43f7-aea3-691500f7e26c",
+[2026-06-18T11:45:41.328Z] [INFO]     "x-client-request-id": "1571b6a9-d024-454a-a466-bbe4072096a7",
+[2026-06-18T11:45:41.328Z] [INFO]     "x-stainless-arch": "x64",
+[2026-06-18T11:45:41.329Z] [INFO]     "x-stainless-lang": "js",
+[2026-06-18T11:45:41.330Z] [INFO]     "x-stainless-os": "Linux",
+[2026-06-18T11:45:41.330Z] [INFO]     "x-stainless-package-version": "0.94.0",
+[2026-06-18T11:45:41.332Z] [INFO]     "x-stainless-retry-count": "0",
+[2026-06-18T11:45:41.332Z] [INFO]     "x-stainless-runtime": "node",
+[2026-06-18T11:45:41.333Z] [INFO]     "x-stainless-runtime-version": "v24.3.0",
+[2026-06-18T11:45:41.333Z] [INFO]     "x-stainless-timeout": "600",
+[2026-06-18T11:45:41.334Z] [INFO]   },
+[2026-06-18T11:45:41.335Z] [INFO] }
+[2026-06-18T11:45:45.092Z] [INFO] [log_4c0f52, request-id: "req_011CcAfm9T9G5hGntazqBwhz"] post https://api.anthropic.com/v1/messages?beta=true succeeded with status 200 in 3788ms
+[2026-06-18T11:45:45.096Z] [INFO] [log_4c0f52] response start {
+[2026-06-18T11:45:45.098Z] [INFO]   url: "https://api.anthropic.com/v1/messages?beta=true",
+[2026-06-18T11:45:45.098Z] [INFO]   status: 200,
+[2026-06-18T11:45:45.098Z] [INFO]   headers: {
+[2026-06-18T11:45:45.099Z] [INFO]     "anthropic-organization-id": "ebc2ac93-f86f-4d15-aff3-de8830d8d789",
+[2026-06-18T11:45:45.100Z] [INFO]     "anthropic-ratelimit-unified-5h-reset": "1781787000",
+[2026-06-18T11:45:45.100Z] [INFO]     "anthropic-ratelimit-unified-5h-status": "allowed",
+[2026-06-18T11:45:45.101Z] [INFO]     "anthropic-ratelimit-unified-5h-utilization": "0.33",
+[2026-06-18T11:45:45.101Z] [INFO]     "anthropic-ratelimit-unified-7d-reset": "1782212400",
+[2026-06-18T11:45:45.101Z] [INFO]     "anthropic-ratelimit-unified-7d-status": "allowed",
+[2026-06-18T11:45:45.101Z] [INFO]     "anthropic-ratelimit-unified-7d-utilization": "0.62",
+[2026-06-18T11:45:45.102Z] [INFO]     "anthropic-ratelimit-unified-fallback-percentage": "0.5",
+[2026-06-18T11:45:45.102Z] [INFO]     "anthropic-ratelimit-unified-overage-disabled-reason": "org_level_disabled",
+[2026-06-18T11:45:45.102Z] [INFO]     "anthropic-ratelimit-unified-overage-status": "rejected",
+[2026-06-18T11:45:45.103Z] [INFO]     "anthropic-ratelimit-unified-representative-claim": "five_hour",
+[2026-06-18T11:45:45.103Z] [INFO]     "anthropic-ratelimit-unified-reset": "1781787000",
+[2026-06-18T11:45:45.103Z] [INFO]     "anthropic-ratelimit-unified-status": "allowed",
+[2026-06-18T11:45:45.103Z] [INFO]     "cache-control": "no-cache",
+[2026-06-18T11:45:45.103Z] [INFO]     "cf-cache-status": "DYNAMIC",
+[2026-06-18T11:45:45.104Z] [INFO]     "cf-ray": "a0da0c992fd0b19e-FRA",
+[2026-06-18T11:45:45.104Z] [INFO]     connection: "keep-alive",
+[2026-06-18T11:45:45.104Z] [INFO]     "content-encoding": "gzip",
+[2026-06-18T11:45:45.104Z] [INFO]     "content-security-policy": "default-src 'none'; frame-ancestors 'none'",
+[2026-06-18T11:45:45.104Z] [INFO]     "content-type": "text/event-stream; charset=utf-8",
+[2026-06-18T11:45:45.105Z] [INFO]     date: "Thu, 18 Jun 2026 11:45:45 GMT",
+[2026-06-18T11:45:45.105Z] [INFO]     "request-id": "req_011CcAfm9T9G5hGntazqBwhz",
+[2026-06-18T11:45:45.105Z] [INFO]     server: "cloudflare",
+[2026-06-18T11:45:45.105Z] [INFO]     "strict-transport-security": "max-age=31536000; includeSubDomains; preload",
+[2026-06-18T11:45:45.106Z] [INFO]     traceresponse: "00-0b43943d1845d41323f9fe0670e39170-a1b7b90cfd538cb2-01",
+[2026-06-18T11:45:45.106Z] [INFO]     "transfer-encoding": "chunked",
+[2026-06-18T11:45:45.106Z] [INFO]     vary: "Accept-Encoding",
+[2026-06-18T11:45:45.107Z] [INFO]     "x-robots-tag": "none",
+[2026-06-18T11:45:45.107Z] [INFO]     "set-cookie": "***",
+[2026-06-18T11:45:45.107Z] [INFO]   },
+[2026-06-18T11:45:45.107Z] [INFO]   durationMs: 3788,
+[2026-06-18T11:45:45.107Z] [INFO] }
+[2026-06-18T11:45:45.107Z] [INFO] response 200 https://api.anthropic.com/v1/messages?beta=true Headers {
+[2026-06-18T11:45:45.107Z] [INFO]   "date": "Thu, 18 Jun 2026 11:45:45 GMT",
+[2026-06-18T11:45:45.108Z] [INFO]   "content-type": "text/event-stream; charset=utf-8",
+[2026-06-18T11:45:45.108Z] [INFO]   "transfer-encoding": "chunked",
+[2026-06-18T11:45:45.108Z] [INFO]   "connection": "keep-alive",
+[2026-06-18T11:45:45.108Z] [INFO]   "cache-control": "no-cache",
+[2026-06-18T11:45:45.108Z] [INFO]   "strict-transport-security": "max-age=31536000; includeSubDomains; preload",
+[2026-06-18T11:45:45.108Z] [INFO]   "content-encoding": "gzip",
+[2026-06-18T11:45:45.109Z] [INFO]   "vary": "Accept-Encoding",
+[2026-06-18T11:45:45.109Z] [INFO]   "content-security-policy": "default-src 'none'; frame-ancestors 'none'",
+[2026-06-18T11:45:45.109Z] [INFO]   "set-cookie": [ "_cfuvid=j1V2_r7koVbjNh.Ss6LlspRcoCOn7IfoF8bhR.uSOJ8-1781783141.3101358-1.0.1.1-izSidswlIv.ODbKCCQncubeSWi93sTtqWBUMfSqJCRA; HttpOnly; SameSite=None; Secure; Path=/; Domain=api.anthropic.com" ],
+[2026-06-18T11:45:45.109Z] [INFO]   "anthropic-ratelimit-unified-status": "allowed",
+[2026-06-18T11:45:45.109Z] [INFO]   "anthropic-ratelimit-unified-5h-status": "allowed",
+[2026-06-18T11:45:45.109Z] [INFO]   "anthropic-ratelimit-unified-5h-reset": "1781787000",
+[2026-06-18T11:45:45.109Z] [INFO]   "anthropic-ratelimit-unified-5h-utilization": "0.33",
+[2026-06-18T11:45:45.110Z] [INFO]   "anthropic-ratelimit-unified-7d-status": "allowed",
+[2026-06-18T11:45:45.110Z] [INFO]   "anthropic-ratelimit-unified-7d-reset": "1782212400",
+[2026-06-18T11:45:45.110Z] [INFO]   "anthropic-ratelimit-unified-7d-utilization": "0.62",
+[2026-06-18T11:45:45.110Z] [INFO]   "anthropic-ratelimit-unified-representative-claim": "five_hour",
+[2026-06-18T11:45:45.110Z] [INFO]   "anthropic-ratelimit-unified-fallback-percentage": "0.5",
+[2026-06-18T11:45:45.111Z] [INFO]   "anthropic-ratelimit-unified-reset": "1781787000",
+[2026-06-18T11:45:45.111Z] [INFO]   "anthropic-ratelimit-unified-overage-disabled-reason": "org_level_disabled",
+[2026-06-18T11:45:45.111Z] [INFO]   "anthropic-ratelimit-unified-overage-status": "rejected",
+[2026-06-18T11:45:45.111Z] [INFO]   "request-id": "req_011CcAfm9T9G5hGntazqBwhz",
+[2026-06-18T11:45:45.111Z] [INFO]   "anthropic-organization-id": "ebc2ac93-f86f-4d15-aff3-de8830d8d789",
+[2026-06-18T11:45:45.112Z] [INFO]   "traceresponse": "00-0b43943d1845d41323f9fe0670e39170-a1b7b90cfd538cb2-01",
+[2026-06-18T11:45:45.112Z] [INFO]   "server": "cloudflare",
+[2026-06-18T11:45:45.112Z] [INFO]   "cf-cache-status": "DYNAMIC",
+[2026-06-18T11:45:45.112Z] [INFO]   "x-robots-tag": "none",
+[2026-06-18T11:45:45.114Z] [INFO]   "cf-ray": "a0da0c992fd0b19e-FRA",
+[2026-06-18T11:45:45.114Z] [INFO] } ReadableStream {
+[2026-06-18T11:45:45.114Z] [INFO]   blob: [Function: blob],
+[2026-06-18T11:45:45.114Z] [INFO]   bytes: [Function: bytes],
+[2026-06-18T11:45:45.115Z] [INFO]   cancel: [Function],
+[2026-06-18T11:45:45.116Z] [INFO]   getReader: [Function],
+[2026-06-18T11:45:45.116Z] [INFO]   json: [Function: json],
+[2026-06-18T11:45:45.116Z] [INFO]   locked: [Getter],
+[2026-06-18T11:45:45.116Z] [INFO]   pipeThrough: [Function],
+[2026-06-18T11:45:45.116Z] [INFO]   pipeTo: [Function],
+[2026-06-18T11:45:45.117Z] [INFO]   tee: [Function],
+[2026-06-18T11:45:45.117Z] [INFO]   text: [Function: text],
+[2026-06-18T11:45:45.117Z] [INFO]   values: [Function: values],
+[2026-06-18T11:45:45.117Z] [INFO]   [Symbol(Symbol.asyncIterator)]: [Function: asyncIterator2],
+[2026-06-18T11:45:45.118Z] [INFO] }
+[2026-06-18T11:45:45.118Z] [INFO] [log_4c0f52] response parsed {
+[2026-06-18T11:45:45.118Z] [INFO]   url: "https://api.anthropic.com/v1/messages?beta=true",
+[2026-06-18T11:45:45.118Z] [INFO]   status: 200,
+[2026-06-18T11:45:45.119Z] [INFO]   body: sU {
+[2026-06-18T11:45:45.119Z] [INFO]     iterator: [AsyncGeneratorFunction: s],
+[2026-06-18T11:45:45.119Z] [INFO]     controller: AbortController {
+[2026-06-18T11:45:45.119Z] [INFO]       signal: [AbortSignal ...],
+[2026-06-18T11:45:45.119Z] [INFO]       abort: [Function: abort],
+[2026-06-18T11:45:45.120Z] [INFO]     },
+[2026-06-18T11:45:45.120Z] [INFO]     [Symbol(Symbol.asyncIterator)]: [Function],
+[2026-06-18T11:45:45.121Z] [INFO]     tee: [Function: tee],
+[2026-06-18T11:45:45.121Z] [INFO]     toReadableStream: [Function: toReadableStream],
+[2026-06-18T11:45:45.122Z] [INFO]   },
+[2026-06-18T11:45:45.122Z] [INFO]   durationMs: 3789,
+[2026-06-18T11:45:45.123Z] [INFO] }
+[2026-06-18T11:45:46.517Z] [INFO] {
+[2026-06-18T11:45:46.517Z] [INFO]   "type": "system",
+[2026-06-18T11:45:46.517Z] [INFO]   "subtype": "thinking_tokens",
+[2026-06-18T11:45:46.517Z] [INFO]   "estimated_tokens": 50,
+[2026-06-18T11:45:46.517Z] [INFO]   "estimated_tokens_delta": 50,
+[2026-06-18T11:45:46.517Z] [INFO]   "uuid": "1ececa8d-5d11-4549-8038-0540c6b3a82e",
+[2026-06-18T11:45:46.517Z] [INFO]   "session_id": "d65e890a-db60-43f7-aea3-691500f7e26c"
+[2026-06-18T11:45:46.517Z] [INFO] }
+[2026-06-18T11:45:47.934Z] [INFO] {
+[2026-06-18T11:45:47.934Z] [INFO]   "type": "system",
+[2026-06-18T11:45:47.934Z] [INFO]   "subtype": "thinking_tokens",
+[2026-06-18T11:45:47.934Z] [INFO]   "estimated_tokens": 172,
+[2026-06-18T11:45:47.934Z] [INFO]   "estimated_tokens_delta": 122,
+[2026-06-18T11:45:47.934Z] [INFO]   "uuid": "be5d056f-a3ec-4d67-be40-66ea5a615311",
+[2026-06-18T11:45:47.934Z] [INFO]   "session_id": "d65e890a-db60-43f7-aea3-691500f7e26c"
+[2026-06-18T11:45:47.934Z] [INFO] }
+[2026-06-18T11:45:47.942Z] [INFO] {
+[2026-06-18T11:45:47.942Z] [INFO]   "type": "assistant",
+[2026-06-18T11:45:47.942Z] [INFO]   "message": {
+[2026-06-18T11:45:47.942Z] [INFO]     "model": "claude-opus-4-8",
+[2026-06-18T11:45:47.942Z] [INFO]     "id": "msg_01CxpfLvUMJBR2GKd9cjx3de",
+[2026-06-18T11:45:47.942Z] [INFO]     "type": "message",
+[2026-06-18T11:45:47.942Z] [INFO]     "role": "assistant",
+[2026-06-18T11:45:47.942Z] [INFO]     "content": [
+[2026-06-18T11:45:47.942Z] [INFO]       {
+[2026-06-18T11:45:47.942Z] [INFO]         "type": "thinking",
+[2026-06-18T11:45:47.942Z] [INFO]         "thinking": "",
+[2026-06-18T11:45:47.942Z] [INFO]         "signature": "EqoFCmMIDhgCKkDsroCvUEkHRJDj3uQMW44jAjPl2cnFzQdttu/bR/feUKJ4x4YucMiWBmArdF+DUDN2nGklmL/8vwArVzjZRQHzMg9jbGF1ZGUtb3B1cy00LTg4AEIIdGhpbmtpbmcSDETkJLxIqEdWYB9ZQxoM/jHYEgtRvqvs9LHrIjDVTbtVxTku9E7QHXyvo47Oyp+l2JOYpVtktU1CwoIZmymwWKsxHegWxYer0Eo4K7Aq9AOtV1etPx+R0ck15Wd87A2eFaoSjTn1zNlCFMNSONgGrD1cv9i5YHBJlgiRuSohb9kumpMFvRcJRNDOk8blLU0CoTBxEGW0FxB7OSk0KkHCcIuJk07z6zYPGL4LeA0ciOlhG3epKp5wNzFChbtKwC5kb86d5Bc9a4ujAG0KmQR3Uz5MZOVXXUj07GFL4FQTzA5cavtY6loYqe5GCCN9EBBXfNjL2HGoixXhMo4w8+Vs+oNGhC2h8BCEUsktQrJNh6kShTiZSNnTnsBQEU8utPewBqPMj6YG4+n8tD+nU2lNdw0zA/LfykWv6+SdFxqI/CKVdqYdaEzwnV/0ApxrFwKiYWrcX/+VtfMX07QFCOP+//1ltwCWVXkciuwV66HovIPoZy0NIRlsUy5G49n3OtIUKdkIlDWFUFPwOo6sjKNfTN9zdzNv9scKKI2qqMe2QM8ZAnUL0PqpPQw+wnNBOG+ox/8HyQk4AGaMiJrBQWp4zS1hC1/jJU33aRam81M2rHSG32ymmR5lDe9hVlW1Q2UVSw14DG3AqTAUcZGap5xEfCqiE1L7z5ngPFPq3IWqI35S5wyYm9E7HhICIXjuZ4B2NNRkQF4SR4Qjxh7Gexvn7RxLHBG3fhPx59ROpL4QZQ1XPkDQDBblbLZ/kIwpt4CnrRb3aBgB"
+[2026-06-18T11:45:47.942Z] [INFO]       }
+[2026-06-18T11:45:47.942Z] [INFO]     ],
+[2026-06-18T11:45:47.942Z] [INFO]     "stop_reason": null,
+[2026-06-18T11:45:47.942Z] [INFO]     "stop_sequence": null,
+[2026-06-18T11:45:47.942Z] [INFO]     "stop_details": null,
+[2026-06-18T11:45:47.942Z] [INFO]     "usage": {
+[2026-06-18T11:45:47.942Z] [INFO]       "input_tokens": 2,
+[2026-06-18T11:45:47.942Z] [INFO]       "cache_creation_input_tokens": 1003,
+[2026-06-18T11:45:47.942Z] [INFO]       "cache_read_input_tokens": 57315,
+[2026-06-18T11:45:47.942Z] [INFO]       "cache_creation": {
+[2026-06-18T11:45:47.942Z] [INFO]         "ephemeral_5m_input_tokens": 0,
+[2026-06-18T11:45:47.942Z] [INFO]         "ephemeral_1h_input_tokens": 1003
+[2026-06-18T11:45:47.942Z] [INFO]       },
+[2026-06-18T11:45:47.942Z] [INFO]       "output_tokens": 3,
+[2026-06-18T11:45:47.942Z] [INFO]       "service_tier": "standard",
+[2026-06-18T11:45:47.942Z] [INFO]       "inference_geo": "not_available"
+[2026-06-18T11:45:47.942Z] [INFO]     },
+[2026-06-18T11:45:47.942Z] [INFO]     "diagnostics": null,
+[2026-06-18T11:45:47.942Z] [INFO]     "context_management": null
+[2026-06-18T11:45:47.942Z] [INFO]   },
+[2026-06-18T11:45:47.942Z] [INFO]   "parent_tool_use_id": null,
+[2026-06-18T11:45:47.942Z] [INFO]   "session_id": "d65e890a-db60-43f7-aea3-691500f7e26c",
+[2026-06-18T11:45:47.942Z] [INFO]   "uuid": "6d52f7ae-1827-4e5c-9b8f-1186b80dfc5d",
+[2026-06-18T11:45:47.942Z] [INFO]   "request_id": "req_011CcAfm9T9G5hGntazqBwhz"
+[2026-06-18T11:45:47.942Z] [INFO] }
+[2026-06-18T11:45:48.210Z] [INFO] {
+[2026-06-18T11:45:48.210Z] [INFO]   "type": "assistant",
+[2026-06-18T11:45:48.210Z] [INFO]   "message": {
+[2026-06-18T11:45:48.210Z] [INFO]     "model": "claude-opus-4-8",
+[2026-06-18T11:45:48.210Z] [INFO]     "id": "msg_01CxpfLvUMJBR2GKd9cjx3de",
+[2026-06-18T11:45:48.210Z] [INFO]     "type": "message",
+[2026-06-18T11:45:48.210Z] [INFO]     "role": "assistant",
+[2026-06-18T11:45:48.210Z] [INFO]     "content": [
+[2026-06-18T11:45:48.210Z] [INFO]       {
+[2026-06-18T11:45:48.210Z] [INFO]         "type": "tool_use",
+[2026-06-18T11:45:48.210Z] [INFO]         "id": "toolu_0139P9L9jnKsPt9ry84Y7cfo",
+[2026-06-18T11:45:48.210Z] [INFO]         "name": "TaskUpdate",
+[2026-06-18T11:45:48.210Z] [INFO]         "input": {
+[2026-06-18T11:45:48.210Z] [INFO]           "taskId": "1",
+[2026-06-18T11:45:48.210Z] [INFO]           "status": "in_progress"
+[2026-06-18T11:45:48.210Z] [INFO]         },
+[2026-06-18T11:45:48.210Z] [INFO]         "caller": {
+[2026-06-18T11:45:48.210Z] [INFO]           "type": "direct"
+[2026-06-18T11:45:48.210Z] [INFO]         }
+[2026-06-18T11:45:48.210Z] [INFO]       }
+[2026-06-18T11:45:48.210Z] [INFO]     ],
+[2026-06-18T11:45:48.210Z] [INFO]     "stop_reason": null,
+[2026-06-18T11:45:48.210Z] [INFO]     "stop_sequence": null,
+[2026-06-18T11:45:48.210Z] [INFO]     "stop_details": null,
+[2026-06-18T11:45:48.210Z] [INFO]     "usage": {
+[2026-06-18T11:45:48.210Z] [INFO]       "input_tokens": 2,
+[2026-06-18T11:45:48.210Z] [INFO]       "cache_creation_input_tokens": 1003,
+[2026-06-18T11:45:48.210Z] [INFO]       "cache_read_input_tokens": 57315,
+[2026-06-18T11:45:48.210Z] [INFO]       "cache_creation": {
+[2026-06-18T11:45:48.210Z] [INFO]         "ephemeral_5m_input_tokens": 0,
+[2026-06-18T11:45:48.210Z] [INFO]         "ephemeral_1h_input_tokens": 1003
+[2026-06-18T11:45:48.210Z] [INFO]       },
+[2026-06-18T11:45:48.210Z] [INFO]       "output_tokens": 3,
+[2026-06-18T11:45:48.210Z] [INFO]       "service_tier": "standard",
+[2026-06-18T11:45:48.210Z] [INFO]       "inference_geo": "not_available"
+[2026-06-18T11:45:48.210Z] [INFO]     },
+[2026-06-18T11:45:48.210Z] [INFO]     "diagnostics": null,
+[2026-06-18T11:45:48.210Z] [INFO]     "context_management": null
+[2026-06-18T11:45:48.210Z] [INFO]   },
+[2026-06-18T11:45:48.210Z] [INFO]   "parent_tool_use_id": null,
+[2026-06-18T11:45:48.210Z] [INFO]   "session_id": "d65e890a-db60-43f7-aea3-691500f7e26c",
+[2026-06-18T11:45:48.210Z] [INFO]   "uuid": "92f83fc4-1839-44de-8104-59e750a74fd9",
+[2026-06-18T11:45:48.210Z] [INFO]   "request_id": "req_011CcAfm9T9G5hGntazqBwhz"
+[2026-06-18T11:45:48.210Z] [INFO] }
+[2026-06-18T11:45:48.222Z] [INFO] {
+[2026-06-18T11:45:48.222Z] [INFO]   "type": "user",
+[2026-06-18T11:45:48.222Z] [INFO]   "message": {
+[2026-06-18T11:45:48.222Z] [INFO]     "role": "user",
+[2026-06-18T11:45:48.222Z] [INFO]     "content": [
+[2026-06-18T11:45:48.222Z] [INFO]       {
+[2026-06-18T11:45:48.222Z] [INFO]         "tool_use_id": "toolu_0139P9L9jnKsPt9ry84Y7cfo",
+[2026-06-18T11:45:48.222Z] [INFO]         "type": "tool_result",
+[2026-06-18T11:45:48.222Z] [INFO]         "content": "Updated task #1 status"
+[2026-06-18T11:45:48.222Z] [INFO]       }
+[2026-06-18T11:45:48.222Z] [INFO]     ]
+[2026-06-18T11:45:48.222Z] [INFO]   },
+[2026-06-18T11:45:48.222Z] [INFO]   "parent_tool_use_id": null,
+[2026-06-18T11:45:48.222Z] [INFO]   "session_id": "d65e890a-db60-43f7-aea3-691500f7e26c",
+[2026-06-18T11:45:48.222Z] [INFO]   "uuid": "4f4e0b51-e20a-423e-b751-435e780fd680",
+[2026-06-18T11:45:48.222Z] [INFO]   "timestamp": "2026-06-18T11:45:48.219Z",
+[2026-06-18T11:45:48.222Z] [INFO]   "tool_use_result": {
+[2026-06-18T11:45:48.222Z] [INFO]     "success": true,
+[2026-06-18T11:45:48.222Z] [INFO]     "taskId": "1",
+[2026-06-18T11:45:48.222Z] [INFO]     "updatedFields": [
+[2026-06-18T11:45:48.222Z] [INFO]       "status"
+[2026-06-18T11:45:48.222Z] [INFO]     ],
+[2026-06-18T11:45:48.222Z] [INFO]     "statusChange": {
+[2026-06-18T11:45:48.222Z] [INFO]       "from": "pending",
+[2026-06-18T11:45:48.222Z] [INFO]       "to": "in_progress"
+[2026-06-18T11:45:48.222Z] [INFO]     }
+[2026-06-18T11:45:48.222Z] [INFO]   }
+[2026-06-18T11:45:48.222Z] [INFO] }
+[2026-06-18T11:45:48.291Z] [INFO] [log_cff91e] sending request {
+[2026-06-18T11:45:48.292Z] [INFO]   method: "post",
+[2026-06-18T11:45:48.292Z] [INFO]   url: "https://api.anthropic.com/v1/messages?beta=true",
+[2026-06-18T11:45:48.292Z] [INFO]   options: {
+[2026-06-18T11:45:48.293Z] [INFO]     method: "post",
+[2026-06-18T11:45:48.293Z] [INFO]     path: "/v1/messages?beta=true",
+[2026-06-18T11:45:48.293Z] [INFO]     body: {
+[2026-06-18T11:45:48.293Z] [INFO]       model: "claude-opus-4-8",
+[2026-06-18T11:45:48.294Z] [INFO]       messages: [
+[2026-06-18T11:45:48.295Z] [INFO]         [Object ...], [Object ...], [Object ...], [Object ...], [Object ...], [Object ...], [Object ...], [Object ...], [Object ...], [Object ...], [Object ...], [Object ...], [Object ...], [Object ...], [Object ...], [Object ...], [Object ...], [Object ...], [Object ...], [Object ...], [Object ...], [Object ...], [Object ...], [Object ...], [Object ...], [Object ...]
+[2026-06-18T11:45:48.295Z] [INFO]       ],
+[2026-06-18T11:45:48.296Z] [INFO]       system: [
+[2026-06-18T11:45:48.296Z] [INFO]         [Object ...], [Object ...], [Object ...], [Object ...]
+[2026-06-18T11:45:48.296Z] [INFO]       ],
+[2026-06-18T11:45:48.298Z] [INFO]       tools: [
+[2026-06-18T11:45:48.298Z] [INFO]         [Object ...], [Object ...], [Object ...], [Object ...], [Object ...], [Object ...], [Object ...], [Object ...], [Object ...], [Object ...]
+[2026-06-18T11:45:48.299Z] [INFO]       ],
+[2026-06-18T11:45:48.300Z] [INFO]       tool_choice: undefined,
+[2026-06-18T11:45:48.301Z] [INFO]       metadata: [Object ...],
+[2026-06-18T11:45:48.301Z] [INFO]       max_tokens: 128000,
+[2026-06-18T11:45:48.302Z] [INFO]       thinking: [Object ...],
+[2026-06-18T11:45:48.303Z] [INFO]       context_management: [Object ...],
+[2026-06-18T11:45:48.304Z] [INFO]       output_config: [Object ...],
+[2026-06-18T11:45:48.304Z] [INFO]       diagnostics: [Object ...],
+[2026-06-18T11:45:48.304Z] [INFO]       stream: true,
+[2026-06-18T11:45:48.305Z] [INFO]     },
+[2026-06-18T11:45:48.306Z] [INFO]     timeout: 600000,
+[2026-06-18T11:45:48.307Z] [INFO]     signal: AbortSignal {
+[2026-06-18T11:45:48.308Z] [INFO]       [Symbol(events.maxEventTargetListeners)]: 50,
+[2026-06-18T11:45:48.309Z] [INFO]       [Symbol(events.maxEventTargetListenersWarned)]: false,
+[2026-06-18T11:45:48.310Z] [INFO]       aborted: false,
+[2026-06-18T11:45:48.310Z] [INFO]       reason: undefined,
+[2026-06-18T11:45:48.310Z] [INFO]       onabort: null,
+[2026-06-18T11:45:48.310Z] [INFO]       throwIfAborted: [Function: throwIfAborted],
+[2026-06-18T11:45:48.311Z] [INFO]       addEventListener: [Function: addEventListener],
+[2026-06-18T11:45:48.311Z] [INFO]       removeEventListener: [Function: removeEventListener],
+[2026-06-18T11:45:48.311Z] [INFO]       dispatchEvent: [Function: dispatchEvent],
+[2026-06-18T11:45:48.311Z] [INFO]     },
+[2026-06-18T11:45:48.311Z] [INFO]     stream: true,
+[2026-06-18T11:45:48.312Z] [INFO]   },
+[2026-06-18T11:45:48.312Z] [INFO]   headers: {
+[2026-06-18T11:45:48.313Z] [INFO]     accept: "application/json",
+[2026-06-18T11:45:48.313Z] [INFO]     "anthropic-beta": "claude-code-20250219,oauth-2025-04-20,interleaved-thinking-2025-05-14,thinking-token-count-2026-05-13,context-management-2025-06-27,prompt-caching-scope-2026-01-05,mid-conversation-system-2026-04-07,advisor-tool-2026-03-01,advanced-tool-use-2025-11-20,effort-2025-11-24,extended-cache-ttl-2025-04-11,cache-diagnosis-2026-04-07",
+[2026-06-18T11:45:48.313Z] [INFO]     "anthropic-dangerous-direct-browser-access": "true",
+[2026-06-18T11:45:48.314Z] [INFO]     "anthropic-version": "2023-06-01",
+[2026-06-18T11:45:48.314Z] [INFO]     authorization: "***",
+[2026-06-18T11:45:48.314Z] [INFO]     "content-type": "application/json",
+[2026-06-18T11:45:48.314Z] [INFO]     "user-agent": "claude-cli/2.1.181 (external, sdk-cli)",
+[2026-06-18T11:45:48.314Z] [INFO]     "x-app": "cli",
+[2026-06-18T11:45:48.315Z] [INFO]     "x-claude-code-session-id": "d65e890a-db60-43f7-aea3-691500f7e26c",
+[2026-06-18T11:45:48.316Z] [INFO]     "x-client-request-id": "536732af-5d9f-4eb7-b348-c18f2aeec0b1",
+[2026-06-18T11:45:48.317Z] [INFO]     "x-stainless-arch": "x64",
+[2026-06-18T11:45:48.318Z] [INFO]     "x-stainless-lang": "js",
+[2026-06-18T11:45:48.318Z] [INFO]     "x-stainless-os": "Linux",
+[2026-06-18T11:45:48.318Z] [INFO]     "x-stainless-package-version": "0.94.0",
+[2026-06-18T11:45:48.319Z] [INFO]     "x-stainless-retry-count": "0",
+[2026-06-18T11:45:48.319Z] [INFO]     "x-stainless-runtime": "node",
+[2026-06-18T11:45:48.319Z] [INFO]     "x-stainless-runtime-version": "v24.3.0",
+[2026-06-18T11:45:48.320Z] [INFO]     "x-stainless-timeout": "600",
+[2026-06-18T11:45:48.321Z] [INFO]   },
+[2026-06-18T11:45:48.321Z] [INFO] }
+[2026-06-18T11:45:49.688Z] [INFO] [log_cff91e, request-id: "req_011CcAfmfuxgYVaGkdvDhLRv"] post https://api.anthropic.com/v1/messages?beta=true succeeded with status 200 in 1397ms
+[2026-06-18T11:45:49.689Z] [INFO] [log_cff91e] response start {
+[2026-06-18T11:45:49.689Z] [INFO]   url: "https://api.anthropic.com/v1/messages?beta=true",
+[2026-06-18T11:45:49.690Z] [INFO]   status: 200,
+[2026-06-18T11:45:49.690Z] [INFO]   headers: {
+[2026-06-18T11:45:49.691Z] [INFO]     "anthropic-organization-id": "ebc2ac93-f86f-4d15-aff3-de8830d8d789",
+[2026-06-18T11:45:49.691Z] [INFO]     "anthropic-ratelimit-unified-5h-reset": "1781787000",
+[2026-06-18T11:45:49.691Z] [INFO]     "anthropic-ratelimit-unified-5h-status": "allowed",
+[2026-06-18T11:45:49.691Z] [INFO]     "anthropic-ratelimit-unified-5h-utilization": "0.33",
+[2026-06-18T11:45:49.692Z] [INFO]     "anthropic-ratelimit-unified-7d-reset": "1782212400",
+[2026-06-18T11:45:49.692Z] [INFO]     "anthropic-ratelimit-unified-7d-status": "allowed",
+[2026-06-18T11:45:49.693Z] [INFO]     "anthropic-ratelimit-unified-7d-utilization": "0.62",
+[2026-06-18T11:45:49.693Z] [INFO]     "anthropic-ratelimit-unified-fallback-percentage": "0.5",
+[2026-06-18T11:45:49.693Z] [INFO]     "anthropic-ratelimit-unified-overage-disabled-reason": "org_level_disabled",
+[2026-06-18T11:45:49.694Z] [INFO]     "anthropic-ratelimit-unified-overage-status": "rejected",
+[2026-06-18T11:45:49.694Z] [INFO]     "anthropic-ratelimit-unified-representative-claim": "five_hour",
+[2026-06-18T11:45:49.694Z] [INFO]     "anthropic-ratelimit-unified-reset": "1781787000",
+[2026-06-18T11:45:49.694Z] [INFO]     "anthropic-ratelimit-unified-status": "allowed",
+[2026-06-18T11:45:49.695Z] [INFO]     "cache-control": "no-cache",
+[2026-06-18T11:45:49.696Z] [INFO]     "cf-cache-status": "DYNAMIC",
+[2026-06-18T11:45:49.696Z] [INFO]     "cf-ray": "a0da0cc4ee72b19e-FRA",
+[2026-06-18T11:45:49.697Z] [INFO]     connection: "keep-alive",
+[2026-06-18T11:45:49.697Z] [INFO]     "content-encoding": "gzip",
+[2026-06-18T11:45:49.698Z] [INFO]     "content-security-policy": "default-src 'none'; frame-ancestors 'none'",
+[2026-06-18T11:45:49.699Z] [INFO]     "content-type": "text/event-stream; charset=utf-8",
+[2026-06-18T11:45:49.700Z] [INFO]     date: "Thu, 18 Jun 2026 11:45:49 GMT",
+[2026-06-18T11:45:49.700Z] [INFO]     "request-id": "req_011CcAfmfuxgYVaGkdvDhLRv",
+[2026-06-18T11:45:49.700Z] [INFO]     server: "cloudflare",
+[2026-06-18T11:45:49.701Z] [INFO]     "strict-transport-security": "max-age=31536000; includeSubDomains; preload",
+[2026-06-18T11:45:49.701Z] [INFO]     traceresponse: "00-78efa8c017fb9e2835c264a178badf75-ab743be812ebbf2d-01",
+[2026-06-18T11:45:49.701Z] [INFO]     "transfer-encoding": "chunked",
+[2026-06-18T11:45:49.702Z] [INFO]     vary: "Accept-Encoding",
+[2026-06-18T11:45:49.702Z] [INFO]     "x-robots-tag": "none",
+[2026-06-18T11:45:49.704Z] [INFO]     "set-cookie": "***",
+[2026-06-18T11:45:49.705Z] [INFO]   },
+[2026-06-18T11:45:49.705Z] [INFO]   durationMs: 1397,
+[2026-06-18T11:45:49.706Z] [INFO] }
+[2026-06-18T11:45:49.706Z] [INFO] response 200 https://api.anthropic.com/v1/messages?beta=true Headers {
+[2026-06-18T11:45:49.706Z] [INFO]   "date": "Thu, 18 Jun 2026 11:45:49 GMT",
+[2026-06-18T11:45:49.707Z] [INFO]   "content-type": "text/event-stream; charset=utf-8",
+[2026-06-18T11:45:49.707Z] [INFO]   "transfer-encoding": "chunked",
+[2026-06-18T11:45:49.708Z] [INFO]   "connection": "keep-alive",
+[2026-06-18T11:45:49.709Z] [INFO]   "cache-control": "no-cache",
+[2026-06-18T11:45:49.709Z] [INFO]   "strict-transport-security": "max-age=31536000; includeSubDomains; preload",
+[2026-06-18T11:45:49.709Z] [INFO]   "content-encoding": "gzip",
+[2026-06-18T11:45:49.710Z] [INFO]   "vary": "Accept-Encoding",
+[2026-06-18T11:45:49.710Z] [INFO]   "content-security-policy": "default-src 'none'; frame-ancestors 'none'",
+[2026-06-18T11:45:49.710Z] [INFO]   "set-cookie": [ "_cfuvid=SE.9Bt4sOC_5D6I_4f2dnoJYdStTYucuFFH3Gj259K4-1781783148.3043444-1.0.1.1-Xgm2OfmfRSqlPpfHZqLPOKXAv6L.5Qs0CFhhCd_rj70; HttpOnly; SameSite=None; Secure; Path=/; Domain=api.anthropic.com" ],
+[2026-06-18T11:45:49.710Z] [INFO]   "anthropic-ratelimit-unified-status": "allowed",
+[2026-06-18T11:45:49.710Z] [INFO]   "anthropic-ratelimit-unified-5h-status": "allowed",
+[2026-06-18T11:45:49.711Z] [INFO]   "anthropic-ratelimit-unified-5h-reset": "1781787000",
+[2026-06-18T11:45:49.712Z] [INFO]   "anthropic-ratelimit-unified-5h-utilization": "0.33",
+[2026-06-18T11:45:49.712Z] [INFO]   "anthropic-ratelimit-unified-7d-status": "allowed",
+[2026-06-18T11:45:49.713Z] [INFO]   "anthropic-ratelimit-unified-7d-reset": "1782212400",
+[2026-06-18T11:45:49.713Z] [INFO]   "anthropic-ratelimit-unified-7d-utilization": "0.62",
+[2026-06-18T11:45:49.713Z] [INFO]   "anthropic-ratelimit-unified-representative-claim": "five_hour",
+[2026-06-18T11:45:49.714Z] [INFO]   "anthropic-ratelimit-unified-fallback-percentage": "0.5",
+[2026-06-18T11:45:49.716Z] [INFO]   "anthropic-ratelimit-unified-reset": "1781787000",
+[2026-06-18T11:45:49.717Z] [INFO]   "anthropic-ratelimit-unified-overage-disabled-reason": "org_level_disabled",
+[2026-06-18T11:45:49.718Z] [INFO]   "anthropic-ratelimit-unified-overage-status": "rejected",
+[2026-06-18T11:45:49.718Z] [INFO]   "request-id": "req_011CcAfmfuxgYVaGkdvDhLRv",
+[2026-06-18T11:45:49.719Z] [INFO]   "anthropic-organization-id": "ebc2ac93-f86f-4d15-aff3-de8830d8d789",
+[2026-06-18T11:45:49.723Z] [INFO]   "traceresponse": "00-78efa8c017fb9e2835c264a178badf75-ab743be812ebbf2d-01",
+[2026-06-18T11:45:49.724Z] [INFO]   "server": "cloudflare",
+[2026-06-18T11:45:49.724Z] [INFO]   "cf-cache-status": "DYNAMIC",
+[2026-06-18T11:45:49.725Z] [INFO]   "x-robots-tag": "none",
+[2026-06-18T11:45:49.727Z] [INFO]   "cf-ray": "a0da0cc4ee72b19e-FRA",
+[2026-06-18T11:45:49.727Z] [INFO] } ReadableStream {
+[2026-06-18T11:45:49.728Z] [INFO]   blob: [Function: blob],
+[2026-06-18T11:45:49.729Z] [INFO]   bytes: [Function: bytes],
+[2026-06-18T11:45:49.730Z] [INFO]   cancel: [Function],
+[2026-06-18T11:45:49.731Z] [INFO]   getReader: [Function],
+[2026-06-18T11:45:49.732Z] [INFO]   json: [Function: json],
+[2026-06-18T11:45:49.733Z] [INFO]   locked: [Getter],
+[2026-06-18T11:45:49.735Z] [INFO]   pipeThrough: [Function],
+[2026-06-18T11:45:49.735Z] [INFO]   pipeTo: [Function],
+[2026-06-18T11:45:49.736Z] [INFO]   tee: [Function],
+[2026-06-18T11:45:49.737Z] [INFO]   text: [Function: text],
+[2026-06-18T11:45:49.738Z] [INFO]   values: [Function: values],
+[2026-06-18T11:45:49.738Z] [INFO]   [Symbol(Symbol.asyncIterator)]: [Function: asyncIterator2],
+[2026-06-18T11:45:49.738Z] [INFO] }
+[2026-06-18T11:45:49.739Z] [INFO] [log_cff91e] response parsed {
+[2026-06-18T11:45:49.741Z] [INFO]   url: "https://api.anthropic.com/v1/messages?beta=true",
+[2026-06-18T11:45:49.742Z] [INFO]   status: 200,
+[2026-06-18T11:45:49.742Z] [INFO]   body: sU {
+[2026-06-18T11:45:49.743Z] [INFO]     iterator: [AsyncGeneratorFunction: s],
+[2026-06-18T11:45:49.744Z] [INFO]     controller: AbortController {
+[2026-06-18T11:45:49.745Z] [INFO]       signal: [AbortSignal ...],
+[2026-06-18T11:45:49.746Z] [INFO]       abort: [Function: abort],
+[2026-06-18T11:45:49.747Z] [INFO]     },
+[2026-06-18T11:45:49.748Z] [INFO]     [Symbol(Symbol.asyncIterator)]: [Function],
+[2026-06-18T11:45:49.750Z] [INFO]     tee: [Function: tee],
+[2026-06-18T11:45:49.750Z] [INFO]     toReadableStream: [Function: toReadableStream],
+[2026-06-18T11:45:49.750Z] [INFO]   },
+[2026-06-18T11:45:49.753Z] [INFO]   durationMs: 1397,
+[2026-06-18T11:45:49.755Z] [INFO] }
+[2026-06-18T11:45:50.742Z] [INFO] {
+[2026-06-18T11:45:50.742Z] [INFO]   "type": "assistant",
+[2026-06-18T11:45:50.742Z] [INFO]   "message": {
+[2026-06-18T11:45:50.742Z] [INFO]     "model": "claude-opus-4-8",
+[2026-06-18T11:45:50.742Z] [INFO]     "id": "msg_01EG3FAiuq4qQNTncRVDYFKK",
+[2026-06-18T11:45:50.742Z] [INFO]     "type": "message",
+[2026-06-18T11:45:50.742Z] [INFO]     "role": "assistant",
+[2026-06-18T11:45:50.742Z] [INFO]     "content": [
+[2026-06-18T11:45:50.742Z] [INFO]       {
+[2026-06-18T11:45:50.742Z] [INFO]         "type": "text",
+[2026-06-18T11:45:50.742Z] [INFO]         "text": "Now I'll write the main document, grounded in the existing RFC (С1–С5), operations taxonomy, Trust & Evidence, and registered external sources."
+[2026-06-18T11:45:50.742Z] [INFO]       }
+[2026-06-18T11:45:50.742Z] [INFO]     ],
+[2026-06-18T11:45:50.742Z] [INFO]     "stop_reason": null,
+[2026-06-18T11:45:50.742Z] [INFO]     "stop_sequence": null,
+[2026-06-18T11:45:50.742Z] [INFO]     "stop_details": null,
+[2026-06-18T11:45:50.742Z] [INFO]     "usage": {
+[2026-06-18T11:45:50.742Z] [INFO]       "input_tokens": 2,
+[2026-06-18T11:45:50.742Z] [INFO]       "cache_creation_input_tokens": 289,
+[2026-06-18T11:45:50.742Z] [INFO]       "cache_read_input_tokens": 58318,
+[2026-06-18T11:45:50.742Z] [INFO]       "cache_creation": {
+[2026-06-18T11:45:50.742Z] [INFO]         "ephemeral_5m_input_tokens": 0,
+[2026-06-18T11:45:50.742Z] [INFO]         "ephemeral_1h_input_tokens": 289
+[2026-06-18T11:45:50.742Z] [INFO]       },
+[2026-06-18T11:45:50.742Z] [INFO]       "output_tokens": 3,
+[2026-06-18T11:45:50.742Z] [INFO]       "service_tier": "standard",
+[2026-06-18T11:45:50.742Z] [INFO]       "inference_geo": "not_available"
+[2026-06-18T11:45:50.742Z] [INFO]     },
+[2026-06-18T11:45:50.742Z] [INFO]     "diagnostics": null,
+[2026-06-18T11:45:50.742Z] [INFO]     "context_management": null
+[2026-06-18T11:45:50.742Z] [INFO]   },
+[2026-06-18T11:45:50.742Z] [INFO]   "parent_tool_use_id": null,
+[2026-06-18T11:45:50.742Z] [INFO]   "session_id": "d65e890a-db60-43f7-aea3-691500f7e26c",
+[2026-06-18T11:45:50.742Z] [INFO]   "uuid": "68973bab-cc7c-4f03-89bc-654ae8086bca",
+[2026-06-18T11:45:50.742Z] [INFO]   "request_id": "req_011CcAfmfuxgYVaGkdvDhLRv"
+[2026-06-18T11:45:50.742Z] [INFO] }
+[2026-06-18T11:48:11.013Z] [INFO] {
+[2026-06-18T11:48:11.013Z] [INFO]   "type": "assistant",
+[2026-06-18T11:48:11.013Z] [INFO]   "message": {
+[2026-06-18T11:48:11.013Z] [INFO]     "model": "claude-opus-4-8",
+[2026-06-18T11:48:11.013Z] [INFO]     "id": "msg_01EG3FAiuq4qQNTncRVDYFKK",
+[2026-06-18T11:48:11.013Z] [INFO]     "type": "message",
+[2026-06-18T11:48:11.013Z] [INFO]     "role": "assistant",
+[2026-06-18T11:48:11.013Z] [INFO]     "content": [
+[2026-06-18T11:48:11.013Z] [INFO]       {
+[2026-06-18T11:48:11.013Z] [INFO]         "type": "tool_use",
+[2026-06-18T11:48:11.013Z] [INFO]         "id": "toolu_01UQx7Fzgm18VMu1EqAbP6J4",
+[2026-06-18T11:48:11.013Z] [INFO]         "name": "Write",
+[2026-06-18T11:48:11.013Z] [INFO]         "input": {
+[2026-06-18T11:48:11.013Z] [INFO]           "file_path": "/tmp/gh-issue-solver-1781783024578/research/mango/ai-classifications-formalization-2026-06.md",
+[2026-06-18T11:48:11.013Z] [INFO]           "content": "---\nstatus: draft\nversion: 0.1\nupdated: 2026-06-18\ntemperature: 0.3\nai-generated: true\n---\n\n# Формализация AI-классификаций и интеграция в роадмап Mango\n\n> **Operating Mode:** `Creative` (синтез, формализация, предложения по интеграции)\n> + `Research` (анализ современных AI-фреймворков).\n> **Lifecycle Stage:** `Research → RFC`.\n> **Trust & Evidence:** все AI-подпроцессы ниже размечены как `Candidate`\n> (доверие E1–E2). Ни один из них **не вводится как стандарт** этим документом —\n> он фиксирует формализацию и предложение по интеграции, решение остаётся за\n> Пользователем ([AI_GOVERNANCE.md](../../AI_GOVERNANCE.md), правило 4).\n\n## Назначение\n\nДокумент продолжает линию исследования Вигерса\n([research/hub/wigers-requirements-analysis-2026-06.md](../hub/wigers-requirements-analysis-2026-06.md))\nи синхронизирующего RFC\n([governance/rfc/requirements-engineering-ai-era-2026.md](../../governance/rfc/requirements-engineering-ai-era-2026.md)).\nЕсли RFC отвечал на вопрос «**что** в онтологии mango стоит синхронизировать с\nВигерсом (С1–С5)», то этот документ отвечает на вопрос «**как именно** новые\nAI-подпроцессы устроены внутри (операции / артефакты / связь с классикой) и **как**\nони входят в роадмап Mango, не ломая принятую модель».\n\nДокумент делает четыре вещи:\n\n1. **Детально формализует** 4 новых AI-подпроцесса (инжиниринг промптов, настройка\n   RAG, проектирование оркестрации агентов, тестирование AI-компонентов) — каждый\n   с операциями (вход → действие → выход), артефактами (описательные и исполнимые)\n   и явной связью с классикой Вигерса/BABOK.\n2. **Интегрирует** их в роадмап Mango как **эволюцию операций** (4 фазы), а не как\n   замену классических операций и не как изолированный «AI-процесс».\n3. **Готовит** материал к синхронизации с `mango_ba_prompts` (С1, С2, С3) —\n   в форме, пригодной для последующего issue во внешнем репозитории.\n4. Для каждого нового элемента даёт **полноценный пример** использования и критерии\n   качества.\n\n### Что этот документ НЕ делает\n\n- **Не** объявляет AI-подпроцессы обязательной нормой. Они `Candidate` (E1–E2)\n  до воспроизводимого подтверждения (НФТ Trust & Evidence).\n- **Не** редактирует mango-ADR. ADR #003–#010 живут в репозитории\n  `mango_ba_prompts` и меняются только через его процесс. Здесь — рекомендации\n  Хаба и заготовки для issue, не правки.\n- **Не** заменяет классические операции AI-версиями (см. §«Что мы отвергли»).\n- **Не** создаёт новые каталоги или стандарты «впрок» (Anti-Inflation,\n  [governance/repo-model.md](../../governance/repo-model.md)).\n\n## Терминологическая рамка (двуязычие)\n\n| Русский | English | Краткое определение |\n| --- | --- | --- |\n| Подпроцесс | Subprocess | Связанная группа операций, дополняющая классический процесс Вигерса (Выявление/Анализ/Спецификация/Проверка). |\n| Операция | Operation | Атомарная единица работы вида «вход → действие → выход» (нотация триады mango, [ADR-003](https://github.com/G-Ivan-A/mango_ba_prompts/blob/main/docs/adr/003-ba-ontology.md)). |\n| Артефакт | Artifact | Результат операции; **описательный** (descriptive, для чтения/отладки) или **исполнимый** (executable, потребляется машиной). |\n| Промпт | Prompt | **Интерфейс к Tool**, а не сам Tool; исполнимый артефакт-текст для LLM. |\n| Инжиниринг промптов | Prompt engineering | Подпроцесс, а не тип требования и не операция верхнего уровня. |\n| Спецификация промпта | Prompt specification | **Описательный** документ промпта (назначение, контекст, критерии), не исполнимый артефакт. |\n| AI-ассистированная операция | AI-assisted operation | Классическая операция, усиленная AI, с обязательной валидацией вывода (E0–E4). |\n| Доверие вывода | Trust & Evidence | Ось E0–E4 разметки уверенности AI-вывода ([methodology RFC](../../governance/rfc/methodology-research-and-proposals.md)). |\n| Статус знания | Knowledge Status | `Candidate` → `Applied`: зрелость практики ([research-memory RFC](../../governance/rfc/research-memory-source-intelligence.md)). |\n\n> **Якорь классификации (из Этапа 3).** `Prompt = интерфейс к Tool` (не сам Tool);\n> `Prompt engineering = подпроцесс` (не операция, не тип требования);\n> `Prompt specification = описательный документ` для отладки/guides. Эти три\n> утверждения — несущая рамка всего документа.\n\n## Что мы отвергли и почему\n\n| ❌ Отвергнуто | Почему |\n| --- | --- |\n| «Просто добавить новые операции в список» | Список не показывает **связи**: как подпроцессы стыкуются с классическими операциями и как меняется роадмап. Нужна формализация, а не перечисление. |\n| «Заменить классические операции AI-версиями» | Классические операции **не устаревают** — они дополняются AI-ассистированными версиями. Показываем эволюцию, а не замену. |\n| «Создать отдельные процессы для AI» | AI-разработка — **расширение** существующих процессов Вигерса, а не отдельный процесс. Показываем интеграцию, а не изоляцию. |\n\nЭти три отклонения согласованы с Anti-Inflation principle: новая сложность вводится\nтолько под реальную операционную боль и без сноса принятой модели.\n\n---\n\n## ФТ-1. Детальная формализация AI-подпроцессов\n\nКаждый подпроцесс описан по единому шаблону: **описание → операции (вход/действие/\nвыход) → артефакты (описательные/исполнимые) → связь с классикой → пример →\nкритерии качества → опора на доверенный источник**.\n\nВсе четыре подпроцесса **дополняют** классические процессы Вигерса, а не заменяют\nих. Сводная карта связей:\n\n| Подпроцесс (RU / EN) | Дополняет процесс Вигерса | Гл. Вигерса | Класс артефакта-результата |\n| --- | --- | --- | --- |\n| Инжиниринг промптов / Prompt Engineering | Документирование требований (Спецификация) | Гл. 10 | descriptive + executable |\n| Настройка RAG / RAG Configuration | Проектирование решений (Анализ→Спецификация) | Гл. 12 | descriptive |\n| Проектирование оркестрации агентов / Agent Orchestration Design | Проектирование архитектуры | Гл. 19 | descriptive |\n| Тестирование AI-компонентов / AI Testing | Проверка требований (Валидация) | Гл. 17 | executable |\n\n### 1. Инжиниринг промптов (Prompt Engineering)\n\n**Описание.** Подпроцесс создания, тестирования и валидации промптов для\nAI-компонентов. Промпт здесь — **интерфейс к Tool** (LLM), а инжиниринг промптов —\n**подпроцесс**, дополняющий классическое «Документирование требований».\n\n**Операции:**\n\n| # | Операция (RU / EN) | Вход | Действие | Выход |\n| --- | --- | --- | --- | --- |\n| 1.1 | Анализ задачи для промпта / Prompt task analysis | бизнес-требование, контекст | определение цели промпта, входных/выходных данных | спецификация задачи для промпта |\n| 1.2 | Написание черновика / Draft authoring | спецификация задачи | создание первой версии промпта | черновик промпта |\n| 1.3 | Тестирование промпта / Prompt testing | черновик, тестовые данные | запуск промпта, анализ результатов | результаты тестирования |\n| 1.4 | Итерация промпта / Prompt iteration | результаты тестирования | улучшение промпта по результатам | улучшенная версия промпта |\n| 1.5 | Валидация промпта / Prompt validation | улучшенная версия | финальная проверка соответствия требованиям | валидированный промпт |\n\n**Артефакты:**\n\n- **Spec промпта / Prompt specification** (descriptive): назначение, входные данные,\n  ожидаемый выход, контекст (какие знания использует), критерии качества, примеры\n  использования, связь с бизнес-требованием. Создаётся **только для критичных**\n  (продакшен) промптов (см. ОВ-3).\n- **Исполнимый промпт / Executable prompt** (executable): текст промпта для LLM.\n\n**Связь с классикой.** Дополняет «Документирование требований» (Вигерс, Гл. 10):\nspec промпта — это требование к AI-компоненту, оформленное по тем же принципам\nясности/проверяемости, что и обычная спецификация требования.\n\n**Пример использования.**\n> Бизнес-требование: «Система должна анализировать документацию заказчика и\n> извлекать требования». Операция 1.1 даёт спецификацию задачи (вход = PDF/DOCX ТЗ;\n> выход = список кандидатов-требований с типом по Вигерсу). Операция 1.2 — черновик\n> промпта. Операция 1.3 — прогон на корпусе тестовых ТЗ. Операция 1.5 — валидация\n> по критериям качества и присвоение доверия E2 (`Candidate`).\n\n**Критерии качества:** промпт соответствует бизнес-требованию; проходит\nтестирование на тестовых данных; валидирован по критериям качества; вывод размечен\nдоверием E0–E4.\n\n**Опора (trusted source).** LangChain (`ext-016`,\n[реестр](../external-knowledge/external-sources-registry.md)) — паттерны\nprompt-templates; инсайт о компонуемых паттернах\n([building-effective-agents](../external-knowledge/external-insights/building-effective-agents-2026-06.md),\n`ext-001`): промпт как простой компонуемый шаг, сложность — только под боль.\n\n### 2. Настройка RAG (RAG Configuration)\n\n**Описание.** Подпроцесс настройки Retrieval-Augmented Generation для\nAI-компонентов: выбор хранилища знаний, стратегии разбиения и поиска.\n\n**Операции:**\n\n| # | Операция (RU / EN) | Вход | Действие | Выход |\n| --- | --- | --- | --- | --- |\n| 2.1 | Выбор векторной базы / Vector store selection | требования к хранению знаний | анализ решений (Chroma, Pinecone, YDB) | выбранная векторная база |\n| 2.2 | Настройка chunking / Chunking configuration | документы для индексации | определение стратегии разделения | настроенный chunking |\n| 2.3 | Настройка retrieval / Retrieval configuration | векторная база, chunking | настройка поиска и ранжирования | настроенный retrieval |\n\n**Артефакты:**\n\n- **Документ конфигурации RAG / RAG configuration document** (descriptive):\n  выбранная векторная база и обоснование, стратегия chunking, параметры retrieval,\n  критерии качества поиска (precision/recall на эталонном наборе запросов).\n\n**Связь с классикой.** Дополняет «Проектирование решений» (Вигерс, Гл. 12):\nконфигурация RAG — это проектное решение по доступу к знаниям, с обоснованием\nвыбора, как и любое архитектурное решение.\n\n**Пример использования.**\n> Для AI-навигатора по продуктам Mango (см.\n> [rag-mapping-roadmap-2026-05.md](rag-mapping-roadmap-2026-05.md)) операция 2.1\n> выбирает векторную базу под `kb/product-matrix.md`; 2.2 задаёт chunking по\n> разделам матрицы (1 фича = 1 chunk); 2.3 настраивает retrieval с ранжированием по\n> домену (`voice-ucaas` / `contact-center` / `digital-channels`).\n\n**Критерии качества:** выбор базы обоснован требованиями; chunking сохраняет\nсемантическую цельность единицы знания; retrieval измеряется на эталонном наборе\n(precision/recall), а не «на глаз».\n\n**Опора (trusted source).** LangChain (`ext-016`) — компоненты retrieval/vector\nstores; Microsoft Foundry samples (`ext-018`/`ext-019`) — production-ready шаблоны\nRAG. Утверждения о применимости — доверие E1–E2 (`Candidate`).\n\n### 3. Проектирование оркестрации агентов (Agent Orchestration Design)\n\n**Описание.** Подпроцесс проектирования взаимодействия между AI-агентами в\nмультиагентной системе: роли, сценарии, протоколы, координация.\n\n**Операции:**\n\n| # | Операция (RU / EN) | Вход | Действие | Выход |\n| --- | --- | --- | --- | --- |\n| 3.1 | Определение сценариев взаимодействия / Interaction scenarios definition | бизнес-требования к мультиагентной системе | определение ролей агентов и сценариев | сценарии взаимодействия |\n| 3.2 | Проектирование протоколов / Communication protocols design | сценарии взаимодействия | определение форматов сообщений и протоколов | спецификация протоколов |\n| 3.3 | Настройка координации / Coordination configuration | спецификация протоколов | настройка координации между агентами | настроенная оркестрация |\n\n**Артефакты:**\n\n- **Диаграмма оркестрации агентов / Agent orchestration diagram** (descriptive):\n  роли агентов, сценарии взаимодействия, протоколы коммуникации, механизмы\n  координации (предпочтительно PlantUML, согласно карте диаграмм mango).\n\n**Связь с классикой.** Дополняет «Проектирование архитектуры» (Вигерс, Гл. 19):\nоркестрация — это архитектурное проектирование, где компоненты — агенты, а связи —\nпротоколы коммуникации.\n\n**Пример использования.**\n> Мультиагентный разбор ТЗ: агент-`ingestion` извлекает текст, агент-`understanding`\n> классифицирует требования по Вигерсу, агент-`validation` проверяет согласованность\n> (бизнес-правила, С2). Операция 3.1 фиксирует роли и поток (orchestrator-workers),\n> 3.2 — формат сообщений (требование + доверие E0–E4), 3.3 — координацию (когда\n> вывод эскалируется человеку).\n\n**Критерии качества:** роли и границы ответственности агентов однозначны; протокол\nпереносит метку доверия вывода; сложность оркестрации оправдана (не «агент ради\nагента» — Anti-Inflation, паттерн «простое > монолитное»).\n\n**Опора (trusted source).** Anthropic «Building Effective Agents» (`ext-001`) —\nпаттерны orchestrator-workers / routing / evaluator-optimizer; CrewAI (`ext-017`) —\nпримеры мультиагентной координации; 12-factor agents\n([insight](../external-knowledge/external-insights/12-factor-agents-2026-06.md)) —\nдисциплина границ агента. Все — `Candidate`.\n\n### 4. Тестирование AI-компонентов (AI Testing)\n\n**Описание.** Подпроцесс тестирования AI-компонентов (промптов, RAG, агентов):\nсценарии, прогон, анализ.\n\n**Операции:**\n\n| # | Операция (RU / EN) | Вход | Действие | Выход |\n| --- | --- | --- | --- | --- |\n| 4.1 | Написание тестовых сценариев / Test scenario authoring | спецификации AI-компонентов | создание тестовых сценариев | тестовые сценарии |\n| 4.2 | Запуск тестов / Test execution | тестовые сценарии, AI-компоненты | выполнение тестов | результаты тестов |\n| 4.3 | Анализ результатов / Result analysis | результаты тестов | анализ качества AI-компонентов | отчёт о тестировании |\n\n**Артефакты:**\n\n- **Набор тестов AI / AI test suite** (executable): тестовые сценарии, ожидаемые\n  результаты, критерии прохождения (порог точности, допустимая доля отказов).\n\n**Связь с классикой.** Дополняет «Валидация требований» (Вигерс, Гл. 17): тестовый\nнабор для AI-компонента — это исполнимая форма проверки требования к нему.\n\n**Пример использования.**\n> Для промпта извлечения требований (подпроцесс 1) операция 4.1 готовит набор из 30\n> эталонных ТЗ с размеченными ожидаемыми требованиями; 4.2 прогоняет промпт; 4.3\n> считает precision/recall извлечения и фиксирует регрессии относительно прошлой\n> версии. Набор хранится как executable-артефакт и переиспользуется при итерациях\n> (операция 1.4).\n\n**Критерии качества:** набор покрывает целевые сценарии и граничные случаи; критерии\nпрохождения числовые и воспроизводимые; результат повышает/понижает доверие\nкомпонента (E0–E4) и статус знания (`Candidate`→`Applied`).\n\n**Опора (trusted source).** Microsoft Foundry samples (`ext-018`) — шаблоны оценки;\nметодологический инсайт о воспроизводимости (research-profile) — числовые критерии\nвместо «выглядит хорошо». Доверие E1–E2.\n\n---\n\n## ФТ-2. Эволюция операций в роадмапе Mango\n\nКлючевой тезис: переход операции в AI-версию — **не «включение кнопки»**. Каждая\nAI-ассистированная операция требует осознанного перехода: **обучение → настройка →\nвалидация → интеграция**. Классические операции при этом сохраняются.\n\n### Карта четырёх фаз\n\n| Фаза | Операции | AI-компоненты | Артефакты | Доверие/статус |\n| --- | --- | --- | --- | --- |\n| **Фаза 0 — текущая** | Классические (интервью, анализ документов, документирование) | Базовые промпты (без AI-assisted операций) | Стандартные (ТЗ по ГОСТ, User Story, Use Case) | — |\n| **Фаза 1 — Trust & Evidence** | Классические + AI-assisted версии | Промпты с валидацией (E0–E4) | Стандартные + Prompt specification | E1–E2 `Candidate` |\n| **Фаза 2 — AI-агенты** | Классические + AI-assisted + новые AI-операции | Полноценные подпроцессы (Prompt eng., RAG config, Agent orchestration) | Стандартные + AI-specific (Prompt spec, RAG config doc, Orchestration diagram) | E2–E3, часть `Applied` |\n| **Фаза 3 — Мультиагентные системы** | Полная интеграция классических и AI-операций | Мультиагентные системы | Комплексные AI-решения | `Applied` |\n\n> **Принцип эволюции, а не замены.** В каждой фазе классическая операция остаётся\n> доступной. AI-версия — это **дополнительная** операция к классической (по образцу\n> С3: alias-crosswalk без переименований в mango).\n\n### Пример эволюции одной операции\n\n| Аспект | Классическая | AI-версия (Фаза 1+) |\n| --- | --- | --- |\n| Название | «Анализ документов» / Document analysis | «AI-assisted document analysis» |\n| Что делает | БА вручную читает ТЗ и извлекает требования | LLM извлекает кандидатов, БА валидирует |\n| Артефакт | список требований | список требований + Prompt specification + метка доверия E0–E4 |\n| Риск | трудозатраты, пропуски | галлюцинации → обязательна валидация (ОВ-4) |\n\nАналогично: «Проверка противоречий» → «AI-powered consistency checking» (опирается\nна явные бизнес-правила С2 как формализуемую опору).\n\n### План перехода для каждой операции (4 шага)\n\n1. **Обучение / Training.** Обучение БА работе с AI-инструментами (что такое промпт,\n   как читать доверие вывода, где AI ошибается).\n2. **Настройка / Configuration.** Настройка AI-инструментов под операцию (промпт,\n   RAG, при необходимости — оркестрация).\n3. **Валидация / Validation.** Валидация AI-выводов: каждый вывод получает уровень\n   доверия E0–E4; операция «Проверка AI-вывода» с критериями качества (ОВ-4).\n4. **Интеграция / Integration.** Интеграция в роадмап: операция добавляется как\n   alias к классической (С3), её артефакты — в реестр (С2-подход), уровень — по оси\n   `requirement_level` (С1).\n\n> **Когда начинать Фазу 2.** После завершения Фазы 1 (Trust & Evidence) и\n> синхронизации С1/С2/С3 с `mango_ba_prompts`. Ориентир — сентябрь 2026 (ОВ-5).\n\n---\n\n## ФТ-3. Подготовка к синхронизации с `mango_ba_prompts` (С1, С2, С3)\n\nНиже — **заготовки**, пригодные для оформления issue во внешнем репозитории\n`mango_ba_prompts`. Они **не** редактируют mango-ADR (внешний репозиторий), а\nготовят материал. Приоритет — С1 и С2 (настоящие пробелы), С3 — лёгкий мост.\n\n### С1 — Ось `requirement_level`\n\n- **Описание.** Ортогональная ось-тег для семантической классификации уровня\n  требования, поверх существующей классификации функциональности\n  (`Domain→Capability→Feature→Atomic Function`), **не заменяя** её.\n- **Значения:** `business` / `user` / `functional` / `non-functional`\n  (Бизнес → Пользователь → Функция + НФТ).\n- **Интеграция:** добавить в ADR-003 (онтология БА) как дополнительный тег-ось (по\n  образцу того, как E0–E4 введены ортогонально Knowledge Status).\n- **Пример:** «Система должна отвечать за 2 секунды» → `requirement_level:\n  non-functional`. «Менеджер хочет видеть статус заявки» → `user`.\n- **AI-ценность:** даёт опору для AI-трассировки вверх (функция → бизнес-цель).\n\n### С2 — Тип «Бизнес-правило» + 5 категорий\n\n- **Описание.** Новый тип-артефакт для явного представления бизнес-правил (внешних\n  норм: политик, законов, формул), которым система обязана соответствовать.\n- **Категории (5, по Вигерсу, Гл. 9):**\n\n  | RU | EN | Пример |\n  | --- | --- | --- |\n  | Факты | Facts | «У заказа есть ровно один плательщик» |\n  | Ограничения | Constraints | «Возврат возможен в течение 14 дней» |\n  | Активаторы операций | Operation activators | «При просрочке оплаты — заблокировать номер» |\n  | Выводы | Inferences | «Если клиент VIP, то скидка 10%» |\n  | Вычисления | Computations | «Итог = сумма позиций × (1 − скидка)» |\n\n- **Интеграция:** добавить в реестр артефактов ADR-003 тип `business-rule` со связью\n  «бизнес-правило → порождает → функцию/ограничение».\n- **Пример:** «Если клиент VIP, то скидка 10%» → тип `Business Rule`, категория\n  `Inference`.\n- **AI-ценность:** бизнес-правила — **первый кандидат** на автоматическую проверку\n  согласованности ИИ (AI-powered consistency checking, Фаза 1).\n\n### С3 — Crosswalk Вигерс ↔ операции mango ↔ BCREQ\n\n- **Описание.** Справочная таблица соответствия процессов (alias-crosswalk, **без**\n  переименований в mango — НФТ совместимости).\n- **Интеграция:** жить в RFC Хаба; опционально — примечание со ссылкой в таксономии\n  операций mango (ADR-004).\n\n| Процесс Вигерса (RU / EN) | Операции mango (ADR-004) | Подпроцесс BCREQ (ADR-009) |\n| --- | --- | --- |\n| Выявление / Elicitation | `ingestion`, `understanding` | П1 |\n| Анализ / Analysis | `modeling`, `research`, `impact_analysis`, `reverse_requirements` | П2, П3 |\n| Спецификация / Specification | `documentation`, `solution_design` | П4 |\n| Проверка / Validation | `validation`, `quality` | П5 |\n| Управление / Management | `governance`, `release_readiness`, `risk_analysis` | П6 |\n\n> **Связь AI-подпроцессов с crosswalk.** Новые AI-подпроцессы (ФТ-1) подвешиваются к\n> процессам Вигерса так же, как операции mango: инжиниринг промптов → Спецификация;\n> настройка RAG → Анализ/Спецификация; оркестрация → (Архитектура) Спецификация;\n> тестирование AI → Проверка. Это сохраняет единую трассировку.\n\n---\n\n## ФТ-4. Полноценные примеры и критерии качества (сводка)\n\nДля каждого нового элемента документ даёт: **описание** (что/зачем), **пример**\n(конкретный кейс — см. §ФТ-1), **связь с классикой** (Вигерс/BABOK), **критерии\nкачества** (как проверить). Сквозной пример, связывающий всё воедино:\n\n> **Кейс: AI-извлечение требований из ТЗ заказчика Mango.**\n> 1. **Инжиниринг промптов** создаёт и валидирует промпт извлечения (артефакты:\n>    Prompt spec + executable prompt). Связь: Документирование требований (Гл. 10).\n> 2. **Настройка RAG** даёт промпту доступ к `kb/product-matrix.md` (артефакт: RAG\n>    config doc). Связь: Проектирование решений (Гл. 12).\n> 3. **Проектирование оркестрации** связывает агентов `ingestion → understanding →\n>    validation` (артефакт: orchestration diagram). Связь: Архитектура (Гл. 19).\n> 4. **Тестирование AI** прогоняет всё на 30 эталонных ТЗ (артефакт: AI test suite).\n>    Связь: Валидация (Гл. 17).\n> 5. Результат размечается доверием **E2 `Candidate`**; уровень требований — по оси\n>    **С1**; найденные правила — тип **С2**; операции маппятся по **С3**.\n\nЭтот кейс соответствует Фазе 1→2 роадмапа и не заменяет ни одну классическую\nоперацию — он добавляет AI-версии поверх них.\n\n---\n\n## Связь с НФТ\n\n| НФТ | Как выполнено |\n| --- | --- |\n| Полнота | 4 подпроцесса описаны не списком, а по единому шаблону (операции/артефакты/связь/пример/критерии). |\n| Примеры | Для каждого элемента — конкретный кейс (§ФТ-1, §ФТ-4). |\n| Связь с классикой | Каждый подпроцесс привязан к главе Вигерса; операции — к BABOK через С3. |\n| Интеграция | Подпроцессы вписаны в 4 фазы роадмапа, а не изолированы. |\n| Двуязычие | Все термины — русский + английский (см. таблицы). |\n| Доверенные ресурсы | Опора на LangChain (`ext-016`), CrewAI (`ext-017`), Microsoft Foundry (`ext-018`/`ext-019`), Anthropic/12-factor (`ext-001`, инсайты); без выдумывания. |\n| Trust & Evidence | Все AI-практики — `Candidate` E1–E2; нормой не объявлены. |\n| Anti-Inflation | Без новых каталогов/стандартов «впрок»; приоритет С1/С2. |\n\n---\n\n## Открытые вопросы\n\n**ОВ-1. Нужно ли создавать отдельные стандарты для AI-подпроцессов?**\nНет. Достаточно описания в этом документе/RFC. Стандарты создаются при возникновении\nконкретной боли (Anti-Inflation).\n\n**ОВ-2. Как интегрировать AI-assisted операции в существующие стандарты mango?**\nЧерез обновление ADR-004 (таксономия операций) — добавить AI-версии как\n**дополнительные** операции к классическим (alias, без переименований, С3).\n\n**ОВ-3. Нужно ли создавать Prompt specification для всех промптов в mango?**\nНет, только для **критичных** (продакшен) промптов. Для экспериментальных достаточно\nисполнимого промпта.\n\n**ОВ-4. Как валидировать AI-выводы в AI-assisted операциях?**\nЧерез Trust & Evidence (E0–E4): каждый AI-вывод получает уровень доверия. Валидация —\nэто операция «Проверка AI-вывода» с числовыми критериями качества.\n\n**ОВ-5. Когда начинать Фазу 2 (AI-агенты) в роадмапе Mango?**\nПосле завершения Фазы 1 (Trust & Evidence) и синхронизации С1/С2/С3 с\n`mango_ba_prompts`. Ориентировочно — сентябрь 2026.\n\n**ОВ-6. Кто владелец синхронизации между Хабом и `mango_ba_prompts`?**\nРепозитории независимы; нужен явный канал. Решение и инициирование issue во внешнем\nрепозитории — за Пользователем (наследует Open Decision RFC).\n\n---\n\n## Источники\n\n- **Первоисточник Вигерса:** Wiegers, K., Beatty, J. *Software Requirements*, 3rd\n  ed., Microsoft Press, 2013 (рус. «Разработка требований к ПО», 2020) — главы 9, 10,\n  12, 17, 19.\n- **Доверенные AI-фреймворки (по реестру\n  [external-sources-registry.md](../external-knowledge/external-sources-registry.md)):**\n  - LangChain — `ext-016` (<https://github.com/langchain-ai/langchain>)\n  - CrewAI — `ext-017` (<https://github.com/crewAIInc/crewAI-examples>)\n  - Microsoft Foundry samples — `ext-018`\n    (<https://github.com/microsoft-foundry/foundry-samples>); AI solution templates —\n    `ext-019`\n  - Microsoft — Agentic AI adoption maturity model — `ext-029`\n- **Инсайты Хаба:**\n  [building-effective-agents](../external-knowledge/external-insights/building-effective-agents-2026-06.md)\n  (`ext-001`),\n  [12-factor-agents](../external-knowledge/external-insights/12-factor-agents-2026-06.md).\n- **mango-ADR (внешний репозиторий `mango_ba_prompts`, не редактируются здесь):**\n  ADR-003 <https://github.com/G-Ivan-A/mango_ba_prompts/blob/main/docs/adr/003-ba-ontology.md> ·\n  ADR-004 <https://github.com/G-Ivan-A/mango_ba_prompts/blob/main/docs/adr/004-operations-taxonomy.md> ·\n  ADR-009 <https://github.com/G-Ivan-A/mango_ba_prompts/blob/main/docs/adr/009-bcreq-formation-process.md>.\n\n## Связанные артефакты\n\n- [governance/rfc/requirements-engineering-ai-era-2026.md](../../governance/rfc/requirements-engineering-ai-era-2026.md)\n  — RFC синхронизации Вигерс ↔ mango (С1–С5); базовый контракт этого документа.\n- [research/hub/wigers-requirements-analysis-2026-06.md](../hub/wigers-requirements-analysis-2026-06.md)\n  — независимое извлечение системы Вигерса (доказательная база).\n- [governance/rfc/research-memory-source-intelligence.md](../../governance/rfc/research-memory-source-intelligence.md)\n  — Knowledge Status (`Candidate`/`Applied`) для разметки AI-практик.\n- [governance/rfc/methodology-research-and-proposals.md](../../governance/rfc/methodology-research-and-proposals.md)\n  — ось доверия E0–E4.\n- [research/mango/rag-mapping-roadmap-2026-05.md](rag-mapping-roadmap-2026-05.md)\n  — roadmap автоматизации БА и RAG-навигатор Mango (контекст RAG-подпроцесса).\n- [governance/repo-model.md](../../governance/repo-model.md) — Anti-Inflation\n  principle.\n"
+[2026-06-18T11:48:11.013Z] [INFO]         },
+[2026-06-18T11:48:11.013Z] [INFO]         "caller": {
+[2026-06-18T11:48:11.013Z] [INFO]           "type": "direct"
+[2026-06-18T11:48:11.013Z] [INFO]         }
+[2026-06-18T11:48:11.013Z] [INFO]       }
+[2026-06-18T11:48:11.013Z] [INFO]     ],
+[2026-06-18T11:48:11.013Z] [INFO]     "stop_reason": null,
+[2026-06-18T11:48:11.013Z] [INFO]     "stop_sequence": null,
+[2026-06-18T11:48:11.013Z] [INFO]     "stop_details": null,
+[2026-06-18T11:48:11.013Z] [INFO]     "usage": {
+[2026-06-18T11:48:11.013Z] [INFO]       "input_tokens": 2,
+[2026-06-18T11:48:11.013Z] [INFO]       "cache_creation_input_tokens": 289,
+[2026-06-18T11:48:11.013Z] [INFO]       "cache_read_input_tokens": 58318,
+[2026-06-18T11:48:11.013Z] [INFO]       "cache_creation": {
+[2026-06-18T11:48:11.013Z] [INFO]         "ephemeral_5m_input_tokens": 0,
+[2026-06-18T11:48:11.013Z] [INFO]         "ephemeral_1h_input_tokens": 289
+[2026-06-18T11:48:11.013Z] [INFO]       },
+[2026-06-18T11:48:11.013Z] [INFO]       "output_tokens": 3,
+[2026-06-18T11:48:11.013Z] [INFO]       "service_tier": "standard",
+[2026-06-18T11:48:11.013Z] [INFO]       "inference_geo": "not_available"
+[2026-06-18T11:48:11.013Z] [INFO]     },
+[2026-06-18T11:48:11.013Z] [INFO]     "diagnostics": null,
+[2026-06-18T11:48:11.013Z] [INFO]     "context_management": null
+[2026-06-18T11:48:11.013Z] [INFO]   },
+[2026-06-18T11:48:11.013Z] [INFO]   "parent_tool_use_id": null,
+[2026-06-18T11:48:11.013Z] [INFO]   "session_id": "d65e890a-db60-43f7-aea3-691500f7e26c",
+[2026-06-18T11:48:11.013Z] [INFO]   "uuid": "66336a66-3896-4fe3-9033-56c824178c65",
+[2026-06-18T11:48:11.013Z] [INFO]   "request_id": "req_011CcAfmfuxgYVaGkdvDhLRv"
+[2026-06-18T11:48:11.013Z] [INFO] }
+[2026-06-18T11:48:11.052Z] [INFO] {
+[2026-06-18T11:48:11.052Z] [INFO]   "type": "user",
+[2026-06-18T11:48:11.052Z] [INFO]   "message": {
+[2026-06-18T11:48:11.052Z] [INFO]     "role": "user",
+[2026-06-18T11:48:11.052Z] [INFO]     "content": [
+[2026-06-18T11:48:11.052Z] [INFO]       {
+[2026-06-18T11:48:11.052Z] [INFO]         "tool_use_id": "toolu_01UQx7Fzgm18VMu1EqAbP6J4",
+[2026-06-18T11:48:11.052Z] [INFO]         "type": "tool_result",
+[2026-06-18T11:48:11.052Z] [INFO]         "content": "File created successfully at: /tmp/gh-issue-solver-1781783024578/research/mango/ai-classifications-formalization-2026-06.md (file state is current in your context — no need to Read it back)"
+[2026-06-18T11:48:11.052Z] [INFO]       }
+[2026-06-18T11:48:11.052Z] [INFO]     ]
+[2026-06-18T11:48:11.052Z] [INFO]   },
+[2026-06-18T11:48:11.052Z] [INFO]   "parent_tool_use_id": null,
+[2026-06-18T11:48:11.052Z] [INFO]   "session_id": "d65e890a-db60-43f7-aea3-691500f7e26c",
+[2026-06-18T11:48:11.052Z] [INFO]   "uuid": "b379f699-e98b-430f-9b0a-2293e31bbfad",
+[2026-06-18T11:48:11.052Z] [INFO]   "timestamp": "2026-06-18T11:48:11.048Z",
+[2026-06-18T11:48:11.052Z] [INFO]   "tool_use_result": {
+[2026-06-18T11:48:11.052Z] [INFO]     "type": "create",
+[2026-06-18T11:48:11.052Z] [INFO]     "filePath": "/tmp/gh-issue-solver-1781783024578/research/mango/ai-classifications-formalization-2026-06.md",
+[2026-06-18T11:48:11.052Z] [INFO]     "content": "---\nstatus: draft\nversion: 0.1\nupdated: 2026-06-18\ntemperature: 0.3\nai-generated: true\n---\n\n# Формализация AI-классификаций и интеграция в роадмап Mango\n\n> **Operating Mode:** `Creative` (синтез, формализация, предложения по интеграции)\n> + `Research` (анализ современных AI-фреймворков).\n> **Lifecycle Stage:** `Research → RFC`.\n> **Trust & Evidence:** все AI-подпроцессы ниже размечены как `Candidate`\n> (доверие E1–E2). Ни один из них **не вводится как стандарт** этим документом —\n> он фиксирует формализацию и предложение по интеграции, решение остаётся за\n> Пользователем ([AI_GOVERNANCE.md](../../AI_GOVERNANCE.md), правило 4).\n\n## Назначение\n\nДокумент продолжает линию исследования Вигерса\n([research/hub/wigers-requirements-analysis-2026-06.md](../hub/wigers-requirements-analysis-2026-06.md))\nи синхронизирующего RFC\n([governance/rfc/requirements-engineering-ai-era-2026.md](../../governance/rfc/requirements-engineering-ai-era-2026.md)).\nЕсли RFC отвечал на вопрос «**что** в онтологии mango стоит синхронизировать с\nВигерсом (С1–С5)», то этот документ отвечает на вопрос «**как именно** новые\nAI-подпроцессы устроены внутри (операции / артефакты / связь с классикой) и **как**\nони входят в роадмап Mango, не ломая принятую модель».\n\nДокумент делает четыре вещи:\n\n1. **Детально формализует** 4 новых AI-подпроцесса (инжиниринг промптов, настройка\n   RAG, проектирование оркестрации агентов, тестирование AI-компонентов) — каждый\n   с операциями (вход → действие → выход), артефактами (описательные и исполнимые)\n   и явной связью с классикой Вигерса/BABOK.\n2. **Интегрирует** их в роадмап Mango как **эволюцию операций** (4 фазы), а не как\n   замену классических операций и не как изолированный «AI-процесс».\n3. **Готовит** материал к синхронизации с `mango_ba_prompts` (С1, С2, С3) —\n   в форме, пригодной для последующего issue во внешнем репозитории.\n4. Для каждого нового элемента даёт **полноценный пример** использования и критерии\n   качества.\n\n### Что этот документ НЕ делает\n\n- **Не** объявляет AI-подпроцессы обязательной нормой. Они `Candidate` (E1–E2)\n  до воспроизводимого подтверждения (НФТ Trust & Evidence).\n- **Не** редактирует mango-ADR. ADR #003–#010 живут в репозитории\n  `mango_ba_prompts` и меняются только через его процесс. Здесь — рекомендации\n  Хаба и заготовки для issue, не правки.\n- **Не** заменяет классические операции AI-версиями (см. §«Что мы отвергли»).\n- **Не** создаёт новые каталоги или стандарты «впрок» (Anti-Inflation,\n  [governance/repo-model.md](../../governance/repo-model.md)).\n\n## Терминологическая рамка (двуязычие)\n\n| Русский | English | Краткое определение |\n| --- | --- | --- |\n| Подпроцесс | Subprocess | Связанная группа операций, дополняющая классический процесс Вигерса (Выявление/Анализ/Спецификация/Проверка). |\n| Операция | Operation | Атомарная единица работы вида «вход → действие → выход» (нотация триады mango, [ADR-003](https://github.com/G-Ivan-A/mango_ba_prompts/blob/main/docs/adr/003-ba-ontology.md)). |\n| Артефакт | Artifact | Результат операции; **описательный** (descriptive, для чтения/отладки) или **исполнимый** (executable, потребляется машиной). |\n| Промпт | Prompt | **Интерфейс к Tool**, а не сам Tool; исполнимый артефакт-текст для LLM. |\n| Инжиниринг промптов | Prompt engineering | Подпроцесс, а не тип требования и не операция верхнего уровня. |\n| Спецификация промпта | Prompt specification | **Описательный** документ промпта (назначение, контекст, критерии), не исполнимый артефакт. |\n| AI-ассистированная операция | AI-assisted operation | Классическая операция, усиленная AI, с обязательной валидацией вывода (E0–E4). |\n| Доверие вывода | Trust & Evidence | Ось E0–E4 разметки уверенности AI-вывода ([methodology RFC](../../governance/rfc/methodology-research-and-proposals.md)). |\n| Статус знания | Knowledge Status | `Candidate` → `Applied`: зрелость практики ([research-memory RFC](../../governance/rfc/research-memory-source-intelligence.md)). |\n\n> **Якорь классификации (из Этапа 3).** `Prompt = интерфейс к Tool` (не сам Tool);\n> `Prompt engineering = подпроцесс` (не операция, не тип требования);\n> `Prompt specification = описательный документ` для отладки/guides. Эти три\n> утверждения — несущая рамка всего документа.\n\n## Что мы отвергли и почему\n\n| ❌ Отвергнуто | Почему |\n| --- | --- |\n| «Просто добавить новые операции в список» | Список не показывает **связи**: как подпроцессы стыкуются с классическими операциями и как меняется роадмап. Нужна формализация, а не перечисление. |\n| «Заменить классические операции AI-версиями» | Классические операции **не устаревают** — они дополняются AI-ассистированными версиями. Показываем эволюцию, а не замену. |\n| «Создать отдельные процессы для AI» | AI-разработка — **расширение** существующих процессов Вигерса, а не отдельный процесс. Показываем интеграцию, а не изоляцию. |\n\nЭти три отклонения согласованы с Anti-Inflation principle: новая сложность вводится\nтолько под реальную операционную боль и без сноса принятой модели.\n\n---\n\n## ФТ-1. Детальная формализация AI-подпроцессов\n\nКаждый подпроцесс описан по единому шаблону: **описание → операции (вход/действие/\nвыход) → артефакты (описательные/исполнимые) → связь с классикой → пример →\nкритерии качества → опора на доверенный источник**.\n\nВсе четыре подпроцесса **дополняют** классические процессы Вигерса, а не заменяют\nих. Сводная карта связей:\n\n| Подпроцесс (RU / EN) | Дополняет процесс Вигерса | Гл. Вигерса | Класс артефакта-результата |\n| --- | --- | --- | --- |\n| Инжиниринг промптов / Prompt Engineering | Документирование требований (Спецификация) | Гл. 10 | descriptive + executable |\n| Настройка RAG / RAG Configuration | Проектирование решений (Анализ→Спецификация) | Гл. 12 | descriptive |\n| Проектирование оркестрации агентов / Agent Orchestration Design | Проектирование архитектуры | Гл. 19 | descriptive |\n| Тестирование AI-компонентов / AI Testing | Проверка требований (Валидация) | Гл. 17 | executable |\n\n### 1. Инжиниринг промптов (Prompt Engineering)\n\n**Описание.** Подпроцесс создания, тестирования и валидации промптов для\nAI-компонентов. Промпт здесь — **интерфейс к Tool** (LLM), а инжиниринг промптов —\n**подпроцесс**, дополняющий классическое «Документирование требований».\n\n**Операции:**\n\n| # | Операция (RU / EN) | Вход | Действие | Выход |\n| --- | --- | --- | --- | --- |\n| 1.1 | Анализ задачи для промпта / Prompt task analysis | бизнес-требование, контекст | определение цели промпта, входных/выходных данных | спецификация задачи для промпта |\n| 1.2 | Написание черновика / Draft authoring | спецификация задачи | создание первой версии промпта | черновик промпта |\n| 1.3 | Тестирование промпта / Prompt testing | черновик, тестовые данные | запуск промпта, анализ результатов | результаты тестирования |\n| 1.4 | Итерация промпта / Prompt iteration | результаты тестирования | улучшение промпта по результатам | улучшенная версия промпта |\n| 1.5 | Валидация промпта / Prompt validation | улучшенная версия | финальная проверка соответствия требованиям | валидированный промпт |\n\n**Артефакты:**\n\n- **Spec промпта / Prompt specification** (descriptive): назначение, входные данные,\n  ожидаемый выход, контекст (какие знания использует), критерии качества, примеры\n  использования, связь с бизнес-требованием. Создаётся **только для критичных**\n  (продакшен) промптов (см. ОВ-3).\n- **Исполнимый промпт / Executable prompt** (executable): текст промпта для LLM.\n\n**Связь с классикой.** Дополняет «Документирование требований» (Вигерс, Гл. 10):\nspec промпта — это требование к AI-компоненту, оформленное по тем же принципам\nясности/проверяемости, что и обычная спецификация требования.\n\n**Пример использования.**\n> Бизнес-требование: «Система должна анализировать документацию заказчика и\n> извлекать требования». Операция 1.1 даёт спецификацию задачи (вход = PDF/DOCX ТЗ;\n> выход = список кандидатов-требований с типом по Вигерсу). Операция 1.2 — черновик\n> промпта. Операция 1.3 — прогон на корпусе тестовых ТЗ. Операция 1.5 — валидация\n> по критериям качества и присвоение доверия E2 (`Candidate`).\n\n**Критерии качества:** промпт соответствует бизнес-требованию; проходит\nтестирование на тестовых данных; валидирован по критериям качества; вывод размечен\nдоверием E0–E4.\n\n**Опора (trusted source).** LangChain (`ext-016`,\n[реестр](../external-knowledge/external-sources-registry.md)) — паттерны\nprompt-templates; инсайт о компонуемых паттернах\n([building-effective-agents](../external-knowledge/external-insights/building-effective-agents-2026-06.md),\n`ext-001`): промпт как простой компонуемый шаг, сложность — только под боль.\n\n### 2. Настройка RAG (RAG Configuration)\n\n**Описание.** Подпроцесс настройки Retrieval-Augmented Generation для\nAI-компонентов: выбор хранилища знаний, стратегии разбиения и поиска.\n\n**Операции:**\n\n| # | Операция (RU / EN) | Вход | Действие | Выход |\n| --- | --- | --- | --- | --- |\n| 2.1 | Выбор векторной базы / Vector store selection | требования к хранению знаний | анализ решений (Chroma, Pinecone, YDB) | выбранная векторная база |\n| 2.2 | Настройка chunking / Chunking configuration | документы для индексации | определение стратегии разделения | настроенный chunking |\n| 2.3 | Настройка retrieval / Retrieval configuration | векторная база, chunking | настройка поиска и ранжирования | настроенный retrieval |\n\n**Артефакты:**\n\n- **Документ конфигурации RAG / RAG configuration document** (descriptive):\n  выбранная векторная база и обоснование, стратегия chunking, параметры retrieval,\n  критерии качества поиска (precision/recall на эталонном наборе запросов).\n\n**Связь с классикой.** Дополняет «Проектирование решений» (Вигерс, Гл. 12):\nконфигурация RAG — это проектное решение по доступу к знаниям, с обоснованием\nвыбора, как и любое архитектурное решение.\n\n**Пример использования.**\n> Для AI-навигатора по продуктам Mango (см.\n> [rag-mapping-roadmap-2026-05.md](rag-mapping-roadmap-2026-05.md)) операция 2.1\n> выбирает векторную базу под `kb/product-matrix.md`; 2.2 задаёт chunking по\n> разделам матрицы (1 фича = 1 chunk); 2.3 настраивает retrieval с ранжированием по\n> домену (`voice-ucaas` / `contact-center` / `digital-channels`).\n\n**Критерии качества:** выбор базы обоснован требованиями; chunking сохраняет\nсемантическую цельность единицы знания; retrieval измеряется на эталонном наборе\n(precision/recall), а не «на глаз».\n\n**Опора (trusted source).** LangChain (`ext-016`) — компоненты retrieval/vector\nstores; Microsoft Foundry samples (`ext-018`/`ext-019`) — production-ready шаблоны\nRAG. Утверждения о применимости — доверие E1–E2 (`Candidate`).\n\n### 3. Проектирование оркестрации агентов (Agent Orchestration Design)\n\n**Описание.** Подпроцесс проектирования взаимодействия между AI-агентами в\nмультиагентной системе: роли, сценарии, протоколы, координация.\n\n**Операции:**\n\n| # | Операция (RU / EN) | Вход | Действие | Выход |\n| --- | --- | --- | --- | --- |\n| 3.1 | Определение сценариев взаимодействия / Interaction scenarios definition | бизнес-требования к мультиагентной системе | определение ролей агентов и сценариев | сценарии взаимодействия |\n| 3.2 | Проектирование протоколов / Communication protocols design | сценарии взаимодействия | определение форматов сообщений и протоколов | спецификация протоколов |\n| 3.3 | Настройка координации / Coordination configuration | спецификация протоколов | настройка координации между агентами | настроенная оркестрация |\n\n**Артефакты:**\n\n- **Диаграмма оркестрации агентов / Agent orchestration diagram** (descriptive):\n  роли агентов, сценарии взаимодействия, протоколы коммуникации, механизмы\n  координации (предпочтительно PlantUML, согласно карте диаграмм mango).\n\n**Связь с классикой.** Дополняет «Проектирование архитектуры» (Вигерс, Гл. 19):\nоркестрация — это архитектурное проектирование, где компоненты — агенты, а связи —\nпротоколы коммуникации.\n\n**Пример использования.**\n> Мультиагентный разбор ТЗ: агент-`ingestion` извлекает текст, агент-`understanding`\n> классифицирует требования по Вигерсу, агент-`validation` проверяет согласованность\n> (бизнес-правила, С2). Операция 3.1 фиксирует роли и поток (orchestrator-workers),\n> 3.2 — формат сообщений (требование + доверие E0–E4), 3.3 — координацию (когда\n> вывод эскалируется человеку).\n\n**Критерии качества:** роли и границы ответственности агентов однозначны; протокол\nпереносит метку доверия вывода; сложность оркестрации оправдана (не «агент ради\nагента» — Anti-Inflation, паттерн «простое > монолитное»).\n\n**Опора (trusted source).** Anthropic «Building Effective Agents» (`ext-001`) —\nпаттерны orchestrator-workers / routing / evaluator-optimizer; CrewAI (`ext-017`) —\nпримеры мультиагентной координации; 12-factor agents\n([insight](../external-knowledge/external-insights/12-factor-agents-2026-06.md)) —\nдисциплина границ агента. Все — `Candidate`.\n\n### 4. Тестирование AI-компонентов (AI Testing)\n\n**Описание.** Подпроцесс тестирования AI-компонентов (промптов, RAG, агентов):\nсценарии, прогон, анализ.\n\n**Операции:**\n\n| # | Операция (RU / EN) | Вход | Действие | Выход |\n| --- | --- | --- | --- | --- |\n| 4.1 | Написание тестовых сценариев / Test scenario authoring | спецификации AI-компонентов | создание тестовых сценариев | тестовые сценарии |\n| 4.2 | Запуск тестов / Test execution | тестовые сценарии, AI-компоненты | выполнение тестов | результаты тестов |\n| 4.3 | Анализ результатов / Result analysis | результаты тестов | анализ качества AI-компонентов | отчёт о тестировании |\n\n**Артефакты:**\n\n- **Набор тестов AI / AI test suite** (executable): тестовые сценарии, ожидаемые\n  результаты, критерии прохождения (порог точности, допустимая доля отказов).\n\n**Связь с классикой.** Дополняет «Валидация требований» (Вигерс, Гл. 17): тестовый\nнабор для AI-компонента — это исполнимая форма проверки требования к нему.\n\n**Пример использования.**\n> Для промпта извлечения требований (подпроцесс 1) операция 4.1 готовит набор из 30\n> эталонных ТЗ с размеченными ожидаемыми требованиями; 4.2 прогоняет промпт; 4.3\n> считает precision/recall извлечения и фиксирует регрессии относительно прошлой\n> версии. Набор хранится как executable-артефакт и переиспользуется при итерациях\n> (операция 1.4).\n\n**Критерии качества:** набор покрывает целевые сценарии и граничные случаи; критерии\nпрохождения числовые и воспроизводимые; результат повышает/понижает доверие\nкомпонента (E0–E4) и статус знания (`Candidate`→`Applied`).\n\n**Опора (trusted source).** Microsoft Foundry samples (`ext-018`) — шаблоны оценки;\nметодологический инсайт о воспроизводимости (research-profile) — числовые критерии\nвместо «выглядит хорошо». Доверие E1–E2.\n\n---\n\n## ФТ-2. Эволюция операций в роадмапе Mango\n\nКлючевой тезис: переход операции в AI-версию — **не «включение кнопки»**. Каждая\nAI-ассистированная операция требует осознанного перехода: **обучение → настройка →\nвалидация → интеграция**. Классические операции при этом сохраняются.\n\n### Карта четырёх фаз\n\n| Фаза | Операции | AI-компоненты | Артефакты | Доверие/статус |\n| --- | --- | --- | --- | --- |\n| **Фаза 0 — текущая** | Классические (интервью, анализ документов, документирование) | Базовые промпты (без AI-assisted операций) | Стандартные (ТЗ по ГОСТ, User Story, Use Case) | — |\n| **Фаза 1 — Trust & Evidence** | Классические + AI-assisted версии | Промпты с валидацией (E0–E4) | Стандартные + Prompt specification | E1–E2 `Candidate` |\n| **Фаза 2 — AI-агенты** | Классические + AI-assisted + новые AI-операции | Полноценные подпроцессы (Prompt eng., RAG config, Agent orchestration) | Стандартные + AI-specific (Prompt spec, RAG config doc, Orchestration diagram) | E2–E3, часть `Applied` |\n| **Фаза 3 — Мультиагентные системы** | Полная интеграция классических и AI-операций | Мультиагентные системы | Комплексные AI-решения | `Applied` |\n\n> **Принцип эволюции, а не замены.** В каждой фазе классическая операция остаётся\n> доступной. AI-версия — это **дополнительная** операция к классической (по образцу\n> С3: alias-crosswalk без переименований в mango).\n\n### Пример эволюции одной операции\n\n| Аспект | Классическая | AI-версия (Фаза 1+) |\n| --- | --- | --- |\n| Название | «Анализ документов» / Document analysis | «AI-assisted document analysis» |\n| Что делает | БА вручную читает ТЗ и извлекает требования | LLM извлекает кандидатов, БА валидирует |\n| Артефакт | список требований | список требований + Prompt specification + метка доверия E0–E4 |\n| Риск | трудозатраты, пропуски | галлюцинации → обязательна валидация (ОВ-4) |\n\nАналогично: «Проверка противоречий» → «AI-powered consistency checking» (опирается\nна явные бизнес-правила С2 как формализуемую опору).\n\n### План перехода для каждой операции (4 шага)\n\n1. **Обучение / Training.** Обучение БА работе с AI-инструментами (что такое промпт,\n   как читать доверие вывода, где AI ошибается).\n2. **Настройка / Configuration.** Настройка AI-инструментов под операцию (промпт,\n   RAG, при необходимости — оркестрация).\n3. **Валидация / Validation.** Валидация AI-выводов: каждый вывод получает уровень\n   доверия E0–E4; операция «Проверка AI-вывода» с критериями качества (ОВ-4).\n4. **Интеграция / Integration.** Интеграция в роадмап: операция добавляется как\n   alias к классической (С3), её артефакты — в реестр (С2-подход), уровень — по оси\n   `requirement_level` (С1).\n\n> **Когда начинать Фазу 2.** После завершения Фазы 1 (Trust & Evidence) и\n> синхронизации С1/С2/С3 с `mango_ba_prompts`. Ориентир — сентябрь 2026 (ОВ-5).\n\n---\n\n## ФТ-3. Подготовка к синхронизации с `mango_ba_prompts` (С1, С2, С3)\n\nНиже — **заготовки**, пригодные для оформления issue во внешнем репозитории\n`mango_ba_prompts`. Они **не** редактируют mango-ADR (внешний репозиторий), а\nготовят материал. Приоритет — С1 и С2 (настоящие пробелы), С3 — лёгкий мост.\n\n### С1 — Ось `requirement_level`\n\n- **Описание.** Ортогональная ось-тег для семантической классификации уровня\n  требования, поверх существующей классификации функциональности\n  (`Domain→Capability→Feature→Atomic Function`), **не заменяя** её.\n- **Значения:** `business` / `user` / `functional` / `non-functional`\n  (Бизнес → Пользователь → Функция + НФТ).\n- **Интеграция:** добавить в ADR-003 (онтология БА) как дополнительный тег-ось (по\n  образцу того, как E0–E4 введены ортогонально Knowledge Status).\n- **Пример:** «Система должна отвечать за 2 секунды» → `requirement_level:\n  non-functional`. «Менеджер хочет видеть статус заявки» → `user`.\n- **AI-ценность:** даёт опору для AI-трассировки вверх (функция → бизнес-цель).\n\n### С2 — Тип «Бизнес-правило» + 5 категорий\n\n- **Описание.** Новый тип-артефакт для явного представления бизнес-правил (внешних\n  норм: политик, законов, формул), которым система обязана соответствовать.\n- **Категории (5, по Вигерсу, Гл. 9):**\n\n  | RU | EN | Пример |\n  | --- | --- | --- |\n  | Факты | Facts | «У заказа есть ровно один плательщик» |\n  | Ограничения | Constraints | «Возврат возможен в течение 14 дней» |\n  | Активаторы операций | Operation activators | «При просрочке оплаты — заблокировать номер» |\n  | Выводы | Inferences | «Если клиент VIP, то скидка 10%» |\n  | Вычисления | Computations | «Итог = сумма позиций × (1 − скидка)» |\n\n- **Интеграция:** добавить в реестр артефактов ADR-003 тип `business-rule` со связью\n  «бизнес-правило → порождает → функцию/ограничение».\n- **Пример:** «Если клиент VIP, то скидка 10%» → тип `Business Rule`, категория\n  `Inference`.\n- **AI-ценность:** бизнес-правила — **первый кандидат** на автоматическую проверку\n  согласованности ИИ (AI-powered consistency checking, Фаза 1).\n\n### С3 — Crosswalk Вигерс ↔ операции mango ↔ BCREQ\n\n- **Описание.** Справочная таблица соответствия процессов (alias-crosswalk, **без**\n  переименований в mango — НФТ совместимости).\n- **Интеграция:** жить в RFC Хаба; опционально — примечание со ссылкой в таксономии\n  операций mango (ADR-004).\n\n| Процесс Вигерса (RU / EN) | Операции mango (ADR-004) | Подпроцесс BCREQ (ADR-009) |\n| --- | --- | --- |\n| Выявление / Elicitation | `ingestion`, `understanding` | П1 |\n| Анализ / Analysis | `modeling`, `research`, `impact_analysis`, `reverse_requirements` | П2, П3 |\n| Спецификация / Specification | `documentation`, `solution_design` | П4 |\n| Проверка / Validation | `validation`, `quality` | П5 |\n| Управление / Management | `governance`, `release_readiness`, `risk_analysis` | П6 |\n\n> **Связь AI-подпроцессов с crosswalk.** Новые AI-подпроцессы (ФТ-1) подвешиваются к\n> процессам Вигерса так же, как операции mango: инжиниринг промптов → Спецификация;\n> настройка RAG → Анализ/Спецификация; оркестрация → (Архитектура) Спецификация;\n> тестирование AI → Проверка. Это сохраняет единую трассировку.\n\n---\n\n## ФТ-4. Полноценные примеры и критерии качества (сводка)\n\nДля каждого нового элемента документ даёт: **описание** (что/зачем), **пример**\n(конкретный кейс — см. §ФТ-1), **связь с классикой** (Вигерс/BABOK), **критерии\nкачества** (как проверить). Сквозной пример, связывающий всё воедино:\n\n> **Кейс: AI-извлечение требований из ТЗ заказчика Mango.**\n> 1. **Инжиниринг промптов** создаёт и валидирует промпт извлечения (артефакты:\n>    Prompt spec + executable prompt). Связь: Документирование требований (Гл. 10).\n> 2. **Настройка RAG** даёт промпту доступ к `kb/product-matrix.md` (артефакт: RAG\n>    config doc). Связь: Проектирование решений (Гл. 12).\n> 3. **Проектирование оркестрации** связывает агентов `ingestion → understanding →\n>    validation` (артефакт: orchestration diagram). Связь: Архитектура (Гл. 19).\n> 4. **Тестирование AI** прогоняет всё на 30 эталонных ТЗ (артефакт: AI test suite).\n>    Связь: Валидация (Гл. 17).\n> 5. Результат размечается доверием **E2 `Candidate`**; уровень требований — по оси\n>    **С1**; найденные правила — тип **С2**; операции маппятся по **С3**.\n\nЭтот кейс соответствует Фазе 1→2 роадмапа и не заменяет ни одну классическую\nоперацию — он добавляет AI-версии поверх них.\n\n---\n\n## Связь с НФТ\n\n| НФТ | Как выполнено |\n| --- | --- |\n| Полнота | 4 подпроцесса описаны не списком, а по единому шаблону (операции/артефакты/связь/пример/критерии). |\n| Примеры | Для каждого элемента — конкретный кейс (§ФТ-1, §ФТ-4). |\n| Связь с классикой | Каждый подпроцесс привязан к главе Вигерса; операции — к BABOK через С3. |\n| Интеграция | Подпроцессы вписаны в 4 фазы роадмапа, а не изолированы. |\n| Двуязычие | Все термины — русский + английский (см. таблицы). |\n| Доверенные ресурсы | Опора на LangChain (`ext-016`), CrewAI (`ext-017`), Microsoft Foundry (`ext-018`/`ext-019`), Anthropic/12-factor (`ext-001`, инсайты); без выдумывания. |\n| Trust & Evidence | Все AI-практики — `Candidate` E1–E2; нормой не объявлены. |\n| Anti-Inflation | Без новых каталогов/стандартов «впрок»; приоритет С1/С2. |\n\n---\n\n## Открытые вопросы\n\n**ОВ-1. Нужно ли создавать отдельные стандарты для AI-подпроцессов?**\nНет. Достаточно описания в этом документе/RFC. Стандарты создаются при возникновении\nконкретной боли (Anti-Inflation).\n\n**ОВ-2. Как интегрировать AI-assisted операции в существующие стандарты mango?**\nЧерез обновление ADR-004 (таксономия операций) — добавить AI-версии как\n**дополнительные** операции к классическим (alias, без переименований, С3).\n\n**ОВ-3. Нужно ли создавать Prompt specification для всех промптов в mango?**\nНет, только для **критичных** (продакшен) промптов. Для экспериментальных достаточно\nисполнимого промпта.\n\n**ОВ-4. Как валидировать AI-выводы в AI-assisted операциях?**\nЧерез Trust & Evidence (E0–E4): каждый AI-вывод получает уровень доверия. Валидация —\nэто операция «Проверка AI-вывода» с числовыми критериями качества.\n\n**ОВ-5. Когда начинать Фазу 2 (AI-агенты) в роадмапе Mango?**\nПосле завершения Фазы 1 (Trust & Evidence) и синхронизации С1/С2/С3 с\n`mango_ba_prompts`. Ориентировочно — сентябрь 2026.\n\n**ОВ-6. Кто владелец синхронизации между Хабом и `mango_ba_prompts`?**\nРепозитории независимы; нужен явный канал. Решение и инициирование issue во внешнем\nрепозитории — за Пользователем (наследует Open Decision RFC).\n\n---\n\n## Источники\n\n- **Первоисточник Вигерса:** Wiegers, K., Beatty, J. *Software Requirements*, 3rd\n  ed., Microsoft Press, 2013 (рус. «Разработка требований к ПО», 2020) — главы 9, 10,\n  12, 17, 19.\n- **Доверенные AI-фреймворки (по реестру\n  [external-sources-registry.md](../external-knowledge/external-sources-registry.md)):**\n  - LangChain — `ext-016` (<https://github.com/langchain-ai/langchain>)\n  - CrewAI — `ext-017` (<https://github.com/crewAIInc/crewAI-examples>)\n  - Microsoft Foundry samples — `ext-018`\n    (<https://github.com/microsoft-foundry/foundry-samples>); AI solution templates —\n    `ext-019`\n  - Microsoft — Agentic AI adoption maturity model — `ext-029`\n- **Инсайты Хаба:**\n  [building-effective-agents](../external-knowledge/external-insights/building-effective-agents-2026-06.md)\n  (`ext-001`),\n  [12-factor-agents](../external-knowledge/external-insights/12-factor-agents-2026-06.md).\n- **mango-ADR (внешний репозиторий `mango_ba_prompts`, не редактируются здесь):**\n  ADR-003 <https://github.com/G-Ivan-A/mango_ba_prompts/blob/main/docs/adr/003-ba-ontology.md> ·\n  ADR-004 <https://github.com/G-Ivan-A/mango_ba_prompts/blob/main/docs/adr/004-operations-taxonomy.md> ·\n  ADR-009 <https://github.com/G-Ivan-A/mango_ba_prompts/blob/main/docs/adr/009-bcreq-formation-process.md>.\n\n## Связанные артефакты\n\n- [governance/rfc/requirements-engineering-ai-era-2026.md](../../governance/rfc/requirements-engineering-ai-era-2026.md)\n  — RFC синхронизации Вигерс ↔ mango (С1–С5); базовый контракт этого документа.\n- [research/hub/wigers-requirements-analysis-2026-06.md](../hub/wigers-requirements-analysis-2026-06.md)\n  — независимое извлечение системы Вигерса (доказательная база).\n- [governance/rfc/research-memory-source-intelligence.md](../../governance/rfc/research-memory-source-intelligence.md)\n  — Knowledge Status (`Candidate`/`Applied`) для разметки AI-практик.\n- [governance/rfc/methodology-research-and-proposals.md](../../governance/rfc/methodology-research-and-proposals.md)\n  — ось доверия E0–E4.\n- [research/mango/rag-mapping-roadmap-2026-05.md](rag-mapping-roadmap-2026-05.md)\n  — roadmap автоматизации БА и RAG-навигатор Mango (контекст RAG-подпроцесса).\n- [governance/repo-model.md](../../governance/repo-model.md) — Anti-Inflation\n  principle.\n",
+[2026-06-18T11:48:11.052Z] [INFO]     "structuredPatch": [],
+[2026-06-18T11:48:11.052Z] [INFO]     "originalFile": null,
+[2026-06-18T11:48:11.052Z] [INFO]     "userModified": false
+[2026-06-18T11:48:11.052Z] [INFO]   }
+[2026-06-18T11:48:11.052Z] [INFO] }
+[2026-06-18T11:48:11.114Z] [INFO] [log_b6e768] sending request {
+[2026-06-18T11:48:11.118Z] [INFO]   method: "post",
+[2026-06-18T11:48:11.119Z] [INFO]   url: "https://api.anthropic.com/v1/messages?beta=true",
+[2026-06-18T11:48:11.121Z] [INFO]   options: {
+[2026-06-18T11:48:11.126Z] [INFO]     method: "post",
+[2026-06-18T11:48:11.129Z] [INFO]     path: "/v1/messages?beta=true",
+[2026-06-18T11:48:11.131Z] [INFO]     body: {
+[2026-06-18T11:48:11.132Z] [INFO]       model: "claude-opus-4-8",
+[2026-06-18T11:48:11.133Z] [INFO]       messages: [
+[2026-06-18T11:48:11.133Z] [INFO]         [Object ...], [Object ...], [Object ...], [Object ...], [Object ...], [Object ...], [Object ...], [Object ...], [Object ...], [Object ...], [Object ...], [Object ...], [Object ...], [Object ...], [Object ...], [Object ...], [Object ...], [Object ...], [Object ...], [Object ...], [Object ...], [Object ...], [Object ...], [Object ...], [Object ...], [Object ...], [Object ...], [Object ...]
+[2026-06-18T11:48:11.134Z] [INFO]       ],
+[2026-06-18T11:48:11.135Z] [INFO]       system: [
+[2026-06-18T11:48:11.135Z] [INFO]         [Object ...], [Object ...], [Object ...], [Object ...]
+[2026-06-18T11:48:11.136Z] [INFO]       ],
+[2026-06-18T11:48:11.137Z] [INFO]       tools: [
+[2026-06-18T11:48:11.138Z] [INFO]         [Object ...], [Object ...], [Object ...], [Object ...], [Object ...], [Object ...], [Object ...], [Object ...], [Object ...], [Object ...]
+[2026-06-18T11:48:11.138Z] [INFO]       ],
+[2026-06-18T11:48:11.139Z] [INFO]       tool_choice: undefined,
+[2026-06-18T11:48:11.140Z] [INFO]       metadata: [Object ...],
+[2026-06-18T11:48:11.141Z] [INFO]       max_tokens: 128000,
+[2026-06-18T11:48:11.141Z] [INFO]       thinking: [Object ...],
+[2026-06-18T11:48:11.142Z] [INFO]       context_management: [Object ...],
+[2026-06-18T11:48:11.142Z] [INFO]       output_config: [Object ...],
+[2026-06-18T11:48:11.142Z] [INFO]       diagnostics: [Object ...],
+[2026-06-18T11:48:11.143Z] [INFO]       stream: true,
+[2026-06-18T11:48:11.143Z] [INFO]     },
+[2026-06-18T11:48:11.144Z] [INFO]     timeout: 600000,
+[2026-06-18T11:48:11.145Z] [INFO]     signal: AbortSignal {
+[2026-06-18T11:48:11.145Z] [INFO]       [Symbol(events.maxEventTargetListeners)]: 50,
+[2026-06-18T11:48:11.146Z] [INFO]       [Symbol(events.maxEventTargetListenersWarned)]: false,
+[2026-06-18T11:48:11.146Z] [INFO]       aborted: false,
+[2026-06-18T11:48:11.146Z] [INFO]       reason: undefined,
+[2026-06-18T11:48:11.146Z] [INFO]       onabort: null,
+[2026-06-18T11:48:11.147Z] [INFO]       throwIfAborted: [Function: throwIfAborted],
+[2026-06-18T11:48:11.149Z] [INFO]       addEventListener: [Function: addEventListener],
+[2026-06-18T11:48:11.149Z] [INFO]       removeEventListener: [Function: removeEventListener],
+[2026-06-18T11:48:11.150Z] [INFO]       dispatchEvent: [Function: dispatchEvent],
+[2026-06-18T11:48:11.150Z] [INFO]     },
+[2026-06-18T11:48:11.150Z] [INFO]     stream: true,
+[2026-06-18T11:48:11.150Z] [INFO]   },
+[2026-06-18T11:48:11.151Z] [INFO]   headers: {
+[2026-06-18T11:48:11.151Z] [INFO]     accept: "application/json",
+[2026-06-18T11:48:11.151Z] [INFO]     "anthropic-beta": "claude-code-20250219,oauth-2025-04-20,interleaved-thinking-2025-05-14,thinking-token-count-2026-05-13,context-management-2025-06-27,prompt-caching-scope-2026-01-05,mid-conversation-system-2026-04-07,advisor-tool-2026-03-01,advanced-tool-use-2025-11-20,effort-2025-11-24,extended-cache-ttl-2025-04-11,cache-diagnosis-2026-04-07",
+[2026-06-18T11:48:11.151Z] [INFO]     "anthropic-dangerous-direct-browser-access": "true",
+[2026-06-18T11:48:11.152Z] [INFO]     "anthropic-version": "2023-06-01",
+[2026-06-18T11:48:11.152Z] [INFO]     authorization: "***",
+[2026-06-18T11:48:11.152Z] [INFO]     "content-type": "application/json",
+[2026-06-18T11:48:11.153Z] [INFO]     "user-agent": "claude-cli/2.1.181 (external, sdk-cli)",
+[2026-06-18T11:48:11.154Z] [INFO]     "x-app": "cli",
+[2026-06-18T11:48:11.154Z] [INFO]     "x-claude-code-session-id": "d65e890a-db60-43f7-aea3-691500f7e26c",
+[2026-06-18T11:48:11.154Z] [INFO]     "x-client-request-id": "3b2dba27-0fd0-4389-92aa-20e03e494d89",
+[2026-06-18T11:48:11.154Z] [INFO]     "x-stainless-arch": "x64",
+[2026-06-18T11:48:11.155Z] [INFO]     "x-stainless-lang": "js",
+[2026-06-18T11:48:11.156Z] [INFO]     "x-stainless-os": "Linux",
+[2026-06-18T11:48:11.158Z] [INFO]     "x-stainless-package-version": "0.94.0",
+[2026-06-18T11:48:11.159Z] [INFO]     "x-stainless-retry-count": "0",
+[2026-06-18T11:48:11.160Z] [INFO]     "x-stainless-runtime": "node",
+[2026-06-18T11:48:11.161Z] [INFO]     "x-stainless-runtime-version": "v24.3.0",
+[2026-06-18T11:48:11.162Z] [INFO]     "x-stainless-timeout": "600",
+[2026-06-18T11:48:11.162Z] [INFO]   },
+[2026-06-18T11:48:11.163Z] [INFO] }
+[2026-06-18T11:48:12.375Z] [INFO] [log_b6e768, request-id: "req_011CcAfxByzorEDhnY6aPmqq"] post https://api.anthropic.com/v1/messages?beta=true succeeded with status 200 in 1262ms
+[2026-06-18T11:48:12.376Z] [INFO] [log_b6e768] response start {
+[2026-06-18T11:48:12.378Z] [INFO]   url: "https://api.anthropic.com/v1/messages?beta=true",
+[2026-06-18T11:48:12.379Z] [INFO]   status: 200,
+[2026-06-18T11:48:12.381Z] [INFO]   headers: {
+[2026-06-18T11:48:12.382Z] [INFO]     "anthropic-organization-id": "ebc2ac93-f86f-4d15-aff3-de8830d8d789",
+[2026-06-18T11:48:12.383Z] [INFO]     "anthropic-ratelimit-unified-5h-reset": "1781787000",
+[2026-06-18T11:48:12.383Z] [INFO]     "anthropic-ratelimit-unified-5h-status": "allowed",
+[2026-06-18T11:48:12.383Z] [INFO]     "anthropic-ratelimit-unified-5h-utilization": "0.34",
+[2026-06-18T11:48:12.384Z] [INFO]     "anthropic-ratelimit-unified-7d-reset": "1782212400",
+[2026-06-18T11:48:12.384Z] [INFO]     "anthropic-ratelimit-unified-7d-status": "allowed",
+[2026-06-18T11:48:12.384Z] [INFO]     "anthropic-ratelimit-unified-7d-utilization": "0.62",
+[2026-06-18T11:48:12.385Z] [INFO]     "anthropic-ratelimit-unified-fallback-percentage": "0.5",
+[2026-06-18T11:48:12.385Z] [INFO]     "anthropic-ratelimit-unified-overage-disabled-reason": "org_level_disabled",
+[2026-06-18T11:48:12.385Z] [INFO]     "anthropic-ratelimit-unified-overage-status": "rejected",
+[2026-06-18T11:48:12.385Z] [INFO]     "anthropic-ratelimit-unified-representative-claim": "five_hour",
+[2026-06-18T11:48:12.387Z] [INFO]     "anthropic-ratelimit-unified-reset": "1781787000",
+[2026-06-18T11:48:12.388Z] [INFO]     "anthropic-ratelimit-unified-status": "allowed",
+[2026-06-18T11:48:12.388Z] [INFO]     "cache-control": "no-cache",
+[2026-06-18T11:48:12.388Z] [INFO]     "cf-cache-status": "DYNAMIC",
+[2026-06-18T11:48:12.389Z] [INFO]     "cf-ray": "a0da10419e73b19e-FRA",
+[2026-06-18T11:48:12.389Z] [INFO]     connection: "keep-alive",
+[2026-06-18T11:48:12.390Z] [INFO]     "content-encoding": "gzip",
+[2026-06-18T11:48:12.390Z] [INFO]     "content-security-policy": "default-src 'none'; frame-ancestors 'none'",
+[2026-06-18T11:48:12.390Z] [INFO]     "content-type": "text/event-stream; charset=utf-8",
+[2026-06-18T11:48:12.391Z] [INFO]     date: "Thu, 18 Jun 2026 11:48:12 GMT",
+[2026-06-18T11:48:12.391Z] [INFO]     "request-id": "req_011CcAfxByzorEDhnY6aPmqq",
+[2026-06-18T11:48:12.391Z] [INFO]     server: "cloudflare",
+[2026-06-18T11:48:12.391Z] [INFO]     "strict-transport-security": "max-age=31536000; includeSubDomains; preload",
+[2026-06-18T11:48:12.392Z] [INFO]     traceresponse: "00-c2fb88762bd5d03431e23b58857633a5-28c7235fe3acd76d-01",
+[2026-06-18T11:48:12.392Z] [INFO]     "transfer-encoding": "chunked",
+[2026-06-18T11:48:12.392Z] [INFO]     vary: "Accept-Encoding",
+[2026-06-18T11:48:12.392Z] [INFO]     "x-robots-tag": "none",
+[2026-06-18T11:48:12.393Z] [INFO]     "set-cookie": "***",
+[2026-06-18T11:48:12.394Z] [INFO]   },
+[2026-06-18T11:48:12.395Z] [INFO]   durationMs: 1262,
+[2026-06-18T11:48:12.395Z] [INFO] }
+[2026-06-18T11:48:12.396Z] [INFO] response 200 https://api.anthropic.com/v1/messages?beta=true Headers {
+[2026-06-18T11:48:12.396Z] [INFO]   "date": "Thu, 18 Jun 2026 11:48:12 GMT",
+[2026-06-18T11:48:12.397Z] [INFO]   "content-type": "text/event-stream; charset=utf-8",
+[2026-06-18T11:48:12.397Z] [INFO]   "transfer-encoding": "chunked",
+[2026-06-18T11:48:12.398Z] [INFO]   "connection": "keep-alive",
+[2026-06-18T11:48:12.398Z] [INFO]   "cache-control": "no-cache",
+[2026-06-18T11:48:12.398Z] [INFO]   "strict-transport-security": "max-age=31536000; includeSubDomains; preload",
+[2026-06-18T11:48:12.398Z] [INFO]   "content-encoding": "gzip",
+[2026-06-18T11:48:12.398Z] [INFO]   "vary": "Accept-Encoding",
+[2026-06-18T11:48:12.399Z] [INFO]   "content-security-policy": "default-src 'none'; frame-ancestors 'none'",
+[2026-06-18T11:48:12.399Z] [INFO]   "set-cookie": [ "_cfuvid=hds1OruleI5BmHcLp84DnMn19ORbu4GmEhS_IGuwVUY-1781783291.1315372-1.0.1.1-dJ9YDoPcTssVJGcYi8pCWPLblHWXW3TS4Vc9Gsvp8X8; HttpOnly; SameSite=None; Secure; Path=/; Domain=api.anthropic.com" ],
+[2026-06-18T11:48:12.399Z] [INFO]   "anthropic-ratelimit-unified-status": "allowed",
+[2026-06-18T11:48:12.399Z] [INFO]   "anthropic-ratelimit-unified-5h-status": "allowed",
+[2026-06-18T11:48:12.400Z] [INFO]   "anthropic-ratelimit-unified-5h-reset": "1781787000",
+[2026-06-18T11:48:12.400Z] [INFO]   "anthropic-ratelimit-unified-5h-utilization": "0.34",
+[2026-06-18T11:48:12.400Z] [INFO]   "anthropic-ratelimit-unified-7d-status": "allowed",
+[2026-06-18T11:48:12.400Z] [INFO]   "anthropic-ratelimit-unified-7d-reset": "1782212400",
+[2026-06-18T11:48:12.400Z] [INFO]   "anthropic-ratelimit-unified-7d-utilization": "0.62",
+[2026-06-18T11:48:12.401Z] [INFO]   "anthropic-ratelimit-unified-representative-claim": "five_hour",
+[2026-06-18T11:48:12.401Z] [INFO]   "anthropic-ratelimit-unified-fallback-percentage": "0.5",
+[2026-06-18T11:48:12.402Z] [INFO]   "anthropic-ratelimit-unified-reset": "1781787000",
+[2026-06-18T11:48:12.402Z] [INFO]   "anthropic-ratelimit-unified-overage-disabled-reason": "org_level_disabled",
+[2026-06-18T11:48:12.403Z] [INFO]   "anthropic-ratelimit-unified-overage-status": "rejected",
+[2026-06-18T11:48:12.403Z] [INFO]   "request-id": "req_011CcAfxByzorEDhnY6aPmqq",
+[2026-06-18T11:48:12.404Z] [INFO]   "anthropic-organization-id": "ebc2ac93-f86f-4d15-aff3-de8830d8d789",
+[2026-06-18T11:48:12.404Z] [INFO]   "traceresponse": "00-c2fb88762bd5d03431e23b58857633a5-28c7235fe3acd76d-01",
+[2026-06-18T11:48:12.404Z] [INFO]   "server": "cloudflare",
+[2026-06-18T11:48:12.405Z] [INFO]   "cf-cache-status": "DYNAMIC",
+[2026-06-18T11:48:12.405Z] [INFO]   "x-robots-tag": "none",
+[2026-06-18T11:48:12.405Z] [INFO]   "cf-ray": "a0da10419e73b19e-FRA",
+[2026-06-18T11:48:12.406Z] [INFO] } ReadableStream {
+[2026-06-18T11:48:12.406Z] [INFO]   blob: [Function: blob],
+[2026-06-18T11:48:12.406Z] [INFO]   bytes: [Function: bytes],
+[2026-06-18T11:48:12.407Z] [INFO]   cancel: [Function],
+[2026-06-18T11:48:12.407Z] [INFO]   getReader: [Function],
+[2026-06-18T11:48:12.408Z] [INFO]   json: [Function: json],
+[2026-06-18T11:48:12.408Z] [INFO]   locked: [Getter],
+[2026-06-18T11:48:12.409Z] [INFO]   pipeThrough: [Function],
+[2026-06-18T11:48:12.409Z] [INFO]   pipeTo: [Function],
+[2026-06-18T11:48:12.409Z] [INFO]   tee: [Function],
+[2026-06-18T11:48:12.410Z] [INFO]   text: [Function: text],
+[2026-06-18T11:48:12.411Z] [INFO]   values: [Function: values],
+[2026-06-18T11:48:12.411Z] [INFO]   [Symbol(Symbol.asyncIterator)]: [Function: asyncIterator2],
+[2026-06-18T11:48:12.413Z] [INFO] }
+[2026-06-18T11:48:12.414Z] [INFO] [log_b6e768] response parsed {
+[2026-06-18T11:48:12.414Z] [INFO]   url: "https://api.anthropic.com/v1/messages?beta=true",
+[2026-06-18T11:48:12.416Z] [INFO]   status: 200,
+[2026-06-18T11:48:12.417Z] [INFO]   body: sU {
+[2026-06-18T11:48:12.418Z] [INFO]     iterator: [AsyncGeneratorFunction: s],
+[2026-06-18T11:48:12.419Z] [INFO]     controller: AbortController {
+[2026-06-18T11:48:12.419Z] [INFO]       signal: [AbortSignal ...],
+[2026-06-18T11:48:12.420Z] [INFO]       abort: [Function: abort],
+[2026-06-18T11:48:12.420Z] [INFO]     },
+[2026-06-18T11:48:12.421Z] [INFO]     [Symbol(Symbol.asyncIterator)]: [Function],
+[2026-06-18T11:48:12.421Z] [INFO]     tee: [Function: tee],
+[2026-06-18T11:48:12.424Z] [INFO]     toReadableStream: [Function: toReadableStream],
+[2026-06-18T11:48:12.425Z] [INFO]   },
+[2026-06-18T11:48:12.425Z] [INFO]   durationMs: 1263,
+[2026-06-18T11:48:12.425Z] [INFO] }
+[2026-06-18T11:48:13.151Z] [INFO] {
+[2026-06-18T11:48:13.151Z] [INFO]   "type": "assistant",
+[2026-06-18T11:48:13.151Z] [INFO]   "message": {
+[2026-06-18T11:48:13.151Z] [INFO]     "model": "claude-opus-4-8",
+[2026-06-18T11:48:13.151Z] [INFO]     "id": "msg_01SQ62fnshxdjYdnQaBJnTjm",
+[2026-06-18T11:48:13.151Z] [INFO]     "type": "message",
+[2026-06-18T11:48:13.151Z] [INFO]     "role": "assistant",
+[2026-06-18T11:48:13.151Z] [INFO]     "content": [
+[2026-06-18T11:48:13.151Z] [INFO]       {
+[2026-06-18T11:48:13.151Z] [INFO]         "type": "text",
+[2026-06-18T11:48:13.151Z] [INFO]         "text": "Now update navigation (README) and artifact-map."
+[2026-06-18T11:48:13.151Z] [INFO]       }
+[2026-06-18T11:48:13.151Z] [INFO]     ],
+[2026-06-18T11:48:13.151Z] [INFO]     "stop_reason": null,
+[2026-06-18T11:48:13.151Z] [INFO]     "stop_sequence": null,
+[2026-06-18T11:48:13.151Z] [INFO]     "stop_details": null,
+[2026-06-18T11:48:13.151Z] [INFO]     "usage": {
+[2026-06-18T11:48:13.151Z] [INFO]       "input_tokens": 2,
+[2026-06-18T11:48:13.151Z] [INFO]       "cache_creation_input_tokens": 11925,
+[2026-06-18T11:48:13.151Z] [INFO]       "cache_read_input_tokens": 58607,
+[2026-06-18T11:48:13.151Z] [INFO]       "cache_creation": {
+[2026-06-18T11:48:13.151Z] [INFO]         "ephemeral_5m_input_tokens": 0,
+[2026-06-18T11:48:13.151Z] [INFO]         "ephemeral_1h_input_tokens": 11925
+[2026-06-18T11:48:13.151Z] [INFO]       },
+[2026-06-18T11:48:13.151Z] [INFO]       "output_tokens": 4,
+[2026-06-18T11:48:13.151Z] [INFO]       "service_tier": "standard",
+[2026-06-18T11:48:13.151Z] [INFO]       "inference_geo": "not_available"
+[2026-06-18T11:48:13.151Z] [INFO]     },
+[2026-06-18T11:48:13.151Z] [INFO]     "diagnostics": null,
+[2026-06-18T11:48:13.151Z] [INFO]     "context_management": null
+[2026-06-18T11:48:13.151Z] [INFO]   },
+[2026-06-18T11:48:13.151Z] [INFO]   "parent_tool_use_id": null,
+[2026-06-18T11:48:13.151Z] [INFO]   "session_id": "d65e890a-db60-43f7-aea3-691500f7e26c",
+[2026-06-18T11:48:13.151Z] [INFO]   "uuid": "57588f18-c0a7-4276-9149-6499694774dd",
+[2026-06-18T11:48:13.151Z] [INFO]   "request_id": "req_011CcAfxByzorEDhnY6aPmqq"
+[2026-06-18T11:48:13.151Z] [INFO] }
+[2026-06-18T11:48:17.490Z] [INFO] {
+[2026-06-18T11:48:17.490Z] [INFO]   "type": "assistant",
+[2026-06-18T11:48:17.490Z] [INFO]   "message": {
+[2026-06-18T11:48:17.490Z] [INFO]     "model": "claude-opus-4-8",
+[2026-06-18T11:48:17.490Z] [INFO]     "id": "msg_01SQ62fnshxdjYdnQaBJnTjm",
+[2026-06-18T11:48:17.490Z] [INFO]     "type": "message",
+[2026-06-18T11:48:17.490Z] [INFO]     "role": "assistant",
+[2026-06-18T11:48:17.490Z] [INFO]     "content": [
+[2026-06-18T11:48:17.490Z] [INFO]       {
+[2026-06-18T11:48:17.490Z] [INFO]         "type": "tool_use",
+[2026-06-18T11:48:17.490Z] [INFO]         "id": "toolu_01UzZbUEUWpzHzXrxES16eeU",
+[2026-06-18T11:48:17.490Z] [INFO]         "name": "Edit",
+[2026-06-18T11:48:17.490Z] [INFO]         "input": {
+[2026-06-18T11:48:17.490Z] [INFO]           "replace_all": false,
+[2026-06-18T11:48:17.490Z] [INFO]           "file_path": "/tmp/gh-issue-solver-1781783024578/research/mango/README.md",
+[2026-06-18T11:48:17.490Z] [INFO]           "old_string": "| [capability-decomposition-2026-05.md](capability-decomposition-2026-05.md) | Справочник атомарных функций пилотных доменов (`voice-ucaas`, `contact-center`, `digital-channels`): параметры, международные источники, примеры ТЗ и связь с НФТ-классами. |",
+[2026-06-18T11:48:17.490Z] [INFO]           "new_string": "| [capability-decomposition-2026-05.md](capability-decomposition-2026-05.md) | Справочник атомарных функций пилотных доменов (`voice-ucaas`, `contact-center`, `digital-channels`): параметры, международные источники, примеры ТЗ и связь с НФТ-классами. |\n| [ai-classifications-formalization-2026-06.md](ai-classifications-formalization-2026-06.md) | Формализация 4 новых AI-подпроцессов (инжиниринг промптов, RAG, оркестрация агентов, тестирование AI), эволюция операций в роадмапе Mango (4 фазы) и подготовка синхронизации с `mango_ba_prompts` (С1/С2/С3). |"
+[2026-06-18T11:48:17.490Z] [INFO]         },
+[2026-06-18T11:48:17.490Z] [INFO]         "caller": {
+[2026-06-18T11:48:17.490Z] [INFO]           "type": "direct"
+[2026-06-18T11:48:17.490Z] [INFO]         }
+[2026-06-18T11:48:17.490Z] [INFO]       }
+[2026-06-18T11:48:17.490Z] [INFO]     ],
+[2026-06-18T11:48:17.490Z] [INFO]     "stop_reason": null,
+[2026-06-18T11:48:17.490Z] [INFO]     "stop_sequence": null,
+[2026-06-18T11:48:17.490Z] [INFO]     "stop_details": null,
+[2026-06-18T11:48:17.490Z] [INFO]     "usage": {
+[2026-06-18T11:48:17.490Z] [INFO]       "input_tokens": 2,
+[2026-06-18T11:48:17.490Z] [INFO]       "cache_creation_input_tokens": 11925,
+[2026-06-18T11:48:17.490Z] [INFO]       "cache_read_input_tokens": 58607,
+[2026-06-18T11:48:17.490Z] [INFO]       "cache_creation": {
+[2026-06-18T11:48:17.490Z] [INFO]         "ephemeral_5m_input_tokens": 0,
+[2026-06-18T11:48:17.490Z] [INFO]         "ephemeral_1h_input_tokens": 11925
+[2026-06-18T11:48:17.490Z] [INFO]       },
+[2026-06-18T11:48:17.490Z] [INFO]       "output_tokens": 4,
+[2026-06-18T11:48:17.490Z] [INFO]       "service_tier": "standard",
+[2026-06-18T11:48:17.490Z] [INFO]       "inference_geo": "not_available"
+[2026-06-18T11:48:17.490Z] [INFO]     },
+[2026-06-18T11:48:17.490Z] [INFO]     "diagnostics": null,
+[2026-06-18T11:48:17.490Z] [INFO]     "context_management": null
+[2026-06-18T11:48:17.490Z] [INFO]   },
+[2026-06-18T11:48:17.490Z] [INFO]   "parent_tool_use_id": null,
+[2026-06-18T11:48:17.490Z] [INFO]   "session_id": "d65e890a-db60-43f7-aea3-691500f7e26c",
+[2026-06-18T11:48:17.490Z] [INFO]   "uuid": "8cb1b107-3c1b-439f-877a-1e43f7248e76",
+[2026-06-18T11:48:17.490Z] [INFO]   "request_id": "req_011CcAfxByzorEDhnY6aPmqq"
+[2026-06-18T11:48:17.490Z] [INFO] }
+[2026-06-18T11:48:17.502Z] [INFO] {
+[2026-06-18T11:48:17.502Z] [INFO]   "type": "user",
+[2026-06-18T11:48:17.502Z] [INFO]   "message": {
+[2026-06-18T11:48:17.502Z] [INFO]     "role": "user",
+[2026-06-18T11:48:17.502Z] [INFO]     "content": [
+[2026-06-18T11:48:17.502Z] [INFO]       {
+[2026-06-18T11:48:17.502Z] [INFO]         "tool_use_id": "toolu_01UzZbUEUWpzHzXrxES16eeU",
+[2026-06-18T11:48:17.502Z] [INFO]         "type": "tool_result",
+[2026-06-18T11:48:17.502Z] [INFO]         "content": "The file /tmp/gh-issue-solver-1781783024578/research/mango/README.md has been updated successfully. (file state is current in your context — no need to Read it back)"
+[2026-06-18T11:48:17.502Z] [INFO]       }
+[2026-06-18T11:48:17.502Z] [INFO]     ]
+[2026-06-18T11:48:17.502Z] [INFO]   },
+[2026-06-18T11:48:17.502Z] [INFO]   "parent_tool_use_id": null,
+[2026-06-18T11:48:17.502Z] [INFO]   "session_id": "d65e890a-db60-43f7-aea3-691500f7e26c",
+[2026-06-18T11:48:17.502Z] [INFO]   "uuid": "4910482e-5c77-45bf-b6a1-6a16d6af456a",
+[2026-06-18T11:48:17.502Z] [INFO]   "timestamp": "2026-06-18T11:48:17.500Z",
+[2026-06-18T11:48:17.502Z] [INFO]   "tool_use_result": {
+[2026-06-18T11:48:17.502Z] [INFO]     "filePath": "/tmp/gh-issue-solver-1781783024578/research/mango/README.md",
+[2026-06-18T11:48:17.502Z] [INFO]     "oldString": "| [capability-decomposition-2026-05.md](capability-decomposition-2026-05.md) | Справочник атомарных функций пилотных доменов (`voice-ucaas`, `contact-center`, `digital-channels`): параметры, международные источники, примеры ТЗ и связь с НФТ-классами. |",
+[2026-06-18T11:48:17.502Z] [INFO]     "newString": "| [capability-decomposition-2026-05.md](capability-decomposition-2026-05.md) | Справочник атомарных функций пилотных доменов (`voice-ucaas`, `contact-center`, `digital-channels`): параметры, международные источники, примеры ТЗ и связь с НФТ-классами. |\n| [ai-classifications-formalization-2026-06.md](ai-classifications-formalization-2026-06.md) | Формализация 4 новых AI-подпроцессов (инжиниринг промптов, RAG, оркестрация агентов, тестирование AI), эволюция операций в роадмапе Mango (4 фазы) и подготовка синхронизации с `mango_ba_prompts` (С1/С2/С3). |",
+[2026-06-18T11:48:17.502Z] [INFO]     "originalFile": "---\nstatus: canonical\nversion: 1.0\nupdated: 2026-05-26\ntemperature: 0.1\nai-generated: false\nsource: research/mango/README-old.md\n---\n\n# Research: MANGO OFFICE\n\nИсследовательские материалы по классификации продуктов, требований,\nдокументационной стратегии и flow анализа тендерных ТЗ MANGO OFFICE.\n\n## Документы\n\n| Документ | Назначение |\n| --- | --- |\n| [classification.md](classification.md) | Рабочая международная и российская классификация IT/Telecom SaaS-продуктов MANGO OFFICE. |\n| [classification-tz.md](classification-tz.md) | Проверка классификатора на корпусе из 30 ТЗ и рекомендации по дополнениям. |\n| [requirements-flow.md](requirements-flow.md) | Flow требований для AI-анализа тендерных ТЗ MANGO OFFICE. |\n| [requirements-lifecycle-uncertainty-2026-05.md](requirements-lifecycle-uncertainty-2026-05.md) | Жизненный цикл требования на доработку: обработка неопределенности, декомпозиция и сравнение с международной практикой. |\n| [rag-mapping-roadmap-2026-05.md](rag-mapping-roadmap-2026-05.md) | Маппинг продуктов/фич как RAG-навигатор, roadmap автоматизации БА и карта применения PlantUML-диаграмм. |\n| [capability-decomposition-2026-05.md](capability-decomposition-2026-05.md) | Справочник атомарных функций пилотных доменов (`voice-ucaas`, `contact-center`, `digital-channels`): параметры, международные источники, примеры ТЗ и связь с НФТ-классами. |\n\n## Воспроизводимость\n\nИсторические HTML-exports публикуются через MkDocs/GitHub Pages и не хранятся\nв репозитории. Исторические scripts для корпуса ТЗ удалены в cleanup issue #49 вместе с\n`experiments-old/`. Метод извлечения и ограничения корпуса сохранены в\n[classification-tz.md](classification-tz.md). Если эксперимент потребуется\nвосстановить, новый воспроизводимый контур должен жить в\n`research/mango/exp-tz-corpus/` по\n[standards/research-profile.md](../../standards/research-profile.md).\n",
+[2026-06-18T11:48:17.502Z] [INFO]     "structuredPatch": [
+[2026-06-18T11:48:17.502Z] [INFO]       {
+[2026-06-18T11:48:17.502Z] [INFO]         "oldStart": 22,
+[2026-06-18T11:48:17.502Z] [INFO]         "oldLines": 6,
+[2026-06-18T11:48:17.502Z] [INFO]         "newStart": 22,
+[2026-06-18T11:48:17.502Z] [INFO]         "newLines": 7,
+[2026-06-18T11:48:17.502Z] [INFO]         "lines": [
+[2026-06-18T11:48:17.502Z] [INFO]           " | [requirements-lifecycle-uncertainty-2026-05.md](requirements-lifecycle-uncertainty-2026-05.md) | Жизненный цикл требования на доработку: обработка неопределенности, декомпозиция и сравнение с международной практикой. |",
+[2026-06-18T11:48:17.502Z] [INFO]           " | [rag-mapping-roadmap-2026-05.md](rag-mapping-roadmap-2026-05.md) | Маппинг продуктов/фич как RAG-навигатор, roadmap автоматизации БА и карта применения PlantUML-диаграмм. |",
+[2026-06-18T11:48:17.502Z] [INFO]           " | [capability-decomposition-2026-05.md](capability-decomposition-2026-05.md) | Справочник атомарных функций пилотных доменов (`voice-ucaas`, `contact-center`, `digital-channels`): параметры, международные источники, примеры ТЗ и связь с НФТ-классами. |",
+[2026-06-18T11:48:17.502Z] [INFO]           "+| [ai-classifications-formalization-2026-06.md](ai-classifications-formalization-2026-06.md) | Формализация 4 новых AI-подпроцессов (инжиниринг промптов, RAG, оркестрация агентов, тестирование AI), эволюция операций в роадмапе Mango (4 фазы) и подготовка синхронизации с `mango_ba_prompts` (С1/С2/С3). |",
+[2026-06-18T11:48:17.502Z] [INFO]           " ",
+[2026-06-18T11:48:17.502Z] [INFO]           " ## Воспроизводимость",
+[2026-06-18T11:48:17.502Z] [INFO]           " "
+[2026-06-18T11:48:17.502Z] [INFO]         ]
+[2026-06-18T11:48:17.502Z] [INFO]       }
+[2026-06-18T11:48:17.502Z] [INFO]     ],
+[2026-06-18T11:48:17.502Z] [INFO]     "userModified": false,
+[2026-06-18T11:48:17.502Z] [INFO]     "replaceAll": false
+[2026-06-18T11:48:17.502Z] [INFO]   }
+[2026-06-18T11:48:17.502Z] [INFO] }
+[2026-06-18T11:48:17.592Z] [INFO] [log_8f1033] sending request {
+[2026-06-18T11:48:17.592Z] [INFO]   method: "post",
+[2026-06-18T11:48:17.593Z] [INFO]   url: "https://api.anthropic.com/v1/messages?beta=true",
+[2026-06-18T11:48:17.593Z] [INFO]   options: {
+[2026-06-18T11:48:17.594Z] [INFO]     method: "post",
+[2026-06-18T11:48:17.595Z] [INFO]     path: "/v1/messages?beta=true",
+[2026-06-18T11:48:17.595Z] [INFO]     body: {
+[2026-06-18T11:48:17.595Z] [INFO]       model: "claude-opus-4-8",
+[2026-06-18T11:48:17.596Z] [INFO]       messages: [
+[2026-06-18T11:48:17.596Z] [INFO]         [Object ...], [Object ...], [Object ...], [Object ...], [Object ...], [Object ...], [Object ...], [Object ...], [Object ...], [Object ...], [Object ...], [Object ...], [Object ...], [Object ...], [Object ...], [Object ...], [Object ...], [Object ...], [Object ...], [Object ...], [Object ...], [Object ...], [Object ...], [Object ...], [Object ...], [Object ...], [Object ...], [Object ...], [Object ...], [Object ...]
+[2026-06-18T11:48:17.596Z] [INFO]       ],
+[2026-06-18T11:48:17.596Z] [INFO]       system: [
+[2026-06-18T11:48:17.597Z] [INFO]         [Object ...], [Object ...], [Object ...], [Object ...]
+[2026-06-18T11:48:17.597Z] [INFO]       ],
+[2026-06-18T11:48:17.597Z] [INFO]       tools: [
+[2026-06-18T11:48:17.597Z] [INFO]         [Object ...], [Object ...], [Object ...], [Object ...], [Object ...], [Object ...], [Object ...], [Object ...], [Object ...], [Object ...]
+[2026-06-18T11:48:17.598Z] [INFO]       ],
+[2026-06-18T11:48:17.599Z] [INFO]       tool_choice: undefined,
+[2026-06-18T11:48:17.599Z] [INFO]       metadata: [Object ...],
+[2026-06-18T11:48:17.599Z] [INFO]       max_tokens: 128000,
+[2026-06-18T11:48:17.600Z] [INFO]       thinking: [Object ...],
+[2026-06-18T11:48:17.600Z] [INFO]       context_management: [Object ...],
+[2026-06-18T11:48:17.600Z] [INFO]       output_config: [Object ...],
+[2026-06-18T11:48:17.601Z] [INFO]       diagnostics: [Object ...],
+[2026-06-18T11:48:17.601Z] [INFO]       stream: true,
+[2026-06-18T11:48:17.602Z] [INFO]     },
+[2026-06-18T11:48:17.602Z] [INFO]     timeout: 600000,
+[2026-06-18T11:48:17.602Z] [INFO]     signal: AbortSignal {
+[2026-06-18T11:48:17.602Z] [INFO]       [Symbol(events.maxEventTargetListeners)]: 50,
+[2026-06-18T11:48:17.602Z] [INFO]       [Symbol(events.maxEventTargetListenersWarned)]: false,
+[2026-06-18T11:48:17.602Z] [INFO]       aborted: false,
+[2026-06-18T11:48:17.603Z] [INFO]       reason: undefined,
+[2026-06-18T11:48:17.603Z] [INFO]       onabort: null,
+[2026-06-18T11:48:17.603Z] [INFO]       throwIfAborted: [Function: throwIfAborted],
+[2026-06-18T11:48:17.603Z] [INFO]       addEventListener: [Function: addEventListener],
+[2026-06-18T11:48:17.604Z] [INFO]       removeEventListener: [Function: removeEventListener],
+[2026-06-18T11:48:17.604Z] [INFO]       dispatchEvent: [Function: dispatchEvent],
+[2026-06-18T11:48:17.604Z] [INFO]     },
+[2026-06-18T11:48:17.604Z] [INFO]     stream: true,
+[2026-06-18T11:48:17.604Z] [INFO]   },
+[2026-06-18T11:48:17.605Z] [INFO]   headers: {
+[2026-06-18T11:48:17.605Z] [INFO]     accept: "application/json",
+[2026-06-18T11:48:17.605Z] [INFO]     "anthropic-beta": "claude-code-20250219,oauth-2025-04-20,interleaved-thinking-2025-05-14,thinking-token-count-2026-05-13,context-management-2025-06-27,prompt-caching-scope-2026-01-05,mid-conversation-system-2026-04-07,advisor-tool-2026-03-01,advanced-tool-use-2025-11-20,effort-2025-11-24,extended-cache-ttl-2025-04-11,cache-diagnosis-2026-04-07",
+[2026-06-18T11:48:17.605Z] [INFO]     "anthropic-dangerous-direct-browser-access": "true",
+[2026-06-18T11:48:17.605Z] [INFO]     "anthropic-version": "2023-06-01",
+[2026-06-18T11:48:17.605Z] [INFO]     authorization: "***",
+[2026-06-18T11:48:17.605Z] [INFO]     "content-type": "application/json",
+[2026-06-18T11:48:17.606Z] [INFO]     "user-agent": "claude-cli/2.1.181 (external, sdk-cli)",
+[2026-06-18T11:48:17.606Z] [INFO]     "x-app": "cli",
+[2026-06-18T11:48:17.606Z] [INFO]     "x-claude-code-session-id": "d65e890a-db60-43f7-aea3-691500f7e26c",
+[2026-06-18T11:48:17.606Z] [INFO]     "x-client-request-id": "904ed643-fb18-47f2-b20a-9851feac339f",
+[2026-06-18T11:48:17.607Z] [INFO]     "x-stainless-arch": "x64",
+[2026-06-18T11:48:17.607Z] [INFO]     "x-stainless-lang": "js",
+[2026-06-18T11:48:17.607Z] [INFO]     "x-stainless-os": "Linux",
+[2026-06-18T11:48:17.607Z] [INFO]     "x-stainless-package-version": "0.94.0",
+[2026-06-18T11:48:17.607Z] [INFO]     "x-stainless-retry-count": "0",
+[2026-06-18T11:48:17.608Z] [INFO]     "x-stainless-runtime": "node",
+[2026-06-18T11:48:17.608Z] [INFO]     "x-stainless-runtime-version": "v24.3.0",
+[2026-06-18T11:48:17.608Z] [INFO]     "x-stainless-timeout": "600",
+[2026-06-18T11:48:17.608Z] [INFO]   },
+[2026-06-18T11:48:17.608Z] [INFO] }
+[2026-06-18T11:48:19.938Z] [INFO] [log_8f1033, request-id: "req_011CcAfxffduz1iQKEvzC2oA"] post https://api.anthropic.com/v1/messages?beta=true succeeded with status 200 in 2346ms
+[2026-06-18T11:48:19.939Z] [INFO] [log_8f1033] response start {
+[2026-06-18T11:48:19.940Z] [INFO]   url: "https://api.anthropic.com/v1/messages?beta=true",
+[2026-06-18T11:48:19.940Z] [INFO]   status: 200,
+[2026-06-18T11:48:19.941Z] [INFO]   headers: {
+[2026-06-18T11:48:19.942Z] [INFO]     "anthropic-organization-id": "ebc2ac93-f86f-4d15-aff3-de8830d8d789",
+[2026-06-18T11:48:19.943Z] [INFO]     "anthropic-ratelimit-unified-5h-reset": "1781787000",
+[2026-06-18T11:48:19.943Z] [INFO]     "anthropic-ratelimit-unified-5h-status": "allowed",
+[2026-06-18T11:48:19.944Z] [INFO]     "anthropic-ratelimit-unified-5h-utilization": "0.34",
+[2026-06-18T11:48:19.945Z] [INFO]     "anthropic-ratelimit-unified-7d-reset": "1782212400",
+[2026-06-18T11:48:19.946Z] [INFO]     "anthropic-ratelimit-unified-7d-status": "allowed",
+[2026-06-18T11:48:19.948Z] [INFO]     "anthropic-ratelimit-unified-7d-utilization": "0.62",
+[2026-06-18T11:48:19.948Z] [INFO]     "anthropic-ratelimit-unified-fallback-percentage": "0.5",
+[2026-06-18T11:48:19.949Z] [INFO]     "anthropic-ratelimit-unified-overage-disabled-reason": "org_level_disabled",
+[2026-06-18T11:48:19.949Z] [INFO]     "anthropic-ratelimit-unified-overage-status": "rejected",
+[2026-06-18T11:48:19.950Z] [INFO]     "anthropic-ratelimit-unified-representative-claim": "five_hour",
+[2026-06-18T11:48:19.950Z] [INFO]     "anthropic-ratelimit-unified-reset": "1781787000",
+[2026-06-18T11:48:19.950Z] [INFO]     "anthropic-ratelimit-unified-status": "allowed",
+[2026-06-18T11:48:19.950Z] [INFO]     "cache-control": "no-cache",
+[2026-06-18T11:48:19.951Z] [INFO]     "cf-cache-status": "DYNAMIC",
+[2026-06-18T11:48:19.951Z] [INFO]     "cf-ray": "a0da106a0a44b19e-FRA",
+[2026-06-18T11:48:19.951Z] [INFO]     connection: "keep-alive",
+[2026-06-18T11:48:19.952Z] [INFO]     "content-encoding": "gzip",
+[2026-06-18T11:48:19.952Z] [INFO]     "content-security-policy": "default-src 'none'; frame-ancestors 'none'",
+[2026-06-18T11:48:19.952Z] [INFO]     "content-type": "text/event-stream; charset=utf-8",
+[2026-06-18T11:48:19.952Z] [INFO]     date: "Thu, 18 Jun 2026 11:48:19 GMT",
+[2026-06-18T11:48:19.952Z] [INFO]     "request-id": "req_011CcAfxffduz1iQKEvzC2oA",
+[2026-06-18T11:48:19.953Z] [INFO]     server: "cloudflare",
+[2026-06-18T11:48:19.953Z] [INFO]     "strict-transport-security": "max-age=31536000; includeSubDomains; preload",
+[2026-06-18T11:48:19.953Z] [INFO]     traceresponse: "00-bd9d3a0049d7525bd73970523d4e710b-396a2cd55ae129fc-01",
+[2026-06-18T11:48:19.953Z] [INFO]     "transfer-encoding": "chunked",
+[2026-06-18T11:48:19.954Z] [INFO]     vary: "Accept-Encoding",
+[2026-06-18T11:48:19.954Z] [INFO]     "x-robots-tag": "none",
+[2026-06-18T11:48:19.954Z] [INFO]     "set-cookie": "***",
+[2026-06-18T11:48:19.954Z] [INFO]   },
+[2026-06-18T11:48:19.955Z] [INFO]   durationMs: 2346,
+[2026-06-18T11:48:19.955Z] [INFO] }
+[2026-06-18T11:48:19.955Z] [INFO] response 200 https://api.anthropic.com/v1/messages?beta=true Headers {
+[2026-06-18T11:48:19.955Z] [INFO]   "date": "Thu, 18 Jun 2026 11:48:19 GMT",
+[2026-06-18T11:48:19.956Z] [INFO]   "content-type": "text/event-stream; charset=utf-8",
+[2026-06-18T11:48:19.956Z] [INFO]   "transfer-encoding": "chunked",
+[2026-06-18T11:48:19.957Z] [INFO]   "connection": "keep-alive",
+[2026-06-18T11:48:19.957Z] [INFO]   "cache-control": "no-cache",
+[2026-06-18T11:48:19.958Z] [INFO]   "strict-transport-security": "max-age=31536000; includeSubDomains; preload",
+[2026-06-18T11:48:19.958Z] [INFO]   "content-encoding": "gzip",
+[2026-06-18T11:48:19.959Z] [INFO]   "vary": "Accept-Encoding",
+[2026-06-18T11:48:19.959Z] [INFO]   "content-security-policy": "default-src 'none'; frame-ancestors 'none'",
+[2026-06-18T11:48:19.960Z] [INFO]   "set-cookie": [ "_cfuvid=ouKyB6JUR57iZIJriQAVa1rSPSFHChxRN6iNR_bYucU-1781783297.6023357-1.0.1.1-BBSrozBKeqdx_.pIfwaYA8kN.gXrAA1VejbY8hOBr8c; HttpOnly; SameSite=None; Secure; Path=/; Domain=api.anthropic.com" ],
+[2026-06-18T11:48:19.962Z] [INFO]   "anthropic-ratelimit-unified-status": "allowed",
+[2026-06-18T11:48:19.963Z] [INFO]   "anthropic-ratelimit-unified-5h-status": "allowed",
+[2026-06-18T11:48:19.964Z] [INFO]   "anthropic-ratelimit-unified-5h-reset": "1781787000",
+[2026-06-18T11:48:19.964Z] [INFO]   "anthropic-ratelimit-unified-5h-utilization": "0.34",
+[2026-06-18T11:48:19.965Z] [INFO]   "anthropic-ratelimit-unified-7d-status": "allowed",
+[2026-06-18T11:48:19.965Z] [INFO]   "anthropic-ratelimit-unified-7d-reset": "1782212400",
+[2026-06-18T11:48:19.966Z] [INFO]   "anthropic-ratelimit-unified-7d-utilization": "0.62",
+[2026-06-18T11:48:19.966Z] [INFO]   "anthropic-ratelimit-unified-representative-claim": "five_hour",
+[2026-06-18T11:48:19.967Z] [INFO]   "anthropic-ratelimit-unified-fallback-percentage": "0.5",
+[2026-06-18T11:48:19.968Z] [INFO]   "anthropic-ratelimit-unified-reset": "1781787000",
+[2026-06-18T11:48:19.969Z] [INFO]   "anthropic-ratelimit-unified-overage-disabled-reason": "org_level_disabled",
+[2026-06-18T11:48:19.970Z] [INFO]   "anthropic-ratelimit-unified-overage-status": "rejected",
+[2026-06-18T11:48:19.971Z] [INFO]   "request-id": "req_011CcAfxffduz1iQKEvzC2oA",
+[2026-06-18T11:48:19.972Z] [INFO]   "anthropic-organization-id": "ebc2ac93-f86f-4d15-aff3-de8830d8d789",
+[2026-06-18T11:48:19.975Z] [INFO]   "traceresponse": "00-bd9d3a0049d7525bd73970523d4e710b-396a2cd55ae129fc-01",
+[2026-06-18T11:48:19.976Z] [INFO]   "server": "cloudflare",
+[2026-06-18T11:48:19.978Z] [INFO]   "cf-cache-status": "DYNAMIC",
+[2026-06-18T11:48:19.978Z] [INFO]   "x-robots-tag": "none",
+[2026-06-18T11:48:19.979Z] [INFO]   "cf-ray": "a0da106a0a44b19e-FRA",
+[2026-06-18T11:48:19.980Z] [INFO] } ReadableStream {
+[2026-06-18T11:48:19.980Z] [INFO]   blob: [Function: blob],
+[2026-06-18T11:48:19.981Z] [INFO]   bytes: [Function: bytes],
+[2026-06-18T11:48:19.981Z] [INFO]   cancel: [Function],
+[2026-06-18T11:48:19.982Z] [INFO]   getReader: [Function],
+[2026-06-18T11:48:19.983Z] [INFO]   json: [Function: json],
+[2026-06-18T11:48:19.983Z] [INFO]   locked: [Getter],
+[2026-06-18T11:48:19.984Z] [INFO]   pipeThrough: [Function],
+[2026-06-18T11:48:19.985Z] [INFO]   pipeTo: [Function],
+[2026-06-18T11:48:19.986Z] [INFO]   tee: [Function],
+[2026-06-18T11:48:19.986Z] [INFO]   text: [Function: text],
+[2026-06-18T11:48:19.986Z] [INFO]   values: [Function: values],
+[2026-06-18T11:48:19.987Z] [INFO]   [Symbol(Symbol.asyncIterator)]: [Function: asyncIterator2],
+[2026-06-18T11:48:19.987Z] [INFO] }
+[2026-06-18T11:48:19.988Z] [INFO] [log_8f1033] response parsed {
+[2026-06-18T11:48:19.988Z] [INFO]   url: "https://api.anthropic.com/v1/messages?beta=true",
+[2026-06-18T11:48:19.989Z] [INFO]   status: 200,
+[2026-06-18T11:48:19.990Z] [INFO]   body: sU {
+[2026-06-18T11:48:19.991Z] [INFO]     iterator: [AsyncGeneratorFunction: s],
+[2026-06-18T11:48:19.991Z] [INFO]     controller: AbortController {
+[2026-06-18T11:48:19.992Z] [INFO]       signal: [AbortSignal ...],
+[2026-06-18T11:48:19.992Z] [INFO]       abort: [Function: abort],
+[2026-06-18T11:48:19.992Z] [INFO]     },
+[2026-06-18T11:48:19.993Z] [INFO]     [Symbol(Symbol.asyncIterator)]: [Function],
+[2026-06-18T11:48:19.994Z] [INFO]     tee: [Function: tee],
+[2026-06-18T11:48:19.995Z] [INFO]     toReadableStream: [Function: toReadableStream],
+[2026-06-18T11:48:19.996Z] [INFO]   },
+[2026-06-18T11:48:19.997Z] [INFO]   durationMs: 2347,
+[2026-06-18T11:48:19.998Z] [INFO] }
+[2026-06-18T11:48:20.513Z] [INFO] {
+[2026-06-18T11:48:20.513Z] [INFO]   "type": "assistant",
+[2026-06-18T11:48:20.513Z] [INFO]   "message": {
+[2026-06-18T11:48:20.513Z] [INFO]     "model": "claude-opus-4-8",
+[2026-06-18T11:48:20.513Z] [INFO]     "id": "msg_01VRBrABJBsKM7Uvb8W1A6wx",
+[2026-06-18T11:48:20.513Z] [INFO]     "type": "message",
+[2026-06-18T11:48:20.513Z] [INFO]     "role": "assistant",
+[2026-06-18T11:48:20.513Z] [INFO]     "content": [
+[2026-06-18T11:48:20.513Z] [INFO]       {
+[2026-06-18T11:48:20.513Z] [INFO]         "type": "tool_use",
+[2026-06-18T11:48:20.513Z] [INFO]         "id": "toolu_01S6x5Z2SMadR9eiMMZsmHrq",
+[2026-06-18T11:48:20.513Z] [INFO]         "name": "Read",
+[2026-06-18T11:48:20.513Z] [INFO]         "input": {
+[2026-06-18T11:48:20.513Z] [INFO]           "file_path": "/tmp/gh-issue-solver-1781783024578/governance/artifact-map.md",
+[2026-06-18T11:48:20.513Z] [INFO]           "offset": 152,
+[2026-06-18T11:48:20.513Z] [INFO]           "limit": 6
+[2026-06-18T11:48:20.513Z] [INFO]         },
+[2026-06-18T11:48:20.513Z] [INFO]         "caller": {
+[2026-06-18T11:48:20.513Z] [INFO]           "type": "direct"
+[2026-06-18T11:48:20.513Z] [INFO]         }
+[2026-06-18T11:48:20.513Z] [INFO]       }
+[2026-06-18T11:48:20.513Z] [INFO]     ],
+[2026-06-18T11:48:20.513Z] [INFO]     "stop_reason": null,
+[2026-06-18T11:48:20.513Z] [INFO]     "stop_sequence": null,
+[2026-06-18T11:48:20.513Z] [INFO]     "stop_details": null,
+[2026-06-18T11:48:20.513Z] [INFO]     "usage": {
+[2026-06-18T11:48:20.513Z] [INFO]       "input_tokens": 2,
+[2026-06-18T11:48:20.513Z] [INFO]       "cache_creation_input_tokens": 577,
+[2026-06-18T11:48:20.513Z] [INFO]       "cache_read_input_tokens": 70532,
+[2026-06-18T11:48:20.513Z] [INFO]       "cache_creation": {
+[2026-06-18T11:48:20.513Z] [INFO]         "ephemeral_5m_input_tokens": 0,
+[2026-06-18T11:48:20.513Z] [INFO]         "ephemeral_1h_input_tokens": 577
+[2026-06-18T11:48:20.513Z] [INFO]       },
+[2026-06-18T11:48:20.513Z] [INFO]       "output_tokens": 54,
+[2026-06-18T11:48:20.513Z] [INFO]       "service_tier": "standard",
+[2026-06-18T11:48:20.513Z] [INFO]       "inference_geo": "not_available"
+[2026-06-18T11:48:20.513Z] [INFO]     },
+[2026-06-18T11:48:20.513Z] [INFO]     "diagnostics": null,
+[2026-06-18T11:48:20.513Z] [INFO]     "context_management": null
+[2026-06-18T11:48:20.513Z] [INFO]   },
+[2026-06-18T11:48:20.513Z] [INFO]   "parent_tool_use_id": null,
+[2026-06-18T11:48:20.513Z] [INFO]   "session_id": "d65e890a-db60-43f7-aea3-691500f7e26c",
+[2026-06-18T11:48:20.513Z] [INFO]   "uuid": "51e679bf-62b8-4f04-95c6-095b89d3bd5c",
+[2026-06-18T11:48:20.513Z] [INFO]   "request_id": "req_011CcAfxffduz1iQKEvzC2oA"
+[2026-06-18T11:48:20.513Z] [INFO] }
+[2026-06-18T11:48:20.523Z] [INFO] {
+[2026-06-18T11:48:20.523Z] [INFO]   "type": "user",
+[2026-06-18T11:48:20.523Z] [INFO]   "message": {
+[2026-06-18T11:48:20.523Z] [INFO]     "role": "user",
+[2026-06-18T11:48:20.523Z] [INFO]     "content": [
+[2026-06-18T11:48:20.523Z] [INFO]       {
+[2026-06-18T11:48:20.523Z] [INFO]         "tool_use_id": "toolu_01S6x5Z2SMadR9eiMMZsmHrq",
+[2026-06-18T11:48:20.523Z] [INFO]         "type": "tool_result",
+[2026-06-18T11:48:20.523Z] [INFO]         "content": "152\t| `/research/mango/taxonomy-concept-2026-05.md` | концепция | — | Draft-концепция Unified Capability Taxonomy для Mango: мета-модель, mapping фич, процесс нормализации, интерфейс команд, метрики, пилот и риски. | ⚠️ По необходимости | `research/mango/classification.md`, `research/mango/classification-tz.md`, `research/mango/requirements-flow.md`, `mango_ba_prompts`, `standards/glossary.md`, `governance/repo-model.md` |\n153\t| `/research/mango/requirements-lifecycle-uncertainty-2026-05.md` | исследование | — | Жизненный цикл требования на доработку Mango: бенчмарк международной практики, моделирование кейсов (`0 → 1`), обработка неопределенности, декомпозиция и рекомендации для стандарта процесса БА. | ⚠️ По необходимости | `research/mango/requirements-flow.md`, `research/mango/taxonomy-concept-2026-05.md`, `research/mango/classification.md`, `mango_ba_prompts`, `standards/glossary.md` |\n154\t| `/research/mango/rag-mapping-roadmap-2026-05.md` | исследование | — | Маппинг продуктов/фич Mango как RAG-навигатор: структура `kb/product-matrix.md`, оценка источников документации, roadmap автоматизации БА и карта PlantUML-диаграмм. | ⚠️ По необходимости | `research/mango/taxonomy-concept-2026-05.md`, `research/mango/requirements-lifecycle-uncertainty-2026-05.md`, `mango_ba_prompts`, `standards/research-profile.md` |\n155\t| `/research/mango/capability-decomposition-2026-05.md` | исследование | — | Справочник атомарных функций пилотных доменов Mango (`voice-ucaas`, `contact-center`, `digital-channels`): параметры, международные источники, примеры ТЗ, критерии атомарности и связь с НФТ-классами. | ⚠️ По необходимости | `research/mango/classification.md`, `research/mango/classification-tz.md`, `research/mango/rag-mapping-roadmap-2026-05.md`, `mango_ba_prompts/standards/GLOSSARY.md` |\n156\t| `/research/hub/project-context-and-bootstrap-patterns-2026-05.md` | исследование | — | Паттерны передачи контекста, предсказуемого project bootstrap и маршрута \"рекомендация -> задача\" на опыте Mango. Scope: repo-wide. | ⚠️ По необходимости | `mango_ba_prompts`, `research/mango/`, `standards/project-structure-inheritance.md` |\n157\t| `/research/hub/ai-collaboration-retrospective-2026-06.md` | исследование | — | Ретроспектива AI-collaboration по сессии проектирования шаблонов споков: ошибки агента, root causes и системные выводы для будущего усиления правил работы AI. Scope: repo-wide. | ⚠️ По необходимости | `AI_GOVERNANCE.md`, `standards/issue-workflow.md`, `governance/repo-model.md`, `research/hub/project-context-and-bootstrap-patterns-2026-05.md` |"
+[2026-06-18T11:48:20.523Z] [INFO]       }
+[2026-06-18T11:48:20.523Z] [INFO]     ]
+[2026-06-18T11:48:20.523Z] [INFO]   },
+[2026-06-18T11:48:20.523Z] [INFO]   "parent_tool_use_id": null,
+[2026-06-18T11:48:20.523Z] [INFO]   "session_id": "d65e890a-db60-43f7-aea3-691500f7e26c",
+[2026-06-18T11:48:20.523Z] [INFO]   "uuid": "a06bd446-f0f0-43af-a4c3-f846ee05c06b",
+[2026-06-18T11:48:20.523Z] [INFO]   "timestamp": "2026-06-18T11:48:20.521Z",
+[2026-06-18T11:48:20.523Z] [INFO]   "tool_use_result": {
+[2026-06-18T11:48:20.523Z] [INFO]     "type": "text",
+[2026-06-18T11:48:20.523Z] [INFO]     "file": {
+[2026-06-18T11:48:20.523Z] [INFO]       "filePath": "/tmp/gh-issue-solver-1781783024578/governance/artifact-map.md",
+[2026-06-18T11:48:20.523Z] [INFO]       "content": "| `/research/mango/taxonomy-concept-2026-05.md` | концепция | — | Draft-концепция Unified Capability Taxonomy для Mango: мета-модель, mapping фич, процесс нормализации, интерфейс команд, метрики, пилот и риски. | ⚠️ По необходимости | `research/mango/classification.md`, `research/mango/classification-tz.md`, `research/mango/requirements-flow.md`, `mango_ba_prompts`, `standards/glossary.md`, `governance/repo-model.md` |\n| `/research/mango/requirements-lifecycle-uncertainty-2026-05.md` | исследование | — | Жизненный цикл требования на доработку Mango: бенчмарк международной практики, моделирование кейсов (`0 → 1`), обработка неопределенности, декомпозиция и рекомендации для стандарта процесса БА. | ⚠️ По необходимости | `research/mango/requirements-flow.md`, `research/mango/taxonomy-concept-2026-05.md`, `research/mango/classification.md`, `mango_ba_prompts`, `standards/glossary.md` |\n| `/research/mango/rag-mapping-roadmap-2026-05.md` | исследование | — | Маппинг продуктов/фич Mango как RAG-навигатор: структура `kb/product-matrix.md`, оценка источников документации, roadmap автоматизации БА и карта PlantUML-диаграмм. | ⚠️ По необходимости | `research/mango/taxonomy-concept-2026-05.md`, `research/mango/requirements-lifecycle-uncertainty-2026-05.md`, `mango_ba_prompts`, `standards/research-profile.md` |\n| `/research/mango/capability-decomposition-2026-05.md` | исследование | — | Справочник атомарных функций пилотных доменов Mango (`voice-ucaas`, `contact-center`, `digital-channels`): параметры, международные источники, примеры ТЗ, критерии атомарности и связь с НФТ-классами. | ⚠️ По необходимости | `research/mango/classification.md`, `research/mango/classification-tz.md`, `research/mango/rag-mapping-roadmap-2026-05.md`, `mango_ba_prompts/standards/GLOSSARY.md` |\n| `/research/hub/project-context-and-bootstrap-patterns-2026-05.md` | исследование | — | Паттерны передачи контекста, предсказуемого project bootstrap и маршрута \"рекомендация -> задача\" на опыте Mango. Scope: repo-wide. | ⚠️ По необходимости | `mango_ba_prompts`, `research/mango/`, `standards/project-structure-inheritance.md` |\n| `/research/hub/ai-collaboration-retrospective-2026-06.md` | исследование | — | Ретроспектива AI-collaboration по сессии проектирования шаблонов споков: ошибки агента, root causes и системные выводы для будущего усиления правил работы AI. Scope: repo-wide. | ⚠️ По необходимости | `AI_GOVERNANCE.md`, `standards/issue-workflow.md`, `governance/repo-model.md`, `research/hub/project-context-and-bootstrap-patterns-2026-05.md` |",
+[2026-06-18T11:48:20.523Z] [INFO]       "numLines": 6,
+[2026-06-18T11:48:20.523Z] [INFO]       "startLine": 152,
+[2026-06-18T11:48:20.523Z] [INFO]       "totalLines": 292
+[2026-06-18T11:48:20.523Z] [INFO]     }
+[2026-06-18T11:48:20.523Z] [INFO]   }
+[2026-06-18T11:48:20.523Z] [INFO] }
+[2026-06-18T11:48:20.587Z] [INFO] [log_80eedd] sending request {
+[2026-06-18T11:48:20.588Z] [INFO]   method: "post",
+[2026-06-18T11:48:20.588Z] [INFO]   url: "https://api.anthropic.com/v1/messages?beta=true",
+[2026-06-18T11:48:20.588Z] [INFO]   options: {
+[2026-06-18T11:48:20.589Z] [INFO]     method: "post",
+[2026-06-18T11:48:20.589Z] [INFO]     path: "/v1/messages?beta=true",
+[2026-06-18T11:48:20.589Z] [INFO]     body: {
+[2026-06-18T11:48:20.589Z] [INFO]       model: "claude-opus-4-8",
+[2026-06-18T11:48:20.590Z] [INFO]       messages: [
+[2026-06-18T11:48:20.590Z] [INFO]         [Object ...], [Object ...], [Object ...], [Object ...], [Object ...], [Object ...], [Object ...], [Object ...], [Object ...], [Object ...], [Object ...], [Object ...], [Object ...], [Object ...], [Object ...], [Object ...], [Object ...], [Object ...], [Object ...], [Object ...], [Object ...], [Object ...], [Object ...], [Object ...], [Object ...], [Object ...], [Object ...], [Object ...], [Object ...], [Object ...], [Object ...], [Object ...]
+[2026-06-18T11:48:20.590Z] [INFO]       ],
+[2026-06-18T11:48:20.591Z] [INFO]       system: [
+[2026-06-18T11:48:20.591Z] [INFO]         [Object ...], [Object ...], [Object ...], [Object ...]
+[2026-06-18T11:48:20.591Z] [INFO]       ],
+[2026-06-18T11:48:20.592Z] [INFO]       tools: [
+[2026-06-18T11:48:20.592Z] [INFO]         [Object ...], [Object ...], [Object ...], [Object ...], [Object ...], [Object ...], [Object ...], [Object ...], [Object ...], [Object ...]
+[2026-06-18T11:48:20.592Z] [INFO]       ],
+[2026-06-18T11:48:20.592Z] [INFO]       tool_choice: undefined,
+[2026-06-18T11:48:20.593Z] [INFO]       metadata: [Object ...],
+[2026-06-18T11:48:20.593Z] [INFO]       max_tokens: 128000,
+[2026-06-18T11:48:20.593Z] [INFO]       thinking: [Object ...],
+[2026-06-18T11:48:20.594Z] [INFO]       context_management: [Object ...],
+[2026-06-18T11:48:20.594Z] [INFO]       output_config: [Object ...],
+[2026-06-18T11:48:20.594Z] [INFO]       diagnostics: [Object ...],
+[2026-06-18T11:48:20.594Z] [INFO]       stream: true,
+[2026-06-18T11:48:20.595Z] [INFO]     },
+[2026-06-18T11:48:20.595Z] [INFO]     timeout: 600000,
+[2026-06-18T11:48:20.595Z] [INFO]     signal: AbortSignal {
+[2026-06-18T11:48:20.595Z] [INFO]       [Symbol(events.maxEventTargetListeners)]: 50,
+[2026-06-18T11:48:20.595Z] [INFO]       [Symbol(events.maxEventTargetListenersWarned)]: false,
+[2026-06-18T11:48:20.595Z] [INFO]       aborted: false,
+[2026-06-18T11:48:20.596Z] [INFO]       reason: undefined,
+[2026-06-18T11:48:20.596Z] [INFO]       onabort: null,
+[2026-06-18T11:48:20.596Z] [INFO]       throwIfAborted: [Function: throwIfAborted],
+[2026-06-18T11:48:20.596Z] [INFO]       addEventListener: [Function: addEventListener],
+[2026-06-18T11:48:20.597Z] [INFO]       removeEventListener: [Function: removeEventListener],
+[2026-06-18T11:48:20.597Z] [INFO]       dispatchEvent: [Function: dispatchEvent],
+[2026-06-18T11:48:20.597Z] [INFO]     },
+[2026-06-18T11:48:20.598Z] [INFO]     stream: true,
+[2026-06-18T11:48:20.601Z] [INFO]   },
+[2026-06-18T11:48:20.601Z] [INFO]   headers: {
+[2026-06-18T11:48:20.601Z] [INFO]     accept: "application/json",
+[2026-06-18T11:48:20.601Z] [INFO]     "anthropic-beta": "claude-code-20250219,oauth-2025-04-20,interleaved-thinking-2025-05-14,thinking-token-count-2026-05-13,context-management-2025-06-27,prompt-caching-scope-2026-01-05,mid-conversation-system-2026-04-07,advisor-tool-2026-03-01,advanced-tool-use-2025-11-20,effort-2025-11-24,extended-cache-ttl-2025-04-11,cache-diagnosis-2026-04-07",
+[2026-06-18T11:48:20.602Z] [INFO]     "anthropic-dangerous-direct-browser-access": "true",
+[2026-06-18T11:48:20.602Z] [INFO]     "anthropic-version": "2023-06-01",
+[2026-06-18T11:48:20.602Z] [INFO]     authorization: "***",
+[2026-06-18T11:48:20.602Z] [INFO]     "content-type": "application/json",
+[2026-06-18T11:48:20.602Z] [INFO]     "user-agent": "claude-cli/2.1.181 (external, sdk-cli)",
+[2026-06-18T11:48:20.603Z] [INFO]     "x-app": "cli",
+[2026-06-18T11:48:20.603Z] [INFO]     "x-claude-code-session-id": "d65e890a-db60-43f7-aea3-691500f7e26c",
+[2026-06-18T11:48:20.603Z] [INFO]     "x-client-request-id": "56363a34-329f-4c1c-a531-120d3a7695ce",
+[2026-06-18T11:48:20.603Z] [INFO]     "x-stainless-arch": "x64",
+[2026-06-18T11:48:20.603Z] [INFO]     "x-stainless-lang": "js",
+[2026-06-18T11:48:20.604Z] [INFO]     "x-stainless-os": "Linux",
+[2026-06-18T11:48:20.604Z] [INFO]     "x-stainless-package-version": "0.94.0",
+[2026-06-18T11:48:20.604Z] [INFO]     "x-stainless-retry-count": "0",
+[2026-06-18T11:48:20.604Z] [INFO]     "x-stainless-runtime": "node",
+[2026-06-18T11:48:20.604Z] [INFO]     "x-stainless-runtime-version": "v24.3.0",
+[2026-06-18T11:48:20.605Z] [INFO]     "x-stainless-timeout": "600",
+[2026-06-18T11:48:20.605Z] [INFO]   },
+[2026-06-18T11:48:20.605Z] [INFO] }
+[2026-06-18T11:48:22.382Z] [INFO] [log_80eedd, request-id: "req_011CcAfxtVots3JssSPk6XPW"] post https://api.anthropic.com/v1/messages?beta=true succeeded with status 200 in 1786ms
+[2026-06-18T11:48:22.392Z] [INFO] [log_80eedd] response start {
+[2026-06-18T11:48:22.399Z] [INFO]   url: "https://api.anthropic.com/v1/messages?beta=true",
+[2026-06-18T11:48:22.400Z] [INFO]   status: 200,
+[2026-06-18T11:48:22.400Z] [INFO]   headers: {
+[2026-06-18T11:48:22.400Z] [INFO]     "anthropic-organization-id": "ebc2ac93-f86f-4d15-aff3-de8830d8d789",
+[2026-06-18T11:48:22.401Z] [INFO]     "anthropic-ratelimit-unified-5h-reset": "1781787000",
+[2026-06-18T11:48:22.401Z] [INFO]     "anthropic-ratelimit-unified-5h-status": "allowed",
+[2026-06-18T11:48:22.404Z] [INFO]     "anthropic-ratelimit-unified-5h-utilization": "0.34",
+[2026-06-18T11:48:22.407Z] [INFO]     "anthropic-ratelimit-unified-7d-reset": "1782212400",
+[2026-06-18T11:48:22.407Z] [INFO]     "anthropic-ratelimit-unified-7d-status": "allowed",
+[2026-06-18T11:48:22.408Z] [INFO]     "anthropic-ratelimit-unified-7d-utilization": "0.62",
+[2026-06-18T11:48:22.409Z] [INFO]     "anthropic-ratelimit-unified-fallback-percentage": "0.5",
+[2026-06-18T11:48:22.409Z] [INFO]     "anthropic-ratelimit-unified-overage-disabled-reason": "org_level_disabled",
+[2026-06-18T11:48:22.409Z] [INFO]     "anthropic-ratelimit-unified-overage-status": "rejected",
+[2026-06-18T11:48:22.413Z] [INFO]     "anthropic-ratelimit-unified-representative-claim": "five_hour",
+[2026-06-18T11:48:22.413Z] [INFO]     "anthropic-ratelimit-unified-reset": "1781787000",
+[2026-06-18T11:48:22.413Z] [INFO]     "anthropic-ratelimit-unified-status": "allowed",
+[2026-06-18T11:48:22.414Z] [INFO]     "cache-control": "no-cache",
+[2026-06-18T11:48:22.414Z] [INFO]     "cf-cache-status": "DYNAMIC",
+[2026-06-18T11:48:22.414Z] [INFO]     "cf-ray": "a0da107cb9c3b19e-FRA",
+[2026-06-18T11:48:22.414Z] [INFO]     connection: "keep-alive",
+[2026-06-18T11:48:22.415Z] [INFO]     "content-encoding": "gzip",
+[2026-06-18T11:48:22.415Z] [INFO]     "content-security-policy": "default-src 'none'; frame-ancestors 'none'",
+[2026-06-18T11:48:22.417Z] [INFO]     "content-type": "text/event-stream; charset=utf-8",
+[2026-06-18T11:48:22.418Z] [INFO]     date: "Thu, 18 Jun 2026 11:48:22 GMT",
+[2026-06-18T11:48:22.418Z] [INFO]     "request-id": "req_011CcAfxtVots3JssSPk6XPW",
+[2026-06-18T11:48:22.418Z] [INFO]     server: "cloudflare",
+[2026-06-18T11:48:22.419Z] [INFO]     "strict-transport-security": "max-age=31536000; includeSubDomains; preload",
+[2026-06-18T11:48:22.422Z] [INFO]     traceresponse: "00-cd3f9efc232176ec63f2c6e769d171fb-cb66833fc0e5f4fc-01",
+[2026-06-18T11:48:22.423Z] [INFO]     "transfer-encoding": "chunked",
+[2026-06-18T11:48:22.444Z] [INFO]     vary: "Accept-Encoding",
+[2026-06-18T11:48:22.446Z] [INFO]     "x-robots-tag": "none",
+[2026-06-18T11:48:22.447Z] [INFO]     "set-cookie": "***",
+[2026-06-18T11:48:22.450Z] [INFO]   },
+[2026-06-18T11:48:22.451Z] [INFO]   durationMs: 1786,
+[2026-06-18T11:48:22.451Z] [INFO] }
+[2026-06-18T11:48:22.452Z] [INFO] response 200 https://api.anthropic.com/v1/messages?beta=true Headers {
+[2026-06-18T11:48:22.452Z] [INFO]   "date": "Thu, 18 Jun 2026 11:48:22 GMT",
+[2026-06-18T11:48:22.452Z] [INFO]   "content-type": "text/event-stream; charset=utf-8",
+[2026-06-18T11:48:22.453Z] [INFO]   "transfer-encoding": "chunked",
+[2026-06-18T11:48:22.453Z] [INFO]   "connection": "keep-alive",
+[2026-06-18T11:48:22.453Z] [INFO]   "cache-control": "no-cache",
+[2026-06-18T11:48:22.456Z] [INFO]   "strict-transport-security": "max-age=31536000; includeSubDomains; preload",
+[2026-06-18T11:48:22.457Z] [INFO]   "content-encoding": "gzip",
+[2026-06-18T11:48:22.458Z] [INFO]   "vary": "Accept-Encoding",
+[2026-06-18T11:48:22.458Z] [INFO]   "content-security-policy": "default-src 'none'; frame-ancestors 'none'",
+[2026-06-18T11:48:22.460Z] [INFO]   "set-cookie": [ "_cfuvid=JEyLkqTWILH.mAAnvSPmV2aDiHlPj5_gnC2tvlOtVo8-1781783300.597148-1.0.1.1-rAiruKB.cxKmKN0lqFLjSn8jVLUDjEuogHz_krpitTc; HttpOnly; SameSite=None; Secure; Path=/; Domain=api.anthropic.com" ],
+[2026-06-18T11:48:22.467Z] [INFO]   "anthropic-ratelimit-unified-status": "allowed",
+[2026-06-18T11:48:22.468Z] [INFO]   "anthropic-ratelimit-unified-5h-status": "allowed",
+[2026-06-18T11:48:22.468Z] [INFO]   "anthropic-ratelimit-unified-5h-reset": "1781787000",
+[2026-06-18T11:48:22.468Z] [INFO]   "anthropic-ratelimit-unified-5h-utilization": "0.34",
+[2026-06-18T11:48:22.468Z] [INFO]   "anthropic-ratelimit-unified-7d-status": "allowed",
+[2026-06-18T11:48:22.468Z] [INFO]   "anthropic-ratelimit-unified-7d-reset": "1782212400",
+[2026-06-18T11:48:22.469Z] [INFO]   "anthropic-ratelimit-unified-7d-utilization": "0.62",
+[2026-06-18T11:48:22.469Z] [INFO]   "anthropic-ratelimit-unified-representative-claim": "five_hour",
+[2026-06-18T11:48:22.469Z] [INFO]   "anthropic-ratelimit-unified-fallback-percentage": "0.5",
+[2026-06-18T11:48:22.469Z] [INFO]   "anthropic-ratelimit-unified-reset": "1781787000",
+[2026-06-18T11:48:22.469Z] [INFO]   "anthropic-ratelimit-unified-overage-disabled-reason": "org_level_disabled",
+[2026-06-18T11:48:22.469Z] [INFO]   "anthropic-ratelimit-unified-overage-status": "rejected",
+[2026-06-18T11:48:22.469Z] [INFO]   "request-id": "req_011CcAfxtVots3JssSPk6XPW",
+[2026-06-18T11:48:22.470Z] [INFO]   "anthropic-organization-id": "ebc2ac93-f86f-4d15-aff3-de8830d8d789",
+[2026-06-18T11:48:22.470Z] [INFO]   "traceresponse": "00-cd3f9efc232176ec63f2c6e769d171fb-cb66833fc0e5f4fc-01",
+[2026-06-18T11:48:22.471Z] [INFO]   "server": "cloudflare",
+[2026-06-18T11:48:22.471Z] [INFO]   "cf-cache-status": "DYNAMIC",
+[2026-06-18T11:48:22.471Z] [INFO]   "x-robots-tag": "none",
+[2026-06-18T11:48:22.476Z] [INFO]   "cf-ray": "a0da107cb9c3b19e-FRA",
+[2026-06-18T11:48:22.477Z] [INFO] } ReadableStream {
+[2026-06-18T11:48:22.478Z] [INFO]   blob: [Function: blob],
+[2026-06-18T11:48:22.478Z] [INFO]   bytes: [Function: bytes],
+[2026-06-18T11:48:22.478Z] [INFO]   cancel: [Function],
+[2026-06-18T11:48:22.479Z] [INFO]   getReader: [Function],
+[2026-06-18T11:48:22.482Z] [INFO]   json: [Function: json],
+[2026-06-18T11:48:22.485Z] [INFO]   locked: [Getter],
+[2026-06-18T11:48:22.487Z] [INFO]   pipeThrough: [Function],
+[2026-06-18T11:48:22.489Z] [INFO]   pipeTo: [Function],
+[2026-06-18T11:48:22.490Z] [INFO]   tee: [Function],
+[2026-06-18T11:48:22.491Z] [INFO]   text: [Function: text],
+[2026-06-18T11:48:22.491Z] [INFO]   values: [Function: values],
+[2026-06-18T11:48:22.491Z] [INFO]   [Symbol(Symbol.asyncIterator)]: [Function: asyncIterator2],
+[2026-06-18T11:48:22.492Z] [INFO] }
+[2026-06-18T11:48:22.492Z] [INFO] [log_80eedd] response parsed {
+[2026-06-18T11:48:22.492Z] [INFO]   url: "https://api.anthropic.com/v1/messages?beta=true",
+[2026-06-18T11:48:22.492Z] [INFO]   status: 200,
+[2026-06-18T11:48:22.492Z] [INFO]   body: sU {
+[2026-06-18T11:48:22.493Z] [INFO]     iterator: [AsyncGeneratorFunction: s],
+[2026-06-18T11:48:22.493Z] [INFO]     controller: AbortController {
+[2026-06-18T11:48:22.493Z] [INFO]       signal: [AbortSignal ...],
+[2026-06-18T11:48:22.493Z] [INFO]       abort: [Function: abort],
+[2026-06-18T11:48:22.494Z] [INFO]     },
+[2026-06-18T11:48:22.495Z] [INFO]     [Symbol(Symbol.asyncIterator)]: [Function],
+[2026-06-18T11:48:22.495Z] [INFO]     tee: [Function: tee],
+[2026-06-18T11:48:22.498Z] [INFO]     toReadableStream: [Function: toReadableStream],
+[2026-06-18T11:48:22.498Z] [INFO]   },
+[2026-06-18T11:48:22.499Z] [INFO]   durationMs: 1795,
+[2026-06-18T11:48:22.499Z] [INFO] }
+[2026-06-18T11:48:23.225Z] [INFO] 
+[2026-06-18T11:48:23.225Z] [INFO] ⚠️  Session interrupted by user (CTRL+C)
+[2026-06-18T11:48:23.226Z] [ERROR] 
+[2026-06-18T11:48:23.226Z] [ERROR] 
+[2026-06-18T11:48:23.226Z] [ERROR] ❌ Claude command failed with exit code 130
+[2026-06-18T11:48:23.229Z] [INFO] 📌 Session ID: d65e890a-db60-43f7-aea3-691500f7e26c
+[2026-06-18T11:48:23.229Z] [INFO] 
+[2026-06-18T11:48:23.229Z] [INFO] 🔍 Checking for uncommitted changes...
+[2026-06-18T11:48:23.236Z] [INFO] 
+[2026-06-18T11:48:23.236Z] [INFO] 💡 To continue this session:
+[2026-06-18T11:48:23.236Z] [INFO] 
+[2026-06-18T11:48:23.236Z] [INFO]    Interactive mode:    (cd "/tmp/gh-issue-solver-1781783024578" && claude --resume d65e890a-db60-43f7-aea3-691500f7e26c --model opus)
+[2026-06-18T11:48:23.236Z] [INFO] 
+[2026-06-18T11:48:23.238Z] [INFO]    Autonomous mode:     (cd "/tmp/gh-issue-solver-1781783024578" && claude --resume d65e890a-db60-43f7-aea3-691500f7e26c --output-format stream-json --dangerously-skip-permissions --model opus -p "Continue.")
+[2026-06-18T11:48:23.238Z] [INFO] 
+[2026-06-18T11:48:23.244Z] [STDOUT]  M research/mango/README.md
+?? research/mango/ai-classifications-formalization-2026-06.md
+[2026-06-18T11:48:23.252Z] [INFO] 📝 Found uncommitted changes
+[2026-06-18T11:48:23.253Z] [INFO] Changes:
+[2026-06-18T11:48:23.254Z] [INFO]    M research/mango/README.md
+[2026-06-18T11:48:23.254Z] [INFO]    ?? research/mango/ai-classifications-formalization-2026-06.md
+[2026-06-18T11:48:23.254Z] [INFO] 💾 Auto-committing changes (--auto-commit-uncommitted-changes is enabled)...
+[2026-06-18T11:48:23.261Z] [INFO] 
+[2026-06-18T11:48:23.261Z] [INFO] 📈 System resources after execution:
+[2026-06-18T11:48:23.262Z] [INFO]    Memory: MemFree:         2061088 kB
+[2026-06-18T11:48:23.264Z] [INFO]    Load: 1.85 1.64 1.51 6/1124 409484
+[2026-06-18T11:48:23.264Z] [INFO] 
+[2026-06-18T11:48:23.264Z] [INFO] 💡 To continue this session:
+[2026-06-18T11:48:23.264Z] [INFO] 
+[2026-06-18T11:48:23.266Z] [INFO]    Interactive mode:    (cd "/tmp/gh-issue-solver-1781783024578" && claude --resume d65e890a-db60-43f7-aea3-691500f7e26c --model opus)
+[2026-06-18T11:48:23.266Z] [INFO] 
+[2026-06-18T11:48:23.267Z] [INFO]    Autonomous mode:     (cd "/tmp/gh-issue-solver-1781783024578" && claude --resume d65e890a-db60-43f7-aea3-691500f7e26c --output-format stream-json --dangerously-skip-permissions --model opus -p "Continue.")
+[2026-06-18T11:48:23.267Z] [INFO] 
+[2026-06-18T11:48:23.269Z] [INFO] 
+[2026-06-18T11:48:23.269Z] [INFO] 💡 To continue this session:
+[2026-06-18T11:48:23.269Z] [INFO]    Interactive mode:    (cd "/tmp/gh-issue-solver-1781783024578" && claude --resume d65e890a-db60-43f7-aea3-691500f7e26c --model opus)
+[2026-06-18T11:48:23.270Z] [INFO]    Autonomous mode:     (cd "/tmp/gh-issue-solver-1781783024578" && claude --resume d65e890a-db60-43f7-aea3-691500f7e26c --output-format stream-json --dangerously-skip-permissions --model opus -p "Continue.")
+[2026-06-18T11:48:23.270Z] [INFO] 
+[2026-06-18T11:48:23.270Z] [INFO] 
+[2026-06-18T11:48:23.270Z] [INFO] 📄 Attaching failure logs to Pull Request...
+[2026-06-18T11:48:23.298Z] [STDOUT] [issue-251-45845bc22310 03a4959] Auto-commit: Changes made by Claude during problem-solving session
+ 2 files changed, 475 insertions(+)
+ create mode 100644 research/mango/ai-classifications-formalization-2026-06.md
+[2026-06-18T11:48:23.300Z] [INFO] ✅ Changes committed successfully
+[2026-06-18T11:48:23.308Z] [INFO] 📤 Pushing changes to remote...

--- a/src/claude.lib.mjs
+++ b/src/claude.lib.mjs
@@ -6,7 +6,7 @@ if (typeof globalThis.use === 'undefined') {
 const { $ } = await use('command-stream');
 const fs = (await use('fs')).promises;
 const path = (await use('path')).default;
-import { log, isENOSPC } from './lib.mjs';
+import { log, isENOSPC, buildToolErrorMessage } from './lib.mjs';
 import { reportError } from './sentry.lib.mjs';
 import { timeouts, retryLimits, claudeCode, getClaudeEnv, getThinkingLevelToTokens, getTokensToThinkingLevel, supportsThinkingBudget, DEFAULT_MAX_THINKING_BUDGET, getMaxOutputTokensForModel } from './config.lib.mjs';
 import { detectUsageLimit, formatUsageLimitMessage, isUsageLimitError } from './usage-limit.lib.mjs';
@@ -1211,8 +1211,8 @@ export const executeClaudeCommand = async params => {
             is503Error,
             anthropicTotalCostUSD: cumulativeAnthropicCostUSDOnStuckRetry, // Issue #1104/#1886
             resultSummary,
-            // Issue #1845: surface the actual error so callers can show it to users
-            errorInfo: { message: lastMessage || 'API explicitly marked error as not retryable', exitCode },
+            // Issue #1845/#1941: surface the actual error, rejecting meaningless fragments (e.g. a lone "}")
+            errorInfo: { message: buildToolErrorMessage({ lastMessage, exitCode, fallback: 'API explicitly marked error as not retryable', toolLabel: 'Claude' }), exitCode },
             queuedFeedback, // Issue #817: Bidirectional mode feedback
           };
         }
@@ -1260,8 +1260,8 @@ export const executeClaudeCommand = async params => {
             is503Error, // preserve for callers that check this
             anthropicTotalCostUSD: cumulativeAnthropicCostUSDOnRetriesExhausted, // Issue #1104/#1886: Include cumulative cost even on failure
             resultSummary, // Issue #1263: Include result summary
-            // Issue #1845: surface the actual error so callers can show it to users
-            errorInfo: { message: lastMessage || `Transient API error persisted after ${maxRetries} retries`, exitCode },
+            // Issue #1845/#1941: surface the actual error, rejecting meaningless fragments (e.g. a lone "}")
+            errorInfo: { message: buildToolErrorMessage({ lastMessage, exitCode, fallback: `Transient API error persisted after ${maxRetries} retries`, toolLabel: 'Claude' }), exitCode },
             queuedFeedback, // Issue #817: Bidirectional mode feedback
           };
         }
@@ -1327,9 +1327,9 @@ export const executeClaudeCommand = async params => {
           errorDuringExecution,
           anthropicTotalCostUSD: cumulativeAnthropicCostUSDOnFailure, // Issue #1104/#1886: cumulative cost even on failure
           resultSummary, // Issue #1263: Include result summary
-          // Issue #1845: surface the core error (e.g. "API Error: Output blocked by content
-          // filtering policy") so users see what actually went wrong, not just a generic message.
-          errorInfo: { message: lastMessage || `Claude command failed with exit code ${exitCode}`, exitCode },
+          // Issue #1845: surface the core error (e.g. "API Error: Output blocked by content filtering policy").
+          // Issue #1941: a lone "}" fragment at interrupt time must not become "CLAUDE execution failed with }".
+          errorInfo: { message: buildToolErrorMessage({ lastMessage, exitCode, fallback: `Claude command failed with exit code ${exitCode}`, toolLabel: 'Claude' }), exitCode },
           queuedFeedback, // Issue #817: Bidirectional mode feedback
         };
       }

--- a/src/gemini.lib.mjs
+++ b/src/gemini.lib.mjs
@@ -10,7 +10,7 @@ if (typeof globalThis.use === 'undefined') {
 
 const { $ } = await use('command-stream');
 
-import { log } from './lib.mjs';
+import { log, buildToolErrorMessage } from './lib.mjs';
 import { reportError } from './sentry.lib.mjs';
 import { timeouts, retryLimits } from './config.lib.mjs';
 import { detectUsageLimit, formatUsageLimitMessage } from './usage-limit.lib.mjs';
@@ -576,8 +576,8 @@ export const executeGeminiCommand = async params => {
           pricingInfo: { modelId: mappedModel, modelName: mappedModel, provider: 'Google', totalCostUSD: null },
           publicPricingEstimate: null,
           resultSummary: geminiJsonState.resultSummary || null,
-          // Issue #1845: surface the actual error so callers can show it to users
-          errorInfo: { message: errorText || `Gemini command failed with exit code ${exitCode}`, exitCode },
+          // Issue #1845/#1941: surface the actual error, rejecting meaningless fragments (e.g. a lone "}")
+          errorInfo: { message: buildToolErrorMessage({ lastMessage: errorText, exitCode, fallback: `Gemini command failed with exit code ${exitCode}`, toolLabel: 'Gemini' }), exitCode },
         };
       }
 

--- a/src/lib.mjs
+++ b/src/lib.mjs
@@ -666,6 +666,53 @@ export const cleanErrorMessage = error => {
 };
 
 /**
+ * Decide whether a string looks like a meaningful, human-readable error message
+ * rather than a stray structural fragment (Issue #1941).
+ *
+ * When a tool process is interrupted mid-stream (CTRL+C / SIGINT) or killed, the
+ * last captured stdout line can be a lone JSON-structural character left over
+ * from a truncated stream — for example a bare `}` or `{`. Surfacing that as the
+ * "core error" produced nonsense failure messages such as
+ * "CLAUDE execution failed with }" / "failed by {". A real error message always
+ * contains at least one letter or digit (in any script), so we treat fragments
+ * that contain none as not meaningful.
+ *
+ * @param {*} value - Candidate error string
+ * @returns {boolean} True when the value contains usable error text
+ */
+export const isMeaningfulErrorText = value => {
+  if (!value || typeof value !== 'string') return false;
+  const collapsed = value.replace(/\s+/g, ' ').trim();
+  if (!collapsed) return false;
+  // Require at least one Unicode letter or number; pure punctuation/brackets
+  // (e.g. "}", "{", "[]", ",") are stream fragments, not real errors.
+  return /[\p{L}\p{N}]/u.test(collapsed);
+};
+
+/**
+ * Build a clean tool error message for `errorInfo.message`, rejecting
+ * meaningless stream fragments (Issue #1941).
+ *
+ * Picks the tool-reported `lastMessage` only when it is meaningful; otherwise
+ * falls back to an interrupt label (exit code 130 = SIGINT/CTRL+C) or the
+ * provided generic fallback. This keeps junk like a lone `}` out of the stored
+ * error so every downstream surface (GitHub comment, terminal, retry logic)
+ * shows something honest.
+ *
+ * @param {Object} options
+ * @param {string} [options.lastMessage] - The last message captured from the tool stream
+ * @param {number} [options.exitCode] - Process exit code
+ * @param {string} [options.fallback] - Generic fallback message
+ * @param {string} [options.toolLabel='Tool'] - Human tool label for the interrupt message
+ * @returns {string} A clean, meaningful error message
+ */
+export const buildToolErrorMessage = ({ lastMessage, exitCode, fallback, toolLabel = 'Tool' } = {}) => {
+  if (isMeaningfulErrorText(lastMessage)) return lastMessage.replace(/\s+/g, ' ').trim();
+  if (exitCode === 130) return `${toolLabel} command interrupted (CTRL+C)`;
+  return fallback;
+};
+
+/**
  * Extract the core/root error string from a tool runner result (Issue #1845).
  *
  * Applies a single precedence everywhere so every failure surface shows the
@@ -674,6 +721,10 @@ export const cleanErrorMessage = error => {
  * usable error string is available. Shared by `formatToolExecutionFailure`
  * (GitHub comments / exit message) and the terminal "Error details:" lines in
  * watch / auto-merge so they never diverge.
+ *
+ * Issue #1941: a meaningless structural fragment (e.g. a lone `}` captured when
+ * a tool is interrupted mid-stream) is treated as "no usable error" so callers
+ * fall back to the generic phrase instead of "execution failed with }".
  *
  * @param {Object} options
  * @param {Object} [options.toolResult] - Result object returned by the tool runner
@@ -687,6 +738,9 @@ export const extractToolErrorCore = ({ toolResult } = {}) => {
   const rawCore = errorInfo?.message || errorInfo?.errorMatch || (typeof errorInfo === 'string' ? errorInfo : null) || toolResult?.result || null;
 
   if (!rawCore || typeof rawCore !== 'string') return null;
+
+  // Issue #1941: reject stray fragments with no letters/digits (e.g. "}").
+  if (!isMeaningfulErrorText(rawCore)) return null;
 
   // Collapse to a single clean line and strip noise.
   const core = rawCore.replace(/\s+/g, ' ').trim();

--- a/src/opencode.lib.mjs
+++ b/src/opencode.lib.mjs
@@ -14,7 +14,7 @@ const path = (await use('path')).default;
 const os = (await use('os')).default;
 
 // Import log from general lib
-import { log } from './lib.mjs';
+import { log, isMeaningfulErrorText, buildToolErrorMessage } from './lib.mjs';
 import { reportError } from './sentry.lib.mjs';
 import { timeouts, retryLimits } from './config.lib.mjs';
 import { detectUsageLimit, formatUsageLimitMessage } from './usage-limit.lib.mjs';
@@ -532,7 +532,8 @@ export const executeOpenCodeCommand = async params => {
           ...pricingResult,
           resultSummary: lastTextContent || null, // Issue #1263: Use last text content from JSON output stream
           // Issue #1845: surface the actual error so callers can show it to users
-          errorInfo: { message: lastMessage || allOutput || `OpenCode command failed with exit code ${exitCode}`, exitCode },
+          // Issue #1941: reject meaningless stream fragments (e.g. a lone "}").
+          errorInfo: { message: buildToolErrorMessage({ lastMessage: isMeaningfulErrorText(lastMessage) ? lastMessage : allOutput, exitCode, fallback: `OpenCode command failed with exit code ${exitCode}`, toolLabel: 'OpenCode' }), exitCode },
         };
       }
 

--- a/src/qwen.lib.mjs
+++ b/src/qwen.lib.mjs
@@ -13,7 +13,7 @@ const fs = (await use('fs')).promises;
 const path = (await use('path')).default;
 const os = (await use('os')).default;
 
-import { log } from './lib.mjs';
+import { log, buildToolErrorMessage } from './lib.mjs';
 import { reportError } from './sentry.lib.mjs';
 import { timeouts, retryLimits } from './config.lib.mjs';
 import { detectUsageLimit, formatUsageLimitMessage } from './usage-limit.lib.mjs';
@@ -633,8 +633,8 @@ export const executeQwenCommand = async params => {
           limitResetTime: null,
           ...usageResult,
           resultSummary,
-          // Issue #1845: surface the actual error so callers can show it to users
-          errorInfo: { message: combinedErrorText || errorMessage || `Qwen Code command failed${exitCode !== 0 ? ` with exit code ${exitCode}` : ''}`, exitCode },
+          // Issue #1845/#1941: surface the actual error, rejecting meaningless fragments (e.g. a lone "}")
+          errorInfo: { message: buildToolErrorMessage({ lastMessage: combinedErrorText || errorMessage, exitCode, fallback: `Qwen Code command failed${exitCode !== 0 ? ` with exit code ${exitCode}` : ''}`, toolLabel: 'Qwen Code' }), exitCode },
         };
       }
 

--- a/tests/solve-queue-tool-tracking.test.mjs
+++ b/tests/solve-queue-tool-tracking.test.mjs
@@ -93,7 +93,10 @@ await asyncTest('agent tasks can start when claude min interval is not reached',
 
 await asyncTest('getStats and getQueueSummary show per-tool breakdown', async () => {
   beforeEach();
-  const queue = new SolveQueue({ verbose: false });
+  // autoStart:false keeps items in the pending queue; with the consumer running
+  // it could shift() an item into processing before we snapshot the counts,
+  // making the pending assertions flaky under CI load (#1941 CI follow-up).
+  const queue = new SolveQueue({ verbose: false, autoStart: false });
   queue.enqueue({ url: 'https://github.com/test/repo/issues/1', args: '', requester: 'testuser', infoBlock: 'Test', tool: 'claude' });
   queue.enqueue({ url: 'https://github.com/test/repo/issues/2', args: '', requester: 'testuser', infoBlock: 'Test', tool: 'agent' });
   queue.enqueue({ url: 'https://github.com/test/repo/issues/3', args: '', requester: 'testuser', infoBlock: 'Test', tool: 'claude' });
@@ -114,7 +117,9 @@ await asyncTest('getStats and getQueueSummary show per-tool breakdown', async ()
 
 await asyncTest('formatStatus includes codex queue', async () => {
   beforeEach();
-  const queue = new SolveQueue({ verbose: false });
+  // autoStart:false so the consumer cannot drain a pending item before the
+  // formatStatus() snapshot (#1941 CI follow-up).
+  const queue = new SolveQueue({ verbose: false, autoStart: false });
   queue.enqueue({ url: 'https://github.com/test/repo/issues/1', args: '', requester: 'testuser', infoBlock: 'Test', tool: 'codex' });
   queue.enqueue({ url: 'https://github.com/test/repo/issues/2', args: '', requester: 'testuser', infoBlock: 'Test', tool: 'qwen' });
   queue.enqueue({ url: 'https://github.com/test/repo/issues/3', args: '', requester: 'testuser', infoBlock: 'Test', tool: 'gemini' });
@@ -127,7 +132,9 @@ await asyncTest('formatStatus includes codex queue', async () => {
 
 await asyncTest('formatStatus includes gemini queue', async () => {
   beforeEach();
-  const queue = new SolveQueue({ verbose: false });
+  // autoStart:false so the single enqueued item stays pending for the snapshot
+  // instead of racing the consumer's shift() into processing (#1941 CI follow-up).
+  const queue = new SolveQueue({ verbose: false, autoStart: false });
   queue.enqueue({ url: 'https://github.com/test/repo/issues/1', args: '', requester: 'testuser', infoBlock: 'Test', tool: 'gemini' });
   const status = await queue.formatStatus();
   assert.ok(status.includes('gemini') && status.includes('pending: 1'), 'Should show gemini queue with 1 pending');

--- a/tests/test-issue-1941-meaningless-error-fragment.test.mjs
+++ b/tests/test-issue-1941-meaningless-error-fragment.test.mjs
@@ -1,0 +1,144 @@
+#!/usr/bin/env node
+/**
+ * Meaningless Error Fragment Unit Tests (Issue #1941)
+ *
+ * Reproduces the bug from issue #1941: "Failed to deliver working session".
+ * When a Claude run was interrupted mid-stream (CTRL+C / SIGINT, exit code 130),
+ * the last captured stdout line was a stray JSON-structural fragment — a lone
+ * "}" — which was stored as `errorInfo.message`. That junk then surfaced in the
+ * GitHub failure comment as:
+ *
+ *   "CLAUDE execution failed with }"          (the reported PR comment)
+ *   "failed by {"                             (the issue title shorthand)
+ *
+ * The fix adds two shared helpers in src/lib.mjs:
+ *   - `isMeaningfulErrorText`  — a fragment with no letters/digits is not a real error
+ *   - `buildToolErrorMessage`  — pick the tool message only when meaningful, else
+ *                                an interrupt label (exit 130) or a generic fallback
+ * and guards `extractToolErrorCore` so meaningless fragments never reach any
+ * failure surface (GitHub comment, terminal "Error details:", retry logic).
+ *
+ * Run with: node tests/test-issue-1941-meaningless-error-fragment.test.mjs
+ *
+ * @see https://github.com/link-assistant/hive-mind/issues/1941
+ */
+
+import assert from 'node:assert/strict';
+import { isMeaningfulErrorText, buildToolErrorMessage, extractToolErrorCore, formatToolExecutionFailure } from '../src/lib.mjs';
+
+let testsPassed = 0;
+let testsFailed = 0;
+
+function test(name, fn) {
+  try {
+    fn();
+    console.log(`✅ ${name}`);
+    testsPassed++;
+  } catch (error) {
+    console.log(`❌ ${name}`);
+    console.log(`   Error: ${error.message}`);
+    testsFailed++;
+  }
+}
+
+console.log('\n📋 isMeaningfulErrorText Tests\n');
+
+test('rejects a lone closing brace (the reported fragment)', () => {
+  assert.equal(isMeaningfulErrorText('}'), false);
+});
+
+test('rejects a lone opening brace (the issue title fragment)', () => {
+  assert.equal(isMeaningfulErrorText('{'), false);
+});
+
+test('rejects pure JSON-structural punctuation', () => {
+  for (const junk of ['{', '}', '[', ']', ',', '},', '{}', '[]', ' } ', '\n}\n', ':', '"', '},{']) {
+    assert.equal(isMeaningfulErrorText(junk), false, `expected ${JSON.stringify(junk)} to be rejected`);
+  }
+});
+
+test('rejects empty / whitespace / non-string values', () => {
+  assert.equal(isMeaningfulErrorText(''), false);
+  assert.equal(isMeaningfulErrorText('   \n\t '), false);
+  assert.equal(isMeaningfulErrorText(null), false);
+  assert.equal(isMeaningfulErrorText(undefined), false);
+  assert.equal(isMeaningfulErrorText(12345), false);
+});
+
+test('accepts real error text (contains letters/digits)', () => {
+  assert.equal(isMeaningfulErrorText('API Error: Output blocked'), true);
+  assert.equal(isMeaningfulErrorText('exit code 1'), true);
+  assert.equal(isMeaningfulErrorText('boom'), true);
+});
+
+test('accepts non-ASCII (Cyrillic) error text', () => {
+  // The reproduced session was solving a Russian-language issue; errors can be non-ASCII.
+  assert.equal(isMeaningfulErrorText('Ошибка сервера'), true);
+});
+
+console.log('\n📋 buildToolErrorMessage Tests\n');
+
+test('keeps a meaningful lastMessage', () => {
+  assert.equal(buildToolErrorMessage({ lastMessage: 'API Error: blocked', exitCode: 1, fallback: 'fb', toolLabel: 'Claude' }), 'API Error: blocked');
+});
+
+test('collapses whitespace in a meaningful lastMessage', () => {
+  assert.equal(buildToolErrorMessage({ lastMessage: 'API Error:\n  blocked\tby   policy', exitCode: 1, fallback: 'fb', toolLabel: 'Claude' }), 'API Error: blocked by policy');
+});
+
+test('labels a CTRL+C interrupt (exit 130) when the fragment is junk', () => {
+  assert.equal(buildToolErrorMessage({ lastMessage: '}', exitCode: 130, fallback: 'fb', toolLabel: 'Claude' }), 'Claude command interrupted (CTRL+C)');
+});
+
+test('uses the generic fallback for junk with a non-interrupt exit code', () => {
+  assert.equal(buildToolErrorMessage({ lastMessage: '}', exitCode: 1, fallback: 'Claude command failed with exit code 1', toolLabel: 'Claude' }), 'Claude command failed with exit code 1');
+});
+
+test('uses the fallback when lastMessage is empty', () => {
+  assert.equal(buildToolErrorMessage({ lastMessage: '', exitCode: 1, fallback: 'fb', toolLabel: 'Claude' }), 'fb');
+});
+
+console.log('\n📋 extractToolErrorCore guard Tests\n');
+
+test('rejects a lone "}" fragment as the core error', () => {
+  assert.equal(extractToolErrorCore({ toolResult: { errorInfo: { message: '}' } } }), null);
+});
+
+test('rejects a lone "{" fragment as the core error', () => {
+  assert.equal(extractToolErrorCore({ toolResult: { errorInfo: { message: '{' } } }), null);
+});
+
+test('rejects punctuation-only fragments via toolResult.result fallback', () => {
+  assert.equal(extractToolErrorCore({ toolResult: { result: '},' } }), null);
+});
+
+test('still returns genuine error text', () => {
+  assert.equal(extractToolErrorCore({ toolResult: { errorInfo: { message: 'API Error: blocked' } } }), 'API Error: blocked');
+});
+
+console.log('\n📋 formatToolExecutionFailure end-to-end (the reported bug)\n');
+
+test('the reported shape no longer produces "CLAUDE execution failed with }"', () => {
+  // Shape returned by claude.lib.mjs when interrupted mid-stream before the fix.
+  const toolResult = { success: false, errorInfo: { message: '}', exitCode: 130 } };
+  const result = formatToolExecutionFailure({ tool: 'claude', toolResult });
+  assert.equal(result, 'CLAUDE execution failed');
+  assert.ok(!result.includes('}'), `Must not surface the junk fragment, got: ${result}`);
+});
+
+test('an interrupt labeled by buildToolErrorMessage reads cleanly', () => {
+  // Shape produced by claude.lib.mjs AFTER the fix for an interrupt.
+  const toolResult = { success: false, errorInfo: { message: 'Claude command interrupted (CTRL+C)', exitCode: 130 } };
+  assert.equal(formatToolExecutionFailure({ tool: 'claude', toolResult }), 'CLAUDE execution failed with Claude command interrupted (CTRL+C)');
+});
+
+// ============================================================================
+// Summary
+// ============================================================================
+
+console.log('\n' + '='.repeat(60));
+console.log(`\n📊 Results: ${testsPassed} passed, ${testsFailed} failed, ${testsPassed + testsFailed} total\n`);
+
+if (testsFailed > 0) {
+  process.exit(1);
+}


### PR DESCRIPTION
## Summary

Fixes #1941 — a failed/interrupted Claude session posted the nonsense GitHub comment **`CLAUDE execution failed with }`** (issue title shorthand: `failed by {`).

### Root cause
The session was **interrupted by CTRL+C (SIGINT, exit code 130)** — *not* an API failure (the last Anthropic call returned HTTP 200). At interrupt time, hive-mind's verbose mode was printing a multi-line `Response`/`ReadableStream` object dump whose final non-JSON line was a lone `}`. In `src/claude.lib.mjs`, the stream loop stores every non-JSON line as `lastMessage` (`lastMessage = line`), so `lastMessage === "}"`. That truthy junk skipped the `||` fallback and became `errorInfo.message`, which the shared error-surfacing chokepoint (from #1845) faithfully rendered in the failure comment.

Two real defects:
1. **Meaningless fragments treated as real errors** — a string with no letters/digits (`}`, `{`, `,`, …) carries no diagnostic value but passed the truthiness check.
2. **Interruptions not labeled** — exit 130 is an operator interruption, but only the terminal said so; the structured message that reaches GitHub did not.

### Fix (applied across the whole codebase)
- **`src/lib.mjs`** — new shared helpers:
  - `isMeaningfulErrorText(value)` — a real error contains ≥1 Unicode letter/digit (`/[\p{L}\p{N}]/u`), so pure punctuation is rejected (and non-ASCII errors like Cyrillic are preserved).
  - `buildToolErrorMessage({ lastMessage, exitCode, fallback, toolLabel })` — uses the tool message only when meaningful, else labels exit-130 interrupts (`"<Tool> command interrupted (CTRL+C)"`), else the generic fallback.
  - `extractToolErrorCore` now rejects meaningless cores → **defence-in-depth**: even call sites that bypass the helper can't surface junk.
- **`src/claude.lib.mjs`** — all three failure-return sites build `errorInfo.message` via `buildToolErrorMessage(... toolLabel: 'Claude')`.
- **`src/opencode.lib.mjs`** — failure-return site uses `buildToolErrorMessage(... toolLabel: 'OpenCode')`.
- `src/agent.lib.mjs` already special-cased exit 130; `src/codex.lib.mjs` doesn't store raw fall-through lines and is covered by the chokepoint guard.

### Result
| Scenario | Before | After |
| --- | --- | --- |
| CTRL+C interrupt (exit 130), `lastMessage = "}"` | `CLAUDE execution failed with }` | `CLAUDE execution failed with Claude command interrupted (CTRL+C)` |
| Junk fragment, non-interrupt exit | `CLAUDE execution failed with }` | `CLAUDE execution failed` |
| Genuine error | unchanged | unchanged |

### Reproduction / tests
New regression test `tests/test-issue-1941-meaningless-error-fragment.test.mjs` (17 cases) reproduces the bug and verifies the fix. Full suite: **272 test files pass**; `npm run lint` clean.

```bash
node tests/test-issue-1941-meaningless-error-fragment.test.mjs
```

### Case study
`docs/case-studies/issue-1941/` — full timeline, requirements table, root-cause analysis, solution plan, library comparison, and downloaded data (issue JSON, failure comment, complete 5,617-line log [secrets already sanitized], error excerpt).

### Upstream reporting
The bug is 100% internal to hive-mind (the upstream PR comment on `G-Ivan-A/hybrid-Intelligence-lab#252` was only the symptom surface). No external issue to file.

### Requirements coverage (from #1941)
- R1 Download/compile logs & data → ✅ `docs/case-studies/issue-1941/data/`
- R2 Deep case study → ✅ README
- R3 Add debug/verbose if data insufficient → ✅ existing verbose tracing was sufficient; interrupts now labeled
- R4 Report to other repo if applicable → ✅ analyzed, none needed
- R5 Fix across entire codebase → ✅ shared chokepoint + all tool runners
- R6 Single PR #1942 → ✅
