### PR TITLE
fix(telegram): preserve queued per-command solve isolation

### DIFF
--- a/.changeset/preserve-queued-solve-isolation.md
+++ b/.changeset/preserve-queued-solve-isolation.md
@@ -1,0 +1,5 @@
+---
+'@link-assistant/hive-mind': patch
+---
+
+Preserve per-command isolation overrides for queued Telegram solve commands.

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,1 +1,0 @@
-# .gitkeep file auto-generated at 2026-06-24T14:27:28.404Z for PR creation at branch issue-1983-afa6c35027d7 for issue https://github.com/link-assistant/hive-mind/issues/1983

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,0 +1,1 @@
+# .gitkeep file auto-generated at 2026-06-24T14:27:28.404Z for PR creation at branch issue-1983-afa6c35027d7 for issue https://github.com/link-assistant/hive-mind/issues/1983

--- a/src/telegram-solve-queue.lib.mjs
+++ b/src/telegram-solve-queue.lib.mjs
@@ -58,6 +58,8 @@ class SolveQueueItem {
     this.requester = options.requester;
     this.infoBlock = options.infoBlock;
     this.tool = options.tool || 'claude';
+    // Issue #1983: preserve per-command isolation through queued execution.
+    this.perCommandIsolation = options.perCommandIsolation || null;
     // Issue #1688: keep parsed URL context (owner/repo/number/type) so completion
     //   notifications can look up linked PRs for issue URLs.
     this.urlContext = options.urlContext || null;

--- a/tests/test-queue-isolation-1551.mjs
+++ b/tests/test-queue-isolation-1551.mjs
@@ -1,9 +1,10 @@
 #!/usr/bin/env node
 // Queue isolation test for issue #1551: agent queue should be independent from claude queue
 import assert from 'node:assert/strict';
+import { createIsolationAwareQueueCallback } from '../src/telegram-isolation.lib.mjs';
 import { SolveQueue } from '../src/telegram-solve-queue.lib.mjs';
 
-const q = new SolveQueue({ verbose: false });
+const q = new SolveQueue({ verbose: false, autoStart: false });
 const mk = (n, tool) => ({ url: `https://github.com/t/r/issues/${n}`, args: '', requester: 'u', infoBlock: 'T', tool });
 
 // Enqueue 2 claude items — agent queue should remain empty
@@ -25,6 +26,42 @@ assert.equal(s2.queued, 3, 'total queued = 3');
 // After fix: position = stats.queuedByTool[tool] + 1 = 2 (correct, per-tool)
 assert.equal((s2.queuedByTool.agent || 0) + 1, 2, 'next agent position = #2');
 assert.equal((s2.queuedByTool.claude || 0) + 1, 3, 'next claude position = #3');
+
+// Issue #1983: per-command isolation must survive enqueue so queued
+// /solve, /claude, and /codex commands do not fall back to the bot default.
+const isolatedItem = q.enqueue({
+  url: 'https://github.com/t/r/issues/4',
+  args: ['https://github.com/t/r/issues/4', '--tool', 'codex'],
+  requester: 'u',
+  infoBlock: 'T',
+  tool: 'codex',
+  perCommandIsolation: 'docker',
+  ctx: { chat: { id: 123 } },
+});
+const isolationCalls = [];
+const trackCalls = [];
+const queueCallback = createIsolationAwareQueueCallback(
+  'screen',
+  {
+    generateSessionId: () => 'queued-isolation-test-session',
+    executeWithIsolation: async (command, args, options) => {
+      isolationCalls.push({ command, args, options });
+      return { success: true, output: 'session: queued-isolation-test-session' };
+    },
+  },
+  (sessionId, sessionInfo) => {
+    trackCalls.push({ sessionId, sessionInfo });
+  },
+  async () => {
+    throw new Error('fallback callback should not run when isolation is configured');
+  },
+  false
+);
+const result = await queueCallback(isolatedItem);
+assert.equal(isolatedItem.perCommandIsolation, 'docker', 'queued item retains per-command isolation');
+assert.equal(result.success, true, 'queued isolated execution succeeds');
+assert.equal(isolationCalls[0].options.backend, 'docker', 'per-command isolation overrides bot default');
+assert.equal(trackCalls[0].sessionInfo.isolationBackend, 'docker', 'tracked session stores effective isolation');
 
 q.stop();
 console.log('✅ Queue isolation test passed (issue #1551)');


### PR DESCRIPTION
Fixes #1983

## Summary
- Store `perCommandIsolation` on `SolveQueueItem` so queued `/solve`, `/claude`, and `/codex` executions keep the user's `--isolation` override.
- Add a regression to the queue isolation test that enqueues a `--isolation docker` item and verifies the isolation-aware queue callback uses `docker` over the bot default `screen`.
- Add the required patch changeset for release automation.
- Checked adjacent command paths: `/hive` and `/task` execute directly through `executeAndUpdateMessage`, so the lost queue-field path only applied to `/solve` queue items.

## Reproduction
Before the fix, the new queued regression failed because the queue item had `perCommandIsolation === undefined`, so the callback resolved the bot default `screen`. After the fix, the queued item retains `docker`, isolated execution succeeds, and tracked session metadata records `isolationBackend: docker`.

## Testing
- `node tests/test-queue-isolation-1551.mjs`
- `node tests/solve-queue.test.mjs`
- `node tests/test-extract-isolation-from-args.mjs`
- `node tests/test-issue-1860-docker-isolation.mjs`
- `npm run lint`
- `npm run format:check`
- `bash scripts/check-mjs-syntax.sh`
- `bash scripts/check-file-line-limits.sh`
- `npm run check:duplication`
- `node scripts/validate-changeset.mjs`
- `npx prettier --check .changeset/preserve-queued-solve-isolation.md`
- `npm test` (`All 287 selected test file(s) passed.`)