### PR TITLE
Make queue startup interval authoritative

### DIFF
--- a/.changeset/authoritative-start-interval.md
+++ b/.changeset/authoritative-start-interval.md
@@ -1,0 +1,5 @@
+---
+'@link-assistant/hive-mind': patch
+---
+
+Make `HIVE_MIND_MIN_START_INTERVAL_MS` authoritative, warn when it is below the recommended 10-minute interval, and deprecate the redundant floor variable.

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,1 +1,0 @@
-# .gitkeep file auto-generated at 2026-07-15T00:14:32.493Z for PR creation at branch issue-2065-3ef76c36c72c for issue https://github.com/link-assistant/hive-mind/issues/2065

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,0 +1,1 @@
+# .gitkeep file auto-generated at 2026-07-15T00:14:32.493Z for PR creation at branch issue-2065-3ef76c36c72c for issue https://github.com/link-assistant/hive-mind/issues/2065

--- a/src/env-config.lib.mjs
+++ b/src/env-config.lib.mjs
@@ -16,6 +16,19 @@ function readExplicitEnv(envVar) {
   return rawValue === undefined ? null : rawValue;
 }
 
+/**
+ * Emit a warning once when an environment variable was explicitly configured.
+ *
+ * @param {string} envVar
+ * @param {string} warningKey
+ * @param {string} message
+ */
+export function warnExplicitEnv(envVar, warningKey, message) {
+  if (readExplicitEnv(envVar) !== null) {
+    warnOnce(`${warningKey}:${envVar}`, message);
+  }
+}
+
 function warnInvalid(envVar, rawValue, type, defaultValue, scope) {
   warnOnce(`invalid:${envVar}`, `[${scope}] ${envVar}=${JSON.stringify(rawValue)} is not a valid ${type}; using default ${defaultValue}.`);
 }

