### PR TITLE
fix(cleanup): make Docker isolation cleanup session-aware

### DIFF
--- a/.changeset/docker-isolation-cleanup.md
+++ b/.changeset/docker-isolation-cleanup.md
@@ -1,0 +1,5 @@
+---
+"@link-assistant/hive-mind": patch
+---
+
+Add session-aware Docker-isolation container cleanup to hive-cleanup.

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,0 +1,1 @@
+# .gitkeep file auto-generated at 2026-06-24T13:48:05.378Z for PR creation at branch issue-1980-0fe995014e18 for issue https://github.com/link-assistant/hive-mind/issues/1980

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,1 +1,0 @@
-# .gitkeep file auto-generated at 2026-06-24T13:48:05.378Z for PR creation at branch issue-1980-0fe995014e18 for issue https://github.com/link-assistant/hive-mind/issues/1980

--- a/src/cleanup.lib.mjs
+++ b/src/cleanup.lib.mjs
@@ -17,6 +17,7 @@
  * @see https://github.com/link-assistant/hive-mind/issues/1848
  */
 
+import { classifyExitStatus, isExecutingSessionStatus, isFailureSessionStatus, isTerminalSessionStatus, normalizeExitCode } from './session-status.lib.mjs';
 import { isValidIssueBranchName, parseIssueBranchName } from './solve.branch.lib.mjs';
 
 /**
@@ -161,6 +162,8 @@ export function buildActiveMatchers(activeTasks) {
       sessionId: task.sessionId || null,
       sessionName: task.sessionName || null,
       status: task.status || null,
+      exitCode: task.exitCode ?? null,
+      isolation: task.isolation || null,
       workspace: task.workspace || null,
     });
   }
@@ -430,4 +433,233 @@ export function formatEntryContext(item) {
   }
 
   return details.length > 0 ? ` (${details.join('; ')})` : '';
+}
+
+export const DEFAULT_DOCKER_ISOLATION_CLEANUP_MODE = 'failed-kept';
+export const DOCKER_ISOLATION_CLEANUP_MODES = new Set(['failed-kept', 'finished', 'all', 'none']);
+
+const DOCKER_ISOLATION_SESSION_NAME_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+function normalizeText(value) {
+  return String(value || '')
+    .trim()
+    .toLowerCase();
+}
+
+/**
+ * Normalize the docker-isolation cleanup policy.
+ *
+ * Modes:
+ *   - failed-kept: default; remove successful exited containers, keep failures
+ *   - finished: remove all terminal/exited task containers
+ *   - all: remove every non-running task container
+ *   - none: report only
+ *
+ * @param {string|null|undefined} value
+ * @returns {'failed-kept'|'finished'|'all'|'none'}
+ */
+export function normalizeDockerIsolationCleanupMode(value) {
+  const mode = normalizeText(value);
+  if (!mode || ['default', 'true', '1', 'yes', 'on', 'success', 'successful', 'failed-kept', 'keep-failed', 'on-failure'].includes(mode)) {
+    return DEFAULT_DOCKER_ISOLATION_CLEANUP_MODE;
+  }
+  if (['false', '0', 'no', 'off', 'none', 'disabled'].includes(mode)) return 'none';
+  if (['finished', 'terminal'].includes(mode)) return 'finished';
+  if (['all', 'everything'].includes(mode)) return 'all';
+  throw new Error(`Invalid docker isolation cleanup mode: ${value}. Expected one of: failed-kept, finished, all, none`);
+}
+
+/**
+ * True when a Docker container name looks like a start-command session UUID.
+ *
+ * @param {string} name
+ * @returns {boolean}
+ */
+export function isDockerIsolationSessionName(name) {
+  return DOCKER_ISOLATION_SESSION_NAME_RE.test(String(name || '').trim());
+}
+
+/**
+ * Parse Docker's status text, e.g. "Exited (137) 10 minutes ago".
+ *
+ * @param {string} status
+ * @returns {number|null}
+ */
+export function parseDockerContainerExitCode(status) {
+  const match = String(status || '').match(/\bExited\s+\((-?\d+)\)/i);
+  return match ? normalizeExitCode(match[1]) : null;
+}
+
+function createSessionLookup(sessionTasks) {
+  const lookup = new Map();
+  const merge = (key, task) => {
+    if (!key) return;
+    const existing = lookup.get(key) || {};
+    lookup.set(key, {
+      ...existing,
+      ...task,
+      status: task.status || existing.status || null,
+      exitCode: task.exitCode ?? existing.exitCode ?? null,
+      isolation: task.isolation || existing.isolation || null,
+      sessionId: task.sessionId || existing.sessionId || null,
+      sessionName: task.sessionName || existing.sessionName || null,
+      workspace: task.workspace || existing.workspace || null,
+    });
+  };
+
+  for (const task of sessionTasks || []) {
+    if (!task) continue;
+    merge(task.sessionId, task);
+    merge(task.sessionName, task);
+  }
+  return lookup;
+}
+
+function normalizeDockerContainer(container) {
+  const name = String(container?.name || container?.Names || container?.Name || '')
+    .replace(/^\//, '')
+    .trim();
+  const state = normalizeText(container?.state || container?.State);
+  const statusText = String(container?.status ?? container?.Status ?? '').trim();
+  const exitCode = normalizeExitCode(container?.exitCode ?? container?.ExitCode ?? parseDockerContainerExitCode(statusText));
+  const running = container?.running === true || state === 'running' || /^Up\b/i.test(statusText);
+  return {
+    ...container,
+    id: container?.id || container?.ID || null,
+    image: container?.image || container?.Image || null,
+    name,
+    state,
+    status: statusText,
+    exitCode,
+    running,
+  };
+}
+
+function inferDockerContainerOutcome(container, session) {
+  const sessionStatus = normalizeText(session?.status);
+  const exitCode = normalizeExitCode(container.exitCode ?? session?.exitCode);
+  const running = container.running || isExecutingSessionStatus(sessionStatus);
+  const containerTerminal = ['exited', 'dead', 'removing'].includes(container.state) || /^Exited\b/i.test(container.status) || exitCode !== null;
+  const sessionTerminal = isTerminalSessionStatus(sessionStatus);
+  const terminal = !running && (sessionTerminal || containerTerminal);
+  const exitStatus = classifyExitStatus(exitCode);
+  const failed = terminal && (isFailureSessionStatus(sessionStatus) || isFailureSessionStatus(exitStatus) || (exitCode !== null && exitCode !== 0));
+  const successful = terminal && !failed && exitCode === 0;
+  const unknown = terminal && !successful && !failed;
+
+  return {
+    running,
+    terminal,
+    exitCode,
+    successful,
+    failed,
+    unknown,
+  };
+}
+
+function dockerCleanupRecord(container, session, outcome, reason) {
+  return {
+    ...container,
+    ...outcome,
+    session: session || null,
+    reason,
+    command: `docker rm -f ${container.name}`,
+  };
+}
+
+/**
+ * Plan selective cleanup for Docker-isolation task containers.
+ *
+ * The input containers are expected to be Docker ps records already filtered to
+ * session UUID names, but the planner filters defensively too. Running
+ * containers are never removed, regardless of mode.
+ *
+ * @param {Object} options
+ * @param {Array} options.containers
+ * @param {Array} [options.sessionTasks]
+ * @param {string} [options.mode]
+ * @returns {{keep: Array, remove: Array, mode: string}}
+ */
+export function planDockerIsolationCleanup(options = {}) {
+  const mode = normalizeDockerIsolationCleanupMode(options.mode);
+  const sessions = createSessionLookup(options.sessionTasks || []);
+  const keep = [];
+  const remove = [];
+
+  for (const rawContainer of options.containers || []) {
+    const container = normalizeDockerContainer(rawContainer);
+    if (!isDockerIsolationSessionName(container.name)) continue;
+
+    const session = sessions.get(container.name) || null;
+    const outcome = inferDockerContainerOutcome(container, session);
+    let reason;
+    let action = 'keep';
+
+    if (mode === 'none') {
+      reason = 'disabled';
+    } else if (outcome.running) {
+      reason = 'active-container';
+    } else if (mode === 'all') {
+      reason = 'all-mode';
+      action = 'remove';
+    } else if (!outcome.terminal) {
+      reason = 'unknown-container-state';
+    } else if (mode === 'finished') {
+      reason = 'finished-container';
+      action = 'remove';
+    } else if (outcome.successful) {
+      reason = 'successful-container';
+      action = 'remove';
+    } else if (outcome.failed) {
+      reason = 'failed-container-kept';
+    } else {
+      reason = 'unknown-outcome-kept';
+    }
+
+    const record = dockerCleanupRecord(container, session, outcome, reason);
+    if (action === 'remove') remove.push(record);
+    else keep.push(record);
+  }
+
+  return { keep, remove, mode };
+}
+
+/**
+ * Human-readable docker-isolation cleanup reason.
+ *
+ * @param {string} reason
+ * @returns {string}
+ */
+export function describeDockerIsolationReason(reason) {
+  const map = {
+    disabled: 'docker-isolation cleanup disabled',
+    'active-container': 'running docker-isolation task',
+    'unknown-container-state': 'container state is not terminal',
+    'successful-container': 'successful docker-isolation task container',
+    'finished-container': 'finished docker-isolation task container',
+    'failed-container-kept': 'failed docker-isolation task kept for debugging',
+    'unknown-outcome-kept': 'docker-isolation task outcome unknown',
+    'all-mode': 'non-running docker-isolation container',
+  };
+  return map[reason] || reason;
+}
+
+/**
+ * Format a docker-isolation container record for CLI logs.
+ *
+ * @param {Object} item
+ * @returns {string}
+ */
+export function formatDockerIsolationContainerSummary(item) {
+  if (!item) return '';
+  const parts = [`session ${item.name}`];
+  if (item.image) parts.push(`image ${item.image}`);
+  if (item.state) parts.push(`state ${item.state}`);
+  if (item.status) parts.push(`status ${item.status}`);
+  if (item.exitCode !== null && item.exitCode !== undefined) parts.push(`exit ${item.exitCode}`);
+  if (item.session) parts.push(formatTaskSummary(item.session));
+  if (item.command && ['disabled', 'failed-container-kept', 'unknown-outcome-kept'].includes(item.reason)) {
+    parts.push(`remove when done: ${item.command}`);
+  }
+  return parts.join(', ');
 }

--- a/src/cleanup.lib.mjs
+++ b/src/cleanup.lib.mjs
@@ -435,8 +435,8 @@ export function formatEntryContext(item) {
   return details.length > 0 ? ` (${details.join('; ')})` : '';
 }
 
-export const DEFAULT_DOCKER_ISOLATION_CLEANUP_MODE = 'failed-kept';
-export const DOCKER_ISOLATION_CLEANUP_MODES = new Set(['failed-kept', 'finished', 'all', 'none']);
+export const DEFAULT_DOCKER_ISOLATION_CLEANUP_MODE = 'succeeded';
+export const DOCKER_ISOLATION_CLEANUP_MODES = new Set(['succeeded', 'all', 'none']);
 
 const DOCKER_ISOLATION_SESSION_NAME_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
 
@@ -450,23 +450,21 @@ function normalizeText(value) {
  * Normalize the docker-isolation cleanup policy.
  *
  * Modes:
- *   - failed-kept: default; remove successful exited containers, keep failures
- *   - finished: remove all terminal/exited task containers
- *   - all: remove every non-running task container
+ *   - succeeded: default; remove successful exited containers, keep failures
+ *   - all: remove all terminal/exited task containers
  *   - none: report only
  *
  * @param {string|null|undefined} value
- * @returns {'failed-kept'|'finished'|'all'|'none'}
+ * @returns {'succeeded'|'all'|'none'}
  */
 export function normalizeDockerIsolationCleanupMode(value) {
   const mode = normalizeText(value);
-  if (!mode || ['default', 'true', '1', 'yes', 'on', 'success', 'successful', 'failed-kept', 'keep-failed', 'on-failure'].includes(mode)) {
+  if (!mode || ['default', 'true', '1', 'yes', 'on', 'succeeded', 'success', 'successful', 'failed-kept', 'keep-failed', 'on-failure'].includes(mode)) {
     return DEFAULT_DOCKER_ISOLATION_CLEANUP_MODE;
   }
   if (['false', '0', 'no', 'off', 'none', 'disabled'].includes(mode)) return 'none';
-  if (['finished', 'terminal'].includes(mode)) return 'finished';
-  if (['all', 'everything'].includes(mode)) return 'all';
-  throw new Error(`Invalid docker isolation cleanup mode: ${value}. Expected one of: failed-kept, finished, all, none`);
+  if (['all', 'everything', 'finished', 'terminal'].includes(mode)) return 'all';
+  throw new Error(`Invalid docker isolation cleanup mode: ${value}. Expected one of: succeeded, all, none`);
 }
 
 /**
@@ -599,12 +597,9 @@ export function planDockerIsolationCleanup(options = {}) {
       reason = 'disabled';
     } else if (outcome.running) {
       reason = 'active-container';
-    } else if (mode === 'all') {
-      reason = 'all-mode';
-      action = 'remove';
     } else if (!outcome.terminal) {
       reason = 'unknown-container-state';
-    } else if (mode === 'finished') {
+    } else if (mode === 'all') {
       reason = 'finished-container';
       action = 'remove';
     } else if (outcome.successful) {

--- a/src/cleanup.mjs
+++ b/src/cleanup.mjs
@@ -137,7 +137,7 @@ System / Ubuntu cleanup (opt-in):
 Docker isolation cleanup:
   --docker-isolation[=<mode>] Clean task containers named by session UUID
                               [default: ${DEFAULT_DOCKER_ISOLATION_CLEANUP_MODE}]
-                              modes: failed-kept, finished, all, none
+                              modes: succeeded, all, none
   --no-docker-isolation       Disable Docker-isolation task container cleanup
 
   --verbose, -v               Verbose logging

--- a/src/cleanup.mjs
+++ b/src/cleanup.mjs
@@ -23,6 +23,7 @@
  *   --no-keep-dirty               allow deleting clones with unpushed changes
  *   --processes                   map claude/codex/etc. PIDs to task sessions
  *   --kill-orphaned-agents        signal orphaned terminal-session agents
+ *   --docker-isolation[=<mode>]   cleanup task containers by session UUID
  *   --apt --journal --docker --npm   Ubuntu/system cleanup (opt-in)
  *   --system                      shorthand for --apt --journal --npm
  *   --sudo                        prefix package-manager commands with sudo
@@ -35,8 +36,8 @@ import path from 'node:path';
 import { promises as fsp } from 'node:fs';
 
 import { isConfirmationYes, readConfirmationLine } from './confirmation.lib.mjs';
-import { classifyEntries, summarize, formatBytes, describeReason, buildActiveMatchers, DEFAULT_PROTECTED_NAMES, formatEntryContext, formatTaskSummary } from './cleanup.lib.mjs';
-import { getTempRoot, listTempEntries, getPathSize, readFolderGitInfo, listProcessHeldPaths, getActiveTasks, listSessionTasks, removePath, runSystemCleanup, collectProcessDebugReport, signalOrphanedAgentTrees } from './cleanup.os.lib.mjs';
+import { classifyEntries, summarize, formatBytes, describeReason, buildActiveMatchers, DEFAULT_PROTECTED_NAMES, formatEntryContext, formatTaskSummary, DEFAULT_DOCKER_ISOLATION_CLEANUP_MODE, describeDockerIsolationReason, formatDockerIsolationContainerSummary, normalizeDockerIsolationCleanupMode, planDockerIsolationCleanup } from './cleanup.lib.mjs';
+import { getTempRoot, listTempEntries, getPathSize, readFolderGitInfo, listProcessHeldPaths, getActiveTasks, listSessionTasks, removePath, runSystemCleanup, collectProcessDebugReport, signalOrphanedAgentTrees, listDockerIsolationContainers, removeDockerContainer } from './cleanup.os.lib.mjs';
 import { formatProcessDebugReport } from './process-debug.lib.mjs';
 
 const args = process.argv.slice(2);
@@ -69,6 +70,17 @@ function parsePidList(values) {
     .flatMap(value => String(value || '').split(','))
     .map(value => Number(value.trim()))
     .filter(value => Number.isInteger(value) && value > 0);
+}
+
+function parseDockerIsolationMode() {
+  if (hasFlag('--no-docker-isolation')) return 'none';
+  const configured = getFlagValue('--docker-isolation') ?? process.env.HIVE_MIND_CLEANUP_DOCKER_ISOLATION ?? process.env.HIVE_CLEANUP_DOCKER_ISOLATION ?? DEFAULT_DOCKER_ISOLATION_CLEANUP_MODE;
+  try {
+    return normalizeDockerIsolationCleanupMode(configured);
+  } catch (error) {
+    console.error(`Error: ${error.message}`);
+    process.exit(1);
+  }
 }
 
 // ---------------------------------------------------------------------------
@@ -117,10 +129,16 @@ Process diagnostics:
 System / Ubuntu cleanup (opt-in):
   --apt                       apt-get clean / autoclean / autoremove
   --journal                   journalctl --vacuum-time=2weeks
-  --docker                    docker system prune -f
+  --docker                    docker system prune -f (host-wide Docker cleanup)
   --npm                       npm cache clean --force
   --system                    Shorthand for --apt --journal --npm
   --sudo                      Prefix package-manager commands with sudo
+
+Docker isolation cleanup:
+  --docker-isolation[=<mode>] Clean task containers named by session UUID
+                              [default: ${DEFAULT_DOCKER_ISOLATION_CLEANUP_MODE}]
+                              modes: failed-kept, finished, all, none
+  --no-docker-isolation       Disable Docker-isolation task container cleanup
 
   --verbose, -v               Verbose logging
   --version                   Show version number
@@ -150,6 +168,7 @@ const options = {
   apt: hasFlag('--apt', '--system'),
   journal: hasFlag('--journal', '--system'),
   docker: hasFlag('--docker'),
+  dockerIsolationMode: parseDockerIsolationMode(),
   npm: hasFlag('--npm', '--system'),
   sudo: hasFlag('--sudo'),
 };
@@ -311,16 +330,47 @@ async function main() {
     await log(`   ${formatBytes(item.size).padStart(7)}  ${item.path}  — ${describeReason(item.reason)}${formatEntryContext(item)}`);
   }
 
-  await log(`\n📊 Summary: keep ${totals.keepCount} (${formatBytes(totals.keepBytes)}), remove ${totals.removeCount} (${formatBytes(totals.removeBytes)})`);
+  let dockerIsolationPlan = { keep: [], remove: [], mode: options.dockerIsolationMode };
+  if (options.dockerIsolationMode === 'none') {
+    await log('\n🐳 Docker isolation containers: disabled (--docker-isolation=none)');
+  } else {
+    const dockerIsolationContainers = listDockerIsolationContainers();
+    dockerIsolationPlan = planDockerIsolationCleanup({
+      containers: dockerIsolationContainers,
+      sessionTasks,
+      mode: options.dockerIsolationMode,
+    });
+
+    await log(`\n🐳 Docker isolation containers (${dockerIsolationPlan.mode}):`);
+    if (dockerIsolationPlan.keep.length === 0 && dockerIsolationPlan.remove.length === 0) {
+      await log('   (none detected)');
+    } else {
+      await log('   KEPT:');
+      if (dockerIsolationPlan.keep.length === 0) await log('      (none)');
+      for (const item of dockerIsolationPlan.keep) {
+        await log(`      ${formatDockerIsolationContainerSummary(item)} — ${describeDockerIsolationReason(item.reason)}`);
+      }
+
+      await log(`   ${options.dryRun ? 'WOULD REMOVE' : 'TO REMOVE'}:`);
+      if (dockerIsolationPlan.remove.length === 0) await log('      (none)');
+      for (const item of dockerIsolationPlan.remove) {
+        await log(`      ${formatDockerIsolationContainerSummary(item)} — ${describeDockerIsolationReason(item.reason)}`);
+      }
+    }
+  }
+
+  await log(`\n📊 Summary: keep ${totals.keepCount} (${formatBytes(totals.keepBytes)}), remove ${totals.removeCount} (${formatBytes(totals.removeBytes)}), docker keep ${dockerIsolationPlan.keep.length}, docker remove ${dockerIsolationPlan.remove.length}`);
 
   // 7. Execute deletion (unless dry-run).
+  const hasTempRemovals = classified.remove.length > 0;
+  const hasDockerRemovals = dockerIsolationPlan.remove.length > 0;
   if (options.dryRun) {
     await log('\n✅ Dry run complete. Re-run without --dry-run to delete.');
-  } else if (classified.remove.length === 0) {
+  } else if (!hasTempRemovals && !hasDockerRemovals) {
     await log('\n✅ Nothing to delete.');
   } else {
     if (!options.force) {
-      console.log(`\n⚠️  This will permanently delete ${classified.remove.length} entries (${formatBytes(totals.removeBytes)}).`);
+      console.log(`\n⚠️  This will permanently delete ${classified.remove.length} entries (${formatBytes(totals.removeBytes)}) and remove ${dockerIsolationPlan.remove.length} Docker isolation containers.`);
       console.log('Type "yes" to confirm, or Ctrl+C to cancel:');
       let answer = '';
       try {
@@ -335,20 +385,39 @@ async function main() {
       }
     }
 
-    await log('\n🗑️  Deleting...');
-    let deleted = 0;
-    let failed = 0;
-    for (const item of classified.remove) {
-      const ok = removePath(item.path);
-      if (ok) {
-        deleted++;
-        await vlog(`   removed ${item.path}`);
-      } else {
-        failed++;
-        await log(`   ⚠️  failed to remove ${item.path}`, { level: 'warn' });
+    if (hasTempRemovals) {
+      await log('\n🗑️  Deleting...');
+      let deleted = 0;
+      let failed = 0;
+      for (const item of classified.remove) {
+        const ok = removePath(item.path);
+        if (ok) {
+          deleted++;
+          await vlog(`   removed ${item.path}`);
+        } else {
+          failed++;
+          await log(`   ⚠️  failed to remove ${item.path}`, { level: 'warn' });
+        }
       }
+      await log(`\n✅ Deleted ${deleted} entries${failed ? `, ${failed} failed` : ''}.`);
     }
-    await log(`\n✅ Deleted ${deleted} entries${failed ? `, ${failed} failed` : ''}.`);
+
+    if (hasDockerRemovals) {
+      await log('\n🐳 Removing Docker isolation containers...');
+      let removed = 0;
+      let failed = 0;
+      for (const item of dockerIsolationPlan.remove) {
+        const ok = removeDockerContainer(item.name);
+        if (ok) {
+          removed++;
+          await log(`   ✓ ${item.command}`);
+        } else {
+          failed++;
+          await log(`   ⚠️  failed: ${item.command}`, { level: 'warn' });
+        }
+      }
+      await log(`\n✅ Removed ${removed} Docker isolation containers${failed ? `, ${failed} failed` : ''}.`);
+    }
   }
 
   // 8. System / Ubuntu cleanup (opt-in).

--- a/src/cleanup.os.lib.mjs
+++ b/src/cleanup.os.lib.mjs
@@ -19,7 +19,7 @@ import path from 'node:path';
 import os from 'node:os';
 import { execFileSync } from 'node:child_process';
 
-import { extractTaskRefsFromCommand, parseRemoteUrl } from './cleanup.lib.mjs';
+import { extractTaskRefsFromCommand, isDockerIsolationSessionName, parseDockerContainerExitCode, parseRemoteUrl } from './cleanup.lib.mjs';
 import { correlateProcesses, parseStartCommandLogMetadata, redactProcessText } from './process-debug.lib.mjs';
 
 /** Run a command, returning trimmed stdout or null on any failure. */
@@ -301,6 +301,73 @@ export function listScreenSessions() {
     });
   }
   return sessions;
+}
+
+function splitDockerNames(value) {
+  return String(value || '')
+    .split(',')
+    .map(name => name.trim().replace(/^\/+/, ''))
+    .filter(Boolean);
+}
+
+/**
+ * Parse `docker ps -a --format '{{json .}}'` output into docker-isolation task
+ * containers. start-command names native Docker isolation containers after the
+ * session UUID, so unrelated host containers are ignored.
+ *
+ * @param {string} output
+ * @returns {Array<{id: string|null, name: string, image: string|null, state: string, status: string, exitCode: number|null, running: boolean}>}
+ */
+export function parseDockerPsJsonLines(output) {
+  const containers = [];
+  const seen = new Set();
+
+  for (const line of String(output || '').split('\n')) {
+    const trimmed = line.trim();
+    if (!trimmed) continue;
+
+    let data;
+    try {
+      data = JSON.parse(trimmed);
+    } catch {
+      continue;
+    }
+
+    const state = String(data.State || data.state || '')
+      .trim()
+      .toLowerCase();
+    const status = String(data.Status || data.status || '').trim();
+    const exitCode = parseDockerContainerExitCode(status);
+    const running = state === 'running' || /^Up\b/i.test(status);
+
+    for (const name of splitDockerNames(data.Names || data.Name || data.names || data.name)) {
+      if (!isDockerIsolationSessionName(name)) continue;
+      if (seen.has(name)) continue;
+      seen.add(name);
+      containers.push({
+        id: data.ID || data.Id || data.id || null,
+        name,
+        image: data.Image || data.image || null,
+        state,
+        status,
+        exitCode,
+        running,
+      });
+    }
+  }
+
+  return containers;
+}
+
+/**
+ * Enumerate Docker-isolation task containers from the local Docker daemon.
+ * Returns an empty list when docker is unavailable.
+ *
+ * @returns {Array}
+ */
+export function listDockerIsolationContainers() {
+  const out = tryExec('docker', ['ps', '-a', '--format', '{{json .}}']);
+  return out ? parseDockerPsJsonLines(out) : [];
 }
 
 function listStartCommandLogFiles(logRoot, maxFiles) {
@@ -677,7 +744,7 @@ export function resolvePrHeadBranch(ref) {
  * @param {Object} [options]
  * @param {boolean} [options.verbose=false]
  * @param {boolean} [options.resolveBranches=false] - resolve PR head branches via gh
- * @returns {Promise<Array<{owner, repo, type, number, branch: string|null, sessionId: string|null, sessionName: string|null, status: string|null, workspace: string|null, terminal: boolean, startTime: string|null}>>}
+ * @returns {Promise<Array<{owner, repo, type, number, branch: string|null, sessionId: string|null, sessionName: string|null, status: string|null, exitCode: number|null, isolation: string|null, workspace: string|null, terminal: boolean, startTime: string|null}>>}
  */
 export async function listSessionTasks(options = {}) {
   const { verbose = false, resolveBranches = false } = options;
@@ -711,6 +778,8 @@ export async function listSessionTasks(options = {}) {
         sessionId: session.uuid || null,
         sessionName: session.sessionName || null,
         status: session.status || null,
+        exitCode: session.exitCode ?? null,
+        isolation: session.isolation || null,
         workspace: session.workingDirectory || null,
         terminal,
         startTime: session.startTime || null,
@@ -782,6 +851,18 @@ export function removePath(targetPath) {
   } catch {
     return false;
   }
+}
+
+/**
+ * Remove a Docker-isolation task container by session UUID. Returns false for
+ * invalid names, missing docker, missing containers, or docker errors.
+ *
+ * @param {string} containerName
+ * @returns {boolean}
+ */
+export function removeDockerContainer(containerName) {
+  if (!isDockerIsolationSessionName(containerName)) return false;
+  return tryExec('docker', ['rm', '-f', containerName], { timeout: 180000, stdio: ['ignore', 'pipe', 'pipe'] }) !== null;
 }
 
 /**

--- a/src/isolation-runner.lib.mjs
+++ b/src/isolation-runner.lib.mjs
@@ -488,7 +488,7 @@ export function readSessionExitFromLog(logPath, options = {}) {
  */
 async function findStartCommandBinary() {
   try {
-    const result = await $`which $`;
+    const result = await $({ mirror: false })`which $`;
     const path = result.stdout?.toString().trim() || '';
     return path || null;
   } catch {

--- a/tests/test-issue-1980-docker-cleanup.mjs
+++ b/tests/test-issue-1980-docker-cleanup.mjs
@@ -1,0 +1,198 @@
+#!/usr/bin/env node
+/**
+ * Regression tests for issue #1980.
+ *
+ * hive-cleanup must clean Docker-isolation task containers by session UUID,
+ * without falling back to host-wide `docker system prune -f`.
+ *
+ * @hive-mind-test-suite default
+ * @see https://github.com/link-assistant/hive-mind/issues/1980
+ */
+
+import assert from 'node:assert/strict';
+
+import { DEFAULT_DOCKER_ISOLATION_CLEANUP_MODE, formatDockerIsolationContainerSummary, normalizeDockerIsolationCleanupMode, planDockerIsolationCleanup } from '../src/cleanup.lib.mjs';
+import { parseDockerPsJsonLines } from '../src/cleanup.os.lib.mjs';
+
+let passed = 0;
+let failed = 0;
+
+function test(name, fn) {
+  try {
+    fn();
+    console.log(`PASS: ${name}`);
+    passed++;
+  } catch (error) {
+    console.log(`FAIL: ${name}`);
+    console.log(`  ${error.stack || error.message}`);
+    failed++;
+  }
+}
+
+const SUCCESS = '11111111-1111-4111-8111-111111111111';
+const FAILED = '22222222-2222-4222-8222-222222222222';
+const RUNNING = '33333333-3333-4333-8333-333333333333';
+const UNKNOWN = '44444444-4444-4444-8444-444444444444';
+
+function dockerPsFixture() {
+  return [
+    { ID: 'abc123', Image: 'konard/hive-mind-dind:latest', Names: SUCCESS, State: 'exited', Status: 'Exited (0) 2 hours ago' },
+    { ID: 'def456', Image: 'konard/hive-mind-dind:latest', Names: FAILED, State: 'exited', Status: 'Exited (1) 1 hour ago' },
+    { ID: 'ghi789', Image: 'konard/hive-mind-dind:latest', Names: RUNNING, State: 'running', Status: 'Up 4 minutes' },
+    { ID: 'jkl012', Image: 'custom/hive-task:dev', Names: UNKNOWN, State: 'exited', Status: 'Exited (137) 10 minutes ago' },
+    { ID: 'mno345', Image: 'postgres:16', Names: 'unrelated-db', State: 'exited', Status: 'Exited (0) 5 hours ago' },
+  ]
+    .map(record => JSON.stringify(record))
+    .join('\n');
+}
+
+function sessionTasks() {
+  return [
+    {
+      owner: 'link-assistant',
+      repo: 'hive-mind',
+      type: 'issue',
+      number: 1980,
+      sessionId: SUCCESS,
+      sessionName: SUCCESS,
+      status: 'executed',
+      exitCode: 0,
+      isolation: 'docker',
+      terminal: true,
+    },
+    {
+      owner: 'link-assistant',
+      repo: 'hive-mind',
+      type: 'issue',
+      number: 1979,
+      sessionId: FAILED,
+      sessionName: FAILED,
+      status: 'failed',
+      exitCode: 1,
+      isolation: 'docker',
+      terminal: true,
+    },
+    {
+      owner: 'link-assistant',
+      repo: 'hive-mind',
+      type: 'issue',
+      number: 1946,
+      sessionId: RUNNING,
+      sessionName: RUNNING,
+      status: 'executing',
+      exitCode: null,
+      isolation: 'docker',
+      terminal: false,
+    },
+  ];
+}
+
+function byName(items) {
+  return new Map(items.map(item => [item.name, item]));
+}
+
+test('parseDockerPsJsonLines filters UUID-named task containers and parses state', () => {
+  const containers = parseDockerPsJsonLines(dockerPsFixture());
+  assert.deepEqual(containers.map(container => container.name).sort(), [FAILED, RUNNING, SUCCESS, UNKNOWN].sort());
+  assert.equal(containers.find(container => container.name === SUCCESS).exitCode, 0);
+  assert.equal(containers.find(container => container.name === FAILED).exitCode, 1);
+  assert.equal(containers.find(container => container.name === RUNNING).running, true);
+  assert.equal(
+    containers.some(container => container.name === 'unrelated-db'),
+    false
+  );
+});
+
+test('default docker-isolation cleanup removes successful exited containers and keeps failed ones', () => {
+  assert.equal(DEFAULT_DOCKER_ISOLATION_CLEANUP_MODE, 'failed-kept');
+  const plan = planDockerIsolationCleanup({
+    containers: parseDockerPsJsonLines(dockerPsFixture()),
+    sessionTasks: sessionTasks(),
+  });
+  const remove = byName(plan.remove);
+  const keep = byName(plan.keep);
+
+  assert.deepEqual([...remove.keys()], [SUCCESS]);
+  assert.equal(remove.get(SUCCESS).command, `docker rm -f ${SUCCESS}`);
+
+  assert.equal(keep.get(FAILED).reason, 'failed-container-kept');
+  assert.equal(keep.get(FAILED).command, `docker rm -f ${FAILED}`);
+  assert.equal(keep.get(RUNNING).reason, 'active-container');
+  assert.equal(keep.get(UNKNOWN).reason, 'failed-container-kept');
+  assert.equal(keep.get(UNKNOWN).command, `docker rm -f ${UNKNOWN}`);
+});
+
+test('docker ps exit status wins over stale unknown session exit code', () => {
+  const staleSessions = sessionTasks().map(task => (task.sessionId === SUCCESS ? { ...task, exitCode: -1 } : task));
+  const plan = planDockerIsolationCleanup({
+    containers: parseDockerPsJsonLines(dockerPsFixture()),
+    sessionTasks: staleSessions,
+  });
+
+  assert.deepEqual(
+    plan.remove.map(item => item.name),
+    [SUCCESS]
+  );
+  assert.equal(plan.remove[0].exitCode, 0);
+  assert.equal(plan.remove[0].reason, 'successful-container');
+});
+
+test('running containers are protected even in all mode', () => {
+  const plan = planDockerIsolationCleanup({
+    containers: parseDockerPsJsonLines(dockerPsFixture()),
+    sessionTasks: sessionTasks(),
+    mode: 'all',
+  });
+
+  assert.deepEqual(plan.remove.map(item => item.name).sort(), [FAILED, SUCCESS, UNKNOWN].sort());
+  assert.equal(byName(plan.keep).get(RUNNING).reason, 'active-container');
+});
+
+test('finished mode removes failed terminal containers too', () => {
+  const plan = planDockerIsolationCleanup({
+    containers: parseDockerPsJsonLines(dockerPsFixture()),
+    sessionTasks: sessionTasks(),
+    mode: 'finished',
+  });
+
+  assert.deepEqual(plan.remove.map(item => item.name).sort(), [FAILED, SUCCESS, UNKNOWN].sort());
+});
+
+test('none mode disables docker-isolation cleanup without hiding discovered containers', () => {
+  const plan = planDockerIsolationCleanup({
+    containers: parseDockerPsJsonLines(dockerPsFixture()),
+    sessionTasks: sessionTasks(),
+    mode: 'none',
+  });
+
+  assert.deepEqual(plan.remove, []);
+  assert.equal(plan.keep.length, 4);
+  assert.ok(plan.keep.every(item => item.reason === 'disabled'));
+});
+
+test('normalizes docker-isolation cleanup mode aliases', () => {
+  assert.equal(normalizeDockerIsolationCleanupMode(null), 'failed-kept');
+  assert.equal(normalizeDockerIsolationCleanupMode(''), 'failed-kept');
+  assert.equal(normalizeDockerIsolationCleanupMode('true'), 'failed-kept');
+  assert.equal(normalizeDockerIsolationCleanupMode('off'), 'none');
+  assert.equal(normalizeDockerIsolationCleanupMode('success'), 'failed-kept');
+  assert.equal(normalizeDockerIsolationCleanupMode('finished'), 'finished');
+  assert.throws(() => normalizeDockerIsolationCleanupMode('surprise'), /Invalid docker isolation cleanup mode/);
+});
+
+test('docker container summary includes session and cleanup context', () => {
+  const plan = planDockerIsolationCleanup({
+    containers: parseDockerPsJsonLines(dockerPsFixture()),
+    sessionTasks: sessionTasks(),
+  });
+  const failedRecord = byName(plan.keep).get(FAILED);
+  const summary = formatDockerIsolationContainerSummary(failedRecord);
+
+  assert.ok(summary.includes(FAILED));
+  assert.ok(summary.includes('exit 1'));
+  assert.ok(summary.includes('link-assistant/hive-mind issue #1979'));
+  assert.ok(summary.includes(`remove when done: docker rm -f ${FAILED}`));
+});
+
+console.log(`\n${passed} passed, ${failed} failed`);
+if (failed > 0) process.exit(1);

--- a/tests/test-issue-1980-docker-cleanup.mjs
+++ b/tests/test-issue-1980-docker-cleanup.mjs
@@ -10,6 +10,7 @@
  */
 
 import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
 
 import { DEFAULT_DOCKER_ISOLATION_CLEANUP_MODE, formatDockerIsolationContainerSummary, normalizeDockerIsolationCleanupMode, planDockerIsolationCleanup } from '../src/cleanup.lib.mjs';
 import { parseDockerPsJsonLines } from '../src/cleanup.os.lib.mjs';
@@ -33,6 +34,7 @@ const SUCCESS = '11111111-1111-4111-8111-111111111111';
 const FAILED = '22222222-2222-4222-8222-222222222222';
 const RUNNING = '33333333-3333-4333-8333-333333333333';
 const UNKNOWN = '44444444-4444-4444-8444-444444444444';
+const CREATED = '55555555-5555-4555-8555-555555555555';
 
 function dockerPsFixture() {
   return [
@@ -40,6 +42,7 @@ function dockerPsFixture() {
     { ID: 'def456', Image: 'konard/hive-mind-dind:latest', Names: FAILED, State: 'exited', Status: 'Exited (1) 1 hour ago' },
     { ID: 'ghi789', Image: 'konard/hive-mind-dind:latest', Names: RUNNING, State: 'running', Status: 'Up 4 minutes' },
     { ID: 'jkl012', Image: 'custom/hive-task:dev', Names: UNKNOWN, State: 'exited', Status: 'Exited (137) 10 minutes ago' },
+    { ID: 'pqr678', Image: 'custom/hive-task:dev', Names: CREATED, State: 'created', Status: 'Created' },
     { ID: 'mno345', Image: 'postgres:16', Names: 'unrelated-db', State: 'exited', Status: 'Exited (0) 5 hours ago' },
   ]
     .map(record => JSON.stringify(record))
@@ -93,7 +96,7 @@ function byName(items) {
 
 test('parseDockerPsJsonLines filters UUID-named task containers and parses state', () => {
   const containers = parseDockerPsJsonLines(dockerPsFixture());
-  assert.deepEqual(containers.map(container => container.name).sort(), [FAILED, RUNNING, SUCCESS, UNKNOWN].sort());
+  assert.deepEqual(containers.map(container => container.name).sort(), [CREATED, FAILED, RUNNING, SUCCESS, UNKNOWN].sort());
   assert.equal(containers.find(container => container.name === SUCCESS).exitCode, 0);
   assert.equal(containers.find(container => container.name === FAILED).exitCode, 1);
   assert.equal(containers.find(container => container.name === RUNNING).running, true);
@@ -104,7 +107,7 @@ test('parseDockerPsJsonLines filters UUID-named task containers and parses state
 });
 
 test('default docker-isolation cleanup removes successful exited containers and keeps failed ones', () => {
-  assert.equal(DEFAULT_DOCKER_ISOLATION_CLEANUP_MODE, 'failed-kept');
+  assert.equal(DEFAULT_DOCKER_ISOLATION_CLEANUP_MODE, 'succeeded');
   const plan = planDockerIsolationCleanup({
     containers: parseDockerPsJsonLines(dockerPsFixture()),
     sessionTasks: sessionTasks(),
@@ -120,6 +123,7 @@ test('default docker-isolation cleanup removes successful exited containers and 
   assert.equal(keep.get(RUNNING).reason, 'active-container');
   assert.equal(keep.get(UNKNOWN).reason, 'failed-container-kept');
   assert.equal(keep.get(UNKNOWN).command, `docker rm -f ${UNKNOWN}`);
+  assert.equal(keep.get(CREATED).reason, 'unknown-container-state');
 });
 
 test('docker ps exit status wins over stale unknown session exit code', () => {
@@ -137,7 +141,7 @@ test('docker ps exit status wins over stale unknown session exit code', () => {
   assert.equal(plan.remove[0].reason, 'successful-container');
 });
 
-test('running containers are protected even in all mode', () => {
+test('all mode removes finished containers but protects running and non-terminal containers', () => {
   const plan = planDockerIsolationCleanup({
     containers: parseDockerPsJsonLines(dockerPsFixture()),
     sessionTasks: sessionTasks(),
@@ -146,16 +150,7 @@ test('running containers are protected even in all mode', () => {
 
   assert.deepEqual(plan.remove.map(item => item.name).sort(), [FAILED, SUCCESS, UNKNOWN].sort());
   assert.equal(byName(plan.keep).get(RUNNING).reason, 'active-container');
-});
-
-test('finished mode removes failed terminal containers too', () => {
-  const plan = planDockerIsolationCleanup({
-    containers: parseDockerPsJsonLines(dockerPsFixture()),
-    sessionTasks: sessionTasks(),
-    mode: 'finished',
-  });
-
-  assert.deepEqual(plan.remove.map(item => item.name).sort(), [FAILED, SUCCESS, UNKNOWN].sort());
+  assert.equal(byName(plan.keep).get(CREATED).reason, 'unknown-container-state');
 });
 
 test('none mode disables docker-isolation cleanup without hiding discovered containers', () => {
@@ -166,17 +161,19 @@ test('none mode disables docker-isolation cleanup without hiding discovered cont
   });
 
   assert.deepEqual(plan.remove, []);
-  assert.equal(plan.keep.length, 4);
+  assert.equal(plan.keep.length, 5);
   assert.ok(plan.keep.every(item => item.reason === 'disabled'));
 });
 
 test('normalizes docker-isolation cleanup mode aliases', () => {
-  assert.equal(normalizeDockerIsolationCleanupMode(null), 'failed-kept');
-  assert.equal(normalizeDockerIsolationCleanupMode(''), 'failed-kept');
-  assert.equal(normalizeDockerIsolationCleanupMode('true'), 'failed-kept');
+  assert.equal(normalizeDockerIsolationCleanupMode(null), 'succeeded');
+  assert.equal(normalizeDockerIsolationCleanupMode(''), 'succeeded');
+  assert.equal(normalizeDockerIsolationCleanupMode('true'), 'succeeded');
   assert.equal(normalizeDockerIsolationCleanupMode('off'), 'none');
-  assert.equal(normalizeDockerIsolationCleanupMode('success'), 'failed-kept');
-  assert.equal(normalizeDockerIsolationCleanupMode('finished'), 'finished');
+  assert.equal(normalizeDockerIsolationCleanupMode('succeeded'), 'succeeded');
+  assert.equal(normalizeDockerIsolationCleanupMode('success'), 'succeeded');
+  assert.equal(normalizeDockerIsolationCleanupMode('failed-kept'), 'succeeded');
+  assert.equal(normalizeDockerIsolationCleanupMode('finished'), 'all');
   assert.throws(() => normalizeDockerIsolationCleanupMode('surprise'), /Invalid docker isolation cleanup mode/);
 });
 
@@ -192,6 +189,11 @@ test('docker container summary includes session and cleanup context', () => {
   assert.ok(summary.includes('exit 1'));
   assert.ok(summary.includes('link-assistant/hive-mind issue #1979'));
   assert.ok(summary.includes(`remove when done: docker rm -f ${FAILED}`));
+});
+
+test('findStartCommandBinary suppresses command-stream stdout mirroring', () => {
+  const source = readFileSync(new URL('../src/isolation-runner.lib.mjs', import.meta.url), 'utf8');
+  assert.match(source, /await\s+\$\(\{\s*mirror:\s*false\s*\}\)`which \$`/);
 });
 
 console.log(`\n${passed} passed, ${failed} failed`);


### PR DESCRIPTION
Fixes #1980

## Summary
- Adds session-aware Docker-isolation cleanup for UUID-named start-command task containers.
- Defaults `hive-cleanup` to `--docker-isolation=succeeded`: remove successful finished task containers, keep failed/unknown/running containers, and print exact `docker rm -f <uuid>` cleanup commands for kept debug containers.
- Adds `--docker-isolation[=succeeded|all|none]` and `--no-docker-isolation`; previous internal aliases are accepted defensively, while `--docker` remains the separate host-wide `docker system prune -f` opt-in.
- `--docker-isolation=all` removes finished containers including failed ones, while still protecting running and non-terminal containers.
- Lists Docker containers with `docker ps -a --format '{{json .}}'` and removes only selected UUID-named task containers with `docker rm -f <uuid>`.
- Silences `findStartCommandBinary()` by running `which $` with `mirror: false`, removing the stray `/home/box/.bun/bin/$` cleanup output.
- Adds a patch changeset and regression coverage for successful, failed, running, non-terminal, unknown, and unrelated Docker container records plus the `$` lookup mirror guard.

## Reproduction
Before this change, `hive-cleanup` had no Docker-isolation-aware container planner: the only Docker cleanup path was the blunt `--docker` system prune, and `findStartCommandBinary()` echoed `which $` output during active-session enumeration. The new `tests/test-issue-1980-docker-cleanup.mjs` fixture reproduces the missing behavior with UUID-named Docker task containers and verifies the default keeps failed containers for debugging while removing successful exited ones.

## Verification
- `node tests/test-issue-1980-docker-cleanup.mjs`
- `node tests/test-cleanup-1848.mjs`
- `node tests/test-cleanup-confirmation-1930.mjs`
- `node src/cleanup.mjs --help`
- `npm run lint`
- `npm run format:check`
- `npm test` (`All 288 selected test file(s) passed.` after merging `origin/main`)
