### PR TITLE
fix: improve task disk usage diagnostics

### DIFF
--- a/.changeset/improve-disk-diagnostics.md
+++ b/.changeset/improve-disk-diagnostics.md
@@ -1,0 +1,5 @@
+---
+"@link-assistant/hive-mind": patch
+---
+
+Improve task disk usage diagnostics for repository and Docker container filesystem reporting.

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,1 +1,0 @@
-# .gitkeep file auto-generated at 2026-06-26T10:07:10.433Z for PR creation at branch issue-1988-d825581f77b8 for issue https://github.com/link-assistant/hive-mind/issues/1988

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,0 +1,1 @@
+# .gitkeep file auto-generated at 2026-06-26T10:07:10.433Z for PR creation at branch issue-1988-d825581f77b8 for issue https://github.com/link-assistant/hive-mind/issues/1988

--- a/src/isolation-runner.lib.mjs
+++ b/src/isolation-runner.lib.mjs
@@ -58,6 +58,11 @@ const DOCKER_ISOLATION_SHELL = 'sh';
 // less headroom than this cannot safely pull one. Diagnostic only — never
 // blocks startup. See issue #1914.
 const DOCKER_ISOLATION_LOW_DISK_GIB = 40;
+// Docker-only start gate used to capture the container writable-layer baseline
+// before the task command begins cloning or generating files. The parent
+// releases the gate immediately after `docker inspect --size`; the fallback
+// keeps the task from hanging forever if the parent exits at the wrong time.
+const DOCKER_START_GATE_WAIT_TENTHS = 300;
 // Sentinel start-command's detached docker logger records when it cannot capture
 // the container's real exit code. A terminal `$ --status` carrying this value is
 // ambiguous — the container may still be running — so we cross-check it against
@@ -92,6 +97,16 @@ function shellQuote(value) {
 
 function buildShellCommand(command, args = []) {
   return [command, ...args].map(shellQuote).join(' ');
+}
+
+function buildDockerStartGatePath(sessionId) {
+  return sessionId ? `/tmp/hive-mind-disk-baseline-${sessionId}` : null;
+}
+
+function buildDockerStartGatedCommand(taskCommand, sessionId) {
+  const gatePath = buildDockerStartGatePath(sessionId);
+  if (!gatePath) return taskCommand;
+  return `gate=${shellQuote(gatePath)}; i=0; while [ ! -e "$gate" ] && [ "$i" -lt ${DOCKER_START_GATE_WAIT_TENTHS} ]; do i=$((i+1)); sleep 0.1; done; rm -f "$gate"; exec ${taskCommand}`;
 }
 
 function shouldRunPrivilegedDockerIsolation(image, env = process.env) {
@@ -234,7 +249,8 @@ export function buildDockerIsolationStartArgs(command, args = [], options = {}) 
     startArgs.push('--volume', `${mount.source}:${mount.target}`);
   }
 
-  startArgs.push('--detached', '--session', sessionId, '--', buildShellCommand(command, args));
+  const taskCommand = buildShellCommand(command, args);
+  startArgs.push('--detached', '--session', sessionId, '--', buildDockerStartGatedCommand(taskCommand, sessionId));
   return startArgs;
 }
 
