### PR TITLE
fix(cleanup): estimate system dry-run reclaim

### DIFF
--- a/.changeset/issue-2005-system-cleanup-dry-run.md
+++ b/.changeset/issue-2005-system-cleanup-dry-run.md
@@ -1,0 +1,6 @@
+---
+'@link-assistant/hive-mind': patch
+---
+
+Report estimated reclaimable space for `hive-cleanup --dry-run` system cleanup
+commands and await system-cleanup logging so dry-run output stays in order.

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,0 +1,1 @@
+# .gitkeep file auto-generated at 2026-07-02T17:23:04.475Z for PR creation at branch issue-2005-c2db986d2eeb for issue https://github.com/link-assistant/hive-mind/issues/2005

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,1 +1,0 @@
-# .gitkeep file auto-generated at 2026-07-02T17:23:04.475Z for PR creation at branch issue-2005-c2db986d2eeb for issue https://github.com/link-assistant/hive-mind/issues/2005

--- a/src/cleanup.mjs
+++ b/src/cleanup.mjs
@@ -422,8 +422,8 @@ async function main() {
 
   // 8. System / Ubuntu cleanup (opt-in).
   if (options.apt || options.journal || options.docker || options.npm) {
-    await log('\n🧴 System cleanup:');
-    runSystemCleanup({
+    await log(options.dryRun ? '\n🧴 System cleanup (dry-run, estimated reclaim):' : '\n🧴 System cleanup:');
+    await runSystemCleanup({
       apt: options.apt,
       journal: options.journal,
       docker: options.docker,

--- a/src/cleanup.os.lib.mjs
+++ b/src/cleanup.os.lib.mjs
@@ -21,6 +21,7 @@ import { execFileSync } from 'node:child_process';
 
 import { extractTaskRefsFromCommand, isDockerIsolationSessionName, parseDockerContainerExitCode, parseRemoteUrl } from './cleanup.lib.mjs';
 import { correlateProcesses, parseStartCommandLogMetadata, redactProcessText } from './process-debug.lib.mjs';
+import { buildSystemCleanupPlan, estimateSystemCleanupPlan, formatSystemCleanupEstimateLine, formatSystemCleanupTotalLine } from './system-cleanup-estimates.lib.mjs';
 
 /** Run a command, returning trimmed stdout or null on any failure. */
 function tryExec(cmd, args, options = {}) {
@@ -867,7 +868,7 @@ export function removeDockerContainer(containerName) {
 
 /**
  * System / Ubuntu cleanup actions. Each is opt-in. In dry-run mode the commands
- * are only described, never executed.
+ * are estimated and described, never executed.
  *
  * @param {Object} options
  * @param {boolean} [options.apt] - apt-get clean / autoclean / autoremove
@@ -877,41 +878,40 @@ export function removeDockerContainer(containerName) {
  * @param {string} [options.journalVacuumTime='2weeks']
  * @param {boolean} [options.dryRun]
  * @param {boolean} [options.useSudo] - prefix package commands with sudo
- * @param {(msg: string) => void} [options.logFn]
- * @returns {Array<{command: string, executed: boolean, ok: boolean|null}>}
+ * @param {(msg: string) => void|Promise<void>} [options.logFn]
+ * @returns {Promise<Array<{command: string, executed: boolean, ok: boolean|null, estimatedBytes?: number|null}>>}
  */
-export function runSystemCleanup(options = {}) {
-  const { apt = false, journal = false, docker = false, npm = false, journalVacuumTime = '2weeks', dryRun = false, useSudo = false, logFn = () => {} } = options;
-
-  const plan = [];
-  const sudo = useSudo ? ['sudo'] : [];
-  if (apt) {
-    plan.push([...sudo, 'apt-get', 'clean']);
-    plan.push([...sudo, 'apt-get', 'autoclean', '-y']);
-    plan.push([...sudo, 'apt-get', 'autoremove', '-y']);
-  }
-  if (journal) {
-    plan.push([...sudo, 'journalctl', `--vacuum-time=${journalVacuumTime}`]);
-  }
-  if (docker) {
-    plan.push(['docker', 'system', 'prune', '-f']);
-  }
-  if (npm) {
-    plan.push(['npm', 'cache', 'clean', '--force']);
-  }
-
+export async function runSystemCleanup(options = {}) {
+  const { apt = false, journal = false, docker = false, npm = false, journalVacuumTime = '2weeks', dryRun = false, useSudo = false, logFn = () => {}, execFn = tryExec } = options;
+  const plan = buildSystemCleanupPlan({ apt, journal, docker, npm, journalVacuumTime, useSudo });
   const results = [];
-  for (const argv of plan) {
-    const display = argv.join(' ');
-    if (dryRun) {
-      logFn(`   [dry-run] would run: ${display}`);
-      results.push({ command: display, executed: false, ok: null });
-      continue;
+
+  if (dryRun) {
+    const estimates = estimateSystemCleanupPlan(plan, {
+      execFn,
+      journalFiles: options.journalFiles,
+      now: options.now || new Date(),
+    });
+    for (const estimate of estimates) {
+      await logFn(formatSystemCleanupEstimateLine(estimate));
+      results.push({
+        command: estimate.command,
+        executed: false,
+        ok: null,
+        estimatedBytes: estimate.estimatedBytes,
+        detail: estimate.detail,
+      });
     }
-    logFn(`   running: ${display}`);
-    const out = tryExec(argv[0], argv.slice(1), { timeout: 180000, stdio: ['ignore', 'pipe', 'pipe'] });
+    await logFn(formatSystemCleanupTotalLine(estimates));
+    return results;
+  }
+
+  for (const item of plan) {
+    const display = item.argv.join(' ');
+    await logFn(`   running: ${display}`);
+    const out = execFn(item.argv[0], item.argv.slice(1), { timeout: 180000, stdio: ['ignore', 'pipe', 'pipe'] });
     const ok = out !== null;
-    logFn(ok ? `   ✓ ${display}` : `   ✗ ${display} (failed or unavailable)`);
+    await logFn(ok ? `   ✓ ${display}` : `   ✗ ${display} (failed or unavailable)`);
     results.push({ command: display, executed: true, ok });
   }
   return results;

--- a/src/system-cleanup-estimates.lib.mjs
+++ b/src/system-cleanup-estimates.lib.mjs
@@ -1,0 +1,256 @@
+import fs from 'node:fs';
+import path from 'node:path';
+
+import { formatBytes } from './cleanup.lib.mjs';
+
+const APT_ARCHIVES_PATH = '/var/cache/apt/archives';
+const JOURNAL_ROOTS = ['/var/log/journal', '/run/log/journal'];
+
+const UNIT_MULTIPLIERS = new Map([
+  ['', 1],
+  ['B', 1],
+  ['BYTE', 1],
+  ['BYTES', 1],
+  ['K', 1024],
+  ['KB', 1024],
+  ['KIB', 1024],
+  ['M', 1024 ** 2],
+  ['MB', 1024 ** 2],
+  ['MIB', 1024 ** 2],
+  ['G', 1024 ** 3],
+  ['GB', 1024 ** 3],
+  ['GIB', 1024 ** 3],
+  ['T', 1024 ** 4],
+  ['TB', 1024 ** 4],
+  ['TIB', 1024 ** 4],
+  ['P', 1024 ** 5],
+  ['PB', 1024 ** 5],
+  ['PIB', 1024 ** 5],
+]);
+
+export function parseHumanBytes(value) {
+  const match = String(value ?? '')
+    .trim()
+    .match(/^([0-9][0-9,]*(?:\.[0-9]+)?)\s*([KMGTPE]?i?B?|bytes?)?/i);
+  if (!match) return null;
+  const number = Number(match[1].replace(/,/g, ''));
+  if (!Number.isFinite(number)) return null;
+  const unit = String(match[2] || 'B')
+    .toUpperCase()
+    .replace(/IB$/, 'IB');
+  const multiplier = UNIT_MULTIPLIERS.get(unit);
+  if (!multiplier) return null;
+  return Math.round(number * multiplier);
+}
+
+export function parseDuBytes(output, blockSize = 1) {
+  const token = String(output ?? '')
+    .trim()
+    .split(/\s+/)[0];
+  const value = Number(token?.replace(/,/g, ''));
+  return Number.isFinite(value) ? Math.round(value * blockSize) : null;
+}
+
+export function parseAptAutoremoveFreedBytes(output) {
+  const text = String(output || '');
+  const freed = text.match(/After this operation,\s+([0-9][0-9,]*(?:\.[0-9]+)?\s*[KMGTPE]?i?B?)\s+disk space will be freed/i);
+  if (freed) return parseHumanBytes(freed[1]);
+  if (/\b0\s+to\s+remove\b/i.test(text)) return 0;
+  return null;
+}
+
+export function parseJournalDiskUsageBytes(output) {
+  const match = String(output || '').match(/\btake up\s+([0-9][0-9,]*(?:\.[0-9]+)?\s*[KMGTPE]?i?B?)\b/i);
+  return match ? parseHumanBytes(match[1]) : null;
+}
+
+export function parseDockerSystemDf(output) {
+  const items = [];
+  for (const line of String(output ?? '').split('\n')) {
+    const trimmed = line.trim();
+    if (!trimmed || /^TYPE\s+/i.test(trimmed)) continue;
+    const parts = trimmed.split(/\s{2,}/).filter(Boolean);
+    if (parts.length < 5) continue;
+    const reclaimable = parts[4];
+    const reclaimableBytes = parseHumanBytes(reclaimable);
+    if (reclaimableBytes == null) continue;
+    items.push({
+      type: parts[0],
+      total: parts[1],
+      active: parts[2],
+      size: parts[3],
+      reclaimable,
+      reclaimableBytes,
+    });
+  }
+  return {
+    items,
+    totalReclaimableBytes: items.reduce((sum, item) => sum + item.reclaimableBytes, 0),
+  };
+}
+
+export function buildSystemCleanupPlan(options = {}) {
+  const { apt = false, journal = false, docker = false, npm = false, journalVacuumTime = '2weeks', useSudo = false } = options;
+  const sudo = useSudo ? ['sudo'] : [];
+  const plan = [];
+  if (apt) {
+    plan.push({ action: 'apt-clean', category: 'apt', argv: [...sudo, 'apt-get', 'clean'] });
+    plan.push({ action: 'apt-autoclean', category: 'apt', argv: [...sudo, 'apt-get', 'autoclean', '-y'] });
+    plan.push({ action: 'apt-autoremove', category: 'apt', argv: [...sudo, 'apt-get', 'autoremove', '-y'] });
+  }
+  if (journal) {
+    plan.push({
+      action: 'journal-vacuum',
+      category: 'journal',
+      argv: [...sudo, 'journalctl', `--vacuum-time=${journalVacuumTime}`],
+      journalVacuumTime,
+    });
+  }
+  if (docker) plan.push({ action: 'docker-prune', category: 'docker', argv: ['docker', 'system', 'prune', '-f'] });
+  if (npm) plan.push({ action: 'npm-cache-clean', category: 'npm', argv: ['npm', 'cache', 'clean', '--force'] });
+  return plan;
+}
+
+function commandDisplay(argv) {
+  return argv.join(' ');
+}
+
+function measurePathBytes(targetPath, execFn) {
+  const exact = parseDuBytes(execFn('du', ['-sb', targetPath]));
+  if (exact != null) return exact;
+  const kib = parseDuBytes(execFn('du', ['-sk', targetPath]), 1024);
+  if (kib != null) return kib;
+  try {
+    return fs.statSync(targetPath).size;
+  } catch {
+    return null;
+  }
+}
+
+function parseDurationMs(spec) {
+  let total = 0;
+  const pattern = /([0-9]+(?:\.[0-9]+)?)\s*(microseconds?|usec|milliseconds?|msec|ms|seconds?|secs?|sec|s|minutes?|mins?|min|m|hours?|hrs?|hr|h|days?|d|weeks?|w|months?|years?|yrs?|yr|y)/gi;
+  let match;
+  while ((match = pattern.exec(String(spec || ''))) !== null) {
+    const value = Number(match[1]);
+    if (!Number.isFinite(value)) continue;
+    const unit = match[2].toLowerCase();
+    if (unit.startsWith('micro') || unit === 'usec') total += value / 1000;
+    else if (unit.startsWith('milli') || unit === 'msec' || unit === 'ms') total += value;
+    else if (unit === 'm' || unit.startsWith('min')) total += value * 60 * 1000;
+    else if (unit === 'h' || unit.startsWith('h')) total += value * 60 * 60 * 1000;
+    else if (unit === 'd' || unit.startsWith('day')) total += value * 24 * 60 * 60 * 1000;
+    else if (unit === 'w' || unit.startsWith('week')) total += value * 7 * 24 * 60 * 60 * 1000;
+    else if (unit.startsWith('month')) total += value * 30 * 24 * 60 * 60 * 1000;
+    else if (unit === 'y' || unit.startsWith('yr') || unit.startsWith('year')) total += value * 365 * 24 * 60 * 60 * 1000;
+    else total += value * 1000;
+  }
+  return total > 0 ? total : null;
+}
+
+function listJournalFiles(roots = JOURNAL_ROOTS) {
+  const files = [];
+  const stack = [...roots];
+  while (stack.length > 0) {
+    const current = stack.pop();
+    let stat;
+    try {
+      stat = fs.statSync(current);
+    } catch {
+      continue;
+    }
+    if (stat.isDirectory()) {
+      let entries;
+      try {
+        entries = fs.readdirSync(current, { withFileTypes: true });
+      } catch {
+        continue;
+      }
+      for (const entry of entries) stack.push(path.join(current, entry.name));
+    } else if (stat.isFile() && /\.journal~?$/.test(current)) {
+      files.push({ path: current, size: stat.size, mtimeMs: stat.mtimeMs });
+    }
+  }
+  return files;
+}
+
+function estimateJournalBytes({ execFn, journalVacuumTime, journalFiles, now }) {
+  const currentBytes = parseJournalDiskUsageBytes(execFn('journalctl', ['--disk-usage']));
+  const durationMs = parseDurationMs(journalVacuumTime);
+  const files = journalFiles ?? listJournalFiles();
+  if (!durationMs) {
+    return {
+      estimatedBytes: null,
+      detail: currentBytes == null ? `unable to parse --vacuum-time=${journalVacuumTime}` : `current journal usage ${formatBytes(currentBytes)}`,
+    };
+  }
+  if (files.length === 0 && currentBytes > 0 && journalFiles == null) {
+    return {
+      estimatedBytes: null,
+      detail: `current journal usage ${formatBytes(currentBytes)}; journal files not readable`,
+    };
+  }
+  const cutoff = new Date(now).getTime() - durationMs;
+  const estimatedBytes = files.filter(file => Number(file.mtimeMs) < cutoff).reduce((sum, file) => sum + (Number(file.size) || 0), 0);
+  const detail = currentBytes == null ? `journal files older than ${journalVacuumTime}` : `journal files older than ${journalVacuumTime}; current usage ${formatBytes(currentBytes)}`;
+  return { estimatedBytes, detail };
+}
+
+function estimateDockerBytes(execFn) {
+  const parsed = parseDockerSystemDf(execFn('docker', ['system', 'df']));
+  if (parsed.items.length === 0) return { estimatedBytes: null, detail: 'docker system df unavailable' };
+  const nonZero = parsed.items.filter(item => item.reclaimableBytes > 0);
+  const detail = nonZero.length === 0 ? 'docker system df reclaimable: 0B' : `docker system df reclaimable: ${nonZero.map(item => `${item.type} ${formatBytes(item.reclaimableBytes)}`).join(', ')}`;
+  return { estimatedBytes: parsed.totalReclaimableBytes, detail };
+}
+
+export function estimateSystemCleanupCommand(item, options = {}) {
+  const execFn = options.execFn || (() => null);
+  const command = commandDisplay(item.argv);
+
+  if (item.action === 'apt-clean') {
+    return { ...item, command, estimatedBytes: measurePathBytes(APT_ARCHIVES_PATH, execFn), detail: APT_ARCHIVES_PATH };
+  }
+  if (item.action === 'apt-autoclean') {
+    return { ...item, command, estimatedBytes: 0, detail: 'already covered by apt-get clean' };
+  }
+  if (item.action === 'apt-autoremove') {
+    const estimatedBytes = parseAptAutoremoveFreedBytes(execFn('apt-get', ['-s', 'autoremove']));
+    return { ...item, command, estimatedBytes, detail: estimatedBytes == null ? 'apt-get -s autoremove unavailable' : 'apt-get -s autoremove' };
+  }
+  if (item.action === 'journal-vacuum') {
+    return { ...item, command, ...estimateJournalBytes({ ...options, journalVacuumTime: item.journalVacuumTime }) };
+  }
+  if (item.action === 'docker-prune') {
+    return { ...item, command, ...estimateDockerBytes(execFn) };
+  }
+  if (item.action === 'npm-cache-clean') {
+    const cachePath = execFn('npm', ['config', 'get', 'cache']);
+    const trimmedPath = cachePath ? cachePath.trim() : '';
+    const estimatedBytes = trimmedPath ? measurePathBytes(trimmedPath, execFn) : null;
+    return {
+      ...item,
+      command,
+      estimatedBytes,
+      detail: trimmedPath || 'npm cache path unavailable',
+    };
+  }
+  return { ...item, command, estimatedBytes: null, detail: 'estimate unavailable' };
+}
+
+export function estimateSystemCleanupPlan(plan, options = {}) {
+  return plan.map(item => estimateSystemCleanupCommand(item, options));
+}
+
+export function formatSystemCleanupEstimateLine(item) {
+  const estimate = item.estimatedBytes == null ? '?' : `~${formatBytes(item.estimatedBytes)}`;
+  const detail = item.detail ? `  (${item.detail})` : '';
+  return `   ${item.command.padEnd(34)} ${estimate.padStart(8)}${detail}`;
+}
+
+export function formatSystemCleanupTotalLine(items) {
+  const knownItems = items.filter(item => item.estimatedBytes != null);
+  const total = knownItems.reduce((sum, item) => sum + item.estimatedBytes, 0);
+  const unknown = knownItems.length < items.length ? ' (known estimates only)' : '';
+  return `   estimated system reclaim:        ~${formatBytes(total)}${unknown}`;
+}

--- a/tests/test-issue-2005-system-cleanup-dry-run.mjs
+++ b/tests/test-issue-2005-system-cleanup-dry-run.mjs
@@ -1,0 +1,129 @@
+#!/usr/bin/env node
+/**
+ * Regression tests for issue #2005.
+ *
+ * `hive-cleanup --dry-run` must report estimated reclaimable bytes for
+ * opt-in system cleanup categories and must await async logging so the final
+ * footer cannot interleave with system-cleanup lines.
+ *
+ * @hive-mind-test-suite default
+ * @see https://github.com/link-assistant/hive-mind/issues/2005
+ */
+
+import assert from 'node:assert/strict';
+
+import { runSystemCleanup } from '../src/cleanup.os.lib.mjs';
+import { parseDockerSystemDf, parseAptAutoremoveFreedBytes, parseJournalDiskUsageBytes } from '../src/system-cleanup-estimates.lib.mjs';
+
+let passed = 0;
+let failed = 0;
+
+async function test(name, fn) {
+  try {
+    await fn();
+    console.log(`PASS: ${name}`);
+    passed++;
+  } catch (error) {
+    console.log(`FAIL: ${name}`);
+    console.log(`  ${error.stack || error.message}`);
+    failed++;
+  }
+}
+
+function makeProbe(outputs) {
+  return (cmd, args) => {
+    const key = `${cmd} ${args.join(' ')}`;
+    return Object.hasOwn(outputs, key) ? outputs[key] : null;
+  };
+}
+
+await test('parseDockerSystemDf sums reclaimable bytes from docker system df', () => {
+  const parsed = parseDockerSystemDf(`TYPE            TOTAL     ACTIVE    SIZE      RECLAIMABLE
+Images          4         2         12.4GB    3.2GB (25%)
+Containers      2         0         212B      212B (100%)
+Local Volumes   1         1         1.5GB     0B (0%)
+Build Cache     8         0         42.1MB    42.1MB`);
+
+  assert.equal(parsed.totalReclaimableBytes, Math.round(3.2 * 1024 ** 3) + 212 + Math.round(42.1 * 1024 ** 2));
+  assert.deepEqual(
+    parsed.items.map(item => item.type),
+    ['Images', 'Containers', 'Local Volumes', 'Build Cache']
+  );
+});
+
+await test('parseAptAutoremoveFreedBytes reads apt simulation output', () => {
+  assert.equal(parseAptAutoremoveFreedBytes('After this operation, 181 MB disk space will be freed.'), 181 * 1024 ** 2);
+  assert.equal(parseAptAutoremoveFreedBytes('0 upgraded, 0 newly installed, 0 to remove and 12 not upgraded.'), 0);
+  assert.equal(parseAptAutoremoveFreedBytes('After this operation, 2,048 kB disk space will be freed.'), 2048 * 1024);
+});
+
+await test('parseJournalDiskUsageBytes reads journalctl disk usage output', () => {
+  assert.equal(parseJournalDiskUsageBytes('Archived and active journals take up 1.6G in the file system.'), Math.round(1.6 * 1024 ** 3));
+});
+
+await test('dry-run logs per-command estimates and a reclaim total', async () => {
+  const logs = [];
+  const results = await runSystemCleanup({
+    apt: true,
+    journal: true,
+    docker: true,
+    npm: true,
+    dryRun: true,
+    now: new Date('2026-07-02T00:00:00.000Z'),
+    journalFiles: [
+      { path: '/var/log/journal/old/system.journal', size: 3 * 1024 ** 3, mtimeMs: new Date('2026-06-01T00:00:00.000Z').getTime() },
+      { path: '/var/log/journal/recent/system.journal', size: 512 * 1024 ** 2, mtimeMs: new Date('2026-07-01T00:00:00.000Z').getTime() },
+    ],
+    execFn: makeProbe({
+      'du -sb /var/cache/apt/archives': `${100 * 1024 ** 2}\t/var/cache/apt/archives`,
+      'apt-get -s autoremove': 'After this operation, 250 MB disk space will be freed.',
+      'journalctl --disk-usage': 'Archived and active journals take up 3.5G in the file system.',
+      'docker system df': `TYPE            TOTAL     ACTIVE    SIZE      RECLAIMABLE
+Images          1         0         800MB     300MB (37%)
+Build Cache     2         0         50MB      20MB`,
+      'npm config get cache': '/tmp/npm-cache',
+      'du -sb /tmp/npm-cache': `${25 * 1024 ** 2}\t/tmp/npm-cache`,
+    }),
+    logFn: message => logs.push(message),
+  });
+
+  assert.ok(logs.some(line => line.includes('apt-get clean') && line.includes('100M')));
+  assert.ok(logs.some(line => line.includes('apt-get autoremove -y') && line.includes('250M')));
+  assert.ok(logs.some(line => line.includes('journalctl --vacuum-time=2weeks') && line.includes('3G')));
+  assert.ok(logs.some(line => line.includes('docker system prune -f') && line.includes('320M')));
+  assert.ok(logs.some(line => line.includes('npm cache clean --force') && line.includes('25M')));
+  assert.ok(logs.some(line => line.includes('estimated system reclaim') && line.includes('3.7G')));
+
+  const byCommand = new Map(results.map(result => [result.command, result]));
+  assert.equal(byCommand.get('apt-get clean').estimatedBytes, 100 * 1024 ** 2);
+  assert.equal(byCommand.get('apt-get autoremove -y').estimatedBytes, 250 * 1024 ** 2);
+  assert.equal(byCommand.get('journalctl --vacuum-time=2weeks').estimatedBytes, 3 * 1024 ** 3);
+  assert.equal(byCommand.get('docker system prune -f').estimatedBytes, 320 * 1024 ** 2);
+  assert.equal(byCommand.get('npm cache clean --force').estimatedBytes, 25 * 1024 ** 2);
+});
+
+await test('runSystemCleanup awaits async logFn calls before resolving', async () => {
+  const logs = [];
+  await runSystemCleanup({
+    docker: true,
+    dryRun: true,
+    execFn: makeProbe({
+      'docker system df': `TYPE            TOTAL     ACTIVE    SIZE      RECLAIMABLE
+Build Cache     1         0         12MB      12MB`,
+    }),
+    logFn: message =>
+      new Promise(resolve => {
+        setImmediate(() => {
+          logs.push(message);
+          resolve();
+        });
+      }),
+  });
+  logs.push('footer');
+
+  assert.equal(logs.at(-1), 'footer');
+  assert.ok(logs.slice(0, -1).some(line => line.includes('docker system prune -f')));
+});
+
+console.log(`\n${passed} passed, ${failed} failed`);
+if (failed > 0) process.exit(1);


### PR DESCRIPTION
## Summary

Closes #2005.

`hive-cleanup --dry-run` now reports estimated reclaimable space for the opt-in system cleanup commands instead of only echoing the commands it would run. The system cleanup runner also awaits async logging, so the system-cleanup lines cannot print after the final log-file footer.

## What changed

- Added `src/system-cleanup-estimates.lib.mjs` for read-only dry-run probes and parsers:
  - apt cache size via `du -sb /var/cache/apt/archives`
  - apt autoremove estimate via `apt-get -s autoremove`
  - journal current usage via `journalctl --disk-usage`, plus an age-based estimate from journal files older than `--vacuum-time`
  - Docker reclaimable total via `docker system df`
  - npm cache size via `npm config get cache` + `du -sb`
- Updated `runSystemCleanup()` to build a shared command plan, return per-command `estimatedBytes` in dry-run mode, and await `logFn` calls.
- Updated the CLI system section heading to make dry-run estimates explicit.
- Added a patch changeset.

## Verification

- [x] `node tests/test-issue-2005-system-cleanup-dry-run.mjs`
- [x] `node tests/test-cleanup-1848.mjs`
- [x] `node tests/test-issue-1980-docker-cleanup.mjs`
- [x] `npm run lint`
- [x] `npm run format:check`
- [x] `npm test` - all 300 selected test files passed
- [x] CLI smoke: `node src/cleanup.mjs --dry-run --no-sessions --no-resolve-branches --no-docker-isolation --apt --journal --docker --npm`

Smoke output included the new system estimate section, for example:

```text
🧴 System cleanup (dry-run, estimated reclaim):
   apt-get clean                           ~0B  (/var/cache/apt/archives)
   apt-get autoclean -y                    ~0B  (already covered by apt-get clean)
   apt-get autoremove -y                   ~0B  (apt-get -s autoremove)
   journalctl --vacuum-time=2weeks         ~0B  (journal files older than 2weeks; current usage 0B)
   docker system prune -f                  ~0B  (docker system df reclaimable: 0B)
   npm cache clean --force               ~216M  (/home/box/.npm)
   estimated system reclaim:        ~216M
```
