### PR TITLE
/task --ci-cd: create CI/CD remediation issues without /fix (#2121)

### DIFF
--- a/.changeset/task-ci-cd-issue-creation.md
+++ b/.changeset/task-ci-cd-issue-creation.md
@@ -1,0 +1,5 @@
+---
+"@link-assistant/hive-mind": minor
+---
+
+Add `/task --ci-cd <repository>` as a CI/CD remediation issue-only fallback for `/fix`.

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,1 +1,0 @@
-# .gitkeep file auto-generated at 2026-07-31T08:36:59.386Z for PR creation at branch issue-2121-e65c8486a058 for issue https://github.com/link-assistant/hive-mind/issues/2121

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,0 +1,1 @@
+# .gitkeep file auto-generated at 2026-07-31T08:36:59.386Z for PR creation at branch issue-2121-e65c8486a058 for issue https://github.com/link-assistant/hive-mind/issues/2121

--- a/README.hi.md
+++ b/README.hi.md
@@ -566,6 +566,11 @@ Examples:
 `--no-solve` का उपयोग करें। विवरण के लिए
 [स्वचालित CI/CD सुधार](docs/CI-CD-BEST-PRACTICES.md#automatic-cicd-remediation) देखें।
 
+यदि पूरा `/fix` workflow उपलब्ध न हो, तो `/task --ci-cd <repository>` केवल वही CI/CD
+issue-generation चरण चलाता है। यह बनाए गए issue का URL लौटाता है; सामान्य solve workflow
+से remediation जारी रखने के लिए `/solve --development-log --deep-analysis --auto-merge`
+से reply करें।
+
 #### `/limits` - उपयोग सीमाएँ दिखाएँ
 
 ```

--- a/README.md
+++ b/README.md
@@ -585,6 +585,11 @@ does not consume itself (e.g. `--tool`, `--model`, `--think`) is forwarded to
 [Automatic CI/CD Remediation](docs/CI-CD-BEST-PRACTICES.md#automatic-cicd-remediation)
 for details.
 
+If the full `/fix` workflow is unavailable, `/task --ci-cd <repository>` runs
+only the same CI/CD issue-generation step. It returns the created issue URL;
+reply with `/solve --development-log --deep-analysis --auto-merge` to continue
+the remediation through the normal solve workflow.
+
 #### `/limits` - Show Usage Limits
 
 ```

--- a/README.ru.md
+++ b/README.ru.md
@@ -566,6 +566,11 @@ Examples:
 `/solve`. Подробнее см.
 [Автоматическое исправление CI/CD](docs/CI-CD-BEST-PRACTICES.md#automatic-cicd-remediation).
 
+Если полный процесс `/fix` недоступен, `/task --ci-cd <repository>` выполняет
+только тот же этап создания issue для CI/CD. Команда возвращает URL созданного
+issue; ответьте `/solve --development-log --deep-analysis --auto-merge`, чтобы
+продолжить исправление обычным процессом solve.
+
 #### `/limits` — Показать лимиты использования
 
 ```

--- a/README.zh.md
+++ b/README.zh.md
@@ -560,6 +560,10 @@ issue 交给 `/solve --development-log --deep-analysis --auto-merge` 处理。�
 issue 的情况下预览，使用 `--no-solve` 可只创建 issue 而不启动 `/solve`。详见
 [自动 CI/CD 修复](docs/CI-CD-BEST-PRACTICES.md#automatic-cicd-remediation)。
 
+如果完整的 `/fix` 流程不可用，`/task --ci-cd <repository>` 只执行相同的 CI/CD issue
+生成步骤。该命令会返回新建 issue 的 URL；回复
+`/solve --development-log --deep-analysis --auto-merge` 即可通过常规 solve 流程继续修复。
+
 #### `/limits` - 显示用量限制
 
 ```

--- a/docs/case-studies/issue-2121/README.md
+++ b/docs/case-studies/issue-2121/README.md
@@ -1,0 +1,167 @@
+# Issue 2121: `/task --ci-cd` CI/CD issue creation
+
+## Summary
+
+Issue [#2121](https://github.com/link-assistant/hive-mind/issues/2121) asks for:
+
+```text
+/task --ci-cd https://github.com/link-assistant/agent
+```
+
+to perform only the issue-creation part of:
+
+```text
+/fix --ci-cd https://github.com/link-assistant/agent
+```
+
+The reported command uses a typographic em dash (`—ci-cd`) in place of two
+ASCII hyphens. The bot instead returned “Missing GitHub repository URL.”
+
+The completed behavior creates the same evidence-rich CI/CD remediation issue
+as `/fix`, returns its URL, and does not start `/fix` or `/solve`. The user can
+reply to the result with:
+
+```text
+/solve --development-log --deep-analysis --auto-merge
+```
+
+## Evidence collected
+
+- The issue body and comments were read through GitHub CLI on 2026-07-31.
+- The issue has no comments.
+- The screenshot was downloaded with authenticated GitHub access, verified as
+  a decodable PNG, and inspected locally. It shows `/task —ci-cd <repo>`
+  followed by the missing-repository error.
+- Prepared PR [#2122](https://github.com/link-assistant/hive-mind/pull/2122)
+  initially contained only a placeholder commit and had no review,
+  conversation, or inline comments.
+- Related issue [#1733](https://github.com/link-assistant/hive-mind/issues/1733)
+  and merged PR [#1929](https://github.com/link-assistant/hive-mind/pull/1929)
+  define `/fix --ci-cd` as issue generation followed by
+  `/solve --development-log --deep-analysis --auto-merge`.
+- Related issue [#1734](https://github.com/link-assistant/hive-mind/issues/1734)
+  and merged PR [#1735](https://github.com/link-assistant/hive-mind/pull/1735)
+  define ordinary `/task` as issue creation only, returning a URL that can be
+  replied to with `/solve`.
+- Issue [#2021](https://github.com/link-assistant/hive-mind/issues/2021) already
+  introduced shared normalization of Telegram en/em dashes to ASCII long-option
+  markers. `/task --ci-cd` reuses that parser.
+
+The captured issue, prepared-PR, related-work, and root-cause facts are
+compiled in [`investigation-data.json`](investigation-data.json). The external
+sources used for the API and CLI facts are recorded in
+[`research-sources.json`](research-sources.json).
+
+## Timeline
+
+1. `/task` issue creation was introduced by #1734/#1735.
+2. `/fix --ci-cd` was introduced by #1733/#1929. Its entry point contained the
+   GitHub context collection while its pure title/body builders were shared.
+3. Typographic option-dash normalization was added for Telegram in #2021.
+4. A user sent `/task —ci-cd <repo>`.
+5. `parseCommandArgs()` correctly normalized `—ci-cd` to `--ci-cd`, but
+   `handleTaskCommand()` had no CI/CD branch.
+6. Because the command was not `--split`, the handler treated it as free-form
+   issue creation. `parseTaskIssueCreationInput()` then saw the option and URL
+   together on one line rather than a standalone repository line, so it
+   reported a missing repository.
+
+## Root cause
+
+The parser was not missing generic “options before URL” support:
+`parseCommandArgs()` already tokenized the first command line and normalized
+typographic dashes. The missing piece was command semantics.
+
+`telegram-task-command.lib.mjs` recognized only two modes:
+
+1. ordinary issue creation; and
+2. issue splitting (`/split` or `--split`).
+
+There was no `--ci-cd` mode. Also, the network-backed context collector lived
+inside executable `fix.mjs`, so calling the same issue-generation logic from
+the task handler would otherwise require duplication or spawning the full fix
+workflow.
+
+## Requirements and coverage
+
+| ID  | Requirement                                                     | Coverage                                                        |
+| --- | --------------------------------------------------------------- | --------------------------------------------------------------- |
+| R1  | Accept `/task --ci-cd <GitHub repository>`                      | Explicit CI/CD mode and repository parser                       |
+| R2  | Accept the screenshot’s `—ci-cd` spelling                       | Existing shared dash normalization plus regression test         |
+| R3  | Work with the option before the URL                             | Token-based repository discovery                                |
+| R4  | Create only the `/fix` issue                                    | Direct shared service call; no command-session execution        |
+| R5  | Produce the same issue as `/fix`                                | Both paths use `prepareCiCdIssue()` and `createCiCdIssue()`     |
+| R6  | Collect languages, commit, and CI runs                          | Shared GitHub-backed service extracted from `fix.mjs`           |
+| R7  | Preserve exact-title/body and template ranking behavior         | Existing `fix.ci-cd.lib.mjs` builders remain authoritative      |
+| R8  | Preserve Bug type/label fallback                                | Shared service calls `createTaskIssue()` with the same metadata |
+| R9  | Return a usable created-issue URL                               | Telegram status message is edited with the full URL             |
+| R10 | Explain how to continue normal execution                        | Response gives the exact `/solve` flags                         |
+| R11 | Do not regress `/task`, `/split`, or `/fix`                     | Focused handler, service, and existing fix tests                |
+| R12 | Document public behavior in all maintained languages            | Four READMEs and four localized help entries                    |
+| R13 | Add release metadata                                            | Minor changeset                                                 |
+| R14 | Compile evidence, requirements, research, and solution analysis | This case study                                                 |
+
+## Solution alternatives
+
+### A. Teach the ordinary issue parser to ignore `--ci-cd`
+
+This would remove the screenshot error but create an issue whose body is merely
+the remaining command text. It would not collect CI runs, languages, the latest
+commit, or template recommendations. It does not satisfy R4–R8.
+
+### B. Spawn `fix <repo> --ci-cd --no-solve`
+
+This reuses behavior, but it turns a short issue-creation interaction into a
+managed command session. The task handler would lose its established direct
+created-URL reply behavior, and callers would have to scrape CLI output. It
+also makes the “issue only” fallback depend on the `/fix` executable path.
+
+### C. Duplicate the collector in the task handler
+
+This is straightforward but allows `/task` and `/fix` to drift in API queries,
+fallback behavior, issue metadata, and prompt construction.
+
+### D. Extract one shared issue service (selected)
+
+`fix.ci-cd-issue.lib.mjs` owns GitHub context collection, preparation, and
+typed issue creation. The `/fix` CLI keeps orchestration and solve spawning;
+the `/task` handler calls only the shared issue service. This gives both entry
+points identical output while preserving their intentionally different
+lifecycle behavior.
+
+## Existing components and external facts
+
+- `parseCommandArgs()` and `normalizeCliArgs()` already handle ASCII, en-dash,
+  and em-dash long options. Reuse avoids command-specific Unicode handling.
+- `parseFixRepository()` already accepts GitHub repository URLs and
+  `owner/repo` shorthand while rejecting deeper issue/PR URLs.
+- `buildCiCdIssueBody()` remains the single prompt builder.
+- `createTaskIssue()` sanitizes title/body, uses a temporary body file, applies
+  optional type/labels, and retries without unsupported metadata.
+- GitHub’s repository-languages endpoint reports bytes of code per language,
+  which supports the existing byte-weighted template order.
+- GitHub’s workflow-runs endpoint supports both `head_sha` and `branch`
+  filters, which supports exact-commit collection plus the existing branch
+  fallback.
+- GitHub’s commit endpoint accepts a branch name as `ref`, which supports
+  resolving the default branch’s latest commit.
+- GitHub CLI officially supports `--body-file`, `--label`, and `--type` for
+  issue creation, matching the existing safe issue-creation implementation.
+
+## Verification strategy
+
+The minimum reproduction is a handler test using the screenshot form:
+
+```text
+/task —ci-cd https://github.com/link-assistant/hive-mind
+```
+
+It asserts that:
+
+- the target repository reaches the CI/CD issue generator;
+- no `/fix` or task command session starts;
+- the response contains the full created issue URL; and
+- the response gives the continuation `/solve` flags.
+
+Additional tests pin ASCII parsing and exercise the shared service with mocked
+GitHub language, repository, commit, workflow-run, and issue-create calls.

--- a/docs/case-studies/issue-2121/investigation-data.json
+++ b/docs/case-studies/issue-2121/investigation-data.json
@@ -1,0 +1,37 @@
+{
+  "capturedAt": "2026-07-31",
+  "issue": {
+    "number": 2121,
+    "url": "https://github.com/link-assistant/hive-mind/issues/2121",
+    "title": "/task --ci-cd",
+    "state": "OPEN",
+    "commentCount": 0,
+    "reportedCommand": "/task —ci-cd https://github.com/link-assistant/agent",
+    "observedReply": "Missing GitHub repository URL"
+  },
+  "preparedPullRequest": {
+    "number": 2122,
+    "url": "https://github.com/link-assistant/hive-mind/pull/2122",
+    "initialDraft": true,
+    "initialReviewCount": 0,
+    "initialConversationCommentCount": 0,
+    "initialInlineCommentCount": 0
+  },
+  "relatedWork": [
+    {
+      "issue": 1733,
+      "pullRequest": 1929,
+      "finding": "/fix --ci-cd owns CI/CD issue generation followed by a solve run"
+    },
+    {
+      "issue": 1734,
+      "pullRequest": 1735,
+      "finding": "/task creates an issue directly and leaves solving as an explicit reply"
+    },
+    {
+      "issue": 2021,
+      "finding": "Telegram command parsing already normalizes en and em dashes to ASCII option prefixes"
+    }
+  ],
+  "rootCauseTrace": ["parseCommandArgs normalized the reported em dash to --ci-cd", "handleTaskCommand recognized only ordinary issue creation and split modes", "the ordinary issue parser received --ci-cd and the repository on one line", "that parser requires the repository to be a standalone repository input", "the handler therefore emitted its missing-repository error"]
+}

--- a/docs/case-studies/issue-2121/research-sources.json
+++ b/docs/case-studies/issue-2121/research-sources.json
@@ -1,0 +1,47 @@
+[
+  {
+    "title": "Hive Mind issue #2121",
+    "url": "https://github.com/link-assistant/hive-mind/issues/2121",
+    "role": "Primary requirements and failure screenshot"
+  },
+  {
+    "title": "Hive Mind issue #1733",
+    "url": "https://github.com/link-assistant/hive-mind/issues/1733",
+    "role": "Defines the full /fix --ci-cd workflow"
+  },
+  {
+    "title": "Hive Mind PR #1929",
+    "url": "https://github.com/link-assistant/hive-mind/pull/1929",
+    "role": "Most recent implementation and architecture of /fix --ci-cd"
+  },
+  {
+    "title": "Hive Mind issue #1734",
+    "url": "https://github.com/link-assistant/hive-mind/issues/1734",
+    "role": "Defines /task as issue creation followed by an optional /solve reply"
+  },
+  {
+    "title": "Hive Mind PR #1735",
+    "url": "https://github.com/link-assistant/hive-mind/pull/1735",
+    "role": "Original Telegram /task issue-creation implementation"
+  },
+  {
+    "title": "GitHub REST API: List repository languages",
+    "url": "https://docs.github.com/en/rest/repos/repos?apiVersion=2022-11-28#list-repository-languages",
+    "role": "Confirms language values are bytes of code per language"
+  },
+  {
+    "title": "GitHub REST API: List workflow runs for a repository",
+    "url": "https://docs.github.com/en/rest/actions/workflow-runs?apiVersion=2022-11-28#list-workflow-runs-for-a-repository",
+    "role": "Confirms head_sha and branch workflow-run filters"
+  },
+  {
+    "title": "GitHub REST API: Get a commit",
+    "url": "https://docs.github.com/en/rest/commits/commits?apiVersion=2022-11-28#get-a-commit",
+    "role": "Confirms a branch name can be used as a commit reference"
+  },
+  {
+    "title": "GitHub CLI manual: gh issue create",
+    "url": "https://cli.github.com/manual/gh_issue_create",
+    "role": "Confirms body-file, label, and issue-type creation options"
+  }
+]

--- a/src/fix.ci-cd-issue.lib.mjs
+++ b/src/fix.ci-cd-issue.lib.mjs
@@ -1,0 +1,137 @@
+/**
+ * Shared GitHub-backed CI/CD issue generation for `/fix --ci-cd` and
+ * `/task --ci-cd` (issues #1733 and #2121).
+ */
+
+import { spawn } from 'child_process';
+import { CI_CD_ISSUE_LABELS, CI_CD_ISSUE_TYPE, buildCiCdIssueBody, buildCiCdIssueTitle } from './fix.ci-cd.lib.mjs';
+import { createTaskIssue } from './task.issue-creation.lib.mjs';
+
+function runCommand(command, args, options = {}) {
+  return new Promise(resolve => {
+    const child = spawn(command, args, {
+      stdio: ['ignore', 'pipe', 'pipe'],
+      env: process.env,
+      ...options,
+    });
+    let stdout = '';
+    let stderr = '';
+    child.stdout.on('data', data => {
+      stdout += data.toString();
+    });
+    child.stderr.on('data', data => {
+      stderr += data.toString();
+    });
+    child.on('error', error => {
+      resolve({ code: 1, stdout, stderr: stderr || error.message });
+    });
+    child.on('close', code => {
+      resolve({ code, stdout, stderr });
+    });
+  });
+}
+
+async function commandOutput(run, command, args) {
+  const result = await run(command, args);
+  if (result.code !== 0) {
+    const output = `${result.stderr || ''}${result.stdout || ''}`.trim();
+    throw new Error(output || `${command} exited with code ${result.code}`);
+  }
+  return result.stdout.trim();
+}
+
+async function detectLanguages(repository, run, warn) {
+  try {
+    const json = await commandOutput(run, 'gh', ['api', `repos/${repository.fullName}/languages`]);
+    return JSON.parse(json);
+  } catch (error) {
+    warn(`⚠️  Could not detect languages: ${error.message}`);
+    return {};
+  }
+}
+
+async function getDefaultBranch(repository, run, warn) {
+  try {
+    return await commandOutput(run, 'gh', ['api', `repos/${repository.fullName}`, '--jq', '.default_branch']);
+  } catch (error) {
+    warn(`⚠️  Could not determine default branch: ${error.message}`);
+    return null;
+  }
+}
+
+async function getLatestCommit(repository, branch, run, warn) {
+  if (!branch) return null;
+  try {
+    const json = await commandOutput(run, 'gh', ['api', `repos/${repository.fullName}/commits/${branch}`, '--jq', '{sha: .sha, message: .commit.message, url: .html_url}']);
+    return JSON.parse(json);
+  } catch (error) {
+    warn(`⚠️  Could not fetch latest commit: ${error.message}`);
+    return null;
+  }
+}
+
+const RUNS_JQ = '[.workflow_runs[] | {name: .name, status: .status, conclusion: .conclusion, html_url: .html_url, head_sha: .head_sha}]';
+
+async function getRunsForCommit(repository, sha, run, warn) {
+  if (!sha) return [];
+  try {
+    const json = await commandOutput(run, 'gh', ['api', `repos/${repository.fullName}/actions/runs?head_sha=${sha}&per_page=100`, '--jq', RUNS_JQ]);
+    const parsed = JSON.parse(json);
+    return Array.isArray(parsed) ? parsed : [];
+  } catch (error) {
+    warn(`⚠️  Could not fetch CI/CD runs: ${error.message}`);
+    return [];
+  }
+}
+
+async function getRecentBranchRuns(repository, branch, run, warn) {
+  if (!branch) return [];
+  try {
+    const json = await commandOutput(run, 'gh', ['api', `repos/${repository.fullName}/actions/runs?branch=${encodeURIComponent(branch)}&per_page=20`, '--jq', RUNS_JQ]);
+    const parsed = JSON.parse(json);
+    return Array.isArray(parsed) ? parsed : [];
+  } catch (error) {
+    warn(`⚠️  Could not fetch recent CI/CD runs for branch ${branch}: ${error.message}`);
+    return [];
+  }
+}
+
+export async function prepareCiCdIssue({ repository, run = runCommand, warn = message => console.warn(message) }) {
+  const [languages, defaultBranch] = await Promise.all([detectLanguages(repository, run, warn), getDefaultBranch(repository, run, warn)]);
+  const commit = await getLatestCommit(repository, defaultBranch, run, warn);
+  let runs = await getRunsForCommit(repository, commit?.sha, run, warn);
+  let runsSource = 'commit';
+
+  if (runs.length === 0) {
+    const branchRuns = await getRecentBranchRuns(repository, defaultBranch, run, warn);
+    if (branchRuns.length > 0) {
+      runs = branchRuns;
+      runsSource = 'branch';
+    }
+  }
+
+  return {
+    repository,
+    defaultBranch,
+    commit,
+    runs,
+    languages,
+    runsSource,
+    title: buildCiCdIssueTitle(),
+    body: buildCiCdIssueBody({ repository, defaultBranch, commit, runs, languages, runsSource }),
+  };
+}
+
+export async function createCiCdIssue({ repository, prepared = null, run = runCommand, log = null, warn = message => console.warn(message) }) {
+  const issueDraft = prepared || (await prepareCiCdIssue({ repository, run, warn }));
+  const issue = await createTaskIssue({
+    repository,
+    title: issueDraft.title,
+    body: issueDraft.body,
+    issueType: CI_CD_ISSUE_TYPE,
+    labels: [...CI_CD_ISSUE_LABELS],
+    run,
+    log,
+  });
+  return { ...issue, prepared: issueDraft };
+}

--- a/src/fix.mjs
+++ b/src/fix.mjs
@@ -16,7 +16,8 @@
 import path from 'path';
 import { spawn } from 'child_process';
 import { fileURLToPath } from 'url';
-import { CI_CD_ISSUE_LABELS, CI_CD_ISSUE_TYPE, buildCiCdIssueBody, buildCiCdIssueTitle, buildSolveArgs, partitionFixArgs, summarizeRunFailures } from './fix.ci-cd.lib.mjs';
+import { buildSolveArgs, partitionFixArgs, summarizeRunFailures } from './fix.ci-cd.lib.mjs';
+import { createCiCdIssue, prepareCiCdIssue } from './fix.ci-cd-issue.lib.mjs';
 import { setupStdioLogInterceptor } from './lib.mjs';
 
 setupStdioLogInterceptor();
@@ -42,95 +43,6 @@ Examples:
   fix.mjs https://github.com/owner/repo --ci-cd
   fix.mjs https://github.com/owner/repo --ci-cd --tool codex --model gpt-5.5
   fix.mjs owner/repo --ci-cd --think max --no-solve`);
-}
-
-function runCommand(command, args, options = {}) {
-  return new Promise(resolve => {
-    const child = spawn(command, args, {
-      stdio: ['ignore', 'pipe', 'pipe'],
-      env: process.env,
-      ...options,
-    });
-    let stdout = '';
-    let stderr = '';
-    child.stdout.on('data', data => {
-      stdout += data.toString();
-    });
-    child.stderr.on('data', data => {
-      stderr += data.toString();
-    });
-    child.on('error', error => {
-      resolve({ code: 1, stdout, stderr: stderr || error.message });
-    });
-    child.on('close', code => {
-      resolve({ code, stdout, stderr });
-    });
-  });
-}
-
-async function commandOutput(command, args) {
-  const result = await runCommand(command, args);
-  if (result.code !== 0) {
-    const output = `${result.stderr || ''}${result.stdout || ''}`.trim();
-    throw new Error(output || `${command} exited with code ${result.code}`);
-  }
-  return result.stdout.trim();
-}
-
-async function detectLanguages(repository) {
-  try {
-    const json = await commandOutput('gh', ['api', `repos/${repository.fullName}/languages`]);
-    return JSON.parse(json);
-  } catch (error) {
-    console.warn(`⚠️  Could not detect languages: ${error.message}`);
-    return {};
-  }
-}
-
-async function getDefaultBranch(repository) {
-  try {
-    return await commandOutput('gh', ['api', `repos/${repository.fullName}`, '--jq', '.default_branch']);
-  } catch (error) {
-    console.warn(`⚠️  Could not determine default branch: ${error.message}`);
-    return null;
-  }
-}
-
-async function getLatestCommit(repository, branch) {
-  if (!branch) return null;
-  try {
-    const json = await commandOutput('gh', ['api', `repos/${repository.fullName}/commits/${branch}`, '--jq', '{sha: .sha, message: .commit.message, url: .html_url}']);
-    return JSON.parse(json);
-  } catch (error) {
-    console.warn(`⚠️  Could not fetch latest commit: ${error.message}`);
-    return null;
-  }
-}
-
-const RUNS_JQ = '[.workflow_runs[] | {name: .name, status: .status, conclusion: .conclusion, html_url: .html_url, head_sha: .head_sha}]';
-
-async function getRunsForCommit(repository, sha) {
-  if (!sha) return [];
-  try {
-    const json = await commandOutput('gh', ['api', `repos/${repository.fullName}/actions/runs?head_sha=${sha}&per_page=100`, '--jq', RUNS_JQ]);
-    const parsed = JSON.parse(json);
-    return Array.isArray(parsed) ? parsed : [];
-  } catch (error) {
-    console.warn(`⚠️  Could not fetch CI/CD runs: ${error.message}`);
-    return [];
-  }
-}
-
-async function getRecentBranchRuns(repository, branch) {
-  if (!branch) return [];
-  try {
-    const json = await commandOutput('gh', ['api', `repos/${repository.fullName}/actions/runs?branch=${encodeURIComponent(branch)}&per_page=20`, '--jq', RUNS_JQ]);
-    const parsed = JSON.parse(json);
-    return Array.isArray(parsed) ? parsed : [];
-  } catch (error) {
-    console.warn(`⚠️  Could not fetch recent CI/CD runs for branch ${branch}: ${error.message}`);
-    return [];
-  }
 }
 
 function resolveSolveCommand() {
@@ -171,28 +83,13 @@ async function main() {
   const repository = parsed.repository;
   console.log(`🔧 /fix --ci-cd for ${repository.fullName}`);
 
-  const [languages, defaultBranch] = await Promise.all([detectLanguages(repository), getDefaultBranch(repository)]);
-  const commit = await getLatestCommit(repository, defaultBranch);
-  let runs = await getRunsForCommit(repository, commit?.sha);
-  let runsSource = 'commit';
-
-  // Release/tag commits frequently produce no runs of their own. Fall back to
-  // the most recent runs on the default branch so the issue stays actionable.
-  if (runs.length === 0) {
-    const branchRuns = await getRecentBranchRuns(repository, defaultBranch);
-    if (branchRuns.length > 0) {
-      runs = branchRuns;
-      runsSource = 'branch';
-    }
-  }
+  const prepared = await prepareCiCdIssue({ repository });
+  const { defaultBranch, commit, runs, runsSource, title, body } = prepared;
 
   const { total, failing } = summarizeRunFailures(runs);
   console.log(`   Default branch: ${defaultBranch || 'unknown'}`);
   console.log(`   Latest commit:  ${commit?.sha ? commit.sha.slice(0, 7) : 'unknown'}`);
   console.log(`   CI/CD runs:     ${total} (${failing} not passing)${runsSource === 'branch' ? ' [recent branch runs]' : ''}`);
-
-  const title = buildCiCdIssueTitle();
-  const body = buildCiCdIssueBody({ repository, defaultBranch, commit, runs, languages, runsSource });
 
   if (parsed.dryRun) {
     console.log('\n--- DRY RUN: issue that would be created ---\n');
@@ -202,16 +99,9 @@ async function main() {
   }
 
   console.log('\n📝 Creating remediation issue...');
-  const { createTaskIssue } = await import('./task.issue-creation.lib.mjs');
-  const issue = await createTaskIssue({
+  const issue = await createCiCdIssue({
     repository,
-    title,
-    body,
-    // The Bug type is what makes /solve --deep-analysis emit the root-cause
-    // instructions this body omits (issue #1733).
-    issueType: CI_CD_ISSUE_TYPE,
-    labels: [...CI_CD_ISSUE_LABELS],
-    run: runCommand,
+    prepared,
     log: message => console.log(message),
   });
   console.log(`✅ Created issue: ${issue.url}`);

--- a/src/locales/en.lino
+++ b/src/locales/en.lino
@@ -556,9 +556,9 @@ en
       locked
         options "🔒 Locked options: `{{options}}`"
       task
-        enabled "*/task* - Create a GitHub issue from a repository link and issue text"
-        usage "Usage: `/task <github-repository-url>` followed by issue text, or reply with `/task`"
-        example "Example: `/task https://github.com/owner/repo` then the issue text on following lines"
+        enabled "*/task* - Create a GitHub issue from text or CI/CD context"
+        usage "Usage: `/task <github-repository-url>` followed by issue text, or `/task --ci-cd <github-repository-url>`"
+        example "Example: `/task --ci-cd https://github.com/owner/repo` creates only the CI/CD remediation issue"
         disabled "*/task* / */split* - ❌ Disabled"
       split
         enabled "*/split* - Split a GitHub issue into smaller issues"

--- a/src/locales/hi.lino
+++ b/src/locales/hi.lino
@@ -556,9 +556,9 @@ hi
       locked
         options "🔒 लॉक किए गए विकल्प: `{{options}}`"
       task
-        enabled "*/task* - repository लिंक और issue text से GitHub issue बनाएँ"
-        usage "उपयोग: `/task <github-repository-url>` के बाद issue text, या `/task` से reply करें"
-        example "उदाहरण: `/task https://github.com/owner/repo`, फिर अगली पंक्तियों में issue text"
+        enabled "*/task* - text या CI/CD context से GitHub issue बनाएँ"
+        usage "उपयोग: `/task <github-repository-url>` के बाद issue text, या `/task --ci-cd <github-repository-url>`"
+        example "उदाहरण: `/task --ci-cd https://github.com/owner/repo` केवल CI/CD remediation issue बनाता है"
         disabled "*/task* / */split* - ❌ अक्षम"
       split
         enabled "*/split* - GitHub issue को छोटे issues में बाँटें"

--- a/src/locales/ru.lino
+++ b/src/locales/ru.lino
@@ -556,9 +556,9 @@ ru
       locked
         options "🔒 Заблокированные опции: `{{options}}`"
       task
-        enabled "*/task* - Создать задачу GitHub из ссылки на репозиторий и текста задачи"
-        usage "Использование: `/task <github-repository-url>` с текстом задачи после команды или ответом `/task`"
-        example "Пример: `/task https://github.com/owner/repo`, затем текст задачи на следующих строках"
+        enabled "*/task* - Создать issue GitHub из текста или контекста CI/CD"
+        usage "Использование: `/task <github-repository-url>` с текстом или `/task --ci-cd <github-repository-url>`"
+        example "Пример: `/task --ci-cd https://github.com/owner/repo` создаёт только issue для исправления CI/CD"
         disabled "*/task* / */split* - ❌ Отключено"
       split
         enabled "*/split* - Разделить задачу GitHub на меньшие задачи"

--- a/src/locales/zh.lino
+++ b/src/locales/zh.lino
@@ -556,9 +556,9 @@ zh
       locked
         options "🔒 锁定选项：`{{options}}`"
       task
-        enabled "*/task* - 根据仓库链接和 issue 文本创建 GitHub issue"
-        usage "用法：`/task <github-repository-url>` 后接 issue 文本，或回复 `/task`"
-        example "示例：`/task https://github.com/owner/repo`，然后在后续行写 issue 文本"
+        enabled "*/task* - 根据文本或 CI/CD 上下文创建 GitHub issue"
+        usage "用法：`/task <github-repository-url>` 后接 issue 文本，或 `/task --ci-cd <github-repository-url>`"
+        example "示例：`/task --ci-cd https://github.com/owner/repo` 只创建 CI/CD 修复 issue"
         disabled "*/task* / */split* - ❌ 已禁用"
       split
         enabled "*/split* - 将 GitHub issue 拆分为更小的 issue"

--- a/src/telegram-task-command.lib.mjs
+++ b/src/telegram-task-command.lib.mjs
@@ -2,6 +2,8 @@ import { buildUserMention } from './buildUserMention.lib.mjs';
 import { validateModelName } from './models/index.mjs';
 import { getLinoYargsFactory } from './cli-arguments.lib.mjs';
 import { createYargsConfig as createTaskYargsConfig } from './task.config.lib.mjs';
+import { createCiCdIssue } from './fix.ci-cd-issue.lib.mjs';
+import { parseFixRepository } from './fix.ci-cd.lib.mjs';
 import { createTaskIssue, parseTaskIssueCreationInput, resolveTaskIssueCreationInput } from './task.issue-creation.lib.mjs';
 import { parseTaskIssueUrl } from './task.split.lib.mjs';
 import { escapeMarkdown } from './telegram-markdown.lib.mjs';
@@ -21,6 +23,10 @@ export function getTaskCommandNameFromText(text) {
 
 export function hasTaskSplitFlag(args) {
   return args.includes('--split') || args.some(arg => arg.startsWith('--split='));
+}
+
+export function hasTaskCiCdFlag(args) {
+  return args.includes('--ci-cd');
 }
 
 export function applyTaskCommandDefaults(args, commandName = 'task') {
@@ -66,6 +72,16 @@ export function buildTaskCommandArgs(text) {
   };
 }
 
+export function buildTaskCiCdCommandArgs(text) {
+  const args = parseCommandArgs(text);
+  const repositoryRaw = args.find(arg => !arg.startsWith('-') && parseFixRepository(arg)) || null;
+  return {
+    args,
+    repositoryRaw,
+    repository: repositoryRaw ? parseFixRepository(repositoryRaw) : null,
+  };
+}
+
 function getReplyText(message) {
   const reply = message?.reply_to_message;
   if (!reply || reply.forum_topic_created) return '';
@@ -97,7 +113,7 @@ function injectLanguageIfMissing(args, locale) {
 }
 
 export function registerTaskCommands(bot, options) {
-  const { VERBOSE, taskEnabled, addBreadcrumb, isOldMessage, isForwarded, isGroupChat, isTopicAuthorized, buildAuthErrorMessage, isChatStopped, getStoppedChatRejectMessage, safeReply, executeAndUpdateMessage, createTaskIssue: createTaskIssueFn = createTaskIssue, resolveLocale = null } = options;
+  const { VERBOSE, taskEnabled, addBreadcrumb, isOldMessage, isForwarded, isGroupChat, isTopicAuthorized, buildAuthErrorMessage, isChatStopped, getStoppedChatRejectMessage, safeReply, executeAndUpdateMessage, createTaskIssue: createTaskIssueFn = createTaskIssue, createCiCdIssue: createCiCdIssueFn = createCiCdIssue, resolveLocale = null } = options;
 
   async function handleTaskCommand(ctx) {
     const commandName = getTaskCommandNameFromText(ctx.message?.text) || 'task';
@@ -138,6 +154,36 @@ export function registerTaskCommands(bot, options) {
 
     const parsedArgs = parseCommandArgs(ctx.message.text);
     const splitMode = commandName === 'split' || hasTaskSplitFlag(parsedArgs);
+    const ciCdMode = commandName === 'task' && hasTaskCiCdFlag(parsedArgs);
+
+    if (splitMode && ciCdMode) {
+      await safeReply(ctx, '❌ `--ci-cd` and `--split` cannot be used together.', { reply_to_message_id: ctx.message.message_id });
+      return;
+    }
+
+    if (ciCdMode) {
+      const built = buildTaskCiCdCommandArgs(ctx.message.text);
+      if (!built.repository) {
+        await safeReply(ctx, `❌ Missing GitHub repository URL. Usage: \`${commandDisplay} --ci-cd <github-repository-url>\`\n\nExample: \`${commandDisplay} --ci-cd https://github.com/owner/repo\``, { reply_to_message_id: ctx.message.message_id });
+        return;
+      }
+
+      const statusMessage = await ctx.reply(`Collecting CI/CD context and creating a GitHub issue in ${built.repository.fullName}...`, {
+        reply_to_message_id: ctx.message.message_id,
+        disable_web_page_preview: true,
+      });
+
+      try {
+        const createdIssue = await createCiCdIssueFn({
+          repository: built.repository,
+          log: message => VERBOSE && console.log(`[VERBOSE] ${message}`),
+        });
+        await editTelegramMessage(ctx, statusMessage, `Created GitHub issue:\n${createdIssue.url}\n\nReply to this message with /solve --development-log --deep-analysis --auto-merge to continue the full CI/CD remediation workflow.`);
+      } catch (error) {
+        await editTelegramMessage(ctx, statusMessage, `Error creating CI/CD issue:\n${error.message || String(error)}`);
+      }
+      return;
+    }
 
     if (!splitMode) {
       const replyText = getReplyText(ctx.message);

--- a/tests/test-fix-ci-cd.mjs
+++ b/tests/test-fix-ci-cd.mjs
@@ -8,6 +8,7 @@
 
 import assert from 'assert/strict';
 import { buildCiCdIssueBody, buildCiCdIssueTitle, buildRunsSection, buildSolveArgs, buildStandardPrompt, buildStandardPromptParagraphs, buildTemplatesSection, CI_CD_ISSUE_LABELS, CI_CD_ISSUE_TITLE, CI_CD_ISSUE_TYPE, CI_CD_TEMPLATES, DEBUG_OUTPUT_PARAGRAPH, FIX_SOLVE_OPTIONS, mapLanguagesToTemplates, normalizeLanguages, parseFixRepository, partitionFixArgs, REPORT_UPSTREAM_PARAGRAPH, summarizeRunFailures, templateUrl } from '../src/fix.ci-cd.lib.mjs';
+import { createCiCdIssue, prepareCiCdIssue } from '../src/fix.ci-cd-issue.lib.mjs';
 import { KEEP_WORKING_PROMPT } from '../src/solve.keep-working.detect.lib.mjs';
 import { buildCreateIssueArgs, createTaskIssue } from '../src/task.issue-creation.lib.mjs';
 import { isBugIssueType } from '../src/development-log.lib.mjs';
@@ -279,6 +280,59 @@ await test('buildCreateIssueArgs passes the issue type and labels to gh', () => 
 
   // Without optional metadata the args stay exactly as /task builds them today.
   assert.deepEqual(buildCreateIssueArgs({ repository: { fullName: 'owner/repo' }, title: 'T', bodyFile: '/tmp/body.md' }), ['issue', 'create', '--repo', 'owner/repo', '--title', 'T', '--body-file', '/tmp/body.md']);
+});
+
+await test('shared CI/CD issue service collects context and creates the same typed issue', async () => {
+  const repository = parseFixRepository('owner/repo');
+  const calls = [];
+  const run = async (command, args) => {
+    calls.push({ command, args });
+    const endpoint = args[1] || '';
+    if (args[0] === 'api' && endpoint.endsWith('/languages')) {
+      return { code: 0, stdout: JSON.stringify({ JavaScript: 900 }), stderr: '' };
+    }
+    if (args[0] === 'api' && endpoint === 'repos/owner/repo') {
+      return { code: 0, stdout: 'main\n', stderr: '' };
+    }
+    if (args[0] === 'api' && endpoint === 'repos/owner/repo/commits/main') {
+      return {
+        code: 0,
+        stdout: JSON.stringify({
+          sha: 'abcdef1234567890',
+          message: 'Latest change',
+          url: 'https://github.com/owner/repo/commit/abcdef1234567890',
+        }),
+        stderr: '',
+      };
+    }
+    if (args[0] === 'api' && endpoint.includes('actions/runs?head_sha=')) {
+      return {
+        code: 0,
+        stdout: JSON.stringify([{ name: 'CI', status: 'completed', conclusion: 'failure', html_url: 'https://github.com/owner/repo/actions/runs/1' }]),
+        stderr: '',
+      };
+    }
+    if (args[0] === 'issue' && args[1] === 'create') {
+      return { code: 0, stdout: 'https://github.com/owner/repo/issues/7\n', stderr: '' };
+    }
+    return { code: 1, stdout: '', stderr: `Unexpected command: ${command} ${args.join(' ')}` };
+  };
+
+  const prepared = await prepareCiCdIssue({ repository, run });
+  assert.equal(prepared.defaultBranch, 'main');
+  assert.equal(prepared.runsSource, 'commit');
+  assert.equal(prepared.title, CI_CD_ISSUE_TITLE);
+  assert.match(prepared.body, /Latest default-branch CI\/CD runs/);
+  assert.match(prepared.body, /js-ai-driven-development-pipeline-template/);
+
+  const issue = await createCiCdIssue({ repository, prepared, run });
+  assert.equal(issue.url, 'https://github.com/owner/repo/issues/7');
+  const createCall = calls.find(call => call.args[0] === 'issue' && call.args[1] === 'create');
+  assert.ok(createCall);
+  assert.ok(createCall.args.includes('--type'));
+  assert.ok(createCall.args.includes('Bug'));
+  assert.ok(createCall.args.includes('--label'));
+  assert.ok(createCall.args.includes('bug'));
 });
 
 await test('createTaskIssue retries without type/labels when the repo rejects them', async () => {

--- a/tests/test-telegram-task-command.mjs
+++ b/tests/test-telegram-task-command.mjs
@@ -5,7 +5,7 @@
  */
 
 import assert from 'assert/strict';
-import { applyTaskCommandDefaults, buildTaskCommandArgs, findTaskIssueUrl, getTaskCommandNameFromText, getTaskToolFromArgs, registerTaskCommands } from '../src/telegram-task-command.lib.mjs';
+import { applyTaskCommandDefaults, buildTaskCiCdCommandArgs, buildTaskCommandArgs, findTaskIssueUrl, getTaskCommandNameFromText, getTaskToolFromArgs, registerTaskCommands } from '../src/telegram-task-command.lib.mjs';
 import { buildTaskIssueTitle, parseTaskIssueCreationInput, resolveTaskIssueCreationInput, stripTaskCommandPrefix } from '../src/task.issue-creation.lib.mjs';
 
 let passed = 0;
@@ -66,6 +66,16 @@ await test('tool can be parsed from task command arguments', () => {
 
 const repoUrl = 'https://github.com/link-assistant/hive-mind';
 const issueText = 'Make task issue creation work\n\nPreserve the full body.';
+
+await test('/task --ci-cd accepts an option before the repository URL', () => {
+  const built = buildTaskCiCdCommandArgs(`/task --ci-cd ${repoUrl}`);
+  assert.deepEqual(built.repository, {
+    owner: 'link-assistant',
+    repo: 'hive-mind',
+    fullName: 'link-assistant/hive-mind',
+    url: repoUrl,
+  });
+});
 
 for (const [name, input] of [
   ['repository link before issue text', `${repoUrl}\n${issueText}`],
@@ -220,6 +230,53 @@ await test('task issue creation replies with the created issue URL', async () =>
   assert.equal(edits[0].messageId, 301);
   assert.match(edits[0].text, /https:\/\/github\.com\/link-assistant\/hive-mind\/issues\/1734/);
   assert.match(edits[0].text, /Reply to this message with \/solve/);
+});
+
+await test('/task --ci-cd creates the standard CI/CD issue without starting /fix', async () => {
+  const bot = { command() {} };
+  const generated = [];
+  const executions = [];
+  const edits = [];
+  const { handleTaskCommand } = registerTaskCommands(bot, {
+    VERBOSE: false,
+    taskEnabled: true,
+    addBreadcrumb: async () => {},
+    isOldMessage: () => false,
+    isGroupChat: () => true,
+    isTopicAuthorized: () => true,
+    buildAuthErrorMessage: () => 'not authorized',
+    isChatStopped: () => false,
+    getStoppedChatRejectMessage: () => 'stopped',
+    safeReply: async () => {
+      throw new Error('safeReply should not be used for valid CI/CD issue creation');
+    },
+    executeAndUpdateMessage: async (...args) => executions.push(args),
+    createCiCdIssue: async options => {
+      generated.push(options);
+      return { url: 'https://github.com/link-assistant/hive-mind/issues/2123' };
+    },
+  });
+
+  const ctx = {
+    chat: { id: 100, type: 'group' },
+    from: { id: 200, username: 'tester' },
+    message: { message_id: 300, text: `/task --ci-cd ${repoUrl}` },
+    reply: async () => ({ chat: { id: 100 }, message_id: 301 }),
+    telegram: {
+      editMessageText: async (chatId, messageId, inlineMessageId, text) => {
+        edits.push({ chatId, messageId, inlineMessageId, text });
+      },
+    },
+  };
+
+  await handleTaskCommand(ctx);
+
+  assert.equal(generated.length, 1);
+  assert.equal(generated[0].repository.fullName, 'link-assistant/hive-mind');
+  assert.equal(executions.length, 0, '/task --ci-cd must not run the full /fix workflow');
+  assert.equal(edits.length, 1);
+  assert.match(edits[0].text, /issues\/2123/);
+  assert.match(edits[0].text, /\/solve --development-log --deep-analysis --auto-merge/);
 });
 
 // Issue #1916: end-to-end handler path for replying to an issue-text message

--- a/tests/test-telegram-task-command.mjs
+++ b/tests/test-telegram-task-command.mjs
@@ -67,14 +67,22 @@ await test('tool can be parsed from task command arguments', () => {
 const repoUrl = 'https://github.com/link-assistant/hive-mind';
 const issueText = 'Make task issue creation work\n\nPreserve the full body.';
 
-await test('/task --ci-cd accepts an option before the repository URL', () => {
-  const built = buildTaskCiCdCommandArgs(`/task --ci-cd ${repoUrl}`);
-  assert.deepEqual(built.repository, {
-    owner: 'link-assistant',
-    repo: 'hive-mind',
-    fullName: 'link-assistant/hive-mind',
-    url: repoUrl,
+for (const option of ['--ci-cd', '—ci-cd']) {
+  await test(`/task ${option} accepts the option before the repository URL`, () => {
+    const built = buildTaskCiCdCommandArgs(`/task ${option} ${repoUrl}`);
+    assert.deepEqual(built.repository, {
+      owner: 'link-assistant',
+      repo: 'hive-mind',
+      fullName: 'link-assistant/hive-mind',
+      url: repoUrl,
+    });
   });
+}
+
+await test('/task --ci-cd rejects a missing repository and issue or pull-request URLs', () => {
+  assert.equal(buildTaskCiCdCommandArgs('/task --ci-cd').repository, null);
+  assert.equal(buildTaskCiCdCommandArgs('/task --ci-cd https://github.com/link-assistant/hive-mind/issues/2121').repository, null);
+  assert.equal(buildTaskCiCdCommandArgs('/task --ci-cd https://github.com/link-assistant/hive-mind/pull/2122').repository, null);
 });
 
 for (const [name, input] of [
@@ -260,7 +268,7 @@ await test('/task --ci-cd creates the standard CI/CD issue without starting /fix
   const ctx = {
     chat: { id: 100, type: 'group' },
     from: { id: 200, username: 'tester' },
-    message: { message_id: 300, text: `/task --ci-cd ${repoUrl}` },
+    message: { message_id: 300, text: `/task —ci-cd ${repoUrl}` },
     reply: async () => ({ chat: { id: 100 }, message_id: 301 }),
     telegram: {
       editMessageText: async (chatId, messageId, inlineMessageId, text) => {


### PR DESCRIPTION
## Summary

Implements `/task --ci-cd <repository>` as the issue-creation-only fallback for `/fix --ci-cd` (issue #2121).

The command now:

1. accepts both ASCII `--ci-cd` and the reported typographic `—ci-cd` spelling;
2. collects the target repository's languages, default-branch commit, and CI/CD runs;
3. creates the same typed CI/CD remediation issue as `/fix --ci-cd`;
4. returns the full created-issue URL without starting `/fix` or `/solve`; and
5. tells the user to reply with `/solve --development-log --deep-analysis --auto-merge` to continue normally.

## Root cause

Telegram's shared argument parser already normalized the reported em dash and tokenized the option before the repository URL. The `/task` handler, however, only distinguished ordinary issue creation from split mode. It therefore sent the complete option-and-URL line to the free-form issue parser, which could not find the repository in its expected standalone form and returned “Missing GitHub repository URL.”

The network-backed CI/CD collector also lived inside executable `fix.mjs`, preventing `/task` from reusing only the issue-creation stage without duplication or spawning the full workflow.

## Implementation

- Extract `prepareCiCdIssue()` and `createCiCdIssue()` into a shared service used by both `/fix` and `/task`.
- Add a dedicated `/task --ci-cd` handler path before ordinary issue parsing.
- Preserve the existing title/body builders, commit-to-branch run fallback, Bug type, and `bug` label fallback.
- Reject missing repositories and issue/PR URLs; reject combining `--ci-cd` with split mode.
- Document the fallback in all four maintained README/help locales.
- Add a minor changeset.
- Add the requested deep case study and machine-readable evidence/source catalogs under `docs/case-studies/issue-2121/`.

## Reproduction and regression coverage

Before this change:

```text
/task —ci-cd https://github.com/link-assistant/agent
→ Missing GitHub repository URL
```

The regression test now sends that exact command shape through `handleTaskCommand()` and asserts:

- the parsed repository reaches the shared CI/CD issue generator;
- no managed task or `/fix` execution starts;
- the created issue URL is returned; and
- the exact continuation solve flags are shown.

Additional tests cover ASCII parsing, invalid repository inputs, shared GitHub context collection, prompt generation, and typed issue creation.

## Verification

- `npm test` — all 358 default test files passed
- `npm run format:check`
- `npm run lint`
- `npm run check:duplication`
- `node tests/docs-validation.mjs`
- `node tests/test-docs-language-sync.mjs`
- `node scripts/validate-changeset.mjs`
- `bash scripts/check-file-line-limits.sh`
- focused task and CI/CD suites: 28/28 each

Closes #2121.