@@ -541,7 +557,7 @@ async function logDockerIsolationPostLaunchDiagnostics(sessionId, env = process.
  * @param {string} [options.sessionId] - UUID for session tracking (auto-generated if not provided)
  * @param {string} [options.tool] - AI tool selected for the task; used to scope Docker auth mounts
  * @param {boolean} [options.verbose] - Enable verbose logging
- * @returns {Promise<{success: boolean, sessionId: string, output: string, error?: string, warning?: string}>}
+ * @returns {Promise<{success: boolean, sessionId: string, output: string, error?: string, warning?: string, containerFilesystemStartBytes?: number|null}>}
  */
 export async function executeWithIsolation(command, args, options = {}) {
   const { backend, verbose = false } = options;
@@ -598,6 +614,15 @@ export async function executeWithIsolation(command, args, options = {}) {
     if (result.error) stream(`[VERBOSE] isolation-runner: Error: ${result.error}`);
   }
 
+  let containerFilesystemStartBytes = null;
+  if (result.success && backend === 'docker') {
+    try {
+      containerFilesystemStartBytes = await getDockerContainerWritableLayerSize(sessionId, verbose);
+    } finally {
+      await releaseDockerContainerStartGate(sessionId, verbose);
+    }
+  }
+
   // Issue #1939: capture the freshly-launched docker session's reported status
   // and the live container state together, so the next iteration has the data to
   // diagnose a premature "executed/-1" status (problem #1) or a surprise image
@@ -611,6 +636,7 @@ export async function executeWithIsolation(command, args, options = {}) {
       success: true,
       sessionId,
       output: result.output,
+      containerFilesystemStartBytes,
     };
   }
 
@@ -829,6 +855,77 @@ export async function checkDockerContainerRunning(containerName, verbose = false
     // `docker inspect` exits non-zero when no such container exists.
     return false;
   }
+}
+
+export function parseDockerContainerWritableLayerSizeOutput(output) {
+  const text = String(output || '').trim();
+  if (!text) return null;
+  const bytes = Number.parseInt(text.split(/\s+/)[0], 10);
+  return Number.isFinite(bytes) && bytes >= 0 ? bytes : null;
+}
+
+/**
+ * Best-effort size of a Docker task container's writable layer.
+ *
+ * `docker inspect --size` exposes `.SizeRw`, which excludes the image's base
+ * layers and counts only filesystem data created or changed by this container.
+ * That is the closest Docker-native representation of per-task disk usage.
+ *
+ * @param {string} containerName - Container name (the session UUID)
+ * @param {boolean} [verbose] - Enable verbose logging
+ * @returns {Promise<number|null>} Writable layer bytes, or null when unavailable.
+ */
+export async function getDockerContainerWritableLayerSize(containerName, verbose = false) {
+  if (!containerName) return null;
+  try {
+    const result = await $({ mirror: false })`docker inspect --size -f ${'{{.SizeRw}}'} ${containerName}`;
+    const bytes = parseDockerContainerWritableLayerSizeOutput(result.stdout?.toString() || '');
+    if (verbose) {
+      const label = bytes === null ? 'unknown' : `${bytes} bytes`;
+      console.log(`[VERBOSE] isolation-runner: docker writable layer size for '${containerName}': ${label}`);
+    }
+    return bytes;
+  } catch (error) {
+    if (verbose) {
+      const stderr = error?.stderr?.toString?.().trim();
+      console.log(`[VERBOSE] isolation-runner: could not inspect writable layer size for '${containerName}': ${stderr || error?.message || error}`);
+    }
+    return null;
+  }
+}
+
+/**
+ * Release the Docker-only start gate after the writable-layer baseline has been
+ * captured. Best-effort: the gated task also has a timeout fallback.
+ *
+ * @param {string} containerName - Container name (the session UUID)
+ * @param {boolean} [verbose] - Enable verbose logging
+ * @returns {Promise<boolean>} true when the gate file was touched.
+ */
+export async function releaseDockerContainerStartGate(containerName, verbose = false) {
+  const gatePath = buildDockerStartGatePath(containerName);
+  if (!containerName || !gatePath) return false;
+  const releaseCommand = `touch ${shellQuote(gatePath)}`;
+  let lastError = null;
+
+  for (let attempt = 1; attempt <= 5; attempt++) {
+    try {
+      await $({ mirror: false })`docker exec ${containerName} sh -c ${releaseCommand}`;
+      if (verbose) {
+        console.log(`[VERBOSE] isolation-runner: released docker start gate for '${containerName}'`);
+      }
+      return true;
+    } catch (error) {
+      lastError = error;
+      await new Promise(resolve => setTimeout(resolve, 200));
+    }
+  }
+
+  if (verbose) {
+    const stderr = lastError?.stderr?.toString?.().trim();
+    console.log(`[VERBOSE] isolation-runner: could not release docker start gate for '${containerName}': ${stderr || lastError?.message || lastError}`);
+  }
+  return false;
 }
 
 /**

--- a/src/session-monitor.lib.mjs
+++ b/src/session-monitor.lib.mjs
@@ -338,24 +338,57 @@ async function resolvePullRequestUrlFromSessionLog(logPath, ctx, { verbose = fal
 }
 
 /**
- * Issue #1945: Parse `📊 [DISK]` checkpoint markers out of the captured solve
- * log and, when the captured sizes cross the 5 GB threshold(s), build a
- * Telegram extraSection that warns the operator. Returns an empty string if
- * the log is unreadable or contains no markers.
+ * Issue #1945/#1988: Parse `📊 [DISK]` repository-size checkpoint markers out
+ * of the captured solve log, optionally add docker writable-layer sizes, and
+ * build the Telegram extraSection. Returns an empty string if there is no
+ * repository or docker filesystem data to show.
  */
-async function buildDiskDiagnosticsExtraSection(logPath, { verbose = false, readFile = fs.readFile } = {}) {
-  if (!logPath) return '';
+async function buildDiskDiagnosticsExtraSection(logPath, { verbose = false, readFile = fs.readFile, isolationBackend = null, containerFilesystemStartBytes = null, containerFilesystemAfterBytes = null } = {}) {
+  if (!logPath && !Number.isFinite(containerFilesystemStartBytes) && !Number.isFinite(containerFilesystemAfterBytes)) return '';
   try {
     const diskLib = await import('./solve.disk-diagnostics.lib.mjs');
-    const logText = await readFile(logPath, 'utf8');
+    let logText = '';
+    if (logPath) {
+      try {
+        logText = await readFile(logPath, 'utf8');
+      } catch (readError) {
+        if (verbose) {
+          console.log(`[VERBOSE] Could not read session log ${logPath} for disk diagnostics: ${readError?.message || readError}`);
+        }
+      }
+    }
     const parsed = diskLib.parseDiskMarkers(logText);
-    if (!parsed.afterClone && !parsed.afterAgent) return '';
-    return diskLib.formatDiskDiagnosticsBlock(parsed);
+    if (!parsed.afterClone && !parsed.afterAgent && !Number.isFinite(containerFilesystemStartBytes) && !Number.isFinite(containerFilesystemAfterBytes)) return '';
+    return diskLib.formatDiskDiagnosticsBlock(parsed, {
+      isolationBackend,
+      containerFilesystemStartBytes,
+      containerFilesystemAfterBytes,
+    });
   } catch (error) {
     if (verbose) {
       console.log(`[VERBOSE] Could not inspect session log ${logPath} for disk diagnostics: ${error?.message || error}`);
     }
     return '';
+  }
+}
+
+async function getDockerContainerFilesystemSizeForSession(sessionName, sessionInfo, { verbose = false, sizeProvider = null } = {}) {
+  if (sessionInfo?.isolationBackend !== 'docker') return null;
+  const containerName = sessionInfo.sessionId || sessionName;
+  if (!containerName) return null;
+  try {
+    if (typeof sizeProvider === 'function') {
+      const bytes = await sizeProvider(containerName, { sessionName, sessionInfo, verbose });
+      return Number.isFinite(bytes) ? bytes : null;
+    }
+    const runner = await getIsolationRunner();
+    if (typeof runner.getDockerContainerWritableLayerSize !== 'function') return null;
+    return await runner.getDockerContainerWritableLayerSize(containerName, verbose);
+  } catch (error) {
+    if (verbose) {
+      console.log(`[VERBOSE] Could not inspect docker filesystem size for ${containerName}: ${error?.message || error}`);
+    }
+    return null;
   }
 }
 
@@ -783,13 +816,22 @@ export async function monitorSessions(bot, verbose = false, options = {}) {
           }
         }
 
