### PR TITLE
Make queue startup interval floor configurable

### DIFF
--- a/.changeset/tunable-queue-start-floor.md
+++ b/.changeset/tunable-queue-start-floor.md
@@ -1,0 +1,5 @@
+---
+'@link-assistant/hive-mind': patch
+---
+
+Allow operators to lower the queue startup interval safety floor with `HIVE_MIND_MIN_START_INTERVAL_FLOOR_MS` while preserving the 10-minute default.

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,1 +1,0 @@
-# .gitkeep file auto-generated at 2026-07-13T02:20:44.805Z for PR creation at branch issue-2053-7be7913611c5 for issue https://github.com/link-assistant/hive-mind/issues/2053

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,0 +1,1 @@
+# .gitkeep file auto-generated at 2026-07-13T02:20:44.805Z for PR creation at branch issue-2053-7be7913611c5 for issue https://github.com/link-assistant/hive-mind/issues/2053

--- a/src/queue-config.lib.mjs
+++ b/src/queue-config.lib.mjs
@@ -192,7 +192,8 @@ const parseIntWithDefault = (envVar, defaultValue) => {
   return isNaN(parsed) ? defaultValue : parsed;
 };
 
-const MINIMUM_START_INTERVAL_MS = 10 * 60 * 1000;
+const DEFAULT_MINIMUM_START_INTERVAL_MS = 10 * 60 * 1000;
+const minimumStartIntervalMs = parseIntWithDefault('HIVE_MIND_MIN_START_INTERVAL_FLOOR_MS', DEFAULT_MINIMUM_START_INTERVAL_MS);
 
 // Parse links notation config from environment variable (if provided)
 const linoConfig = parseQueueConfig(getenv('HIVE_MIND_QUEUE_CONFIG', ''));
@@ -276,7 +277,9 @@ export const QUEUE_CONFIG = {
   // MIN_START_INTERVAL_MS: Minimum global spacing between task startups.
   // Issue #2015: after resource thresholds clear, starting a backlog in a burst
   // can kill the next batch before host metrics have time to settle.
-  MIN_START_INTERVAL_MS: Math.max(parseIntWithDefault('HIVE_MIND_MIN_START_INTERVAL_MS', MINIMUM_START_INTERVAL_MS), MINIMUM_START_INTERVAL_MS), // at least 10 minutes between starts
+  // Issue #2053: operators can explicitly lower the safety floor on hosts where
+  // resource metrics settle sooner. The default remains 10 minutes.
+  MIN_START_INTERVAL_MS: Math.max(parseIntWithDefault('HIVE_MIND_MIN_START_INTERVAL_MS', DEFAULT_MINIMUM_START_INTERVAL_MS), minimumStartIntervalMs),
   CONSUMER_POLL_INTERVAL_MS: parseIntWithDefault('HIVE_MIND_CONSUMER_POLL_INTERVAL_MS', 60000), // 1 minute between queue checks
   MESSAGE_UPDATE_INTERVAL_MS: parseIntWithDefault('HIVE_MIND_MESSAGE_UPDATE_INTERVAL_MS', 60000), // 1 minute between status message updates
 

--- a/tests/test-issue-2015-queue-stability.mjs
+++ b/tests/test-issue-2015-queue-stability.mjs
@@ -81,11 +81,27 @@ await test('queue startup interval defaults to a 10-minute minimum', async () =>
   assertEqual(QUEUE_CONFIG.MIN_START_INTERVAL_MS, 10 * 60 * 1000, 'default startup interval should be 10 minutes');
 });
 
-await test('queue startup interval cannot be configured below 10 minutes', async () => {
+await test('queue startup interval uses a 10-minute floor by default', async () => {
   const value = readSpawnedNumber('src/queue-config.lib.mjs', 'mod.QUEUE_CONFIG.MIN_START_INTERVAL_MS', {
     HIVE_MIND_MIN_START_INTERVAL_MS: '60000',
   });
   assertEqual(value, 10 * 60 * 1000, 'configured startup interval should be clamped to 10 minutes');
+});
+
+await test('queue startup interval floor can be lowered explicitly', async () => {
+  const value = readSpawnedNumber('src/queue-config.lib.mjs', 'mod.QUEUE_CONFIG.MIN_START_INTERVAL_MS', {
+    HIVE_MIND_MIN_START_INTERVAL_MS: '300000',
+    HIVE_MIND_MIN_START_INTERVAL_FLOOR_MS: '300000',
+  });
+  assertEqual(value, 5 * 60 * 1000, 'configured startup interval should use the operator-selected floor');
+});
+
+await test('queue startup interval is clamped to the configured floor', async () => {
+  const value = readSpawnedNumber('src/queue-config.lib.mjs', 'mod.QUEUE_CONFIG.MIN_START_INTERVAL_MS', {
+    HIVE_MIND_MIN_START_INTERVAL_MS: '60000',
+    HIVE_MIND_MIN_START_INTERVAL_FLOOR_MS: '300000',
+  });
+  assertEqual(value, 5 * 60 * 1000, 'configured startup interval should not go below the operator-selected floor');
 });
 
 await test('minimum startup interval is global across tools', async () => {


### PR DESCRIPTION
## Summary

- add `HIVE_MIND_MIN_START_INTERVAL_FLOOR_MS` as an operator-tunable lower bound
- retain the safe 10-minute floor when the new variable is unset or invalid
- add regression coverage for the default floor, an explicitly lowered floor, and clamping to that configured floor
- add a patch changeset

Fixes #2053

## Reproduction

Before this change, importing the queue configuration with `HIVE_MIND_MIN_START_INTERVAL_MS=300000` always produced `MIN_START_INTERVAL_MS=600000` because the requested value was clamped to a hard-coded 10-minute minimum. The new regression test demonstrated the bug by setting both the requested interval and the explicit floor to 300000; before the implementation it received 600000 instead of 300000.

## Configuration

The safe default is unchanged. To opt into a five-minute startup interval, set both:

```sh
HIVE_MIND_MIN_START_INTERVAL_MS=300000
HIVE_MIND_MIN_START_INTERVAL_FLOOR_MS=300000
```

Requests below the configured floor are still clamped to that floor.

## Verification

- `node tests/test-issue-2015-queue-stability.mjs` (30 assertions)
- `npm run lint`
- `npm test` (all 322 selected test files)
- `npx prettier --check src/queue-config.lib.mjs tests/test-issue-2015-queue-stability.mjs .changeset/tunable-queue-start-floor.md`
- `git diff --check`