### PR TITLE
lenv-reader: accept bare indented LINO option/value links

### DIFF
--- a/.changeset/fuzzy-lenv-links.md
+++ b/.changeset/fuzzy-lenv-links.md
@@ -1,0 +1,5 @@
+---
+"@link-assistant/hive-mind": patch
+---
+
+Allow bare indented LINO option/value links in .lenv configuration, matching parenthesized links.

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,0 +1,1 @@
+# .gitkeep file auto-generated at 2026-06-23T16:01:24.634Z for PR creation at branch issue-1972-e808f7475a25 for issue https://github.com/link-assistant/hive-mind/issues/1972

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,1 +1,0 @@
-# .gitkeep file auto-generated at 2026-06-23T16:01:24.634Z for PR creation at branch issue-1972-e808f7475a25 for issue https://github.com/link-assistant/hive-mind/issues/1972

--- a/src/lenv-reader.lib.mjs
+++ b/src/lenv-reader.lib.mjs
@@ -39,10 +39,6 @@ const LinoParser = linoModule.Parser || linoModule.default?.Parser;
 
 const fs = await import('fs');
 
-function isCliOptionToken(value) {
-  return /^--[a-zA-Z0-9][a-zA-Z0-9=_.-]*$/.test(value) || /^-[a-zA-Z]$/.test(value);
-}
-
 function collectStringValues(value, result = []) {
   if (value && typeof value === 'object' && Array.isArray(value.values)) {
     if (value.id !== null && value.id !== undefined) {
@@ -55,25 +51,6 @@ function collectStringValues(value, result = []) {
     result.push(String(value));
   }
   return result;
-}
-
-function validateNoBareSameLineOptions(content) {
-  let currentVar = 'configuration';
-
-  for (const line of content.split(/\r?\n/)) {
-    const trimmed = line.trim();
-    if (!trimmed || trimmed === '(' || trimmed === ')') continue;
-
-    const topLevelMatch = !/^\s/.test(line) ? trimmed.match(/^([A-Za-z_][A-Za-z0-9_]*):(?:\s*(.*))?$/) : null;
-    const valueText = topLevelMatch ? (topLevelMatch[2] || '').trim() : trimmed;
-    if (topLevelMatch) currentVar = topLevelMatch[1];
-    if (!valueText || valueText === '(' || valueText === ')' || valueText.startsWith('(')) continue;
-
-    const parts = valueText.split(/\s+/).filter(Boolean);
-    if (parts.length > 1 && isCliOptionToken(parts[0])) {
-      throw new Error(`Invalid LINO format in "${currentVar}": Multiple values on the same line are not supported.\n` + `Found: "${parts.join(' ')}"\n` + `Each value must be on its own line with proper indentation, or grouped explicitly as a parenthesized link.`);
-    }
-  }
 }
 
 /**
@@ -97,8 +74,6 @@ export class LenvReader {
     const result = {};
 
     try {
-      validateNoBareSameLineOptions(content);
-
       // Parse the entire content as LINO
       const parsed = this.parser.parse(content);
 

--- a/tests/test-lenv-reader.mjs
+++ b/tests/test-lenv-reader.mjs
@@ -380,32 +380,50 @@ runTest('loadLenvConfig function', async () => {
 // Validation Tests (Issue #1086)
 // ===============================================
 
-// Test 17: Reject same-line options
-runTest('reject same-line options', () => {
+// Test 17: Accept bare same-line option/value links
+runTest('accept bare same-line option/value links', () => {
   const reader = new LenvReader();
   const config = `TELEGRAM_HIVE_OVERRIDES:
   --option1
-  --option2  --option3`;
+  --option2 value3`;
 
-  let errorThrown = false;
-  let errorMessage = '';
-  try {
-    reader.parse(config);
-  } catch (error) {
-    errorThrown = true;
-    errorMessage = error.message;
-  }
+  const result = reader.parse(config);
+  const expected = `(
+  --option1
+  --option2
+  value3
+)`;
 
-  if (!errorThrown) {
-    throw new Error('Expected error for same-line options, but no error was thrown');
-  }
-
-  if (!errorMessage.includes('Multiple values on the same line')) {
-    throw new Error(`Expected 'Multiple values on the same line' error, got: ${errorMessage}`);
+  if (result.TELEGRAM_HIVE_OVERRIDES !== expected) {
+    throw new Error(`Expected flattened bare option/value link, got: ${result.TELEGRAM_HIVE_OVERRIDES}`);
   }
 });
 
-// Test 18: Reject invalid character ? in options
+// Test 18: Bare and parenthesized option/value links parse identically
+runTest('parse bare and parenthesized option/value links identically', () => {
+  const reader = new LenvReader();
+  const bare = `TELEGRAM_SOLVE_OVERRIDES:
+  --attach-logs
+  --verbose
+  --no-tool-check
+  --disable-report-issue
+  --isolation docker`;
+  const parenthesized = `TELEGRAM_SOLVE_OVERRIDES:
+  --attach-logs
+  --verbose
+  --no-tool-check
+  --disable-report-issue
+  (--isolation docker)`;
+
+  const bareResult = reader.parse(bare);
+  const parenthesizedResult = reader.parse(parenthesized);
+
+  if (bareResult.TELEGRAM_SOLVE_OVERRIDES !== parenthesizedResult.TELEGRAM_SOLVE_OVERRIDES) {
+    throw new Error(`Expected bare and parenthesized overrides to match.\nBare: ${bareResult.TELEGRAM_SOLVE_OVERRIDES}\nParenthesized: ${parenthesizedResult.TELEGRAM_SOLVE_OVERRIDES}`);
+  }
+});
+
+// Test 19: Reject invalid character ? in options
 runTest('reject invalid character ? in options', () => {
   const reader = new LenvReader();
   const config = `TELEGRAM_HIVE_OVERRIDES:
@@ -430,7 +448,7 @@ runTest('reject invalid character ? in options', () => {
   }
 });
 
-// Test 19: Reject invalid character @ in options
+// Test 20: Reject invalid character @ in options
 runTest('reject invalid character @ in options', () => {
   const reader = new LenvReader();
   const config = `TELEGRAM_HIVE_OVERRIDES:
@@ -454,7 +472,7 @@ runTest('reject invalid character @ in options', () => {
   }
 });
 
-// Test 20: Accept valid options with = sign
+// Test 21: Accept valid options with = sign
 runTest('accept valid options with = sign', () => {
   const reader = new LenvReader();
   const config = `TELEGRAM_HIVE_OVERRIDES:
@@ -472,7 +490,7 @@ runTest('accept valid options with = sign', () => {
   }
 });
 
-// Test 21: Accept valid hyphenated options
+// Test 22: Accept valid hyphenated options
 runTest('accept valid hyphenated options', () => {
   const reader = new LenvReader();
   const config = `TELEGRAM_HIVE_OVERRIDES:
@@ -490,7 +508,7 @@ runTest('accept valid hyphenated options', () => {
   }
 });
 
-// Test 22: Non-option values should NOT be validated for special chars
+// Test 23: Non-option values should NOT be validated for special chars
 runTest('non-option values are not validated', () => {
   const reader = new LenvReader();
   const config = `TELEGRAM_BOT_TOKEN: some-token-with-special!@#
@@ -506,7 +524,7 @@ TELEGRAM_ALLOWED_CHATS:
   }
 });
 
-// Test 23: Accept explicit parenthesized lists
+// Test 24: Accept explicit parenthesized lists
 runTest('accept explicit parenthesized lists', () => {
   const reader = new LenvReader();
   const config = `LINO_LIST: (
@@ -523,7 +541,7 @@ runTest('accept explicit parenthesized lists', () => {
   }
 });
 
-// Test 24: Validation error message includes the problematic value
+// Test 25: Validation error message includes the problematic value
 runTest('validation error message includes problematic value', () => {
   const reader = new LenvReader();
   const config = `TELEGRAM_HIVE_OVERRIDES:
@@ -541,7 +559,7 @@ runTest('validation error message includes problematic value', () => {
   }
 });
 
-// Test 25: Accept parenthesized option/value links
+// Test 26: Accept parenthesized option/value links
 runTest('accept parenthesized option/value links', () => {
   const reader = new LenvReader();
   const config = `TELEGRAM_HIVE_OVERRIDES:
@@ -560,7 +578,7 @@ runTest('accept parenthesized option/value links', () => {
   }
 });
 
-// Test 26: Accept issue #1658 Telegram configuration shape
+// Test 27: Accept issue #1658 Telegram configuration shape
 runTest('accept issue #1658 Telegram configuration shape', () => {
   const reader = new LenvReader();
   const config = `TELEGRAM_BOT_TOKEN: 'test-token'

--- a/tests/test-lino.mjs
+++ b/tests/test-lino.mjs
@@ -260,22 +260,14 @@ runTest('round-trip with numeric strings', () => {
 console.log('\n📋 Edge Case Tests (Issue #1086 Related)\n');
 
 // Test 23: Same-line parsing behavior
-// Note: This tests the current behavior where same-line items create nested structures
-// The lenv-reader should reject these, but lino.parseStringValues may not extract all values
-runTest('parseStringValues with same-line items (nested structure)', () => {
-  // When items are on the same line, LINO parser creates nested tuples
-  // The original parseStringValues only extracts top-level values
+// Same-line values are valid whole-line links in LINO and should be flattened.
+runTest('parseStringValues with same-line items', () => {
   const input = `(
   --option1
   --option2  --option3
 )`;
   const result = lino.parseStringValues(input);
-  // According to user feedback, same-line options should be rejected at lenv-reader level
-  // Here we just test the current behavior
-  if (result.length === 0) {
-    throw new Error('Should return at least one value');
-  }
-  // We expect --option1 to be extracted, --option2 and --option3 may be in nested structure
+  assertEqual(result, ['--option1', '--option2', '--option3'], 'Should flatten same-line values');
 });
 
 // Test 24: Options with equals sign


### PR DESCRIPTION
Fixes #1972

## Summary

- Removed the raw-line `validateNoBareSameLineOptions` guard from `LenvReader.parse`, allowing the official `links-notation` parser to accept valid whole-line links such as `--isolation docker`.
- Kept parsed-output option validation, so typo characters in option-like values such as `--option?` and `--option@name` still fail with the existing helpful error.
- Added regression coverage proving the user's bare `TELEGRAM_SOLVE_OVERRIDES` block parses identically to the parenthesized `(--isolation docker)` form.
- Added a patch changeset for the user-visible LENV parsing fix.

## Reproduction

Before the fix, `tests/test-lenv-reader.mjs` with this block failed with `Multiple values on the same line are not supported`:

```lino
TELEGRAM_SOLVE_OVERRIDES:
  --attach-logs
  --verbose
  --no-tool-check
  --disable-report-issue
  --isolation docker
```

After the fix, that bare form and the parenthesized form below produce the same parsed value:

```lino
TELEGRAM_SOLVE_OVERRIDES:
  --attach-logs
  --verbose
  --no-tool-check
  --disable-report-issue
  (--isolation docker)
```

## Tests

```bash
node tests/test-lenv-reader.mjs
node tests/test-lino.mjs
npm run lint
npm run format:check
npm test
```

`npm test` passed all 285 selected test files locally. Local install/checks ran under Node v20.20.2, which emits the repo's expected engine warning because `package.json` requires Node >=24.0.0.