-        // Issue #1945: append a "💾 Disk usage" block (with warnings when the
-        // cloned repo, the delta during the run, or the total exceed 5 GB)
-        // parsed from the captured solve log markers.
+        // Issue #1945/#1988: append a "💾 Disk usage" block from repository
+        // size markers and, for docker isolation, the container writable layer.
         const diskExtraSections = [];
         try {
           const diskLogPath = statusResult?.logPath || sessionInfo?.logPath || null;
-          const diskBlock = await buildDiskDiagnosticsExtraSection(diskLogPath, { verbose });
+          const containerFilesystemAfterBytes = await getDockerContainerFilesystemSizeForSession(sessionName, sessionInfo, {
+            verbose,
+            sizeProvider: options.dockerContainerSizeProvider,
+          });
+          const diskBlock = await buildDiskDiagnosticsExtraSection(diskLogPath, {
+            verbose,
+            readFile: options.readFile,
+            isolationBackend: sessionInfo?.isolationBackend || statusResult?.isolation || null,
+            containerFilesystemStartBytes: Number.isFinite(sessionInfo?.containerFilesystemStartBytes) ? sessionInfo.containerFilesystemStartBytes : null,
+            containerFilesystemAfterBytes,
+          });
           if (diskBlock) diskExtraSections.push(diskBlock);
         } catch (diskError) {
           if (verbose) {

--- a/src/session-store.lib.mjs
+++ b/src/session-store.lib.mjs
@@ -33,7 +33,7 @@ import path from 'node:path';
 // excluded so the snapshot stays small and safe to reload.
 // `args` (#1927 review follow-up) is persisted so a killed /solve can be resumed
 // with its exact original invocation plus `--resume <lastSessionId>`.
-const PERSISTABLE_FIELDS = ['chatId', 'messageId', 'startTime', 'url', 'command', 'isolationBackend', 'sessionId', 'tool', 'infoBlock', 'urlContext', 'requesterUserId', 'showLimits', 'locale', 'logPath', 'args'];
+const PERSISTABLE_FIELDS = ['chatId', 'messageId', 'startTime', 'url', 'command', 'isolationBackend', 'sessionId', 'containerFilesystemStartBytes', 'tool', 'infoBlock', 'urlContext', 'requesterUserId', 'showLimits', 'locale', 'logPath', 'args'];
 
 /**
  * Resolve the directory durable bot state is written to. Honors

--- a/src/solve.disk-diagnostics.lib.mjs
+++ b/src/solve.disk-diagnostics.lib.mjs
@@ -10,12 +10,8 @@
  *
  * Both checkpoints are written to the captured solve log as a single-line
  * structured marker. The Telegram bot's `session-monitor.lib.mjs` parses those
- * markers and, on the completion message, surfaces a Telegram block plus
- * warnings when any of the three thresholds from the issue are crossed:
- *
- *   - cloned repository  > WARNING_THRESHOLD_BYTES
- *   - delta during run   > WARNING_THRESHOLD_BYTES
- *   - total space used   > WARNING_THRESHOLD_BYTES
+ * markers and, on the completion message, surfaces a Telegram block plus a
+ * warning when total task disk usage crosses the configured threshold.
  *
  * Implementation notes:
  *
@@ -220,54 +216,79 @@ export function computeDiskWarnings(parsed, threshold = WARNING_THRESHOLD_BYTES)
 
 /**
  * Telegram block (Markdown code fence) describing the captured sizes plus,
- * when any threshold is crossed, a `⚠️ Warnings:` tail. Returns an empty
- * string when there are no markers in the log (no logs ⇒ no surprise output).
+ * when the task total crosses the threshold, a warning tail. Returns an empty
+ * string when there are no markers or docker container filesystem sizes to show
+ * (no logs ⇒ no surprise output).
  *
  * Returned shape:
  *
  *   💾 Disk usage (gh-issue-solver-…)
  *   ```
- *   Cloned repository: 12.0 GB
- *   After agent:       12.4 GB (+500.0 MB)
- *   Threshold:         5.0 GB
+ *   Repository size:
+ *     Cloned:          12.0 GB
+ *     On completion:   12.4 GB (+500 MB)
  *
- *   ⚠️ Cloned repository exceeds 5.0 GB
- *   ⚠️ Total disk usage exceeds 5.0 GB
+ *   ⚠️ Total disk usage per task exceeds 5.0 GB
  *   ```
  *
  * @param {{afterClone: object|null, afterAgent: object|null}} parsed
  * @param {Object} [options]
  * @param {number} [options.threshold=WARNING_THRESHOLD_BYTES]
  * @param {string} [options.title='💾 Disk usage']
+ * @param {string} [options.isolationBackend] - Adds container filesystem details for docker isolation.
+ * @param {number|null} [options.containerFilesystemStartBytes]
+ * @param {number|null} [options.containerFilesystemAfterBytes]
  * @returns {string}
  */
 export function formatDiskDiagnosticsBlock(parsed, options = {}) {
-  if (!parsed || (!parsed.afterClone && !parsed.afterAgent)) return '';
   const threshold = Number.isFinite(options.threshold) ? options.threshold : WARNING_THRESHOLD_BYTES;
   const title = options.title || '💾 Disk usage';
-  const warnings = computeDiskWarnings(parsed, threshold);
+  const isolationBackend = String(options.isolationBackend || '').toLowerCase();
+  const isDockerIsolation = isolationBackend === 'docker';
+  const containerFilesystemStartBytes = Number.isFinite(options.containerFilesystemStartBytes) ? options.containerFilesystemStartBytes : null;
+  const containerFilesystemAfterBytes = Number.isFinite(options.containerFilesystemAfterBytes) ? options.containerFilesystemAfterBytes : null;
+  const hasRepositoryMarkers = Boolean(parsed?.afterClone || parsed?.afterAgent);
+  const hasContainerFilesystemMarkers = isDockerIsolation && (containerFilesystemStartBytes !== null || containerFilesystemAfterBytes !== null);
+  if (!hasRepositoryMarkers && !hasContainerFilesystemMarkers) return '';
+
   const lines = [];
-  const cloneBytes = parsed.afterClone?.bytes ?? null;
-  const totalBytes = parsed.afterAgent?.bytes ?? null;
-  const deltaBytes = parsed.afterAgent?.deltaBytes ?? null;
-  if (cloneBytes !== null) {
-    lines.push(`Cloned repository: ${formatBytes(cloneBytes)}`);
+  const cloneBytes = parsed?.afterClone?.bytes ?? null;
+  const totalBytes = parsed?.afterAgent?.bytes ?? null;
+  const deltaBytes = parsed?.afterAgent?.deltaBytes ?? null;
+
+  const pushSizeLine = (label, bytes, suffix = '') => {
+    if (bytes === null) return;
+    lines.push(`  ${label.padEnd(16)} ${formatBytes(bytes)}${suffix}`);
+  };
+
+  if (hasRepositoryMarkers) {
+    lines.push('Repository size:');
+    pushSizeLine('Cloned:', cloneBytes);
+    if (totalBytes !== null) {
+      const deltaStr = deltaBytes !== null ? ` (${formatBytesDelta(deltaBytes)})` : '';
+      pushSizeLine('On completion:', totalBytes, deltaStr);
+    } else if (deltaBytes !== null) {
+      lines.push(`  ${'Delta during run:'.padEnd(16)} ${formatBytesDelta(deltaBytes)}`);
+    }
   }
-  if (totalBytes !== null) {
-    const deltaStr = deltaBytes !== null ? ` (${formatBytesDelta(deltaBytes)})` : '';
-    lines.push(`After agent:       ${formatBytes(totalBytes)}${deltaStr}`);
-  } else if (deltaBytes !== null) {
-    lines.push(`Delta during run:  ${formatBytesDelta(deltaBytes)}`);
+
+  if (hasContainerFilesystemMarkers) {
+    lines.push('Container filesystem size:');
+    pushSizeLine('On start:', containerFilesystemStartBytes);
+    pushSizeLine('On completion:', containerFilesystemAfterBytes);
   }
-  lines.push(`Threshold:         ${formatBytes(threshold)}`);
+
+  const taskTotalBytes = isDockerIsolation && containerFilesystemAfterBytes !== null ? containerFilesystemAfterBytes : (totalBytes ?? cloneBytes);
   const warningLines = [];
-  if (warnings.cloneTooLarge) warningLines.push(`⚠️ Cloned repository exceeds ${formatBytes(threshold)}`);
-  if (warnings.deltaTooLarge) warningLines.push(`⚠️ Folder grew by more than ${formatBytes(threshold)} during the run`);
-  if (warnings.totalTooLarge) warningLines.push(`⚠️ Total disk usage exceeds ${formatBytes(threshold)}`);
+  if (Number.isFinite(taskTotalBytes) && taskTotalBytes > threshold) {
+    warningLines.push(`⚠️ Total disk usage per task exceeds ${formatBytes(threshold)}`);
+  }
+
   if (warningLines.length) {
     lines.push('');
     lines.push(...warningLines);
   }
+
   return `${title}\n\`\`\`\n${lines.join('\n')}\n\`\`\``;
 }
 

--- a/src/telegram-command-execution.lib.mjs
+++ b/src/telegram-command-execution.lib.mjs
@@ -127,6 +127,10 @@ export function buildExecuteAndUpdateMessage(deps) {
       trackSession(session, sessionInfo, VERBOSE);
       await safeEdit(formatStartingWorkSessionMessage({ sessionName: session, isolationBackend: iso.backend, infoBlock, locale }));
       result = await iso.runner.executeWithIsolation(commandName, args, { backend: iso.backend, sessionId: session, tool, verbose: VERBOSE });
+      if (result.success && sessionInfo && Number.isFinite(result.containerFilesystemStartBytes)) {
+        sessionInfo.containerFilesystemStartBytes = result.containerFilesystemStartBytes;
+        trackSession(session, sessionInfo, VERBOSE);
+      }
       if (!result.success) {
         // The launch never produced a live container — drop the optimistic
         // tracking so a phantom session is not monitored or resumed.

--- a/src/telegram-isolation.lib.mjs
+++ b/src/telegram-isolation.lib.mjs
@@ -92,6 +92,7 @@ export function createIsolationAwareQueueCallback(botIsolationBackend, botIsolat
             command: item.command || 'solve',
             isolationBackend: iso.backend,
             sessionId: sid,
+            containerFilesystemStartBytes: Number.isFinite(r.containerFilesystemStartBytes) ? r.containerFilesystemStartBytes : null,
             tool,
             infoBlock: item.infoBlock,
             // Issue #1688: propagate URL context + requester through the queue so the

--- a/tests/test-issue-1860-docker-isolation.mjs
+++ b/tests/test-issue-1860-docker-isolation.mjs
@@ -18,7 +18,7 @@
  * @see https://github.com/link-assistant/hive-mind/issues/1914
  */
 
-import { buildDockerIsolationStartArgs, buildStartCommandArgs, getDockerIsolationAuthMounts, getDockerIsolationImage } from '../src/isolation-runner.lib.mjs';
+import { buildDockerIsolationStartArgs, buildStartCommandArgs, getDockerIsolationAuthMounts, getDockerIsolationImage, parseDockerContainerWritableLayerSizeOutput } from '../src/isolation-runner.lib.mjs';
 import { buildExecuteAndUpdateMessage } from '../src/telegram-command-execution.lib.mjs';
 import { createIsolationAwareQueueCallback } from '../src/telegram-isolation.lib.mjs';
 import { resolveLogPath } from '../src/telegram-log-command.lib.mjs';
@@ -70,6 +70,12 @@ console.log('\n--- Docker isolation image selection ---');
 assertEqual(getDockerIsolationImage({ env: { HIVE_MIND_IMAGE_VARIANT: 'dind' } }), 'konard/hive-mind-dind:latest', 'dind Hive Mind image spawns the dind Docker isolation image');
 assertEqual(getDockerIsolationImage({ env: { HIVE_MIND_IMAGE_VARIANT: 'regular' } }), 'konard/hive-mind:latest', 'regular Hive Mind image spawns the regular Docker isolation image');
 assertEqual(getDockerIsolationImage({ env: { HIVE_MIND_DOCKER_ISOLATION_IMAGE: 'local/hive-mind-test:dev', HIVE_MIND_IMAGE_VARIANT: 'dind' } }), 'local/hive-mind-test:dev', 'explicit Docker isolation image override wins');
+
+console.log('\n--- Docker writable layer size parsing ---');
+
+assertEqual(parseDockerContainerWritableLayerSizeOutput('123456\n'), 123456, 'docker inspect SizeRw output parses as bytes');
+assertEqual(parseDockerContainerWritableLayerSizeOutput('<no value>\n'), null, 'missing SizeRw output returns null');
+assertEqual(parseDockerContainerWritableLayerSizeOutput(''), null, 'empty SizeRw output returns null');
 
 console.log('\n--- Tool-scoped credential mounts ---');
 
@@ -124,7 +130,8 @@ assertEqual(dockerStartArgs.includes('/home/box/.config/gh:/home/box/.config/gh'
 assertEqual(dockerStartArgs.includes('/home/box/.codex:/home/box/.codex'), true, 'Docker isolation mounts Codex credentials');
 assertNotIncludes(dockerStartArgs.join(' '), '.claude', 'Docker isolation does not mount Claude credentials for a Codex task');
 assertEqual(dockerStartArgs[dockerStartArgs.length - 2], '--', 'start-command receives an explicit command separator before the task command');
-assertEqual(dockerStartArgs[dockerStartArgs.length - 1], "'solve' 'https://github.com/link-assistant/hive-mind/issues/1855' '--tool' 'codex'", 'the separated command is a single shell string preserving the solve arguments');
+assertIncludes(dockerStartArgs[dockerStartArgs.length - 1], "gate='/tmp/hive-mind-disk-baseline-28b8eba8-14a6-4dd0-8782-a87db8809c11'", 'Docker isolation gates the task until the writable-layer baseline is captured');
+assertIncludes(dockerStartArgs[dockerStartArgs.length - 1], "exec 'solve' 'https://github.com/link-assistant/hive-mind/issues/1855' '--tool' 'codex'", 'the separated command preserves the solve arguments after releasing the disk baseline gate');
 
 // buildStartCommandArgs(backend:'docker') must delegate verbatim to the exported buildDockerIsolationStartArgs.
 const dockerStartArgsDirect = buildDockerIsolationStartArgs('solve', ['https://github.com/link-assistant/hive-mind/issues/1855', '--tool', 'codex'], {
@@ -187,7 +194,7 @@ const executeAndUpdateMessage = buildExecuteAndUpdateMessage({
       generateSessionId: () => 'direct-session-1860',
       executeWithIsolation: async (command, args, options) => {
         directIsolationCalls.push({ command, args, options });
-        return { success: true, output: 'session: direct-session-1860' };
+        return { success: true, output: 'session: direct-session-1860', containerFilesystemStartBytes: 123456 };
       },
     },
   }),
@@ -230,6 +237,7 @@ assertEqual(directIsolationCalls.length, 1, 'direct isolated execution invokes t
 assertEqual(directIsolationCalls[0].options.backend, 'docker', 'direct isolated execution keeps docker backend');
 assertEqual(directIsolationCalls[0].options.tool, 'codex', 'direct isolated execution passes the selected tool');
 assertEqual(directTrackCalls[0].sessionInfo.tool, 'codex', 'direct tracked session stores the selected tool');
+assertEqual(directTrackCalls.at(-1).sessionInfo.containerFilesystemStartBytes, 123456, 'direct tracked session stores docker filesystem start size after launch');
 
 const queuedIsolationCalls = [];
 const queuedTrackCalls = [];
@@ -239,7 +247,7 @@ const queueCallback = createIsolationAwareQueueCallback(
     generateSessionId: () => 'queued-session-1860',
     executeWithIsolation: async (command, args, options) => {
       queuedIsolationCalls.push({ command, args, options });
-      return { success: true, output: 'session: queued-session-1860' };
+      return { success: true, output: 'session: queued-session-1860', containerFilesystemStartBytes: 234567 };
     },
   },
   (sessionId, sessionInfo) => {
@@ -265,6 +273,7 @@ assertEqual(queuedIsolationCalls.length, 1, 'queued isolated execution invokes t
 assertEqual(queuedIsolationCalls[0].options.backend, 'docker', 'queued isolated execution keeps docker backend');
 assertEqual(queuedIsolationCalls[0].options.tool, 'codex', 'queued isolated execution passes the selected tool');
 assertEqual(queuedTrackCalls[0].sessionInfo.tool, 'codex', 'queued tracked session stores the selected tool');
+assertEqual(queuedTrackCalls[0].sessionInfo.containerFilesystemStartBytes, 234567, 'queued tracked session stores docker filesystem start size');
 
 console.log(`\nResult: ${passed} passed, ${failed} failed`);
 

--- a/tests/test-issue-1914-native-docker-isolation.mjs
+++ b/tests/test-issue-1914-native-docker-isolation.mjs
@@ -46,6 +46,11 @@ function assertNotIncludes(haystack, needle, label) {
   else fail(label, `string NOT containing ${needle}`, haystack);
 }
 
+function assertIncludes(haystack, needle, label) {
+  if (haystack.includes(needle)) pass(label);
+  else fail(label, `string containing ${needle}`, haystack);
+}
+
 const valueAfter = (arr, flag) => arr[arr.indexOf(flag) + 1];
 
 const url = 'https://github.com/link-assistant/hive-mind/issues/1914';
@@ -80,7 +85,8 @@ assertEqual(valueAfter(dockerArgs, '--shell'), 'sh', 'docker isolation forces th
 assertEqual(dockerArgs.includes('--detached'), true, 'docker isolation runs detached');
 assertEqual(valueAfter(dockerArgs, '--session'), 'uuid-docker', 'the session UUID is passed as --session (and is also the container name)');
 assertEqual(dockerArgs[dockerArgs.length - 2], '--', 'a command separator precedes the task command');
-assertEqual(dockerArgs[dockerArgs.length - 1], `'solve' '${url}'`, 'the task command is passed after the separator as a single shell-quoted string');
+assertIncludes(dockerArgs[dockerArgs.length - 1], "gate='/tmp/hive-mind-disk-baseline-uuid-docker'", 'the task command waits behind the docker writable-layer baseline gate');
+assertIncludes(dockerArgs[dockerArgs.length - 1], `exec 'solve' '${url}'`, 'the original task command is preserved after the baseline gate');
 
 console.log('\n--- Regular (non-dind) variant ---');
 

--- a/tests/test-issue-1927-session-store.mjs
+++ b/tests/test-issue-1927-session-store.mjs
@@ -36,6 +36,7 @@ const serialized = serializeSessionInfo({
   command: 'solve',
   isolationBackend: 'screen',
   sessionId: 'uuid-1',
+  containerFilesystemStartBytes: 123456,
   tool: 'claude',
   logPath: '/var/log/session.log',
   // runtime-only fields that must NOT be persisted:
@@ -44,6 +45,7 @@ const serialized = serializeSessionInfo({
 });
 assert(serialized.startTime === '2026-06-14T19:00:00.000Z', 'serializeSessionInfo converts startTime to an ISO string');
 assert(serialized.logPath === '/var/log/session.log', 'serializeSessionInfo keeps logPath (needed for footer recovery on resume)');
+assert(serialized.containerFilesystemStartBytes === 123456, 'serializeSessionInfo keeps docker filesystem start size');
 assert(!('bot' in serialized) && !('limitsSnapshot' in serialized), 'serializeSessionInfo drops runtime-only fields (bot, limitsSnapshot)');
 
 const round = deserializeSessionInfo(serialized);
@@ -60,7 +62,7 @@ try {
 
   store.persist('uuid-1', { chatId: 5, messageId: 7, startTime, url: 'https://github.com/acme/widgets/issues/42', command: 'solve', isolationBackend: 'screen', sessionId: 'uuid-1', logPath: '/var/log/s1.log' });
   clock = new Date('2026-06-14T19:01:00.000Z');
-  store.persist('uuid-2', { chatId: 6, startTime, url: 'https://github.com/acme/widgets/issues/43', command: 'hive', isolationBackend: 'docker', sessionId: 'uuid-2' });
+  store.persist('uuid-2', { chatId: 6, startTime, url: 'https://github.com/acme/widgets/issues/43', command: 'hive', isolationBackend: 'docker', sessionId: 'uuid-2', containerFilesystemStartBytes: 234567 });
 
   assert(fs.existsSync(store.snapshotPath), 'persist writes sessions.json');
   const snapshot = JSON.parse(fs.readFileSync(store.snapshotPath, 'utf8'));
@@ -73,6 +75,8 @@ try {
   const one = loaded.find(s => s.sessionName === 'uuid-1');
   assert(one && one.sessionInfo.startTime instanceof Date, 'load rehydrates startTime to a Date');
   assert(one.sessionInfo.logPath === '/var/log/s1.log', 'load round-trips logPath');
+  const two = loaded.find(s => s.sessionName === 'uuid-2');
+  assert(two.sessionInfo.containerFilesystemStartBytes === 234567, 'load round-trips docker filesystem start size');
 
   // Remove one (completion) — it leaves the snapshot but the OTHER stays.
   clock = new Date('2026-06-14T19:10:49.822Z');

--- a/tests/test-issue-1945-disk-diagnostics.mjs
+++ b/tests/test-issue-1945-disk-diagnostics.mjs
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 /**
- * Tests for src/solve.disk-diagnostics.lib.mjs (issue #1945).
+ * Tests for src/solve.disk-diagnostics.lib.mjs (issues #1945/#1988).
  *
  * Covers:
  *   - measureDirectorySize() returns a finite byte count on a real dir, null
@@ -18,6 +18,7 @@
  * Run with: node tests/test-issue-1945-disk-diagnostics.mjs
  *
  * @see https://github.com/link-assistant/hive-mind/issues/1945
+ * @see https://github.com/link-assistant/hive-mind/issues/1988
  */
 
 import assert from 'node:assert/strict';
@@ -223,20 +224,23 @@ await test('formatDiskDiagnosticsBlock: under threshold → no warnings tail', (
     afterAgent: { bytes: 2 * 1024 ** 3, deltaBytes: 1 * 1024 ** 3, path: '/tmp/x' },
   });
   assert.match(block, /^💾 Disk usage/);
-  assert.match(block, /Cloned repository: 1\.0 GB/);
-  assert.match(block, /After agent:\s+2\.0 GB \(\+1\.0 GB\)/);
-  assert.match(block, /Threshold:\s+5\.0 GB/);
+  assert.match(block, /Repository size:/);
+  assert.match(block, /Cloned:\s+1\.0 GB/);
+  assert.match(block, /On completion:\s+2\.0 GB \(\+1\.0 GB\)/);
+  assert.doesNotMatch(block, /Container filesystem size:/);
+  assert.doesNotMatch(block, /Threshold:/);
   assert.doesNotMatch(block, /⚠️/);
 });
 
-await test('formatDiskDiagnosticsBlock: above all thresholds → emits ALL three warnings', () => {
+await test('formatDiskDiagnosticsBlock: above threshold → emits a task-total warning', () => {
   const block = formatDiskDiagnosticsBlock({
     afterClone: { bytes: 6 * 1024 ** 3, path: '/tmp/x' },
     afterAgent: { bytes: 12 * 1024 ** 3, deltaBytes: 6 * 1024 ** 3, path: '/tmp/x' },
   });
-  assert.match(block, /⚠️ Cloned repository exceeds 5\.0 GB/);
-  assert.match(block, /⚠️ Folder grew by more than 5\.0 GB during the run/);
-  assert.match(block, /⚠️ Total disk usage exceeds 5\.0 GB/);
+  assert.match(block, /⚠️ Total disk usage per task exceeds 5\.0 GB/);
+  assert.doesNotMatch(block, /Cloned repository exceeds/);
+  assert.doesNotMatch(block, /Folder grew by more than/);
+  assert.doesNotMatch(block, /Threshold:/);
 });
 
 await test('formatDiskDiagnosticsBlock: only clone known → block still renders', () => {
@@ -244,10 +248,47 @@ await test('formatDiskDiagnosticsBlock: only clone known → block still renders
     afterClone: { bytes: 6 * 1024 ** 3, path: '/tmp/x' },
     afterAgent: null,
   });
-  assert.match(block, /Cloned repository: 6\.0 GB/);
-  assert.match(block, /⚠️ Cloned repository exceeds 5\.0 GB/);
+  assert.match(block, /Cloned:\s+6\.0 GB/);
+  assert.match(block, /⚠️ Total disk usage per task exceeds 5\.0 GB/);
   // No "After agent" line because the second checkpoint was never reached.
-  assert.doesNotMatch(block, /After agent:/);
+  assert.doesNotMatch(block, /On completion:/);
+});
+
+await test('formatDiskDiagnosticsBlock: docker isolation includes container filesystem size', () => {
+  const block = formatDiskDiagnosticsBlock(
+    {
+      afterClone: { bytes: 248 * 1024 ** 2, path: '/tmp/x' },
+      afterAgent: { bytes: 13 * 1024 ** 3, deltaBytes: 13 * 1024 ** 3 - 248 * 1024 ** 2, path: '/tmp/x' },
+    },
+    {
+      isolationBackend: 'docker',
+      containerFilesystemStartBytes: 300 * 1024 ** 2,
+      containerFilesystemAfterBytes: 14 * 1024 ** 3,
+    }
+  );
+  assert.match(block, /Repository size:/);
+  assert.match(block, /Cloned:\s+248 MB/);
+  assert.match(block, /On completion:\s+13\.0 GB \(\+12\.8 GB\)/);
+  assert.match(block, /Container filesystem size:/);
+  assert.match(block, /On start:\s+300 MB/);
+  assert.match(block, /On completion:\s+14\.0 GB/);
+  assert.match(block, /⚠️ Total disk usage per task exceeds 5\.0 GB/);
+});
+
+await test('formatDiskDiagnosticsBlock: screen isolation shows repository size only', () => {
+  const block = formatDiskDiagnosticsBlock(
+    {
+      afterClone: { bytes: 248 * 1024 ** 2, path: '/tmp/x' },
+      afterAgent: { bytes: 300 * 1024 ** 2, deltaBytes: 52 * 1024 ** 2, path: '/tmp/x' },
+    },
+    {
+      isolationBackend: 'screen',
+      containerFilesystemStartBytes: 10 * 1024 ** 3,
+      containerFilesystemAfterBytes: 11 * 1024 ** 3,
+    }
+  );
+  assert.match(block, /Repository size:/);
+  assert.doesNotMatch(block, /Container filesystem size:/);
 });
 
 // --- recordAfterCloneSize / recordAfterAgentSize emit a marker via log ---

--- a/tests/test-issue-1945-session-monitor-integration.mjs
+++ b/tests/test-issue-1945-session-monitor-integration.mjs
@@ -3,7 +3,7 @@
  * Integration test: the captured solve log markers from
  * `solve.disk-diagnostics.lib.mjs` are recovered by
  * `session-monitor.lib.mjs` and turned into the expected Telegram extraSection
- * with the right warnings on (issue #1945).
+ * with the right warnings on (issues #1945/#1988).
  *
  * This test does NOT spawn a real solve run or attach to Telegram. It writes a
  * synthetic captured-log file that contains the two `📊 [DISK]` markers and
@@ -14,6 +14,7 @@
  * Run with: node tests/test-issue-1945-session-monitor-integration.mjs
  *
  * @see https://github.com/link-assistant/hive-mind/issues/1945
+ * @see https://github.com/link-assistant/hive-mind/issues/1988
  */
 
 import assert from 'node:assert/strict';
@@ -70,11 +71,11 @@ await test('captured log → disk block surfaces in the completion message', asy
     });
     assert.match(message, /Work session finished successfully/);
     assert.match(message, /💾 Disk usage/);
-    assert.match(message, /Cloned repository: 12\.0 GB/);
-    assert.match(message, /After agent:\s+13\.0 GB \(\+1\.0 GB\)/);
-    // Only the cloned-repo threshold is crossed (12 > 5; total 13 > 5; delta 1 < 5).
-    assert.match(message, /⚠️ Cloned repository exceeds 5\.0 GB/);
-    assert.match(message, /⚠️ Total disk usage exceeds 5\.0 GB/);
+    assert.match(message, /Repository size:/);
+    assert.match(message, /Cloned:\s+12\.0 GB/);
+    assert.match(message, /On completion:\s+13\.0 GB \(\+1\.0 GB\)/);
+    assert.match(message, /⚠️ Total disk usage per task exceeds 5\.0 GB/);
+    assert.doesNotMatch(message, /Cloned repository exceeds/);
     assert.doesNotMatch(message, /Folder grew by more than/);
   } finally {
     fs.rmSync(logFile, { force: true });
@@ -86,15 +87,15 @@ await test('captured log with only the AFTER_CLONE marker (agent crashed) still 
   try {
     const parsed = parseDiskMarkers(fs.readFileSync(logFile, 'utf8'));
     const block = formatDiskDiagnosticsBlock(parsed);
-    assert.match(block, /Cloned repository: 6\.0 GB/);
-    assert.match(block, /⚠️ Cloned repository exceeds 5\.0 GB/);
-    assert.doesNotMatch(block, /After agent:/);
+    assert.match(block, /Cloned:\s+6\.0 GB/);
+    assert.match(block, /⚠️ Total disk usage per task exceeds 5\.0 GB/);
+    assert.doesNotMatch(block, /On completion:/);
   } finally {
     fs.rmSync(logFile, { force: true });
   }
 });
 
-await test('captured log with delta > 5 GB only flags the delta warning', async () => {
+await test('captured log warns only when total task usage is above threshold', async () => {
   const logFile = writeFakeLog([
     buildDiskMarker({ phase: DISK_PHASE_AFTER_CLONE, bytes: 100 * 1024 * 1024, path: '/tmp/foo' }),
     buildDiskMarker({
@@ -110,7 +111,35 @@ await test('captured log with delta > 5 GB only flags the delta warning', async 
     // delta is EXACTLY 5 GB (== threshold) — must NOT warn (strict >).
     assert.doesNotMatch(block, /Folder grew by more than/);
     // total IS strictly greater than threshold.
-    assert.match(block, /⚠️ Total disk usage exceeds 5\.0 GB/);
+    assert.match(block, /⚠️ Total disk usage per task exceeds 5\.0 GB/);
+  } finally {
+    fs.rmSync(logFile, { force: true });
+  }
+});
+
+await test('docker isolation block includes repository and container filesystem sections', async () => {
+  const logFile = writeFakeLog([
+    buildDiskMarker({ phase: DISK_PHASE_AFTER_CLONE, bytes: 248 * 1024 ** 2, path: '/tmp/foo' }),
+    buildDiskMarker({
+      phase: DISK_PHASE_AFTER_AGENT,
+      bytes: 13 * 1024 ** 3,
+      deltaBytes: 13 * 1024 ** 3 - 248 * 1024 ** 2,
+      path: '/tmp/foo',
+    }),
+  ]);
+  try {
+    const parsed = parseDiskMarkers(fs.readFileSync(logFile, 'utf8'));
+    const block = formatDiskDiagnosticsBlock(parsed, {
+      isolationBackend: 'docker',
+      containerFilesystemStartBytes: 300 * 1024 ** 2,
+      containerFilesystemAfterBytes: 14 * 1024 ** 3,
+    });
+    assert.match(block, /Repository size:/);
+    assert.match(block, /Cloned:\s+248 MB/);
+    assert.match(block, /Container filesystem size:/);
+    assert.match(block, /On start:\s+300 MB/);
+    assert.match(block, /On completion:\s+14\.0 GB/);
+    assert.match(block, /⚠️ Total disk usage per task exceeds 5\.0 GB/);
   } finally {
     fs.rmSync(logFile, { force: true });
   }


### PR DESCRIPTION
Fixes #1988

## Summary

- Reformat completion disk diagnostics into separate `Repository size` and, for Docker isolation, `Container filesystem size` sections.
- Remove the standalone `Threshold:` line and replace the old cloned/delta/total warnings with a single `Total disk usage per task exceeds 5.0 GB` warning only when the task total crosses the threshold.
- Capture Docker container writable-layer size with `docker inspect --size` (`SizeRw`), excluding image base layers, and persist the start size for completion monitoring.
- Gate Docker task startup briefly so the writable-layer baseline is captured before the solve command begins cloning or writing task files; screen/tmux output remains repository-only.
- Add a patch changeset for the release workflow.

## Reproduction

Before this change, the disk diagnostics formatter emitted the old labels (`Cloned repository`, `After agent`, `Threshold`) and separate cloned/delta/total warnings. The updated regression expectations in `tests/test-issue-1945-disk-diagnostics.mjs` reproduce the issue #1988 output mismatch and verify the new screen/Docker shapes.

## Verification

- `node tests/test-issue-1945-disk-diagnostics.mjs`
- `node tests/test-issue-1945-session-monitor-integration.mjs`
- `node tests/test-issue-1860-docker-isolation.mjs`
- `node tests/test-issue-1914-native-docker-isolation.mjs`
- `node tests/test-issue-1927-session-store.mjs`
- `node tests/test-issue-1979-docker-container-reaping.mjs`
- `node scripts/validate-changeset.mjs`
- `npx prettier --check .changeset/improve-disk-diagnostics.md`
- `npm run lint`
- `npm run format:check`
- `npm test` (`All 291 selected test file(s) passed.`)
- `git diff --check`
