### PR TITLE
fix: trust clean merge state over stale CI failures

### DIFF
--- a/.changeset/stale-rerun-checks.md
+++ b/.changeset/stale-rerun-checks.md
@@ -1,0 +1,5 @@
+---
+'@link-assistant/hive-mind': patch
+---
+
+Stop auto-restarting for stale failed check-runs when GitHub reports the pull request as clean and mergeable

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,0 +1,1 @@
+# .gitkeep file auto-generated at 2026-07-10T07:05:08.431Z for PR creation at branch issue-2031-7c3b577d9efa for issue https://github.com/link-assistant/hive-mind/issues/2031

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,1 +1,0 @@
-# .gitkeep file auto-generated at 2026-07-10T07:05:08.431Z for PR creation at branch issue-2031-7c3b577d9efa for issue https://github.com/link-assistant/hive-mind/issues/2031

--- a/src/github-merge.lib.mjs
+++ b/src/github-merge.lib.mjs
@@ -446,7 +446,7 @@ export async function checkPRCIStatus(owner, repo, prNumber, verbose = false) {
  * @param {string} repo - Repository name
  * @param {number} prNumber - Pull request number
  * @param {boolean} verbose - Whether to log verbose output
- * @returns {Promise<{mergeable: boolean, reason: string|null, terminal?: boolean}>}
+ * @returns {Promise<{mergeable: boolean, mergeableState?: string|null, mergeStateStatus?: string|null, reason: string|null, terminal?: boolean}>}
  */
 export async function checkPRMergeable(owner, repo, prNumber, verbose = false) {
   // Issue #1339: GitHub computes mergeability asynchronously. When mergeStateStatus is
@@ -473,7 +473,7 @@ export async function checkPRMergeable(owner, repo, prNumber, verbose = false) {
         if (verbose) {
           console.log(`[VERBOSE] /merge: PR #${prNumber} mergeability still UNKNOWN after ${MAX_UNKNOWN_RETRIES} attempts`);
         }
-        return { mergeable: false, reason: `Merge state: UNKNOWN (GitHub could not compute mergeability after ${MAX_UNKNOWN_RETRIES} attempts)` };
+        return { mergeable: false, mergeableState: pr.mergeable, mergeStateStatus: pr.mergeStateStatus, reason: `Merge state: UNKNOWN (GitHub could not compute mergeability after ${MAX_UNKNOWN_RETRIES} attempts)` };
       }
 
       const mergeable = pr.mergeable === 'MERGEABLE';
@@ -505,7 +505,7 @@ export async function checkPRMergeable(owner, repo, prNumber, verbose = false) {
         console.log(`[VERBOSE] /merge: PR #${prNumber} mergeable: ${mergeable}, state: ${pr.mergeStateStatus}`);
       }
 
-      return { mergeable, reason };
+      return { mergeable, mergeableState: pr.mergeable, mergeStateStatus: pr.mergeStateStatus, reason };
     } catch (error) {
       if (isTerminalGitHubEntityError(error)) {
         const terminalError = getTerminalGitHubEntityErrorMessage(error);

--- a/src/solve.auto-merge-helpers.lib.mjs
+++ b/src/solve.auto-merge-helpers.lib.mjs
@@ -464,6 +464,22 @@ export const shouldResetNoRunsCounter = (ciStatus, noWorkflowRunsForCommit = fal
   return Boolean(ciStatus && ciStatus.status !== 'no_checks');
 };
 
+/**
+ * Issue #2031: GitHub can retain a failed check-run from an older workflow run
+ * alongside a newer successful run for the same job and HEAD SHA. The raw
+ * check-run rollup then says "failure" even though GitHub's live PR state is
+ * CLEAN/MERGEABLE. Only this explicit pair is strong enough to override the
+ * rollup; every other merge state remains conservative.
+ */
+export const isAuthoritativeCleanMergeState = mergeStatus => mergeStatus?.mergeable === true && mergeStatus?.mergeableState === 'MERGEABLE' && mergeStatus?.mergeStateStatus === 'CLEAN';
+
+export const reconcileStaleCIBlockers = (blockers, ciStatus, mergeStatus) => {
+  if (ciStatus?.status !== 'failure' || !isAuthoritativeCleanMergeState(mergeStatus)) {
+    return blockers;
+  }
+  return blockers.filter(blocker => blocker.type !== 'ci_failure' && blocker.type !== 'ci_cancelled');
+};
+
 export const getMergeBlockers = async (owner, repo, prNumber, verbose = false, checkCount = 1, prBranchRef = null) => {
   const blockers = [];
 
@@ -943,6 +959,16 @@ export const getMergeBlockers = async (owner, repo, prNumber, verbose = false, c
       details: [],
     });
     return { blockers, ciStatus, noCiConfigured: false, noCiTriggered: false, noWorkflowRunsForCommit };
+  }
+
+  if (ciStatus.status === 'failure' && isAuthoritativeCleanMergeState(mergeStatus)) {
+    const staleFailureBlockers = blockers.filter(blocker => blocker.type === 'ci_failure' || blocker.type === 'ci_cancelled');
+    if (staleFailureBlockers.length > 0) {
+      if (verbose) {
+        await log(`[VERBOSE] /merge: PR #${prNumber} is CLEAN/MERGEABLE according to GitHub; ignoring ${staleFailureBlockers.length} stale CI failure/cancellation blocker(s) from the raw check-run rollup`);
+      }
+      blockers.splice(0, blockers.length, ...reconcileStaleCIBlockers(blockers, ciStatus, mergeStatus));
+    }
   }
 
   if (!mergeStatus.mergeable) {

--- a/tests/test-stale-rerun-check-2031.mjs
+++ b/tests/test-stale-rerun-check-2031.mjs
@@ -1,0 +1,34 @@
+#!/usr/bin/env node
+
+/**
+ * @hive-mind-test-suite default
+ *
+ * Regression tests for issue #2031: an obsolete failed check-run must not
+ * restart the AI when GitHub says the live PR is CLEAN and MERGEABLE.
+ */
+
+import assert from 'node:assert/strict';
+import { isAuthoritativeCleanMergeState, reconcileStaleCIBlockers } from '../src/solve.auto-merge-helpers.lib.mjs';
+
+const staleRerunIncident = {
+  mergeable: true,
+  mergeableState: 'MERGEABLE',
+  mergeStateStatus: 'CLEAN',
+};
+
+assert.equal(isAuthoritativeCleanMergeState(staleRerunIncident), true, 'CLEAN/MERGEABLE must override a stale rollup failure');
+
+const staleRollupBlockers = [
+  { type: 'ci_failure', message: 'old title check failed' },
+  { type: 'ci_cancelled', message: 'superseded run' },
+  { type: 'external_review_limit', message: 'review credits exhausted' },
+];
+assert.deepEqual(reconcileStaleCIBlockers(staleRollupBlockers, { status: 'failure' }, staleRerunIncident), [{ type: 'external_review_limit', message: 'review credits exhausted' }], 'only stale CI failure/cancellation blockers should be removed');
+assert.deepEqual(reconcileStaleCIBlockers(staleRollupBlockers, { status: 'failure' }, { mergeable: false, mergeableState: 'CONFLICTING', mergeStateStatus: 'DIRTY' }), staleRollupBlockers, 'conflicts must retain every CI blocker');
+assert.deepEqual(reconcileStaleCIBlockers(staleRollupBlockers, { status: 'pending' }, staleRerunIncident), staleRollupBlockers, 'pending CI must remain pending even when GitHub currently reports CLEAN');
+
+for (const mergeStatus of [{ mergeable: false, mergeableState: 'CONFLICTING', mergeStateStatus: 'DIRTY' }, { mergeable: false, mergeableState: 'MERGEABLE', mergeStateStatus: 'BLOCKED' }, { mergeable: false, mergeableState: 'MERGEABLE', mergeStateStatus: 'BEHIND' }, { mergeable: false, mergeableState: null, mergeStateStatus: 'UNKNOWN' }, { mergeable: true, mergeableState: 'MERGEABLE', mergeStateStatus: 'UNSTABLE' }, { mergeable: true }, null]) {
+  assert.equal(isAuthoritativeCleanMergeState(mergeStatus), false, `must not override rollup failures for ${JSON.stringify(mergeStatus)}`);
+}
+
+console.log('✅ Issue #2031 stale re-run check reconciliation tests passed');


### PR DESCRIPTION
## Summary

Fixes #2031.

Stops `--auto-restart-until-mergeable` from spending every restart iteration on an obsolete failed check-run when GitHub's live pull-request state is already both `CLEAN` and `MERGEABLE`.

## Root cause and reproduction

GitHub keeps check-runs from separate workflow `run_id` values side by side on one HEAD SHA. Re-running an old workflow replays its original `pull_request` payload, so a title-validation job can fail against an obsolete title while newer runs for the same job succeed. The raw check-run rollup still contains that failure, but GitHub reports the live PR as clean and mergeable.

Before this fix, `getMergeBlockers()` converted that raw failure into `ci_failure`, causing an AI restart. Since neither a new AI session nor another passing workflow run can remove the old run's check, every iteration made zero progress until the safety limit.

## Changes

- Return the raw `mergeable` and `mergeStateStatus` values from `checkPRMergeable()`.
- Reconcile rollup failures only when GitHub confirms the strict authoritative pair `MERGEABLE` + `CLEAN`.
- Remove only `ci_failure` and `ci_cancelled` blockers in that case; preserve external-review limits and all non-CI blockers.
- Keep conservative behavior for `BLOCKED`, `BEHIND`, `DIRTY`, `UNSTABLE`, `UNKNOWN`, incomplete data, and pending CI.
- Add a default-suite regression test and a patch changeset.

## Automated verification

- `node tests/test-stale-rerun-check-2031.mjs`
- `npm test` — all 315 default test files passed
- `npm run lint`
- `npm run format:check`
- `bash scripts/check-file-line-limits.sh`
- `git diff --check`

All commands were run with Node 24.15.0.