--- a/src/queue-config.lib.mjs
+++ b/src/queue-config.lib.mjs
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 import { ensureUseM } from './use-m-bootstrap.lib.mjs';
-import { clampEnvValue, parseIntegerEnv, parseNumberEnv } from './env-config.lib.mjs';
+import { parseIntegerEnv, parseNumberEnv, warnExplicitEnv } from './env-config.lib.mjs';
 
 /**
  * Queue Configuration Module
@@ -183,7 +183,32 @@ const parseFloatWithDefault = (envVar, defaultValue) => parseNumberEnv(envVar, d
 const parseIntWithDefault = (envVar, defaultValue) => parseIntegerEnv(envVar, defaultValue, { scope: 'queue-config' });
 
 const DEFAULT_MINIMUM_START_INTERVAL_MS = 10 * 60 * 1000;
-const minimumStartIntervalMs = parseIntWithDefault('HIVE_MIND_MIN_START_INTERVAL_FLOOR_MS', DEFAULT_MINIMUM_START_INTERVAL_MS);
+const START_INTERVAL_ENV = 'HIVE_MIND_MIN_START_INTERVAL_MS';
+const LEGACY_START_INTERVAL_FLOOR_ENV = 'HIVE_MIND_MIN_START_INTERVAL_FLOOR_MS';
+
+function resolveMinimumStartIntervalMs() {
+  const hasExplicitInterval = process.env[START_INTERVAL_ENV] !== undefined;
+  const hasLegacyFloor = process.env[LEGACY_START_INTERVAL_FLOOR_ENV] !== undefined;
+
+  if (hasLegacyFloor) {
+    warnExplicitEnv(LEGACY_START_INTERVAL_FLOOR_ENV, 'deprecated', `[queue-config] ${LEGACY_START_INTERVAL_FLOOR_ENV} is deprecated; use ${START_INTERVAL_ENV} instead.`);
+  }
+
+  let interval = DEFAULT_MINIMUM_START_INTERVAL_MS;
+  if (hasExplicitInterval) {
+    interval = parseIntWithDefault(START_INTERVAL_ENV, DEFAULT_MINIMUM_START_INTERVAL_MS);
+  } else if (hasLegacyFloor) {
+    interval = parseIntWithDefault(LEGACY_START_INTERVAL_FLOOR_ENV, DEFAULT_MINIMUM_START_INTERVAL_MS);
+  }
+
+  if (hasExplicitInterval && interval < DEFAULT_MINIMUM_START_INTERVAL_MS) {
+    warnExplicitEnv(START_INTERVAL_ENV, 'recommendation', `[queue-config] ${START_INTERVAL_ENV}=${interval} is below the recommended ${DEFAULT_MINIMUM_START_INTERVAL_MS} ms; short intervals can start a backlog before host metrics settle (#2015).`);
+  }
+
+  return interval;
+}
+
+const minimumStartIntervalMs = resolveMinimumStartIntervalMs();
 
 // Parse links notation config from environment variable (if provided)
 const linoConfig = parseQueueConfig(getenv('HIVE_MIND_QUEUE_CONFIG', ''));
@@ -267,13 +292,10 @@ export const QUEUE_CONFIG = {
   // MIN_START_INTERVAL_MS: Minimum global spacing between task startups.
   // Issue #2015: after resource thresholds clear, starting a backlog in a burst
   // can kill the next batch before host metrics have time to settle.
-  // Issue #2053: operators can explicitly lower the safety floor on hosts where
-  // resource metrics settle sooner. The default remains 10 minutes.
-  MIN_START_INTERVAL_MS: clampEnvValue('HIVE_MIND_MIN_START_INTERVAL_MS', parseIntWithDefault('HIVE_MIND_MIN_START_INTERVAL_MS', DEFAULT_MINIMUM_START_INTERVAL_MS), {
-    minimum: minimumStartIntervalMs,
-    scope: 'queue-config',
-    hint: 'Set HIVE_MIND_MIN_START_INTERVAL_FLOOR_MS to lower the minimum.',
-  }),
+  // Issue #2065: an explicit interval is authoritative. The deprecated floor
+  // remains a fallback for existing deployments, while the default remains the
+  // safe 10-minute interval introduced for issue #2015.
+  MIN_START_INTERVAL_MS: minimumStartIntervalMs,
   CONSUMER_POLL_INTERVAL_MS: parseIntWithDefault('HIVE_MIND_CONSUMER_POLL_INTERVAL_MS', 60000), // 1 minute between queue checks
   MESSAGE_UPDATE_INTERVAL_MS: parseIntWithDefault('HIVE_MIND_MESSAGE_UPDATE_INTERVAL_MS', 60000), // 1 minute between status message updates
 

--- a/tests/test-issue-2015-queue-stability.mjs
+++ b/tests/test-issue-2015-queue-stability.mjs
@@ -81,27 +81,34 @@ await test('queue startup interval defaults to a 10-minute minimum', async () =>
   assertEqual(QUEUE_CONFIG.MIN_START_INTERVAL_MS, 10 * 60 * 1000, 'default startup interval should be 10 minutes');
 });
 
-await test('queue startup interval uses a 10-minute floor by default', async () => {
+await test('an explicit queue startup interval is authoritative', async () => {
   const value = readSpawnedNumber('src/queue-config.lib.mjs', 'mod.QUEUE_CONFIG.MIN_START_INTERVAL_MS', {
     HIVE_MIND_MIN_START_INTERVAL_MS: '60000',
   });
-  assertEqual(value, 10 * 60 * 1000, 'configured startup interval should be clamped to 10 minutes');
+  assertEqual(value, 60 * 1000, 'configured startup interval should not be clamped to the default');
 });
 
-await test('queue startup interval floor can be lowered explicitly', async () => {
+await test('matching deprecated floor preserves existing configurations', async () => {
   const value = readSpawnedNumber('src/queue-config.lib.mjs', 'mod.QUEUE_CONFIG.MIN_START_INTERVAL_MS', {
     HIVE_MIND_MIN_START_INTERVAL_MS: '300000',
     HIVE_MIND_MIN_START_INTERVAL_FLOOR_MS: '300000',
   });
-  assertEqual(value, 5 * 60 * 1000, 'configured startup interval should use the operator-selected floor');
+  assertEqual(value, 5 * 60 * 1000, 'matching legacy configuration should retain its five-minute interval');
 });
 
-await test('queue startup interval is clamped to the configured floor', async () => {
+await test('queue startup interval takes precedence over the deprecated floor', async () => {
   const value = readSpawnedNumber('src/queue-config.lib.mjs', 'mod.QUEUE_CONFIG.MIN_START_INTERVAL_MS', {
     HIVE_MIND_MIN_START_INTERVAL_MS: '60000',
     HIVE_MIND_MIN_START_INTERVAL_FLOOR_MS: '300000',
   });
-  assertEqual(value, 5 * 60 * 1000, 'configured startup interval should not go below the operator-selected floor');
+  assertEqual(value, 60 * 1000, 'configured startup interval should be authoritative when both variables are present');
+});
+
+await test('deprecated floor remains a fallback for existing configurations', async () => {
+  const value = readSpawnedNumber('src/queue-config.lib.mjs', 'mod.QUEUE_CONFIG.MIN_START_INTERVAL_MS', {
+    HIVE_MIND_MIN_START_INTERVAL_FLOOR_MS: '300000',
+  });
+  assertEqual(value, 5 * 60 * 1000, 'legacy floor should supply the interval when the authoritative variable is absent');
 });
 
 await test('minimum startup interval is global across tools', async () => {

--- a/tests/test-issue-2062-config-warnings.mjs
+++ b/tests/test-issue-2062-config-warnings.mjs
@@ -46,9 +46,16 @@ function countMatches(value, pattern) {
 const queueFloor = importWithEnv('src/queue-config.lib.mjs', 'mod.QUEUE_CONFIG.MIN_START_INTERVAL_MS', {
   HIVE_MIND_MIN_START_INTERVAL_MS: '300000',
 });
-assertEqual(queueFloor.value, 600000, 'startup interval should retain its safety floor');
-assertMatch(queueFloor.stderr, /\[queue-config\] HIVE_MIND_MIN_START_INTERVAL_MS=300000 is below the minimum \(600000\); using 600000\./, 'startup interval clamp should explain the discarded value');
-assertMatch(queueFloor.stderr, /Set HIVE_MIND_MIN_START_INTERVAL_FLOOR_MS to lower the minimum\./, 'startup interval warning should explain how to lower the floor');
+assertEqual(queueFloor.value, 300000, 'explicit startup interval should be authoritative');
+assertMatch(queueFloor.stderr, /\[queue-config\] HIVE_MIND_MIN_START_INTERVAL_MS=300000 is below the recommended 600000 ms;/, 'short startup interval should explain the recommended safety value');
+assertMatch(queueFloor.stderr, /short intervals can start a backlog before host metrics settle \(#2015\)\./, 'short startup interval should explain the operational risk');
+
+const deprecatedFloor = importWithEnv('src/queue-config.lib.mjs', 'mod.QUEUE_CONFIG.MIN_START_INTERVAL_MS', {
+  HIVE_MIND_MIN_START_INTERVAL_MS: '60000',
+  HIVE_MIND_MIN_START_INTERVAL_FLOOR_MS: '300000',
+});
+assertEqual(deprecatedFloor.value, 60000, 'deprecated floor should not override the authoritative interval');
+assertMatch(deprecatedFloor.stderr, /\[queue-config\] HIVE_MIND_MIN_START_INTERVAL_FLOOR_MS is deprecated; use HIVE_MIND_MIN_START_INTERVAL_MS instead\./, 'deprecated floor should explain its replacement');
 
 const cacheCeiling = importWithEnv('src/config.lib.mjs', 'mod.cacheTtl.system', {
   HIVE_MIND_SYSTEM_CACHE_TTL_MS: '300000',


### PR DESCRIPTION
## Summary

- make an explicitly configured `HIVE_MIND_MIN_START_INTERVAL_MS` authoritative instead of clamping it against a second variable
- retain the safe 10-minute interval when neither variable is configured
- keep `HIVE_MIND_MIN_START_INTERVAL_FLOOR_MS` as a deprecated fallback for existing deployments and warn operators to migrate
- warn about the #2015 backlog-settling risk when an explicit interval is below the recommended 600000 ms
- add a patch changeset

Fixes #2065

## Reproduction

Before this change, importing the queue configuration with only:

```sh
HIVE_MIND_MIN_START_INTERVAL_MS=300000
```

produced `QUEUE_CONFIG.MIN_START_INTERVAL_MS=600000`. The default floor silently overrode the operator's explicit five-minute interval unless `HIVE_MIND_MIN_START_INTERVAL_FLOOR_MS` was also set to the same value.

The regression test now verifies that the same configuration produces `300000` and emits a safety recommendation without changing the value.

## Compatibility

- no variables set: remains `600000`
- `HIVE_MIND_MIN_START_INTERVAL_MS` set: its valid parsed value wins
- both variables set: `HIVE_MIND_MIN_START_INTERVAL_MS` wins and the floor emits a deprecation warning
- only the legacy floor set: it remains honored as a fallback and emits a deprecation warning

## Verification

- `node tests/test-issue-2062-config-warnings.mjs` (17 assertions)
- `node tests/test-issue-2015-queue-stability.mjs` (33 assertions)
- `npm run lint`
- Prettier check for all touched source, test, and changeset files
- `git diff --check`
- [GitHub Actions run 29379636395](https://github.com/link-assistant/hive-mind/actions/runs/29379636395) passed all required checks, including the complete Node 24 default and GitHub-integration test suites

The local Node 20 `npm test` run stopped in untouched `tests/test-hive.mjs`; the same dry-run assertion reproduced on a clean `origin/main` worktree. The repository requires Node 24+, and the full Node 24 CI suite passes.
